### PR TITLE
[fix] Separate compilation of C++ library and Python binding library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 
 set(XGRAMMAR_INCLUDE_PATH
     ${PROJECT_SOURCE_DIR}/3rdparty/picojson ${PROJECT_SOURCE_DIR}/3rdparty/dlpack/include
-    ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/cpp
+    ${PROJECT_SOURCE_DIR}/include
 )
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -58,5 +58,4 @@ target_compile_definitions(xgrammar PUBLIC ${XGRAMMAR_COMPILE_DEFINITIONS})
 
 if(BUILD_PYTHON_BINDINGS)
   add_subdirectory(${PROJECT_SOURCE_DIR}/cpp/pybind)
-  target_compile_options(xgrammar PUBLIC ${TORCH_CXX_FLAGS})
 endif()

--- a/cpp/pybind/CMakeLists.txt
+++ b/cpp/pybind/CMakeLists.txt
@@ -33,23 +33,23 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 
 find_library(TORCH_PYTHON_LIBRARY torch_python PATH "${TORCH_INSTALL_PREFIX}/lib")
 
-file(GLOB_RECURSE XGRAMMAR_BINDINGS_PATH ${PROJECT_SOURCE_DIR}/cpp/pybind/*.cc)
+# The compilation flags for bindings is different from the main library as torch requires
+# -D_GLIBCXX_USE_CXX11_ABI=0. So we compile bindings separately.
+file(GLOB_RECURSE XGRAMMAR_BINDINGS_PATH ${PROJECT_SOURCE_DIR}/cpp/*.cc)
 pybind11_add_module(xgrammar_bindings ${XGRAMMAR_BINDINGS_PATH})
 target_include_directories(xgrammar_bindings PUBLIC ${XGRAMMAR_INCLUDE_PATH})
 target_compile_definitions(xgrammar_bindings PUBLIC ${XGRAMMAR_COMPILE_DEFINITIONS})
 target_link_libraries(xgrammar_bindings PUBLIC ${TORCH_LIBRARIES} ${TORCH_PYTHON_LIBRARY})
-target_link_libraries(xgrammar_bindings PUBLIC xgrammar)
 set_target_properties(
   xgrammar_bindings PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/python/xgrammar"
 )
 
-if (MSVC)
+if(MSVC)
   file(GLOB TORCH_DLLS "${TORCH_INSTALL_PREFIX}/lib/*.dll")
-  add_custom_command(TARGET xgrammar_bindings
-                     POST_BUILD
-                     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                     ${TORCH_DLLS}
-                     $<TARGET_FILE_DIR:xgrammar_bindings>)
-endif (MSVC)
-
-set(TORCH_CXX_FLAGS ${TORCH_CXX_FLAGS} PARENT_SCOPE)
+  add_custom_command(
+    TARGET xgrammar_bindings
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${TORCH_DLLS}
+            $<TARGET_FILE_DIR:xgrammar_bindings>
+  )
+endif(MSVC)


### PR DESCRIPTION
Our python binding library requires linking to libtorch, which requires setting `-D_GLIBCXX_USE_CXX11_ABI=0` in compilation flags. However, we do not want to set this for C++, as the downstream application linking to it may not set this to be true. So we separate the compilation of C++ lib and python binding lib, and only the latter will set this flag.