### PR TITLE
[Package] Fix error in pypi long description

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -91,6 +91,7 @@ def main() -> None:
         author="MLC Team",
         description="Efficient, Flexible and Portable Structured Generation",
         long_description=open(os.path.join(PROJECT_DIR, "README.md")).read(),
+        long_description_content_type="text/markdown",
         licence="Apache 2.0",
         classifiers=[
             "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This PR adds `long_description_content_type` to fix parsing error in pypi long description.