### PR TITLE
[Compiler] Special case max_thread=1 to not use ThreadPool or mutex

### DIFF
--- a/python/xgrammar/apply_token_bitmask_cpu.py
+++ b/python/xgrammar/apply_token_bitmask_cpu.py
@@ -32,31 +32,25 @@ def apply_token_bitmask_inplace_cpu(
             f"bitmask and logits must have the same number of dimensions, but "
             + f"got {bitmask.dim()} and {logits.dim()}"
         )
+    if bitmask.dim() != 1 and bitmask.dim() != 2:
+        raise ValueError("Unsupported logits and bitmask dimensions: {}".format(bitmask.dim()))
 
-    # Determine if batch dimension is present
+    # Expand both to (batch_size, xxx_size), where batch_size is 1
     if logits.dim() == 1:
-        # No batch dimension
-        vocab_size = logits.size(0)
-        if indices is not None:
-            raise ValueError("Indices are not supported for 1D logits.")
-        bool_mask = _bitmask_to_bool_mask(bitmask, vocab_size)  # Shape (vocab_size,)
+        logits = logits.unsqueeze(0)
+        bitmask = bitmask.unsqueeze(0)
+
+    batch_size, vocab_size = logits.size()
+    if indices is None:
+        if batch_size != bitmask.size(0):
+            raise ValueError("Batch size of logits and bitmask must match")
+        bool_mask = _bitmask_to_bool_mask(bitmask, vocab_size)  # Shape (batch_size, vocab_size)
         logits.masked_fill_(~bool_mask, -float("inf"))
-    elif logits.dim() == 2:
-        batch_size, vocab_size = logits.size()
-        if indices is None:
-            if batch_size != bitmask.size(0):
-                raise ValueError("Batch size of logits and bitmask must match")
-            bool_mask = _bitmask_to_bool_mask(bitmask, vocab_size)  # Shape (batch_size, vocab_size)
-            logits.masked_fill_(~bool_mask, -float("inf"))
-        else:
-            if not isinstance(indices, torch.Tensor):
-                indices = torch.tensor(indices, dtype=torch.int32, device=logits.device)
-            len_indices = len(indices)
-            if len_indices != bitmask.size(0):
-                raise ValueError("The length of indices and bitmask's batch size must match.")
-            bool_mask = _bitmask_to_bool_mask(
-                bitmask, vocab_size
-            )  # Shape (len_indices, vocab_size)
-            logits[indices] = logits[indices].masked_fill_(~bool_mask, -float("inf"))
     else:
-        raise ValueError("Unsupported logits dimensions: {}".format(logits.dim()))
+        if not isinstance(indices, torch.Tensor):
+            indices = torch.tensor(indices, dtype=torch.int32, device=logits.device)
+        len_indices = len(indices)
+        if len_indices != bitmask.size(0):
+            raise ValueError("The length of indices and bitmask's batch size must match.")
+        bool_mask = _bitmask_to_bool_mask(bitmask, vocab_size)  # Shape (len_indices, vocab_size)
+        logits[indices] = logits[indices].masked_fill_(~bool_mask, -float("inf"))

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -40,11 +40,13 @@ def test_compiled_grammar():
     check_matcher(matcher_2)
 
 
-def test_grammar_compiler_json():
+# Test max_threads=1 since we have a special logic to avoid using ThreadPool and mutex
+@pytest.mark.parametrize("max_threads", (8, 1))
+def test_grammar_compiler_json(max_threads):
     tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-chat-hf")
     tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
     time_start = time.monotonic_ns()
-    grammar_compiler = xgr.GrammarCompiler(tokenizer_info)
+    grammar_compiler = xgr.GrammarCompiler(tokenizer_info, max_threads=max_threads)
     time_end = time.monotonic_ns()
     print(f"Time to init cached grammar compiler: {(time_end - time_start) / 1e3} us")
 


### PR DESCRIPTION
This PR bypasses using `ThreadPool` or `std::mutex` when `max_threads=1` when compiling grammar. This is motivated by how WebAssembly does not have good support for multithreading.

Unrelated to this, fix a bug in CPU bitmasking.

Tested with `pytest tests/`.