### PR TITLE
[Fix] Update config.cmake

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,8 +1,3 @@
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
 set(XGRAMMAR_BUILD_PYTHON_BINDINGS ON)
 set(XGRAMMAR_BUILD_CXX_TESTS OFF)
-# set it to your own architecture
-set(XGRAMMAR_CUDA_ARCHITECTURES
-    native
-    CACHE STRING "CUDA architectures"
-)


### PR DESCRIPTION
This PR removes useless config info in config.cmake.