### PR TITLE
[init] Rename GrammarStateMatcher -> GrammarMatcher

### DIFF
--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -36,7 +36,7 @@ BNFGrammar BNFGrammar::Deserialize(const std::string& json_string) {
   return BNFJSONParser::Parse(json_string);
 }
 
-// Optimized json grammar for the speed of the grammar state matcher
+// Optimized json grammar for the speed of the gramma matcher
 const std::string kJSONGrammarString = R"(
 main ::= (
     "{" [ \n\t]* members_and_embrace |

--- a/cpp/grammar_matcher_base.h
+++ b/cpp/grammar_matcher_base.h
@@ -1,7 +1,7 @@
 /*!
  *  Copyright (c) 2024 by Contributors
- * \file xgrammar/grammar_state_matcher_base.h
- * \brief The base class of GrammarStateMatcher. It implements a character-based matching automata.
+ * \file xgrammar/grammar_matcher_base.h
+ * \brief The base class of GrammarMatcher. It implements a character-based matching automata.
  */
 #ifndef XGRAMMAR_GRAMMAR_STATE_MATCHER_BASE_H_
 #define XGRAMMAR_GRAMMAR_STATE_MATCHER_BASE_H_
@@ -12,30 +12,30 @@
 #include <vector>
 
 #include "grammar_ast.h"
-#include "grammar_state_matcher_state.h"
+#include "grammar_matcher_state.h"
 #include "support/encoding.h"
 
 namespace xgrammar {
 
 /*!
- * \brief The base class of GrammarStateMatcher. It implements a character-based matching
+ * \brief The base class of GrammarMatcher. It implements a character-based matching
  * automata, and supports accepting a character, rolling back by character, etc.
  */
-class GrammarStateMatcherBase {
+class GrammarMatcherBase {
  protected:
   using RuleExpr = BNFGrammar::Impl::RuleExpr;
   using RuleExprType = BNFGrammar::Impl::RuleExprType;
 
  public:
   /*!
-   * \brief Construct a GrammarStateMatcherBase with the given grammar and initial rule position.
+   * \brief Construct a GrammarMatcherBase with the given grammar and initial rule position.
    * \param grammar The grammar to match.
    * \param init_rule_position The initial rule position. If not specified, the main rule will be
    * used.
    * \param expand_init_rule_position Whether to expand the initial rule position to all possible
    * locations. See ExpandRulePosition.
    */
-  GrammarStateMatcherBase(
+  GrammarMatcherBase(
       const BNFGrammar& grammar,
       RulePosition init_rule_position = kInvalidRulePosition,
       bool expand_init_rule_position = true
@@ -123,7 +123,7 @@ class GrammarStateMatcherBase {
 };
 
 /*! \brief Check the codepoint is contained in the character class. */
-inline bool GrammarStateMatcherBase::CheckIfAccepted(
+inline bool GrammarMatcherBase::CheckIfAccepted(
     const RulePosition& rule_position, uint8_t char_value
 ) const {
   auto current_sequence = grammar_->GetRuleExpr(rule_position.sequence_id);
@@ -155,7 +155,7 @@ inline bool GrammarStateMatcherBase::CheckIfAccepted(
   }
 }
 
-inline RulePosition GrammarStateMatcherBase::UpdatePositionWithChar(
+inline RulePosition GrammarMatcherBase::UpdatePositionWithChar(
     const RulePosition& rule_position, uint8_t char_value
 ) const {
   auto current_sequence = grammar_->GetRuleExpr(rule_position.sequence_id);
@@ -203,7 +203,7 @@ inline RulePosition GrammarStateMatcherBase::UpdatePositionWithChar(
   }
 }
 
-inline bool GrammarStateMatcherBase::AcceptChar(uint8_t char_value, bool verbose) {
+inline bool GrammarMatcherBase::AcceptChar(uint8_t char_value, bool verbose) {
   if (verbose) {
     XGRAMMAR_LOG(INFO) << "Matching char: " << static_cast<int>(char_value) << " \""
                        << PrintAsEscapedUTF8(char_value) << "\"";
@@ -256,26 +256,26 @@ inline bool GrammarStateMatcherBase::AcceptChar(uint8_t char_value, bool verbose
   return true;
 }
 
-inline bool GrammarStateMatcherBase::CanReachEnd() const {
+inline bool GrammarMatcherBase::CanReachEnd() const {
   const auto& last_stack_tops = stack_tops_history_.GetLatest();
   return std::any_of(last_stack_tops.begin(), last_stack_tops.end(), [&](int32_t id) {
     return tree_.IsEndPosition(tree_[id]);
   });
 }
 
-inline void GrammarStateMatcherBase::RollbackChars(int rollback_cnt) {
+inline void GrammarMatcherBase::RollbackChars(int rollback_cnt) {
   stack_tops_history_.Rollback(rollback_cnt);
 }
 
-inline void GrammarStateMatcherBase::DiscardEarliestChars(int discard_cnt) {
+inline void GrammarMatcherBase::DiscardEarliestChars(int discard_cnt) {
   stack_tops_history_.DiscardEarliest(discard_cnt);
 }
 
-inline std::string GrammarStateMatcherBase::PrintStackState(int steps_behind_latest) const {
+inline std::string GrammarMatcherBase::PrintStackState(int steps_behind_latest) const {
   return stack_tops_history_.PrintHistory(steps_behind_latest);
 }
 
-inline void GrammarStateMatcherBase::PushInitialState(
+inline void GrammarMatcherBase::PushInitialState(
     RulePosition init_rule_position, bool expand_init_rule_position
 ) {
   if (init_rule_position == kInvalidRulePosition) {
@@ -303,7 +303,7 @@ inline void GrammarStateMatcherBase::PushInitialState(
   }
 }
 
-inline std::pair<bool, RulePosition> GrammarStateMatcherBase::GetNextPositionInSequence(
+inline std::pair<bool, RulePosition> GrammarMatcherBase::GetNextPositionInSequence(
     const RulePosition& rule_position, bool consider_parent
 ) const {
   auto sequence = grammar_->GetRuleExpr(rule_position.sequence_id);
@@ -341,7 +341,7 @@ inline std::pair<bool, RulePosition> GrammarStateMatcherBase::GetNextPositionInS
   return {true, next_position};
 }
 
-inline bool GrammarStateMatcherBase::ExpandRulePosition(
+inline bool GrammarMatcherBase::ExpandRulePosition(
     RulePosition cur_rule_position,
     std::vector<int32_t>* new_stack_tops,
     bool consider_parent,

--- a/cpp/grammar_matcher_state.h
+++ b/cpp/grammar_matcher_state.h
@@ -1,7 +1,7 @@
 /*!
  *  Copyright (c) 2024 by Contributors
- * \file xgrammar/grammar_state_matcher_state.h
- * \brief The header for the definition of the state used in the grammar state matcher.
+ * \file xgrammar/grammar_matcher_state.h
+ * \brief The header for the definition of the state used in the gramma matcher.
  */
 #ifndef XGRAMMAR_GRAMMAR_STATE_MATCHER_STATE_H_
 #define XGRAMMAR_GRAMMAR_STATE_MATCHER_STATE_H_
@@ -347,8 +347,8 @@ inline std::string RulePositionTree::PrintNode(const RulePosition& rule_position
     auto element = grammar_->GetRuleExpr(sequence[rule_position.element_id]);
     if (element.type == BNFGrammar::Impl::RuleExprType::kByteString) {
       ss << ", element in string: " << rule_position.element_in_string;
-    } else if (element.type == BNFGrammar::Impl::RuleExprType::kCharacterClass || //
-      element.type == BNFGrammar::Impl::RuleExprType::kCharacterClassStar) {
+    } else if (element.type == BNFGrammar::Impl::RuleExprType::kCharacterClass ||
+               element.type == BNFGrammar::Impl::RuleExprType::kCharacterClassStar) {
       ss << ", left utf8 bytes: " << rule_position.left_utf8_bytes;
     }
   }

--- a/cpp/pybind/pybind.cc
+++ b/cpp/pybind/pybind.cc
@@ -37,18 +37,16 @@ PYBIND11_MODULE(xgrammar_bindings, m) {
       .def_static("from_huggingface", &TokenizerInfo::FromHuggingFace)
       .def_static("from_vocab_and_metadata", &TokenizerInfo::FromVocabAndMetadata);
 
-  auto pyGrammarStateMatcher = py::class_<GrammarStateMatcher>(m, "GrammarStateMatcher");
-  pyGrammarStateMatcher.def(py::init(&GrammarStateMatcher_Init))
-      .def("accept_token", &GrammarStateMatcher::AcceptToken)
-      .def("_accept_string", &GrammarStateMatcher::_AcceptString)
-      .def("find_next_token_bitmask", &GrammarStateMatcher_FindNextTokenBitmask)
-      .def_static(
-          "get_rejected_tokens_from_bitmask", &GrammarStateMatcher_GetRejectedTokensFromBitMask
-      )
-      .def("is_terminated", &GrammarStateMatcher::IsTerminated)
-      .def("reset", &GrammarStateMatcher::Reset)
-      .def_property_readonly("vocab_size", &GrammarStateMatcher::GetVocabSize)
-      .def("find_jump_forward_string", &GrammarStateMatcher::FindJumpForwardString)
-      .def("rollback", &GrammarStateMatcher::Rollback)
-      .def_property_readonly("max_rollback_steps", &GrammarStateMatcher::GetMaxRollbackSteps);
+  auto pyGrammarMatcher = py::class_<GrammarMatcher>(m, "GrammarMatcher");
+  pyGrammarMatcher.def(py::init(&GrammarMatcher_Init))
+      .def("accept_token", &GrammarMatcher::AcceptToken)
+      .def("_accept_string", &GrammarMatcher::_AcceptString)
+      .def("find_next_token_bitmask", &GrammarMatcher_FindNextTokenBitmask)
+      .def_static("get_rejected_tokens_from_bitmask", &GrammarMatcher_GetRejectedTokensFromBitMask)
+      .def("is_terminated", &GrammarMatcher::IsTerminated)
+      .def("reset", &GrammarMatcher::Reset)
+      .def_property_readonly("vocab_size", &GrammarMatcher::GetVocabSize)
+      .def("find_jump_forward_string", &GrammarMatcher::FindJumpForwardString)
+      .def("rollback", &GrammarMatcher::Rollback)
+      .def_property_readonly("max_rollback_steps", &GrammarMatcher::GetMaxRollbackSteps);
 }

--- a/cpp/pybind/python_methods.cc
+++ b/cpp/pybind/python_methods.cc
@@ -50,7 +50,7 @@ std::vector<pybind11::bytes> TokenizerInfo_GetRawVocab(TokenizerInfo& tokenizer)
   return py_result;
 }
 
-GrammarStateMatcher GrammarStateMatcher_Init(
+GrammarMatcher GrammarMatcher_Init(
     const BNFGrammar& grammar,
     const TokenizerInfo& tokenizer_info,
     std::optional<std::vector<int>> stop_token_ids,
@@ -58,8 +58,8 @@ GrammarStateMatcher GrammarStateMatcher_Init(
     std::optional<int> mask_vocab_size,
     int max_rollback_steps
 ) {
-  return GrammarStateMatcher(
-      GrammarStateMatcher::CreateInitContext(grammar, tokenizer_info),
+  return GrammarMatcher(
+      GrammarMatcher::CreateInitContext(grammar, tokenizer_info),
       stop_token_ids,
       terminate_without_stop_token,
       mask_vocab_size,
@@ -67,20 +67,20 @@ GrammarStateMatcher GrammarStateMatcher_Init(
   );
 }
 
-torch::Tensor GrammarStateMatcher_FindNextTokenBitmask(GrammarStateMatcher& matcher) {
-  auto buffer_size = GrammarStateMatcher::GetBufferSize(matcher.GetVocabSize());
+torch::Tensor GrammarMatcher_FindNextTokenBitmask(GrammarMatcher& matcher) {
+  auto buffer_size = GrammarMatcher::GetBufferSize(matcher.GetVocabSize());
   auto result = torch::empty({buffer_size}, torch::dtype(torch::kInt32).device(torch::kCPU, 0));
   auto result_dltensor = at::toDLPack(result)->dl_tensor;
   matcher.FindNextTokenBitmask(&result_dltensor);
   return result;
 }
 
-std::vector<int> GrammarStateMatcher_GetRejectedTokensFromBitMask(
+std::vector<int> GrammarMatcher_GetRejectedTokensFromBitMask(
     torch::Tensor token_bitmask, size_t vocab_size
 ) {
   std::vector<int> result;
   auto token_bitmask_dltensor = at::toDLPack(token_bitmask)->dl_tensor;
-  GrammarStateMatcher::GetRejectedTokensFromBitMask(token_bitmask_dltensor, vocab_size, &result);
+  GrammarMatcher::GetRejectedTokensFromBitMask(token_bitmask_dltensor, vocab_size, &result);
   return result;
 }
 

--- a/cpp/pybind/python_methods.h
+++ b/cpp/pybind/python_methods.h
@@ -32,7 +32,7 @@ std::string TokenizerInfo_GetVocabType(const TokenizerInfo& tokenizer);
 
 std::vector<pybind11::bytes> TokenizerInfo_GetRawVocab(TokenizerInfo& tokenizer);
 
-GrammarStateMatcher GrammarStateMatcher_Init(
+GrammarMatcher GrammarMatcher_Init(
     const BNFGrammar& grammar,
     const TokenizerInfo& tokenizer_info,
     std::optional<std::vector<int>> stop_token_ids,
@@ -41,9 +41,9 @@ GrammarStateMatcher GrammarStateMatcher_Init(
     int max_rollback_steps
 );
 
-torch::Tensor GrammarStateMatcher_FindNextTokenBitmask(GrammarStateMatcher& matcher);
+torch::Tensor GrammarMatcher_FindNextTokenBitmask(GrammarMatcher& matcher);
 
-std::vector<int> GrammarStateMatcher_GetRejectedTokensFromBitMask(
+std::vector<int> GrammarMatcher_GetRejectedTokensFromBitMask(
     torch::Tensor token_bitmask, size_t vocab_size
 );
 

--- a/include/xgrammar/xgrammar.h
+++ b/include/xgrammar/xgrammar.h
@@ -196,7 +196,7 @@ class TokenizerInfo {
 // };
 
 /*!
- * \brief The init context of a GrammarStateMatcher. It contains the preprocessing results of the
+ * \brief The init context of a GrammarMatcher. It contains the preprocessing results of the
  * grammar and tokenizer.
  */
 class GrammarMatcherInitContext;
@@ -216,9 +216,9 @@ class GrammarMatcherInitContext;
  * \example
  * \code
  * Tokenizer tokenizer = ...;
- * auto init_ctx = GrammarStateMatcher::CreateInitContext(grammar,
+ * auto init_ctx = GrammarMatcher::CreateInitContext(grammar,
  *                                                        tokenizer->PostProcessedVocab());
- * GrammarStateMatcher matcher(init_ctx, 10);
+ * GrammarMatcher matcher(init_ctx, 10);
  * matcher->AcceptToken(67);
  *
  * // Construct a DLTensor with shape (tokenizer.GetVocabSize() + 31) / 32, and dtype uint32.
@@ -229,15 +229,15 @@ class GrammarMatcherInitContext;
  * matcher->Rollback(1);
  * \endcode
  */
-class GrammarStateMatcher {
+class GrammarMatcher {
  public:
   /*!
-   * \brief Construct a GrammarStateMatcher from the preprocessing result of type
+   * \brief Construct a GrammarMatcher from the preprocessing result of type
    * GrammarMatcherInitContext.
    * \param init_ctx The init context. It is obtained through
    * CreateInitContext as a result of preprocessing the grammar and tokenizer.
    */
-  GrammarStateMatcher(
+  GrammarMatcher(
       std::shared_ptr<GrammarMatcherInitContext> init_ctx,
       std::optional<std::vector<int>> stop_token_ids = std::nullopt,
       bool terminate_without_stop_token = false,
@@ -247,8 +247,8 @@ class GrammarStateMatcher {
 
   /*!
    * \brief Specify a grammar and decoded vocabulary to return their preprocessing results. These
-   * results are used to construct a GrammarStateMatcher. They can be stored elsewhere for quick
-   * construction of GrammarStateMatcher.
+   * results are used to construct a GrammarMatcher. They can be stored elsewhere for quick
+   * construction of GrammarMatcher.
    * \param grammar The grammar that the matcher follows.
    * \param decoded_vocab The tokens that the matcher requires for matching.
    */
@@ -316,7 +316,7 @@ class GrammarStateMatcher {
   /*! \brief Reset the matcher to the initial state. */
   void Reset();
 
-  XGRAMMAR_DEFINE_PIMPL_METHODS(GrammarStateMatcher);
+  XGRAMMAR_DEFINE_PIMPL_METHODS(GrammarMatcher);
 };
 
 /*!
@@ -326,14 +326,14 @@ class GrammarStateMatcher {
  * create every grammar state init context. If multiple toke tables are used to create init
  * contexts, an instance of this class for each vocabulary should be created.
  */
-class GrammarInitContextCache {
+class GrammarMatcherInitContextCache {
  public:
   /*!
-   * \brief Construct a GrammarInitContextCache with a vocabulary. This class will always create
-   * grammar state init contexts with this vocabulary.
+   * \brief Construct a GrammarMatcherInitContextCache with a vocabulary. This class will always
+   * create grammar state init contexts with this vocabulary.
    * \param decoded_vocab The vocabulary that the grammar will use.
    */
-  GrammarInitContextCache(const std::vector<std::string>& decoded_vocab);
+  GrammarMatcherInitContextCache(const std::vector<std::string>& decoded_vocab);
 
   /*! \brief Get the init context for pure JSON. */
   std::shared_ptr<GrammarMatcherInitContext> GetInitContextForJSON();
@@ -344,7 +344,7 @@ class GrammarInitContextCache {
   /*! \brief Clear the interal cache of init contexts. */
   void Clear();
 
-  XGRAMMAR_DEFINE_PIMPL_METHODS(GrammarInitContextCache);
+  XGRAMMAR_DEFINE_PIMPL_METHODS(GrammarMatcherInitContextCache);
 };
 
 }  // namespace xgrammar

--- a/python/xgrammar/__init__.py
+++ b/python/xgrammar/__init__.py
@@ -20,5 +20,5 @@ from .xgrammar import (
     VocabType,
     TokenizerInfo,
     GrammarMatcherInitContext,
-    GrammarStateMatcher,
+    GrammarMatcher,
 )

--- a/python/xgrammar/xgrammar.py
+++ b/python/xgrammar/xgrammar.py
@@ -339,12 +339,12 @@ class GrammarMatcherInitContext:
         self.handle = _core.GrammarMatcherInitContext(grammar.handle, decoded_vocab)
 
 
-# class GrammarInitContextCache:
+# class GrammarMatcherInitContextCache:
 #     def __init__(self, vocab: List[bytes]):
-#         self.handle = _core.GrammarInitContextCache(cache.handle)
+#         self.handle = _core.GrammarMatcherInitContextCache(cache.handle)
 
 
-class GrammarStateMatcher(XGObject):
+class GrammarMatcher(XGObject):
     """A stateful matcher to match tokens to the specified BNF grammar. This class is the core logic
     of the grammar-guided generation.
 
@@ -399,7 +399,7 @@ class GrammarStateMatcher(XGObject):
             raise ValueError(f"Unsupported tokenizer_or_vocab type: {type(tokenizer_or_vocab)}")
 
         self.init_with_handle(
-            _core.GrammarStateMatcher(
+            _core.GrammarMatcher(
                 grammar.handle,
                 tokenizer_or_vocab.handle,
                 stop_token_ids,
@@ -477,7 +477,7 @@ class GrammarStateMatcher(XGObject):
             A list of rejected token ids.
 
         """
-        return _core.GrammarStateMatcher.get_rejected_tokens_from_bitmask(bitmask, vocab_size)
+        return _core.GrammarMatcher.get_rejected_tokens_from_bitmask(bitmask, vocab_size)
 
     # @staticmethod
     # def apply_token_bitmask(tensor: torch.Tensor, bitmask: torch.Tensor) -> torch.Tensor:
@@ -540,7 +540,7 @@ class GrammarStateMatcher(XGObject):
 
     def is_terminated(self) -> bool:
         """Check if the matcher has accepted the stop token and terminated. See also
-        GrammarStateMatcher.accept_token.
+        GrammarMatcher.accept_token.
 
         Returns
         -------

--- a/tests/python/test_builtin_grammar_json.py
+++ b/tests/python/test_builtin_grammar_json.py
@@ -5,14 +5,14 @@ from typing import List, Optional
 
 import pytest
 from transformers import AutoTokenizer
-from xgrammar import BNFGrammar, BuiltinGrammar, GrammarStateMatcher
+from xgrammar import BNFGrammar, BuiltinGrammar, GrammarMatcher
 
 
 json_grammar = BuiltinGrammar.json()
 
 
 def match_complete_string(grammar: BNFGrammar, input_str: str) -> bool:
-    matcher = GrammarStateMatcher(grammar, terminate_without_stop_token=True)
+    matcher = GrammarMatcher(grammar, terminate_without_stop_token=True)
     can_accept = matcher._accept_string(input_str)
     can_terminate = matcher.is_terminated()
     return can_accept and can_terminate
@@ -282,7 +282,7 @@ def test_find_next_rejected_tokens(
         use_fast=True,
         trust_remote_code=True,
     )
-    matcher = GrammarStateMatcher(json_grammar, tokenizer)
+    matcher = GrammarMatcher(json_grammar, tokenizer)
     input_bytes = input_str.encode("utf-8")
     rejected_sizes = []
 
@@ -290,7 +290,7 @@ def test_find_next_rejected_tokens(
         time_start = time.monotonic_ns()
         bitmask = matcher.find_next_token_bitmask()
         time_mid = time.monotonic_ns()
-        rejected_token_ids = GrammarStateMatcher.get_rejected_tokens_from_bitmask(
+        rejected_token_ids = GrammarMatcher.get_rejected_tokens_from_bitmask(
             bitmask, matcher.vocab_size
         )
         time_end = time.monotonic_ns()
@@ -309,7 +309,7 @@ def test_find_next_rejected_tokens(
         print(f"Time to accept_token: {(time_end - time_start) / 1e3} us")
 
     bitmask = matcher.find_next_token_bitmask()
-    rejected_token_ids = GrammarStateMatcher.get_rejected_tokens_from_bitmask(
+    rejected_token_ids = GrammarMatcher.get_rejected_tokens_from_bitmask(
         bitmask, matcher.vocab_size
     )
     rejected_sizes.append(len(rejected_token_ids))

--- a/tests/python/test_builtin_grammar_json_schema.py
+++ b/tests/python/test_builtin_grammar_json_schema.py
@@ -1,14 +1,9 @@
-"""This test is adopted from test_grammar_state_matcher_json.py, but the grammar is parsed from
-a unoptimized, non-simplified EBNF string. This is to test the robustness of the grammar state
-matcher.
-"""
-
 from typing import Dict, List, Tuple
 
 import pytest
 from pydantic import BaseModel
 from transformers import AutoTokenizer
-from xgrammar import GrammarStateMatcher
+from xgrammar import GrammarMatcher
 from xgrammar.xgrammar import BuiltinGrammar
 
 
@@ -39,13 +34,13 @@ def test_json_schema_accept_find_token():
 
     tokenizer_path = "meta-llama/Llama-2-7b-chat-hf"
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_fast=True)
-    matcher = GrammarStateMatcher(grammar, tokenizer)
+    matcher = GrammarMatcher(grammar, tokenizer)
 
     for c in instance_str:
         matcher.find_next_token_bitmask()
         assert matcher._accept_string(c)
     final_bitmask = matcher.find_next_token_bitmask()
-    final_rejected_tokens = GrammarStateMatcher.get_rejected_tokens_from_bitmask(
+    final_rejected_tokens = GrammarMatcher.get_rejected_tokens_from_bitmask(
         final_bitmask, matcher.vocab_size
     )
     assert 2 not in final_rejected_tokens
@@ -80,7 +75,7 @@ def test_json_schema_find_jump_forward_string():
 
     tokenizer_path = "meta-llama/Llama-2-7b-chat-hf"
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_fast=True)
-    matcher = GrammarStateMatcher(grammar, tokenizer)
+    matcher = GrammarMatcher(grammar, tokenizer)
 
     for i, c in enumerate(instance_str):
         jump_forward_str = matcher.find_jump_forward_string()

--- a/tests/python/test_custom_grammar.py
+++ b/tests/python/test_custom_grammar.py
@@ -1,6 +1,5 @@
-"""This test is adopted from test_grammar_state_matcher_json.py, but the grammar is parsed from
-a unoptimized, non-simplified EBNF string. This is to test the robustness of the grammar state
-matcher.
+"""This test is adopted from test_builtin_grammar_json.py, but the grammar is parsed from
+a unoptimized, non-simplified EBNF string. This is to test the robustness of the grammar matcher.
 """
 
 import time
@@ -8,11 +7,11 @@ from typing import List, Optional
 
 import pytest
 from transformers import AutoTokenizer
-from xgrammar import BNFGrammar, GrammarStateMatcher
+from xgrammar import BNFGrammar, GrammarMatcher
 
 
 def match_complete_string(grammar: BNFGrammar, input_str: str) -> bool:
-    matcher = GrammarStateMatcher(grammar, terminate_without_stop_token=True)
+    matcher = GrammarMatcher(grammar, terminate_without_stop_token=True)
     can_accept = matcher._accept_string(input_str)
     can_terminate = matcher.is_terminated()
     return can_accept and can_terminate
@@ -327,7 +326,7 @@ def test_find_next_rejected_tokens(
         use_fast=True,
         trust_remote_code=True,
     )
-    matcher = GrammarStateMatcher(json_grammar, tokenizer)
+    matcher = GrammarMatcher(json_grammar, tokenizer)
     input_bytes = input_str.encode("utf-8")
     rejected_sizes = []
 
@@ -337,7 +336,7 @@ def test_find_next_rejected_tokens(
         time_mid = time.monotonic_ns()
 
         print(f"Time to find_next_token_bitmask: {(time_mid - time_start) / 1e3} us")
-        rejected_token_ids = GrammarStateMatcher.get_rejected_tokens_from_bitmask(
+        rejected_token_ids = GrammarMatcher.get_rejected_tokens_from_bitmask(
             bitmask, matcher.vocab_size
         )
         time_end = time.monotonic_ns()
@@ -355,7 +354,7 @@ def test_find_next_rejected_tokens(
         print(f"Time to accept_token: {(time_end - time_start) / 1e3} us")
 
     bitmask = matcher.find_next_token_bitmask()
-    rejected_token_ids = GrammarStateMatcher.get_rejected_tokens_from_bitmask(
+    rejected_token_ids = GrammarMatcher.get_rejected_tokens_from_bitmask(
         bitmask, matcher.vocab_size
     )
     rejected_sizes.append(len(rejected_token_ids))

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import pytest
 from pydantic import BaseModel, Field, TypeAdapter
-from xgrammar import BuiltinGrammar, GrammarStateMatcher
+from xgrammar import BuiltinGrammar, GrammarMatcher
 from xgrammar.xgrammar import BNFGrammar
 
 
@@ -26,7 +26,7 @@ def check_schema_with_grammar(
 
 
 def match_complete_string(grammar: BNFGrammar, input_str: str) -> bool:
-    matcher = GrammarStateMatcher(grammar, terminate_without_stop_token=True)
+    matcher = GrammarMatcher(grammar, terminate_without_stop_token=True)
     can_accept = matcher._accept_string(input_str)
     can_terminate = matcher.is_terminated()
     return can_accept and can_terminate


### PR DESCRIPTION
This PR renames GrammarStateMatcher to GrammarMatcher for simplicity. It also renames GrammarInitContextCache to GrammarMatcherInitContextCache for clearity. 