### PR TITLE
[HF] Change quick start example to HF, make it run on both CUDA and Mac

### DIFF
--- a/examples/hf_transformers/transformers_example.py
+++ b/examples/hf_transformers/transformers_example.py
@@ -3,20 +3,20 @@ This example demonstrates how to use XGrammar in Huggingface's transformers, int
 a minimal LogitsProcessor.
 """
 
-import xgrammar as xgr
-import torch
-
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
+import torch
+import xgrammar as xgr
 
+device = "cuda"
+# device = "cpu"
 
-# 0. Instantiate model
-# Or any HF model you want
+# 0. Instantiate with any HF model you want
 model_name = "Qwen/Qwen2.5-0.5B-Instruct"
 # model_name = "microsoft/Phi-3.5-mini-instruct"
 # model_name = "meta-llama/Llama-3.2-1B-Instruct"
 
 model = AutoModelForCausalLM.from_pretrained(
-    model_name, torch_dtype=torch.float32, device_map="auto"
+    model_name, torch_dtype=torch.float32, device_map=device
 )
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 config = AutoConfig.from_pretrained(model_name)

--- a/python/xgrammar/apply_token_bitmask_cpu.py
+++ b/python/xgrammar/apply_token_bitmask_cpu.py
@@ -50,7 +50,7 @@ def apply_token_bitmask_inplace_cpu(
             logits.masked_fill_(~bool_mask, -float("inf"))
         else:
             if not isinstance(indices, torch.Tensor):
-                indices = torch.tensor(indices, dtype=torch.long, device=logits.device)
+                indices = torch.tensor(indices, dtype=torch.int32, device=logits.device)
             len_indices = len(indices)
             if len_indices != bitmask.size(0):
                 raise ValueError("The length of indices and bitmask's batch size must match.")

--- a/python/xgrammar/contrib/hf.py
+++ b/python/xgrammar/contrib/hf.py
@@ -74,8 +74,6 @@ class LogitsProcessor(transformers.LogitsProcessor):
                 "Expect input_ids.shape[0] to be LogitsProcessor.batch_size."
                 + f"Got {input_ids.shape[0]} for the former, and {self.batch_size} for the latter."
             )
-        if scores.device.type != "cuda":
-            raise RuntimeError("logits must be on CUDA")
 
         if not self.prefilled:
             # Have not sampled a token yet

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -30,6 +30,8 @@ from .apply_token_bitmask_cpu import apply_token_bitmask_inplace_cpu
 
 bitmask_dtype = torch.int32
 
+is_cuda_available = torch.cuda.is_available()
+
 
 def get_bitmask_shape(batch_size: int, vocab_size: int) -> Tuple[int, int]:
     """Return the shape of the bitmask (batch_size, ceil(vocab_size / 32))"""
@@ -45,7 +47,7 @@ def allocate_token_bitmask(batch_size: int, vocab_size: int) -> torch.Tensor:
         return torch.empty(
             xgr.get_bitmask_shape(batch_size, vocab_size),
             dtype=xgr.bitmask_dtype,
-            pin_memory=True,
+            pin_memory=torch.cuda.is_available(),
         )
 
     Parameters
@@ -63,12 +65,13 @@ def allocate_token_bitmask(batch_size: int, vocab_size: int) -> torch.Tensor:
 
     Note
     ----
-    This is the default way of allocating a bitmask. You can also customize the implementation.
+    - This is the default way of allocating a bitmask. You can also customize the implementation.
+    - For CUDA, use `pin_memory` in `torch.empty()` to speed up data transfer from CPU to GPU.
     """
     return torch.empty(
         get_bitmask_shape(batch_size, vocab_size),
         dtype=bitmask_dtype,
-        pin_memory=True,
+        pin_memory=is_cuda_available,
     )
 
 


### PR DESCRIPTION
This PR uses the `transformers_example.py` as Quick Start example in the doc. Tried on both CUDA and Mac (with `device="cpu"`). Also change `pin_memory=torch.cuda.is_available(),` for `allocate_token_bitmask()` since it is not supported for all devices (e.g. Mac).