### PR TITLE
[Fix] Add <|eos|> as a stop token

### DIFF
--- a/cpp/grammar_matcher_preproc.h
+++ b/cpp/grammar_matcher_preproc.h
@@ -393,8 +393,8 @@ CompiledGrammar::Impl::Impl(
     // Phi-2: <|endoftext|>
     // Gemma: <eos>, <end_of_turn>
     if (token == "</s>" || token == "<|end_of_text|>" || token == "<|eot_id|>" ||
-        token == "<|endoftext|>" || token == "<eos>" || token == "<end_of_turn>" ||
-        token == "<｜end▁of▁sentence｜>") {
+        token == "<|endoftext|>" || token == "<eos>" || token == "<|eos|>" ||
+        token == "<end_of_turn>" || token == "<｜end▁of▁sentence｜>") {
       this->detected_stop_token_ids.push_back(i);
     } else if ((token[0] == '<' && token.back() == '>' && token.size() >= 3) ||
                token == "[@BOS@]") {

--- a/python/xgrammar/xgrammar.py
+++ b/python/xgrammar/xgrammar.py
@@ -483,11 +483,7 @@ class CompiledGrammar(XGObject):
         object will be constructed from the tokenizer or the vocabulary.
     """
 
-    def __init__(
-        self,
-        grammar: BNFGrammar,
-        tokenizer_info: Optional[TokenizerInfo] = None,
-    ) -> None:
+    def __init__(self, grammar: BNFGrammar, tokenizer_info: Optional[TokenizerInfo] = None) -> None:
         if tokenizer_info is None:
             tokenizer_info = TokenizerInfo([])
 
@@ -505,19 +501,8 @@ class CachedGrammarCompiler(XGObject):
         The tokenizer or the vocabulary. Its meaning is the same as in GrammarMatcher.
     """
 
-    def __init__(
-        self,
-        tokenizer_or_vocab: Union[PreTrainedTokenizerBase, TokenizerInfo, List[Union[bytes, str]]],
-    ):
-        # convert tokenizer_or_vocab to TokenizerInfo
-        if isinstance(tokenizer_or_vocab, PreTrainedTokenizerBase):
-            tokenizer_or_vocab = TokenizerInfo.from_huggingface(tokenizer_or_vocab)
-        elif isinstance(tokenizer_or_vocab, list):
-            tokenizer_or_vocab = TokenizerInfo(tokenizer_or_vocab)
-        if not isinstance(tokenizer_or_vocab, TokenizerInfo):
-            raise ValueError(f"Unsupported tokenizer_or_vocab type: {type(tokenizer_or_vocab)}")
-
-        self.init_with_handle(_core.CachedGrammarCompiler(tokenizer_or_vocab.handle))
+    def __init__(self, tokenizer_info: TokenizerInfo):
+        self.init_with_handle(_core.CachedGrammarCompiler(tokenizer_info.handle))
 
     def get_compiled_grammar_for_json(self) -> CompiledGrammar:
         """Get CompiledGrammar from the standard JSON.
@@ -598,9 +583,7 @@ class GrammarMatcher(XGObject):
     def __init__(
         self,
         grammar: BNFGrammar,
-        tokenizer_or_vocab: Union[
-            None, PreTrainedTokenizerBase, TokenizerInfo, List[Union[bytes, str]]
-        ] = None,
+        tokenizer_info: Optional[TokenizerInfo] = None,
         *,
         override_stop_tokens: Union[None, int, List[int]] = None,
         terminate_without_stop_token: bool = False,
@@ -667,9 +650,7 @@ class GrammarMatcher(XGObject):
     def __init__(
         self,
         grammar_or_context: Union[BNFGrammar, CompiledGrammar],
-        tokenizer_or_vocab: Union[
-            None, PreTrainedTokenizerBase, TokenizerInfo, List[Union[bytes, str]]
-        ] = None,
+        tokenizer_info: Optional[TokenizerInfo] = None,
         *,
         override_stop_tokens: Union[None, int, List[int]] = None,
         terminate_without_stop_token: bool = False,
@@ -677,7 +658,7 @@ class GrammarMatcher(XGObject):
         max_rollback_tokens: int = 0,
     ) -> None:
         if isinstance(grammar_or_context, BNFGrammar):
-            compiled_grammar = CompiledGrammar(grammar_or_context, tokenizer_or_vocab)
+            compiled_grammar = CompiledGrammar(grammar_or_context, tokenizer_info)
         else:
             compiled_grammar = grammar_or_context
 

--- a/python/xgrammar/xgrammar.py
+++ b/python/xgrammar/xgrammar.py
@@ -486,21 +486,12 @@ class CompiledGrammar(XGObject):
     def __init__(
         self,
         grammar: BNFGrammar,
-        tokenizer_or_vocab: Union[
-            None, PreTrainedTokenizerBase, TokenizerInfo, List[Union[bytes, str]]
-        ] = None,
+        tokenizer_info: Optional[TokenizerInfo] = None,
     ) -> None:
-        # convert tokenizer_or_vocab to TokenizerInfo
-        if isinstance(tokenizer_or_vocab, PreTrainedTokenizerBase):
-            tokenizer_or_vocab = TokenizerInfo.from_huggingface(tokenizer_or_vocab)
-        elif isinstance(tokenizer_or_vocab, list):
-            tokenizer_or_vocab = TokenizerInfo(tokenizer_or_vocab)
-        elif tokenizer_or_vocab is None:
-            tokenizer_or_vocab = TokenizerInfo([])
-        if not isinstance(tokenizer_or_vocab, TokenizerInfo):
-            raise ValueError(f"Unsupported tokenizer_or_vocab type: {type(tokenizer_or_vocab)}")
+        if tokenizer_info is None:
+            tokenizer_info = TokenizerInfo([])
 
-        self.init_with_handle(_core.CompiledGrammar(grammar.handle, tokenizer_or_vocab.handle))
+        self.init_with_handle(_core.CompiledGrammar(grammar.handle, tokenizer_info.handle))
 
 
 class CachedGrammarCompiler(XGObject):

--- a/tests/python/test_builtin_grammar_json.py
+++ b/tests/python/test_builtin_grammar_json.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 import pytest
 from transformers import AutoTokenizer
 
-from xgrammar import BNFGrammar, BuiltinGrammar, GrammarMatcher
+from xgrammar import BNFGrammar, BuiltinGrammar, GrammarMatcher, TokenizerInfo
 
 json_grammar = BuiltinGrammar.json()
 
@@ -283,7 +283,8 @@ def test_get_next_rejected_tokens(
         use_fast=True,
         trust_remote_code=True,
     )
-    matcher = GrammarMatcher(json_grammar, tokenizer)
+    tokenizer_info = TokenizerInfo.from_huggingface(tokenizer)
+    matcher = GrammarMatcher(json_grammar, tokenizer_info)
     input_bytes = input_str.encode("utf-8")
     rejected_sizes = []
 

--- a/tests/python/test_builtin_grammar_json_schema.py
+++ b/tests/python/test_builtin_grammar_json_schema.py
@@ -5,8 +5,7 @@ import pytest
 from pydantic import BaseModel
 from transformers import AutoTokenizer
 
-from xgrammar import GrammarMatcher
-from xgrammar.xgrammar import BuiltinGrammar
+from xgrammar import BuiltinGrammar, GrammarMatcher, TokenizerInfo
 
 
 def test_json_schema_accept_find_token():
@@ -36,7 +35,8 @@ def test_json_schema_accept_find_token():
 
     tokenizer_path = "meta-llama/Llama-2-7b-chat-hf"
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_fast=True)
-    matcher = GrammarMatcher(grammar, tokenizer)
+    tokenizer_info = TokenizerInfo.from_huggingface(tokenizer)
+    matcher = GrammarMatcher(grammar, tokenizer_info)
 
     for c in instance_str:
         matcher.get_next_token_bitmask()
@@ -77,7 +77,8 @@ def test_json_schema_find_jump_forward_string():
 
     tokenizer_path = "meta-llama/Llama-2-7b-chat-hf"
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_fast=True)
-    matcher = GrammarMatcher(grammar, tokenizer)
+    tokenizer_info = TokenizerInfo.from_huggingface(tokenizer)
+    matcher = GrammarMatcher(grammar, tokenizer_info)
 
     for i, c in enumerate(instance_str):
         jump_forward_str = matcher.find_jump_forward_string()

--- a/tests/python/test_custom_grammar.py
+++ b/tests/python/test_custom_grammar.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 import pytest
 from transformers import AutoTokenizer
 
-from xgrammar import BNFGrammar, GrammarMatcher
+from xgrammar import BNFGrammar, GrammarMatcher, TokenizerInfo
 
 
 def match_complete_string(grammar: BNFGrammar, input_str: str) -> bool:
@@ -328,7 +328,8 @@ def test_get_next_rejected_tokens(
         use_fast=True,
         trust_remote_code=True,
     )
-    matcher = GrammarMatcher(json_grammar, tokenizer)
+    tokenizer_info = TokenizerInfo.from_huggingface(tokenizer)
+    matcher = GrammarMatcher(json_grammar, tokenizer_info)
     input_bytes = input_str.encode("utf-8")
     rejected_sizes = []
 

--- a/tests/python/test_grammar_matcher.py
+++ b/tests/python/test_grammar_matcher.py
@@ -81,7 +81,8 @@ def test_get_next_rejected_tokens(
         use_fast=True,
         trust_remote_code=True,
     )
-    matcher = GrammarMatcher(json_grammar, tokenizer)
+    tokenizer_info = TokenizerInfo.from_huggingface(tokenizer)
+    matcher = GrammarMatcher(json_grammar, tokenizer_info)
     input_bytes = input_str.encode("utf-8")
     rejected_sizes = []
 
@@ -117,7 +118,8 @@ def test_token_operations():
     input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', "}"]
     input_ids = [vocab.index(t) for t in input_splitted]
 
-    matcher = GrammarMatcher(json_grammar, vocab)
+    tokenizer_info = TokenizerInfo(vocab)
+    matcher = GrammarMatcher(json_grammar, tokenizer_info)
 
     expected = [
         ["{"],
@@ -177,7 +179,8 @@ def test_rollback():
     input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', "}"]
     input_ids = [vocab.index(t) for t in input_splitted]
 
-    matcher = GrammarMatcher(json_grammar, vocab, max_rollback_tokens=5)
+    tokenizer_info = TokenizerInfo(vocab)
+    matcher = GrammarMatcher(json_grammar, tokenizer_info, max_rollback_tokens=5)
 
     assert matcher.max_rollback_tokens == 5
 
@@ -207,7 +210,8 @@ def test_reset():
     input_splitted = ["{", '"', "abc", 'b"', ":", "6", ", ", " ", '"a":true', "}"]
     input_ids = [vocab.index(t) for t in input_splitted]
 
-    matcher = GrammarMatcher(json_grammar, vocab)
+    tokenizer_info = TokenizerInfo(vocab)
+    matcher = GrammarMatcher(json_grammar, tokenizer_info)
 
     orig_result = []
 
@@ -246,8 +250,9 @@ def test_termination():
         "</s>",
     ]
     input_ids = [vocab.index(t) for t in input_splitted]
+    tokenizer_info = TokenizerInfo(vocab)
 
-    matcher = GrammarMatcher(json_grammar, vocab, max_rollback_tokens=5)
+    matcher = GrammarMatcher(json_grammar, tokenizer_info, max_rollback_tokens=5)
 
     for i in input_ids:
         matcher.get_next_token_bitmask()
@@ -283,7 +288,8 @@ def test_mask_vocab_size():
         "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " ", '"a":true',
         # fmt: on
     ]
-    matcher = GrammarMatcher(json_grammar, vocab, mask_vocab_size=64)
+    tokenizer_info = TokenizerInfo(vocab)
+    matcher = GrammarMatcher(json_grammar, tokenizer_info, mask_vocab_size=64)
     assert matcher.mask_vocab_size == 64
 
     mask = matcher.get_next_token_bitmask()


### PR DESCRIPTION
This PR adds <|eos|> as a stop token in the logic of detecting the stop token.