### PR TITLE
[Fix] Fix local Python package installation

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -17,7 +17,7 @@ def get_version() -> str:
         raise RuntimeError(msg)
     with open(version_path) as f:
         code = compile(f.read(), version_path, "exec")
-    loc = {}
+    loc = {"__file__": version_path}
     exec(code, loc)
     if "__version__" not in loc:
         msg = "Version info is not found in xgrammar/version.py"
@@ -104,7 +104,7 @@ def main() -> None:
         package_data={"xgrammar": [xgrammar_lib_path]},
         zip_safe=False,
         install_requires=parse_requirements("requirements.txt")[0],
-        python_requires=">=3.7, <4",
+        python_requires=">=3.8, <4",
         url="https://github.com/mlc-ai/xgrammar",
         distclass=BinaryDistribution,
     )

--- a/python/xgrammar/version.py
+++ b/python/xgrammar/version.py
@@ -20,7 +20,7 @@ import subprocess
 
 # ---------------------------------------------------
 
-__version__ = "0.1.0"
+__version__ = "0.1.5"
 PROJ_ROOT = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 
 
@@ -128,7 +128,6 @@ def main():
         help="Use git describe to generate development version.",
     )
     parser.add_argument("--dry-run", action="store_true")
-    pub_ver, local_ver = git_describe_version()
     opt = parser.parse_args()
     pub_ver, local_ver = None, None
     if opt.git_describe:

--- a/scripts/sync_package.py
+++ b/scripts/sync_package.py
@@ -1,4 +1,5 @@
-""" Synchronize name and the tvm version """
+""" Synchronize name and version """
+
 import argparse
 import os
 import re
@@ -11,9 +12,7 @@ def py_str(cstr):
 
 def checkout_source(src, tag):
     def run_cmd(cmd):
-        proc = subprocess.Popen(
-            cmd, cwd=src, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-        )
+        proc = subprocess.Popen(cmd, cwd=src, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         (out, _) = proc.communicate()
         if proc.returncode != 0:
             msg = "git error: %s" % cmd
@@ -55,7 +54,7 @@ def get_version_tag(args):
     - local_ver: includes major, minor, dev and last git hash
                  e.g. "0.8.dev1473+gb7488ef47".
     """
-    version_py = os.path.join(args.src, "version.py")
+    version_py = os.path.join(args.src, "python", args.package_name, "version.py")
     libversion = {"__file__": version_py}
     exec(
         compile(open(version_py, "rb").read(), version_py, "exec"),
@@ -81,20 +80,14 @@ def update_setup(args, package_name):
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Synchronize the package name and version."
-    )
+    parser = argparse.ArgumentParser(description="Synchronize the package name and version.")
     parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Run the syncronization process without modifying any files.",
     )
-    parser.add_argument(
-        "--package", type=str, required=True, help="The package to sync for."
-    )
-    parser.add_argument(
-        "--package-name", type=str, required=True, help="The output package name"
-    )
+    parser.add_argument("--package", type=str, required=True, help="The package to sync for.")
+    parser.add_argument("--package-name", type=str, required=True, help="The output package name")
     parser.add_argument(
         "--nightly",
         action="store_true",
@@ -108,8 +101,7 @@ def main():
         type=str,
         metavar="DIR_NAME",
         default="",
-        help="Set the directory in which sources will be checked out. "
-        "Defaults to package",
+        help="Set the directory in which sources will be checked out. " "Defaults to package",
     )
     parser.add_argument(
         "--version",


### PR DESCRIPTION
This PR fixes the problem in local installation of python package. It fixes the wrong path of `version.py` in `setup.py`.

Co-authored-by: zanderjiang <zander.jiang@gmail.com>
