### PR TITLE
[Fix] Add support for GBNF inline comment

### DIFF
--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -92,10 +92,11 @@ void EBNFParser::ConsumeSpace(bool allow_newline) {
                     (allow_newline && (Peek() == '\n' || Peek() == '\r')))) {
     Consume();
     if (Peek(-1) == '#') {
+      auto start = cur_column_ - 1;
       while (Peek() && Peek() != '\n' && Peek() != '\r') {
         Consume();
       }
-      if (!Peek()) {
+      if (!Peek() || start != 1 /* Reserve \n for inline comment */) {
         return;
       }
       Consume();

--- a/tests/python/test_grammar_parser.py
+++ b/tests/python/test_grammar_parser.py
@@ -18,6 +18,20 @@ c ::= (("c"))
     after = str(grammar)
     assert after == expected
 
+def test_bnf_comment():
+    before = """# top comment
+root ::= a b # inline comment
+a ::= "a"
+b ::= "b"
+# bottom comment
+"""
+    expected = """root ::= ((a b))
+a ::= (("a"))
+b ::= (("b"))
+"""
+    grammar = xgr.Grammar.from_ebnf(before)
+    after = str(grammar)
+    assert after == expected
 
 def test_ebnf():
     before = """root ::= b c | b root


### PR DESCRIPTION
Current `grammar_parser.cc` can't handle inline comment correctly:

```gbnf
root ::= a # inline comment
a ::= "a"
```

Raise following error:

```
EBNF parse error at line 2, column 3: Expect element
```

Fixed by preventing inline comments from consuming line breaks.

P.S. How about integrating `llama.cpp`'s GBNF parsing implementation? Current implementation doesn't seems to be robust enough.