### PR TITLE
[init] Set C++ optimization level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,17 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 if(MSVC)
   set(CMAKE_CXX_FLAGS "/Wall /WX ${CMAKE_CXX_FLAGS}")
 else()
-  set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -pedantic -Wno-unused-parameter ${CMAKE_CXX_FLAGS}")
+  if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_CXX_FLAGS "-Ofast ${CMAKE_CXX_FLAGS}")
+  endif()
+
+  set(CMAKE_CXX_FLAGS
+      "-Wall -Wextra -Werror -pedantic -Wno-unused-parameter -flto=auto ${CMAKE_CXX_FLAGS}"
+  )
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)
-  message(STATUS "No build type specified; defaulting to CMAKE_BUILD_TYPE=Debug.")
+  message(STATUS "No build type specified; defaulting to CMAKE_BUILD_TYPE=RelWithDebugInfo.")
   set(CMAKE_BUILD_TYPE
       "RelWithDebugInfo"
       CACHE STRING "The build type" FORCE

--- a/cpp/pybind/python_methods.cc
+++ b/cpp/pybind/python_methods.cc
@@ -66,7 +66,7 @@ std::vector<pybind11::bytes> TokenizerInfo_GetDecodedTokenTable(
 
 torch::Tensor GrammarStateMatcher_FindNextTokenBitmask(GrammarStateMatcher& matcher) {
   auto buffer_size = GrammarStateMatcher::GetBufferSize(matcher.GetVocabSize());
-  auto result = torch::empty({buffer_size}, torch::dtype(torch::kUInt32).device(torch::kCPU, 0));
+  auto result = torch::empty({buffer_size}, torch::dtype(torch::kInt32).device(torch::kCPU, 0));
   auto result_dltensor = at::toDLPack(result)->dl_tensor;
   matcher.FindNextTokenBitmask(&result_dltensor);
   return result;

--- a/cpp/tokenizer.cc
+++ b/cpp/tokenizer.cc
@@ -7,6 +7,7 @@
 #include <xgrammar/support/encoding.h>
 #include <xgrammar/xgrammar.h>
 
+#include <array>
 #include <chrono>
 #include <memory>
 #include <unordered_map>
@@ -179,10 +180,6 @@ inline std::string SpaceReplacerDecoder(const std::string& token) {
   return result;
 }
 
-// declare a chrono duration accumulator
-std::chrono::microseconds duration1(0);
-std::chrono::microseconds duration2(0);
-
 /*!
  * \brief ByteLevel decoder: inverses the bytes-to-unicode transformation in the encoding process
  * as in
@@ -211,14 +208,10 @@ inline std::string ByteLevelDecoder(const std::string& token) {
   };
   // clang-format on
 
-  auto tm1 = std::chrono::high_resolution_clock::now();
-
   auto unicode_codepoints = ParseUTF8(token.c_str(), UTF8ErrorPolicy::kReturnInvalid);
   if (unicode_codepoints.size() == 1 && unicode_codepoints[0] == kInvalidUTF8) {
     return token;
   }
-  auto tm2 = std::chrono::high_resolution_clock::now();
-  auto tm3 = std::chrono::high_resolution_clock::now();
 
   std::string decoded;
   decoded.reserve(unicode_codepoints.size());
@@ -232,16 +225,6 @@ inline std::string ByteLevelDecoder(const std::string& token) {
     }
     decoded += static_cast<char>(char_to_byte_map[unicode_codepoint]);
   }
-  auto tm4 = std::chrono::high_resolution_clock::now();
-
-  // logic: duration1 += tm2 - tm1 - tm3 + tm2
-  duration1 += std::chrono::duration_cast<std::chrono::microseconds>(tm2 - tm1);
-  //  -
-  //  std::chrono::duration_cast<std::chrono::microseconds>(tm3 - tm2);
-  duration2 += std::chrono::duration_cast<std::chrono::microseconds>(tm4 - tm3);
-  //  -
-  //  std::chrono::duration_cast<std::chrono::microseconds>(tm3 - tm2);
-
   return decoded;
 }
 

--- a/tests/python/test_builtin_grammar_json_schema.py
+++ b/tests/python/test_builtin_grammar_json_schema.py
@@ -4,16 +4,14 @@
 a unoptimized, non-simplified EBNF string. This is to test the robustness of the grammar state
 matcher."""
 import json
-import sys
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import pytest
 from pydantic import BaseModel
+from transformers import AutoTokenizer
 
 from xgrammar import BNFGrammar, GrammarStateMatcher
 from xgrammar.xgrammar import BuiltinGrammar
-
-from transformers import AutoTokenizer
 
 
 def test_json_schema_accept_find_token():

--- a/tests/python/test_grammar_state_matcher.py
+++ b/tests/python/test_grammar_state_matcher.py
@@ -1,12 +1,12 @@
 # pylint: disable=missing-module-docstring,missing-function-docstring
 # pylint: disable=redefined-outer-name,unbalanced-tuple-unpacking
 """This test uses the optimized JSON grammar provided by the grammar library."""
-import time
 from typing import List, Optional
 
 import pytest
 import torch
 from transformers import AutoTokenizer
+
 from xgrammar import BNFGrammar, BuiltinGrammar, GrammarStateMatcher
 
 json_grammar = BuiltinGrammar.json()


### PR DESCRIPTION
This PR sets the default optimization level of release build to `-Ofast`, therefore solves the performance issue.

This PR also changes the dtype of the output tensor mask from `uint32` to `int32` since pytorch<2.4 does not support uint32 tensors.