### PR TITLE
[Refactor] Remove libtorch dependency

### DIFF
--- a/cpp/pybind/CMakeLists.txt
+++ b/cpp/pybind/CMakeLists.txt
@@ -17,44 +17,18 @@ else()
 endif()
 find_package(pybind11 CONFIG REQUIRED)
 
-# Setup PyTorch
-execute_process(
-  COMMAND ${Python3_EXECUTABLE} "-c" "import torch; print(torch.utils.cmake_prefix_path,end='');"
-  RESULT_VARIABLE TORCH_CMAKE_DIR_RET
-  OUTPUT_VARIABLE TORCH_CMAKE_DIR
-)
-if(TORCH_CMAKE_DIR_RET MATCHES 0)
-  list(APPEND CMAKE_PREFIX_PATH "${TORCH_CMAKE_DIR}")
-else()
-  message(FATAL_ERROR "PyTorch is not installed. Please install PyTorch with pip or conda first")
-endif()
-
-find_package(Torch CONFIG REQUIRED)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
-
-find_library(TORCH_PYTHON_LIBRARY torch_python PATH "${TORCH_INSTALL_PREFIX}/lib")
-
-# The compilation flags for bindings is different from the main library as torch requires
-# -D_GLIBCXX_USE_CXX11_ABI=0. So we compile bindings separately.
 file(GLOB_RECURSE XGRAMMAR_BINDINGS_PATH ${PROJECT_SOURCE_DIR}/cpp/*.cc)
-
 pybind11_add_module(xgrammar_bindings ${XGRAMMAR_BINDINGS_PATH})
 target_include_directories(xgrammar_bindings PUBLIC ${XGRAMMAR_INCLUDE_PATH})
 
-target_link_libraries(xgrammar_bindings PUBLIC ${TORCH_LIBRARIES} ${TORCH_PYTHON_LIBRARY})
 set(LIB_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/python/xgrammar")
 set_target_properties(xgrammar_bindings PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIRECTORY})
-set_target_properties(xgrammar_bindings PROPERTIES LIBRARY_OUTPUT_DIRECTORY_DEBUG ${LIB_OUTPUT_DIRECTORY})
-set_target_properties(xgrammar_bindings PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE ${LIB_OUTPUT_DIRECTORY})
-set_target_properties(xgrammar_bindings PROPERTIES LIBRARY_OUTPUT_DIRECTORY_REL_WITH_DEB_INFO ${LIB_OUTPUT_DIRECTORY})
-
-if(MSVC)
-  file(GLOB TORCH_DLLS "${TORCH_INSTALL_PREFIX}/lib/*.dll")
-  add_custom_command(
-    TARGET xgrammar_bindings
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${TORCH_DLLS}
-            $<TARGET_FILE_DIR:xgrammar_bindings>
-  )
-endif(MSVC)
+set_target_properties(
+  xgrammar_bindings PROPERTIES LIBRARY_OUTPUT_DIRECTORY_DEBUG ${LIB_OUTPUT_DIRECTORY}
+)
+set_target_properties(
+  xgrammar_bindings PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE ${LIB_OUTPUT_DIRECTORY}
+)
+set_target_properties(
+  xgrammar_bindings PROPERTIES LIBRARY_OUTPUT_DIRECTORY_REL_WITH_DEB_INFO ${LIB_OUTPUT_DIRECTORY}
+)

--- a/cpp/pybind/python_methods.h
+++ b/cpp/pybind/python_methods.h
@@ -8,7 +8,6 @@
 #define XGRAMMAR_PYBIND_PYTHON_METHODS_H_
 
 #include <pybind11/pybind11.h>
-#include <torch/extension.h>
 #include <xgrammar/xgrammar.h>
 
 #include <optional>
@@ -31,11 +30,11 @@ std::string TokenizerInfo_GetVocabType(const TokenizerInfo& tokenizer);
 std::vector<pybind11::bytes> TokenizerInfo_GetDecodedVocab(const TokenizerInfo& tokenizer);
 
 void GrammarMatcher_FillNextTokenBitmask(
-    GrammarMatcher& matcher, torch::Tensor token_bitmask, int index
+    GrammarMatcher& matcher, intptr_t token_bitmask_ptr, std::vector<int64_t> shape, int32_t index
 );
 
 std::vector<int> Matcher_DebugGetMaskedTokensFromBitmask(
-    torch::Tensor token_bitmask, int32_t vocab_size, int32_t index
+    intptr_t token_bitmask_ptr, std::vector<int64_t> shape, int32_t vocab_size, int32_t index
 );
 
 }  // namespace xgrammar

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -216,7 +216,11 @@ class GrammarMatcher(XGRObject):
         index : int, default: 0
             The batch id of the bitmask.
         """
-        self._handle.fill_next_token_bitmask(bitmask, index)
+        if bitmask.device.type != "cpu":
+            raise ValueError("bitmask should be on CPU.")
+        if bitmask.dtype != bitmask_dtype:
+            raise ValueError(f"bitmask should be of type {bitmask_dtype}.")
+        self._handle.fill_next_token_bitmask(bitmask.data_ptr(), list(bitmask.shape), index)
 
     def find_jump_forward_string(self) -> str:
         """Find the jump-forward string for jump-forward decoding. This is the longest string that


### PR DESCRIPTION
This PR removes the dependency of libtorch in C++. It will pass data_ptr to C++ instead of torch::Tensor.