### PR TITLE
[Fix] Rename method and variable names

### DIFF
--- a/cpp/pybind/pybind.cc
+++ b/cpp/pybind/pybind.cc
@@ -33,7 +33,7 @@ PYBIND11_MODULE(xgrammar_bindings, m) {
       .def_property_readonly(
           "prepend_space_in_tokenization", &TokenizerInfo::GetPrependSpaceInTokenization
       )
-      .def_property_readonly("raw_vocab", &TokenizerInfo_GetRawVocab)
+      .def_property_readonly("decoded_vocab", &TokenizerInfo_GetDecodedVocab)
       .def("dump_metadata", &TokenizerInfo::DumpMetadata)
       .def_static("from_huggingface", &TokenizerInfo::FromHuggingFace)
       .def_static("from_vocab_and_metadata", &TokenizerInfo::FromVocabAndMetadata);
@@ -66,7 +66,7 @@ PYBIND11_MODULE(xgrammar_bindings, m) {
            int>())
       .def("accept_token", &GrammarMatcher::AcceptToken)
       .def("accept_string", &GrammarMatcher::AcceptString)
-      .def("find_next_token_bitmask", &GrammarMatcher_FindNextTokenBitmask)
+      .def("get_next_token_bitmask", &GrammarMatcher_FindNextTokenBitmask)
       .def_static("get_rejected_tokens_from_bitmask", &GrammarMatcher_GetRejectedTokensFromBitMask)
       .def("is_terminated", &GrammarMatcher::IsTerminated)
       .def("reset", &GrammarMatcher::Reset)

--- a/cpp/pybind/python_methods.cc
+++ b/cpp/pybind/python_methods.cc
@@ -23,7 +23,7 @@ BNFGrammar BNFGrammar_InitNoNormalization(
 }
 
 TokenizerInfo TokenizerInfo_Init(
-    const std::vector<std::string>& vocab,
+    const std::vector<std::string>& encoded_vocab,
     std::string vocab_type,
     bool prepend_space_in_tokenization
 ) {
@@ -32,7 +32,7 @@ TokenizerInfo TokenizerInfo_Init(
       {"BYTE_FALLBACK", VocabType::BYTE_FALLBACK},
       {"BYTE_LEVEL", VocabType::BYTE_LEVEL},
   };
-  return TokenizerInfo(vocab, VOCAB_TYPE_MAP.at(vocab_type), prepend_space_in_tokenization);
+  return TokenizerInfo(encoded_vocab, VOCAB_TYPE_MAP.at(vocab_type), prepend_space_in_tokenization);
 }
 
 std::string TokenizerInfo_GetVocabType(const TokenizerInfo& tokenizer) {
@@ -40,8 +40,8 @@ std::string TokenizerInfo_GetVocabType(const TokenizerInfo& tokenizer) {
   return VOCAB_TYPE_NAMES[static_cast<int>(tokenizer.GetVocabType())];
 }
 
-std::vector<pybind11::bytes> TokenizerInfo_GetRawVocab(TokenizerInfo& tokenizer) {
-  auto result = tokenizer.GetRawVocab();
+std::vector<pybind11::bytes> TokenizerInfo_GetDecodedVocab(TokenizerInfo& tokenizer) {
+  auto result = tokenizer.GetDecodedVocab();
   std::vector<pybind11::bytes> py_result;
   py_result.reserve(result.size());
   for (const auto& item : result) {
@@ -54,7 +54,7 @@ torch::Tensor GrammarMatcher_FindNextTokenBitmask(GrammarMatcher& matcher) {
   auto buffer_size = GrammarMatcher::GetBufferSize(matcher.GetMaskVocabSize());
   auto result = torch::empty({buffer_size}, torch::dtype(torch::kInt32).device(torch::kCPU, 0));
   auto result_dltensor = at::toDLPack(result)->dl_tensor;
-  matcher.FindNextTokenBitmask(&result_dltensor);
+  matcher.GetNextTokenBitmask(&result_dltensor);
   return result;
 }
 

--- a/cpp/pybind/python_methods.h
+++ b/cpp/pybind/python_methods.h
@@ -23,14 +23,14 @@ BNFGrammar BNFGrammar_InitNoNormalization(
 );
 
 TokenizerInfo TokenizerInfo_Init(
-    const std::vector<std::string>& vocab,
+    const std::vector<std::string>& encoded_vocab,
     std::string vocab_type,
     bool prepend_space_in_tokenization
 );
 
 std::string TokenizerInfo_GetVocabType(const TokenizerInfo& tokenizer);
 
-std::vector<pybind11::bytes> TokenizerInfo_GetRawVocab(TokenizerInfo& tokenizer);
+std::vector<pybind11::bytes> TokenizerInfo_GetDecodedVocab(TokenizerInfo& tokenizer);
 
 torch::Tensor GrammarMatcher_FindNextTokenBitmask(GrammarMatcher& matcher);
 

--- a/tests/python/test_builtin_grammar_json.py
+++ b/tests/python/test_builtin_grammar_json.py
@@ -273,7 +273,7 @@ tokenizer_path__input_str__expected_rejected_sizes = [
     "tokenizer_path, input_str, expected_rejected_sizes",
     tokenizer_path__input_str__expected_rejected_sizes,
 )
-def test_find_next_rejected_tokens(
+def test_get_next_rejected_tokens(
     tokenizer_path: str,
     input_str: str,
     expected_rejected_sizes: Optional[List[int]],
@@ -289,13 +289,13 @@ def test_find_next_rejected_tokens(
 
     for i, c in enumerate(input_bytes):
         time_start = time.monotonic_ns()
-        bitmask = matcher.find_next_token_bitmask()
+        bitmask = matcher.get_next_token_bitmask()
         time_mid = time.monotonic_ns()
         rejected_token_ids = GrammarMatcher.get_rejected_tokens_from_bitmask(
             bitmask, matcher.mask_vocab_size
         )
         time_end = time.monotonic_ns()
-        print(f"Time to find_next_token_bitmask: {(time_mid - time_start) / 1e3} us")
+        print(f"Time to get_next_token_bitmask: {(time_mid - time_start) / 1e3} us")
         print(f"Time to get_rejected_tokens_from_bitmask: {(time_end - time_mid) / 1e3} us")
         rejected_sizes.append(len(rejected_token_ids))
         if expected_rejected_sizes is not None:
@@ -309,7 +309,7 @@ def test_find_next_rejected_tokens(
         time_end = time.monotonic_ns()
         print(f"Time to accept_token: {(time_end - time_start) / 1e3} us")
 
-    bitmask = matcher.find_next_token_bitmask()
+    bitmask = matcher.get_next_token_bitmask()
     rejected_token_ids = GrammarMatcher.get_rejected_tokens_from_bitmask(
         bitmask, matcher.mask_vocab_size
     )

--- a/tests/python/test_builtin_grammar_json_schema.py
+++ b/tests/python/test_builtin_grammar_json_schema.py
@@ -39,9 +39,9 @@ def test_json_schema_accept_find_token():
     matcher = GrammarMatcher(grammar, tokenizer)
 
     for c in instance_str:
-        matcher.find_next_token_bitmask()
+        matcher.get_next_token_bitmask()
         assert matcher.accept_string(c)
-    final_bitmask = matcher.find_next_token_bitmask()
+    final_bitmask = matcher.get_next_token_bitmask()
     final_rejected_tokens = GrammarMatcher.get_rejected_tokens_from_bitmask(
         final_bitmask, matcher.mask_vocab_size
     )

--- a/tests/python/test_custom_grammar.py
+++ b/tests/python/test_custom_grammar.py
@@ -318,7 +318,7 @@ tokenizer_path__input_str__expected_rejected_sizes = [
     "tokenizer_path, input_str, expected_rejected_sizes",
     tokenizer_path__input_str__expected_rejected_sizes,
 )
-def test_find_next_rejected_tokens(
+def test_get_next_rejected_tokens(
     tokenizer_path: str,
     input_str: str,
     expected_rejected_sizes: Optional[List[int]],
@@ -334,10 +334,10 @@ def test_find_next_rejected_tokens(
 
     for i, c in enumerate(input_bytes):
         time_start = time.monotonic_ns()
-        bitmask = matcher.find_next_token_bitmask()
+        bitmask = matcher.get_next_token_bitmask()
         time_mid = time.monotonic_ns()
 
-        print(f"Time to find_next_token_bitmask: {(time_mid - time_start) / 1e3} us")
+        print(f"Time to get_next_token_bitmask: {(time_mid - time_start) / 1e3} us")
         rejected_token_ids = GrammarMatcher.get_rejected_tokens_from_bitmask(
             bitmask, matcher.mask_vocab_size
         )
@@ -355,7 +355,7 @@ def test_find_next_rejected_tokens(
         time_end = time.monotonic_ns()
         print(f"Time to accept_token: {(time_end - time_start) / 1e3} us")
 
-    bitmask = matcher.find_next_token_bitmask()
+    bitmask = matcher.get_next_token_bitmask()
     rejected_token_ids = GrammarMatcher.get_rejected_tokens_from_bitmask(
         bitmask, matcher.mask_vocab_size
     )

--- a/tests/python/test_regex_converter.py
+++ b/tests/python/test_regex_converter.py
@@ -319,17 +319,17 @@ def test_mask_generation(tokenizer_path: str, regex: str, instance: str):
     matcher = GrammarMatcher(matcher_compiled_grammar)
     for c in instance.encode("utf-8"):
         time_start = time.monotonic_ns()
-        matcher.find_next_token_bitmask()
+        matcher.get_next_token_bitmask()
         time_end = time.monotonic_ns()
-        print(f"Time for find_next_token_bitmask: {(time_end - time_start) / 1e3} us")
+        print(f"Time for get_next_token_bitmask: {(time_end - time_start) / 1e3} us")
         accepted = matcher.accept_string(bytes([c]))
         assert accepted
         print(f"Accepting {c}")
 
     time_start = time.monotonic_ns()
-    matcher.find_next_token_bitmask()
+    matcher.get_next_token_bitmask()
     time_end = time.monotonic_ns()
-    print(f"Time for find_next_token_bitmask: {(time_end - time_start) / 1e3} us")
+    print(f"Time for get_next_token_bitmask: {(time_end - time_start) / 1e3} us")
 
 
 if __name__ == "__main__":

--- a/tests/python/test_tokenizer_info.py
+++ b/tests/python/test_tokenizer_info.py
@@ -71,18 +71,18 @@ def test_properties(
 
 
 @pytest.mark.parametrize("tokenizer_path", tokenizer_paths)
-def test_raw_vocab(tokenizer_path: str):
+def test_decoded_vocab(tokenizer_path: str):
     tokenizer = AutoTokenizer.from_pretrained(
         tokenizer_path,
         use_fast=True,
         trust_remote_code=True,
     )
     tokenizer_info = TokenizerInfo.from_huggingface(tokenizer)
-    raw_vocab = tokenizer_info.raw_vocab
-    assert isinstance(raw_vocab, list)
-    assert all(isinstance(token, bytes) for token in raw_vocab)
-    assert len(raw_vocab) == len(tokenizer.get_vocab())
-    assert len(raw_vocab) == tokenizer_info.vocab_size
+    decoded_vocab = tokenizer_info.decoded_vocab
+    assert isinstance(decoded_vocab, list)
+    assert all(isinstance(token, bytes) for token in decoded_vocab)
+    assert len(decoded_vocab) == len(tokenizer.get_vocab())
+    assert len(decoded_vocab) == tokenizer_info.vocab_size
 
 
 tokenizer_paths_token_ids_raw_tokens = [
@@ -114,7 +114,7 @@ def test_vocab_conversion(tokenizer_path: str, token_ids: List[int], raw_tokens:
         trust_remote_code=True,
     )
     tokenizer_info = TokenizerInfo.from_huggingface(tokenizer)
-    vocab = tokenizer_info.raw_vocab
+    vocab = tokenizer_info.decoded_vocab
     for token_id, raw_token in zip(token_ids, raw_tokens):
         assert vocab[token_id] == raw_token
 
@@ -145,14 +145,14 @@ def test_dump_metadata_load(tokenizer_path: str, metadata_str: str):
     tokenizer_info = TokenizerInfo.from_huggingface(tokenizer)
     assert tokenizer_info.dump_metadata() == metadata_str
 
-    vocab = tokenizer.get_vocab()
-    vocab = [token for token, _ in sorted(vocab.items(), key=lambda x: x[1])]
+    encoded_vocab = tokenizer.get_vocab()
+    encoded_vocab = [token for token, _ in sorted(encoded_vocab.items(), key=lambda x: x[1])]
 
-    loaded = TokenizerInfo.from_vocab_and_metadata(vocab, metadata_str)
-    assert loaded.raw_vocab == tokenizer_info.raw_vocab
+    loaded = TokenizerInfo.from_vocab_and_metadata(encoded_vocab, metadata_str)
+    assert loaded.decoded_vocab == tokenizer_info.decoded_vocab
 
-    loaded_new = TokenizerInfo(tokenizer_info.raw_vocab)
-    assert loaded_new.raw_vocab == tokenizer_info.raw_vocab
+    loaded_new = TokenizerInfo(tokenizer_info.decoded_vocab)
+    assert loaded_new.decoded_vocab == tokenizer_info.decoded_vocab
 
 
 if __name__ == "__main__":

--- a/web/example/src/example.ts
+++ b/web/example/src/example.ts
@@ -10,7 +10,7 @@ async function getTokenizerInfoAndTokenizerFromUrl(
     // 1. Get tokenizer, we use "@mlc-ai/web-tokenizers" here, but any should work
     const jsonBuffer = await (await fetch(tokenizerUrl)).arrayBuffer();
     const tokenizer = await Tokenizer.fromJSON(jsonBuffer);
-    // 2. Get raw vocab
+    // 2. Get encoded vocab
     const tstartGetToken = performance.now();
     const rawTokenTable: string[] = [];
     const vocabSize = tokenizer.getVocabSize();
@@ -51,7 +51,7 @@ async function jsonExample() {
     for (let i = 0; i < encodedTokens.length; i++) {
         // 3.1 Generate token bitmask that will modify logits of the LLM
         if (!grammarMatcher.isTerminated()) {
-            const bitmask = await grammarMatcher.findNextTokenBitmask();
+            const bitmask = await grammarMatcher.getNextTokenBitmask();
             // For debugging, we can check the rejected token IDs from the mask
             const rejectedIDs = await GrammarMatcher.getRejectedTokensFromBitmask(
                 bitmask,
@@ -146,7 +146,7 @@ async function jsonSchemaExample() {
     for (let i = 0; i < encodedTokens.length; i++) {
         // 3.1 Generate token bitmask that will modify logits of the LLM
         if (!grammarMatcher.isTerminated()) {
-            const bitmask = await grammarMatcher.findNextTokenBitmask();
+            const bitmask = await grammarMatcher.getNextTokenBitmask();
             // For debugging, we can check the rejected token IDs from the mask
             const rejectedIDs = await GrammarMatcher.getRejectedTokensFromBitmask(
                 bitmask,

--- a/web/src/xgrammar.ts
+++ b/web/src/xgrammar.ts
@@ -203,26 +203,26 @@ export class TokenizerInfo {
   /**
    * Get the post-processed vocab. Returned as a handle of type binding.VectorString
    */
-  getRawVocabHandle(): any {
-    return this.handle.GetRawVocab();
+  getDecodedVocabHandle(): any {
+    return this.handle.GetDecodedVocab();
   }
 
   /**
    * Instantiate with raw vocab and the vocab type by internally post-processing
    * the raw vocab by decoding each token with the provided vocab type.
-   * @param {string[]} rawVocab: the vocab in the form of a string list of tokens,
+   * @param {string[]} encodedVocab: the vocab in the form of a string list of tokens,
    * ordered by their token id. It should include all the special tokens.
    * @param {string} vocabType: either "byte_fallback", "byte_level", or `raw`. See `tokenizer.cc`
    * for its semantic.
    */
   static async createTokenizerInfo(
-    rawVocab: string[],
+    encodedVocab: string[],
     vocabType: string,
     prependSpaceInTokenization: boolean,
   ): Promise<TokenizerInfo> {
     await asyncInitBinding();
     // Convert string[] to std::vector<std::string>
-    const rawVocabVec = binding.vecStringFromJSArray(rawVocab);
+    const rawVocabVec = binding.vecStringFromJSArray(encodedVocab);
     // Instantiate TokenizerInfo
     return new TokenizerInfo(new binding.TokenizerInfo(
       rawVocabVec,
@@ -338,9 +338,9 @@ export class GrammarMatcher {
    *
    * @returns {Int32Array} An array representing the bitmask that masks the rejected token IDs
    */
-  async findNextTokenBitmask(): Promise<Int32Array> {
+  async getNextTokenBitmask(): Promise<Int32Array> {
     await asyncInitBinding();
-    const maskIntVector = this.handle.FindNextTokenBitmask()  // a handle of std::vector<int32_t>
+    const maskIntVector = this.handle.GetNextTokenBitmask()  // a handle of std::vector<int32_t>
     const maskInt32Array = binding.vecIntToView(maskIntVector).slice();
     maskIntVector.delete();
     return maskInt32Array;
@@ -348,7 +348,7 @@ export class GrammarMatcher {
 
   /**
    *
-   * @param {Int32Array} bitmask Bitmask returned by findNextTokenBitmask().
+   * @param {Int32Array} bitmask Bitmask returned by getNextTokenBitmask().
    * @param {number} vocabSize Vocab size returned by getVocabSize().
    * @returns An array of vocab ID that will be rejected as a result of the bitmask.
    */


### PR DESCRIPTION
This PR renames these variables and methods for simplicity:
- `GrammarMatcher.find_next_token_bitmask` -> `GrammarMatcher.get_next_token_bitmask`
- `GrammarMatcher.__init__(stop_token_ids)` -> `GrammarMatcher.__init__(override_stop_tokens)`
- `TokenizerInfo.raw_vocab` -> `TokenizerInfo.decoded_vocab`