### PR TITLE
[feature] stop_token_id and apply_token_bitmask

### DIFF
--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -156,6 +156,8 @@ class GrammarMatcher::Impl : public GrammarMatcherBase {
 
   size_t GetMaskVocabSize() const { return mask_vocab_size_; }
 
+  const std::vector<int>& GetStopTokenIds() const { return stop_token_ids_; }
+
   bool IsTerminated() const;
 
   void Reset() {
@@ -670,6 +672,10 @@ void GrammarMatcher::Rollback(int num_tokens) { pimpl_->Rollback(num_tokens); }
 int GrammarMatcher::GetMaxRollbackTokens() const { return pimpl_->GetMaxRollbackTokens(); }
 
 size_t GrammarMatcher::GetMaskVocabSize() const { return pimpl_->GetMaskVocabSize(); }
+
+const std::vector<int>& GrammarMatcher::GetStopTokenIds() const {
+  return pimpl_->GetStopTokenIds();
+}
 
 bool GrammarMatcher::IsTerminated() const { return pimpl_->IsTerminated(); }
 

--- a/cpp/grammar_matcher_preproc.h
+++ b/cpp/grammar_matcher_preproc.h
@@ -375,7 +375,8 @@ GrammarMatcherInitContext::Impl::Impl(
     // Phi-2: <|endoftext|>
     // Gemma: <eos>, <end_of_turn>
     if (token == "</s>" || token == "<|end_of_text|>" || token == "<|eot_id|>" ||
-        token == "<|endoftext|>" || token == "<eos>" || token == "<end_of_turn>") {
+        token == "<|endoftext|>" || token == "<eos>" || token == "<end_of_turn>" ||
+        token == "<｜end▁of▁sentence｜>") {
       this->detected_stop_token_ids.push_back(i);
     } else if ((token[0] == '<' && token.back() == '>' && token.size() >= 3) ||
                token == "[@BOS@]") {

--- a/cpp/pybind/pybind.cc
+++ b/cpp/pybind/pybind.cc
@@ -65,8 +65,9 @@ PYBIND11_MODULE(xgrammar_bindings, m) {
       .def_static("get_rejected_tokens_from_bitmask", &GrammarMatcher_GetRejectedTokensFromBitMask)
       .def("is_terminated", &GrammarMatcher::IsTerminated)
       .def("reset", &GrammarMatcher::Reset)
-      .def_property_readonly("mask_vocab_size", &GrammarMatcher::GetMaskVocabSize)
       .def("find_jump_forward_string", &GrammarMatcher::FindJumpForwardString)
       .def("rollback", &GrammarMatcher::Rollback)
-      .def_property_readonly("max_rollback_tokens", &GrammarMatcher::GetMaxRollbackTokens);
+      .def_property_readonly("mask_vocab_size", &GrammarMatcher::GetMaskVocabSize)
+      .def_property_readonly("max_rollback_tokens", &GrammarMatcher::GetMaxRollbackTokens)
+      .def_property_readonly("stop_token_ids", &GrammarMatcher::GetStopTokenIds);
 }

--- a/cpp/support/dynamic_bitset.h
+++ b/cpp/support/dynamic_bitset.h
@@ -136,7 +136,8 @@ class DynamicBitset {
     int blk = pos / BITS_PER_BLOCK;
     int ind = pos % BITS_PER_BLOCK;
     uint32_t fore = (~data_[blk]) >> ind;
-    return fore ? pos + LowestBit(fore) : DoFindZeroFrom(blk + 1);
+    int result = fore ? pos + LowestBit(fore) : DoFindZeroFrom(blk + 1);
+    return result < size_ ? result : -1;
   }
 
  private:

--- a/cpp/support/encoding.h
+++ b/cpp/support/encoding.h
@@ -6,6 +6,8 @@
 #ifndef XGRAMMAR_SUPPORT_ENCODING_H_
 #define XGRAMMAR_SUPPORT_ENCODING_H_
 // TODO(yixin): enhance performance
+
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/include/xgrammar/xgrammar.h
+++ b/include/xgrammar/xgrammar.h
@@ -283,6 +283,8 @@ class GrammarMatcher {
    */
   void Rollback(int num_tokens = 1);
 
+  const std::vector<int>& GetStopTokenIds() const;
+
   /*! \brief Get the maximum number of rollback tokens allowed. */
   int GetMaxRollbackTokens() const;
 


### PR DESCRIPTION
This PR adds two methods to GrammarMatcher:
1. stop_token_id: returns the ids of the stop tokens used in the current matcher
2. apply_token_bitmask: Apply the bitmask to the logits in-place. Now only supports 1-dim input.

This PR also fixes the problem in detecting eos tokens for deepseek models.

