### PR TITLE
[feature] Add flag for customizing mask size

### DIFF
--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -5,10 +5,10 @@
 
 #include "grammar_functor.h"
 
-#include <xgrammar/support/encoding.h>
 #include <xgrammar/xgrammar.h>
 
 #include "grammar_ast.h"
+#include "support/encoding.h"
 
 namespace xgrammar {
 

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -6,12 +6,12 @@
 #include "grammar_parser.h"
 
 #include <picojson.h>
-#include <xgrammar/support/encoding.h>
 
 #include <memory>
 
 #include "grammar_ast.h"
 #include "grammar_builder.h"
+#include "support/encoding.h"
 
 namespace xgrammar {
 
@@ -139,7 +139,8 @@ std::string EBNFParserImpl::ParseName(bool accept_empty) {
 int32_t EBNFParserImpl::ParseCharacterClass() {
   static constexpr TCodepoint kUnknownUpperBound = -4;
   static const std::unordered_map<std::string, TCodepoint> kCustomEscapeMap = {
-      {"\\-", '-'}, {"\\]", ']'}};
+      {"\\-", '-'}, {"\\]", ']'}
+  };
 
   std::vector<BNFGrammarBuilder::CharacterClassElement> elements;
 

--- a/cpp/grammar_serializer.cc
+++ b/cpp/grammar_serializer.cc
@@ -6,7 +6,8 @@
 #include "grammar_serializer.h"
 
 #include <picojson.h>
-#include <xgrammar/support/encoding.h>
+
+#include "support/encoding.h"
 
 namespace xgrammar {
 
@@ -64,7 +65,8 @@ std::string BNFGrammarPrinter::PrintByteString(const RuleExpr& rule_expr) {
 
 std::string BNFGrammarPrinter::PrintCharacterClass(const RuleExpr& rule_expr) {
   static const std::unordered_map<TCodepoint, std::string> kCustomEscapeMap = {
-      {'-', "\\-"}, {']', "\\]"}};
+      {'-', "\\-"}, {']', "\\]"}
+  };
   std::string result = "[";
   bool is_negative = static_cast<bool>(rule_expr[0]);
   if (is_negative) {
@@ -128,7 +130,6 @@ std::string BNFGrammarPrinter::ToString() {
   return result;
 }
 
-
 std::string BNFGrammarJSONSerializer::ToString() {
   picojson::object grammar_json_obj;
 
@@ -155,7 +156,6 @@ std::string BNFGrammarJSONSerializer::ToString() {
   auto grammar_json = picojson::value(grammar_json_obj);
   return grammar_json.serialize(prettify_);
 }
-
 
 // TVM_REGISTER_GLOBAL("mlc.grammar.BNFGrammarToString").set_body_typed([](const BNFGrammar&
 // grammar) {

--- a/cpp/grammar_state_matcher_base.h
+++ b/cpp/grammar_state_matcher_base.h
@@ -6,7 +6,6 @@
 #ifndef XGRAMMAR_GRAMMAR_STATE_MATCHER_BASE_H_
 #define XGRAMMAR_GRAMMAR_STATE_MATCHER_BASE_H_
 
-#include <xgrammar/support/encoding.h>
 #include <xgrammar/xgrammar.h>
 
 #include <algorithm>
@@ -14,6 +13,7 @@
 
 #include "grammar_ast.h"
 #include "grammar_state_matcher_state.h"
+#include "support/encoding.h"
 
 namespace xgrammar {
 
@@ -392,7 +392,8 @@ inline bool GrammarStateMatcherBase::ExpandRulePosition(
         // Find the positions in every choice of the referred rule
         can_be_empty |= ExpandRulePosition(ref_rule_position, new_stack_tops, false);
       }
-    } else if (element.type == RuleExprType::kCharacterClass || element.type == RuleExprType::kByteString) {
+    } else if (element.type == RuleExprType::kCharacterClass ||
+               element.type == RuleExprType::kByteString) {
       // Case 3. Character class or byte string. cannot be empty.
       new_stack_tops->push_back(new_node_id);
       can_be_empty = false;

--- a/cpp/grammar_state_matcher_preproc.h
+++ b/cpp/grammar_state_matcher_preproc.h
@@ -6,7 +6,6 @@
 #ifndef XGRAMMAR_GRAMMAR_STATE_MATCHER_PREPROC_H_
 #define XGRAMMAR_GRAMMAR_STATE_MATCHER_PREPROC_H_
 
-#include <xgrammar/support/encoding.h>
 #include <xgrammar/xgrammar.h>
 
 #include <unordered_set>
@@ -15,6 +14,7 @@
 #include "grammar_ast.h"
 #include "grammar_state_matcher_base.h"
 #include "support/dynamic_bitset.h"
+#include "support/encoding.h"
 #include "support/utils.h"
 
 namespace xgrammar {
@@ -296,7 +296,8 @@ inline CatagorizedTokens GrammarStateMatcherForInitContext::GetCatagorizedTokens
 
     if (accepted) {
       tmp_accepted_indices_.push_back(i);
-    } else if (can_reach_end && consider_parent_rule && IsTokenPassLookaheadAssertion(token, tmp_can_reach_end_stack_)) {
+    } else if (can_reach_end && consider_parent_rule &&
+               IsTokenPassLookaheadAssertion(token, tmp_can_reach_end_stack_)) {
       // 1. If the current rule is the main rule (consider_parent_rule=false), there are no
       // uncertain tokens. Not accepted tokens are just rejected.
       // 2. If a token cannot pass the lookahead assertion, it is rejected.
@@ -341,7 +342,8 @@ std::shared_ptr<GrammarMatcherInitContext> GrammarStateMatcher::CreateInitContex
     if (token == "</s>" || token == "<|end_of_text|>" || token == "<|eot_id|>" ||
         token == "<|endoftext|>" || token == "<eos>" || token == "<end_of_turn>") {
       ptr->detected_stop_token_ids.push_back(i);
-    } else if ((token[0] == '<' && token.back() == '>' && token.size() >= 3) || token == "[@BOS@]") {
+    } else if ((token[0] == '<' && token.back() == '>' && token.size() >= 3) ||
+               token == "[@BOS@]") {
       // gemma treats [@BOS@] as a special token
       ptr->special_token_ids.insert(i);
     } else {

--- a/cpp/pybind/pybind.cc
+++ b/cpp/pybind/pybind.cc
@@ -41,12 +41,14 @@ PYBIND11_MODULE(xgrammar_bindings, m) {
                     const std::vector<std::string>&,
                     std::optional<std::vector<int>>,
                     bool,
+                    std::optional<int>,
                     int>(&GrammarStateMatcher_Init)))
       .def(py::init(py::overload_cast<
                     const BNFGrammar&,
                     std::nullptr_t,
                     std::optional<std::vector<int>>,
                     bool,
+                    std::optional<int>,
                     int>(&GrammarStateMatcher_Init)))
       .def("accept_token", &GrammarStateMatcher::AcceptToken)
       .def("_accept_string", &GrammarStateMatcher::_AcceptString)

--- a/cpp/pybind/python_methods.cc
+++ b/cpp/pybind/python_methods.cc
@@ -27,12 +27,14 @@ GrammarStateMatcher GrammarStateMatcher_Init(
     const std::vector<std::string>& vocab,
     std::optional<std::vector<int>> stop_token_ids,
     bool terminate_without_stop_token,
+    std::optional<int> mask_vocab_size,
     int max_rollback_steps
 ) {
   return GrammarStateMatcher(
       GrammarStateMatcher::CreateInitContext(grammar, vocab),
       stop_token_ids,
       terminate_without_stop_token,
+      mask_vocab_size,
       max_rollback_steps
   );
 }
@@ -42,12 +44,14 @@ GrammarStateMatcher GrammarStateMatcher_Init(
     std::nullptr_t,
     std::optional<std::vector<int>> stop_token_ids,
     bool terminate_without_stop_token,
+    std::optional<int> mask_vocab_size,
     int max_rollback_steps
 ) {
   return GrammarStateMatcher(
       GrammarStateMatcher::CreateInitContext(grammar, {}),
       stop_token_ids,
       terminate_without_stop_token,
+      mask_vocab_size,
       max_rollback_steps
   );
 }

--- a/cpp/pybind/python_methods.h
+++ b/cpp/pybind/python_methods.h
@@ -27,6 +27,7 @@ GrammarStateMatcher GrammarStateMatcher_Init(
     const std::vector<std::string>& vocab,
     std::optional<std::vector<int>> stop_token_ids,
     bool terminate_without_stop_token,
+    std::optional<int> mask_vocab_size,
     int max_rollback_steps
 );
 
@@ -35,6 +36,7 @@ GrammarStateMatcher GrammarStateMatcher_Init(
     std::nullptr_t,
     std::optional<std::vector<int>> stop_token_ids,
     bool terminate_without_stop_token,
+    std::optional<int> mask_vocab_size,
     int max_rollback_steps
 );
 

--- a/cpp/support/encoding.cc
+++ b/cpp/support/encoding.cc
@@ -2,7 +2,7 @@
  *  Copyright (c) 2024 by Contributors
  * \file xgrammar/support/encoding.cc
  */
-#include <xgrammar/support/encoding.h>
+#include "encoding.h"
 
 #include <array>
 
@@ -51,7 +51,8 @@ std::string PrintAsEscapedUTF8(
       {'\t', "\\t"},
       {'\v', "\\v"},
       {'\0', "\\0"},
-      {'\x1B', "\\e"}};
+      {'\x1B', "\\e"}
+  };
 
   if (auto it = additional_escape_map.find(codepoint); it != additional_escape_map.end()) {
     return it->second;
@@ -182,7 +183,8 @@ std::pair<TCodepoint, const char*> ParseNextUTF8OrEscaped(
       {"\\t", '\t'},
       {"\\v", '\v'},
       {"\\0", '\0'},
-      {"\\e", '\x1B'}};
+      {"\\e", '\x1B'}
+  };
   if (utf8[0] != '\\') {
     return ParseNextUTF8(utf8, UTF8ErrorPolicy::kReturnInvalid);
   }

--- a/cpp/support/encoding.h
+++ b/cpp/support/encoding.h
@@ -5,7 +5,7 @@
  */
 #ifndef XGRAMMAR_SUPPORT_ENCODING_H_
 #define XGRAMMAR_SUPPORT_ENCODING_H_
-// TODO(yixin): move major logic to cpp/; enhance performance
+// TODO(yixin): enhance performance
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/cpp/tokenizer.cc
+++ b/cpp/tokenizer.cc
@@ -4,7 +4,6 @@
  */
 
 #include <picojson.h>
-#include <xgrammar/support/encoding.h>
 #include <xgrammar/xgrammar.h>
 
 #include <array>
@@ -12,6 +11,7 @@
 #include <memory>
 #include <unordered_map>
 
+#include "support/encoding.h"
 #include "support/logging.h"
 
 namespace xgrammar {

--- a/include/xgrammar/xgrammar.h
+++ b/include/xgrammar/xgrammar.h
@@ -210,6 +210,7 @@ class GrammarStateMatcher {
       std::shared_ptr<GrammarMatcherInitContext> init_ctx,
       std::optional<std::vector<int>> stop_token_ids = std::nullopt,
       bool terminate_without_stop_token = false,
+      std::optional<int> mask_vocab_size = std::nullopt,
       int max_rollback_steps = 0
   );
 

--- a/python/xgrammar/xgrammar.py
+++ b/python/xgrammar/xgrammar.py
@@ -386,6 +386,7 @@ class GrammarStateMatcher:
         *,
         stop_token_ids: Union[None, int, List[int]] = None,
         terminate_without_stop_token: bool = False,
+        mask_vocab_size: Optional[int] = None,
         max_rollback_steps: int = 0,
     ) -> None:
         if isinstance(stop_token_ids, int):
@@ -408,6 +409,7 @@ class GrammarStateMatcher:
             vocab,
             stop_token_ids,
             terminate_without_stop_token,
+            mask_vocab_size,
             max_rollback_steps,
         )
 

--- a/tests/python/test_grammar_state_matcher.py
+++ b/tests/python/test_grammar_state_matcher.py
@@ -264,5 +264,21 @@ sub_rule ::= "b"
     assert matcher.find_jump_forward_string() == "bb"
 
 
+def test_mask_vocab_size():
+    vocab = [
+        # fmt: off
+        "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " ", '"a":true',
+        # fmt: on
+    ]
+    matcher = GrammarStateMatcher(json_grammar, vocab, mask_vocab_size=64)
+    assert matcher.vocab_size == 64
+
+    mask = matcher.find_next_token_bitmask()
+    assert mask.shape == (2,)
+
+    rejected_tokens = GrammarStateMatcher.get_rejected_tokens_from_bitmask(mask, matcher.vocab_size)
+    assert rejected_tokens == [i for i in range(64) if i != 7]
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Some models, such as qwen and phi-2, has a larger model vocab size than their tokenizer vocab size. The reason for that is the model vocab size will be round up to a power of 2, e.g. 32. In such cases, the mask size should be align with the model vocab size since it is applied to the logits.

This PR adds a parameter mask_vocab_size to GrammarStateMatcher to specify the model vocab size.