### PR TITLE
[Feature] Update apply mask kernels

### DIFF
--- a/cpp/matcher.cc
+++ b/cpp/matcher.cc
@@ -61,6 +61,76 @@ void _DebugGetMaskedTokensFromBitmask(
   }
 }
 
+void ApplyTokenBitmaskInplaceCPU(
+    DLTensor* logits, const DLTensor& bitmask, std::optional<std::vector<int>> indices
+) {
+  auto start = std::chrono::high_resolution_clock::now();
+  XGRAMMAR_CHECK(logits->device.device_type == kDLCPU)
+      << "The provided logits's device is not valid: should be CPU";
+  XGRAMMAR_CHECK(bitmask.device.device_type == kDLCPU)
+      << "The provided bitmask's device is not valid: should be CPU";
+  int batch_size;
+  int vocab_size;
+  if (logits->ndim == 2) {
+    batch_size = logits->shape[0];
+    vocab_size = logits->shape[1];
+  } else {
+    batch_size = 1;
+    vocab_size = logits->shape[0];
+  }
+  int bitmask_size = GetBitmaskSize(vocab_size);
+  if (bitmask.ndim == 2) {
+    XGRAMMAR_CHECK(bitmask.shape[0] == batch_size)
+        << "The provided bitmask's batch size is not consistent with logits";
+    XGRAMMAR_CHECK(bitmask.shape[1] == bitmask_size)
+        << "The provided bitmask's bitmask size is not consistent with logits";
+  } else {
+    XGRAMMAR_CHECK(bitmask.ndim == 1)
+        << "The provided bitmask's shape is not valid: should be (batch_size, vocab_size)";
+    XGRAMMAR_CHECK(bitmask.shape[0] == bitmask_size)
+        << "The provided bitmask's bitmask size is not consistent with logits";
+  }
+  XGRAMMAR_CHECK(
+      logits->dtype.code == kDLFloat && logits->dtype.bits == 32 && logits->dtype.lanes == 1
+  ) << "The provided logits's dtype is not valid: should be float32";
+  XGRAMMAR_CHECK(
+      bitmask.dtype.code == kDLInt && bitmask.dtype.bits == 32 && bitmask.dtype.lanes == 1
+  ) << "The provided bitmask's dtype is not valid: should be int32";
+
+  std::vector<int> indices_value;
+  if (indices.has_value()) {
+    indices_value = indices.value();
+    std::sort(indices_value.begin(), indices_value.end());
+    indices_value.erase(
+        std::unique(indices_value.begin(), indices_value.end()), indices_value.end()
+    );
+    XGRAMMAR_CHECK(indices_value.back() < batch_size)
+        << "The provided indices is out of bounds: " << indices_value.back()
+        << " >= " << batch_size;
+  } else {
+    indices_value.resize(batch_size);
+    for (int i = 0; i < batch_size; ++i) {
+      indices_value[i] = i;
+    }
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  XGRAMMAR_LOG(INFO) << "C++ check indices: " << duration.count() << " us";
+
+  start = std::chrono::high_resolution_clock::now();
+  for (auto idx : indices_value) {
+    uint32_t* data_ptr = reinterpret_cast<uint32_t*>(bitmask.data) + idx * bitmask_size;
+    DynamicBitset bitset(vocab_size, data_ptr);
+    auto logits_ptr = reinterpret_cast<float*>(logits->data) + idx * vocab_size;
+    for (int i = bitset.FindFirstZero(); i != -1; i = bitset.FindNextZero(i)) {
+      logits_ptr[i] = -std::numeric_limits<float>::infinity();
+    }
+  }
+  end = std::chrono::high_resolution_clock::now();
+  duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  XGRAMMAR_LOG(INFO) << "Time taken: " << duration.count() << " us";
+}
+
 /*
  * Note on the matching algorithm
  *

--- a/cpp/matcher.cc
+++ b/cpp/matcher.cc
@@ -64,7 +64,6 @@ void _DebugGetMaskedTokensFromBitmask(
 void ApplyTokenBitmaskInplaceCPU(
     DLTensor* logits, const DLTensor& bitmask, std::optional<std::vector<int>> indices
 ) {
-  auto start = std::chrono::high_resolution_clock::now();
   XGRAMMAR_CHECK(logits->device.device_type == kDLCPU)
       << "The provided logits's device is not valid: should be CPU";
   XGRAMMAR_CHECK(bitmask.device.device_type == kDLCPU)
@@ -113,11 +112,7 @@ void ApplyTokenBitmaskInplaceCPU(
       indices_value[i] = i;
     }
   }
-  auto end = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  XGRAMMAR_LOG(INFO) << "C++ check indices: " << duration.count() << " us";
 
-  start = std::chrono::high_resolution_clock::now();
   for (auto idx : indices_value) {
     uint32_t* data_ptr = reinterpret_cast<uint32_t*>(bitmask.data) + idx * bitmask_size;
     DynamicBitset bitset(vocab_size, data_ptr);
@@ -126,9 +121,6 @@ void ApplyTokenBitmaskInplaceCPU(
       logits_ptr[i] = -std::numeric_limits<float>::infinity();
     }
   }
-  end = std::chrono::high_resolution_clock::now();
-  duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  XGRAMMAR_LOG(INFO) << "Time taken: " << duration.count() << " us";
 }
 
 /*

--- a/cpp/pybind/pybind.cc
+++ b/cpp/pybind/pybind.cc
@@ -84,4 +84,7 @@ PYBIND11_MODULE(xgrammar_bindings, m) {
       )
       .def("_regex_to_ebnf", &RegexToEBNF)
       .def("_get_masked_tokens_from_bitmask", &Matcher_DebugGetMaskedTokensFromBitmask);
+
+  auto pyKernelsModule = m.def_submodule("kernels");
+  pyKernelsModule.def("apply_token_bitmask_inplace_cpu", &Kernels_ApplyTokenBitmaskInplaceCPU);
 }

--- a/cpp/pybind/python_methods.cc
+++ b/cpp/pybind/python_methods.cc
@@ -100,8 +100,6 @@ void Kernels_ApplyTokenBitmaskInplaceCPU(
     std::pair<int64_t, int64_t> bitmask_shape,
     std::optional<std::vector<int>> indices
 ) {
-  auto start = std::chrono::high_resolution_clock::now();
-
   std::array<int64_t, 2> logits_shape_arr = {logits_shape.first, logits_shape.second};
   std::array<int64_t, 2> bitmask_shape_arr = {bitmask_shape.first, bitmask_shape.second};
 
@@ -124,15 +122,8 @@ void Kernels_ApplyTokenBitmaskInplaceCPU(
       nullptr,
       0
   };
-  auto end = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  XGRAMMAR_LOG(INFO) << "pybind convert: " << duration.count() << " us";
 
   ApplyTokenBitmaskInplaceCPU(&logits_dltensor, bitmask_dltensor, indices);
-
-  end = std::chrono::high_resolution_clock::now();
-  duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-  XGRAMMAR_LOG(INFO) << "pybind inner total: " << duration.count() << " us";
 }
 
 }  // namespace xgrammar

--- a/cpp/pybind/python_methods.cc
+++ b/cpp/pybind/python_methods.cc
@@ -8,6 +8,7 @@
 #include <xgrammar/xgrammar.h>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <iostream>
@@ -90,6 +91,48 @@ std::vector<int> Matcher_DebugGetMaskedTokensFromBitmask(
   std::vector<int> result;
   _DebugGetMaskedTokensFromBitmask(&result, bitmask_dltensor, vocab_size, index);
   return result;
+}
+
+void Kernels_ApplyTokenBitmaskInplaceCPU(
+    intptr_t logits_ptr,
+    std::pair<int64_t, int64_t> logits_shape,
+    intptr_t bitmask_ptr,
+    std::pair<int64_t, int64_t> bitmask_shape,
+    std::optional<std::vector<int>> indices
+) {
+  auto start = std::chrono::high_resolution_clock::now();
+
+  std::array<int64_t, 2> logits_shape_arr = {logits_shape.first, logits_shape.second};
+  std::array<int64_t, 2> bitmask_shape_arr = {bitmask_shape.first, bitmask_shape.second};
+
+  DLTensor logits_dltensor{
+      reinterpret_cast<void*>(logits_ptr),
+      DLDevice{kDLCPU, 0},
+      2,
+      DLDataType{kDLFloat, 32, 1},
+      logits_shape_arr.data(),
+      nullptr,
+      0
+  };
+
+  DLTensor bitmask_dltensor{
+      reinterpret_cast<void*>(bitmask_ptr),
+      DLDevice{kDLCPU, 0},
+      2,
+      GetBitmaskDLType(),
+      bitmask_shape_arr.data(),
+      nullptr,
+      0
+  };
+  auto end = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  XGRAMMAR_LOG(INFO) << "pybind convert: " << duration.count() << " us";
+
+  ApplyTokenBitmaskInplaceCPU(&logits_dltensor, bitmask_dltensor, indices);
+
+  end = std::chrono::high_resolution_clock::now();
+  duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+  XGRAMMAR_LOG(INFO) << "pybind inner total: " << duration.count() << " us";
 }
 
 }  // namespace xgrammar

--- a/cpp/pybind/python_methods.h
+++ b/cpp/pybind/python_methods.h
@@ -37,6 +37,14 @@ std::vector<int> Matcher_DebugGetMaskedTokensFromBitmask(
     intptr_t token_bitmask_ptr, std::vector<int64_t> shape, int32_t vocab_size, int32_t index
 );
 
+void Kernels_ApplyTokenBitmaskInplaceCPU(
+    intptr_t logits_ptr,
+    std::pair<int64_t, int64_t> logits_shape,
+    intptr_t bitmask_ptr,
+    std::pair<int64_t, int64_t> bitmask_shape,
+    std::optional<std::vector<int>> indices
+);
+
 }  // namespace xgrammar
 
 #endif  // XGRAMMAR_PYBIND_PYTHON_METHODS_H_

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -26,6 +26,12 @@ void _DebugGetMaskedTokensFromBitmask(
     std::vector<int>* rejected_tokens, const DLTensor& token_bitmask, int vocab_size, int index = 0
 );
 
+void ApplyTokenBitmaskInplaceCPU(
+    DLTensor* logits,
+    const DLTensor& bitmask,
+    std::optional<std::vector<int>> indices = std::nullopt
+);
+
 /*!
  * \brief A stateful matcher to match tokens to the specified BNF grammar. This class is the core
  * logic of the grammar-guided generation.

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cpu.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cpu.py
@@ -1,19 +1,11 @@
 """CPU implementation for in-place applying token mask."""
 
+import time
 from typing import List, Optional, Union
 
 import torch
 
-
-def _bitmask_to_bool_mask(bitmask: torch.Tensor, vocab_size: int) -> torch.Tensor:
-    bits_per_block = 32
-    bitmask_size = bitmask.size(-1)
-    # Expand bitmask to bits
-    shifts = torch.arange(bits_per_block, device=bitmask.device, dtype=torch.int32)
-    bits = (bitmask.unsqueeze(-1) >> shifts) & 1  # Shape (*, bits_per_block)
-    bits = bits.view(bitmask.size(0), -1)  # Shape (batch_size, bitmask_size * bits_per_block)
-    bool_mask = bits[:, :vocab_size].to(torch.bool)  # Truncate to vocab_size
-    return bool_mask
+from ..base import _core
 
 
 def apply_token_bitmask_inplace_cpu(
@@ -21,37 +13,48 @@ def apply_token_bitmask_inplace_cpu(
     bitmask: torch.Tensor,
     indices: Optional[Union[List[int], torch.Tensor]] = None,
 ) -> None:
-    """Exactly the same as `apply_token_bitmask_inplace()`, but `logits` is on the CPU.
-    So we use CPU implementation rather than launching a CUDA kernel.
-    """
+    """Apply token bitmask in-place on CPU."""
+    start = time.monotonic_ns()
     if logits.device.type != "cpu":
         raise ValueError("logits must be on CPU")
-    if bitmask.device != logits.device:
-        raise ValueError("bitmask must be on the same device as logits")
-    if bitmask.dim() != logits.dim():
-        raise ValueError(
-            f"bitmask and logits must have the same number of dimensions, but "
-            + f"got {bitmask.dim()} and {logits.dim()}"
-        )
+    if bitmask.device.type != "cpu":
+        raise ValueError("bitmask must be on CPU")
+    if logits.dtype != torch.float32:
+        raise ValueError("logits must be of type float32")
+    if bitmask.dtype != torch.int32:
+        raise ValueError("bitmask must be of type int32")
+    if logits.dim() != 1 and logits.dim() != 2:
+        raise ValueError("logits should be 1D or 2D, but got {}D".format(logits.dim()))
     if bitmask.dim() != 1 and bitmask.dim() != 2:
-        raise ValueError("Unsupported logits and bitmask dimensions: {}".format(bitmask.dim()))
+        raise ValueError("bitmask should be 1D or 2D, but got {}D".format(bitmask.dim()))
 
-    # Expand both to (batch_size, xxx_size), where batch_size is 1
-    if logits.dim() == 1:
-        logits = logits.unsqueeze(0)
-        bitmask = bitmask.unsqueeze(0)
+    # logits_shape = list(logits.shape)
+    # bitmask_shape = list(bitmask.shape)
+    # end = time.monotonic_ns()
+    # print(f"Python prepare: {(end - start) / 1e3} us")
 
-    batch_size, vocab_size = logits.size()
-    if indices is None:
-        if batch_size != bitmask.size(0):
-            raise ValueError("Batch size of logits and bitmask must match")
-        bool_mask = _bitmask_to_bool_mask(bitmask, vocab_size)  # Shape (batch_size, vocab_size)
-        logits.masked_fill_(~bool_mask, -float("inf"))
-    else:
-        if not isinstance(indices, torch.Tensor):
-            indices = torch.tensor(indices, dtype=torch.int32, device=logits.device)
-        len_indices = len(indices)
-        if len_indices != bitmask.size(0):
-            raise ValueError("The length of indices and bitmask's batch size must match.")
-        bool_mask = _bitmask_to_bool_mask(bitmask, vocab_size)  # Shape (len_indices, vocab_size)
-        logits[indices] = logits[indices].masked_fill_(~bool_mask, -float("inf"))
+    # _core.kernels.apply_token_bitmask_inplace_cpu(
+    #     logits.data_ptr(),
+    #     logits_shape,
+    #     bitmask.data_ptr(),
+    #     bitmask_shape,
+    #     indices,
+    # )
+
+    logits_shape = (logits.shape[0],) if logits.dim() == 1 else (logits.shape[0], logits.shape[1])
+    bitmask_shape = (
+        (bitmask.shape[0],) if bitmask.dim() == 1 else (bitmask.shape[0], bitmask.shape[1])
+    )
+    end = time.monotonic_ns()
+    print(f"Python prepare: {(end - start) / 1e3} us")
+
+    # start = time.monotonic_ns()
+    _core.kernels.apply_token_bitmask_inplace_cpu(
+        logits.data_ptr(),
+        logits_shape,
+        bitmask.data_ptr(),
+        bitmask_shape,
+        indices,
+    )
+    end = time.monotonic_ns()
+    print(f"Python inner: {(end - start) / 1e3} us")

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cpu.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cpu.py
@@ -14,7 +14,6 @@ def apply_token_bitmask_inplace_cpu(
     indices: Optional[Union[List[int], torch.Tensor]] = None,
 ) -> None:
     """Apply token bitmask in-place on CPU."""
-    start = time.monotonic_ns()
     if logits.device.type != "cpu":
         raise ValueError("logits must be on CPU")
     if bitmask.device.type != "cpu":
@@ -28,27 +27,11 @@ def apply_token_bitmask_inplace_cpu(
     if bitmask.dim() != 1 and bitmask.dim() != 2:
         raise ValueError("bitmask should be 1D or 2D, but got {}D".format(bitmask.dim()))
 
-    # logits_shape = list(logits.shape)
-    # bitmask_shape = list(bitmask.shape)
-    # end = time.monotonic_ns()
-    # print(f"Python prepare: {(end - start) / 1e3} us")
-
-    # _core.kernels.apply_token_bitmask_inplace_cpu(
-    #     logits.data_ptr(),
-    #     logits_shape,
-    #     bitmask.data_ptr(),
-    #     bitmask_shape,
-    #     indices,
-    # )
-
-    logits_shape = (logits.shape[0],) if logits.dim() == 1 else (logits.shape[0], logits.shape[1])
+    logits_shape = (1, logits.shape[0]) if logits.dim() == 1 else (logits.shape[0], logits.shape[1])
     bitmask_shape = (
-        (bitmask.shape[0],) if bitmask.dim() == 1 else (bitmask.shape[0], bitmask.shape[1])
+        (1, bitmask.shape[0]) if bitmask.dim() == 1 else (bitmask.shape[0], bitmask.shape[1])
     )
-    end = time.monotonic_ns()
-    print(f"Python prepare: {(end - start) / 1e3} us")
 
-    # start = time.monotonic_ns()
     _core.kernels.apply_token_bitmask_inplace_cpu(
         logits.data_ptr(),
         logits_shape,
@@ -56,5 +39,3 @@ def apply_token_bitmask_inplace_cpu(
         bitmask_shape,
         indices,
     )
-    end = time.monotonic_ns()
-    print(f"Python inner: {(end - start) / 1e3} us")

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -83,7 +83,7 @@ def _regex_to_ebnf(regex: str, with_rule_name: bool = True) -> str:
     return _core.testing._regex_to_ebnf(regex, with_rule_name)
 
 
-def _match_grammar_with_string(
+def _is_grammar_accept_string(
     grammar: Union[Grammar, str], input_str: str, debug_print: bool = False
 ) -> bool:
     if isinstance(grammar, str):

--- a/tests/cpp/test_parallel.cc
+++ b/tests/cpp/test_parallel.cc
@@ -23,7 +23,7 @@ static_assert(
 );
 
 // simulate a CompiledGrammar object
-struct Grammar {
+struct MockGrammar {
   std::size_t uuid;
   std::byte padding[sizeof(CompiledGrammar) - sizeof(std::size_t)];
 };
@@ -31,9 +31,9 @@ struct Grammar {
 using namespace std::chrono_literals;
 
 TEST(XGrammarParallelTest, CacheEfficiency) {
-  auto cache = ThreadSafeCache<std::string, Grammar>{[](const std::string&) {
+  auto cache = ThreadSafeCache<std::string, MockGrammar>{[](const std::string&) {
     std::this_thread::sleep_for(1s);  // simulate a slow operation
-    return Grammar{.uuid = counter++, .padding = {}};
+    return MockGrammar{.uuid = counter++, .padding = {}};
   }};
   auto futures = std::vector<std::future<std::size_t>>{};
 

--- a/tests/python/test_builtin_grammar_json.py
+++ b/tests/python/test_builtin_grammar_json.py
@@ -9,7 +9,7 @@ import torch
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
-from xgrammar.testing import _get_masked_tokens_from_bitmask, _match_grammar_with_string
+from xgrammar.testing import _get_masked_tokens_from_bitmask, _is_grammar_accept_string
 
 json_grammar = xgr.Grammar.builtin_json_grammar()
 
@@ -51,7 +51,7 @@ json_input_accepted = [
 
 @pytest.mark.parametrize("json_input_accepted", json_input_accepted)
 def test_json_accept(json_input_accepted: str):
-    assert _match_grammar_with_string(json_grammar, json_input_accepted)
+    assert _is_grammar_accept_string(json_grammar, json_input_accepted)
 
 
 json_input_refused = (
@@ -77,7 +77,7 @@ json_input_refused = (
 
 @pytest.mark.parametrize("json_input_refused", json_input_refused)
 def test_json_refuse(json_input_refused: str):
-    assert not _match_grammar_with_string(json_grammar, json_input_refused)
+    assert not _is_grammar_accept_string(json_grammar, json_input_refused)
 
 
 json_input_pressure = (
@@ -209,7 +209,7 @@ json_input_pressure = (
 
 @pytest.mark.parametrize("json_input_pressure", json_input_pressure)
 def test_json_pressure(json_input_pressure: str):
-    assert _match_grammar_with_string(json_grammar, json_input_pressure)
+    assert _is_grammar_accept_string(json_grammar, json_input_pressure)
 
 
 tokenizer_path__input_str__expected_rejected_sizes = [

--- a/tests/python/test_custom_grammar.py
+++ b/tests/python/test_custom_grammar.py
@@ -11,7 +11,7 @@ import torch
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
-from xgrammar.testing import _get_masked_tokens_from_bitmask, _match_grammar_with_string
+from xgrammar.testing import _get_masked_tokens_from_bitmask, _is_grammar_accept_string
 
 
 def test_simple():
@@ -22,9 +22,9 @@ rule3 ::= "c"
 """
 
     grammar = xgr.Grammar.from_ebnf(grammar_str)
-    assert _match_grammar_with_string(grammar, "bab")
-    assert not _match_grammar_with_string(grammar, "abb")
-    assert _match_grammar_with_string(grammar, "cab")
+    assert _is_grammar_accept_string(grammar, "bab")
+    assert not _is_grammar_accept_string(grammar, "abb")
+    assert _is_grammar_accept_string(grammar, "cab")
 
 
 def test_custom_root_rule():
@@ -38,8 +38,8 @@ basic_object ::= "{" ("" | ws basic_string ws ":" ws basic_any ( ws "," ws basic
 ws ::= [ \n\t]*
 """
     grammar = xgr.Grammar.from_ebnf(json_grammar_simple_ebnf, root_rule_name="basic_string")
-    assert _match_grammar_with_string(grammar, r'"abc\r\n"')
-    assert not _match_grammar_with_string(grammar, r'{"name": "John" }')
+    assert _is_grammar_accept_string(grammar, r'"abc\r\n"')
+    assert not _is_grammar_accept_string(grammar, r'{"name": "John" }')
 
 
 json_grammar_ebnf = r"""
@@ -96,7 +96,7 @@ json_input_accepted = [
 
 @pytest.mark.parametrize("json_input_accepted", json_input_accepted)
 def test_json_accept(json_input_accepted: str):
-    assert _match_grammar_with_string(json_grammar, json_input_accepted)
+    assert _is_grammar_accept_string(json_grammar, json_input_accepted)
 
 
 json_input_refused = (
@@ -122,7 +122,7 @@ json_input_refused = (
 
 @pytest.mark.parametrize("json_input_refused", json_input_refused)
 def test_json_refuse(json_input_refused: str):
-    assert not _match_grammar_with_string(json_grammar, json_input_refused)
+    assert not _is_grammar_accept_string(json_grammar, json_input_refused)
 
 
 json_input_pressure = (
@@ -254,7 +254,7 @@ json_input_pressure = (
 
 @pytest.mark.parametrize("json_input_pressure", json_input_pressure)
 def test_json_pressure(json_input_pressure: str):
-    assert _match_grammar_with_string(json_grammar, json_input_pressure)
+    assert _is_grammar_accept_string(json_grammar, json_input_pressure)
 
 
 tokenizer_path__input_str__expected_rejected_sizes = [

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -7,7 +7,7 @@ import pytest
 from pydantic import BaseModel, Field, TypeAdapter, WithJsonSchema, create_model
 
 import xgrammar as xgr
-from xgrammar.testing import _json_schema_to_ebnf, _match_grammar_with_string
+from xgrammar.testing import _is_grammar_accept_string, _json_schema_to_ebnf
 
 
 def check_schema_with_grammar(
@@ -47,9 +47,9 @@ def check_schema_with_json(
     )
 
     if is_accepted:
-        assert _match_grammar_with_string(json_schema_grammar, json_str)
+        assert _is_grammar_accept_string(json_schema_grammar, json_str)
     else:
-        assert not _match_grammar_with_string(json_schema_grammar, json_str)
+        assert not _is_grammar_accept_string(json_schema_grammar, json_str)
 
 
 def check_schema_with_instance(

--- a/tests/python/test_regex_converter.py
+++ b/tests/python/test_regex_converter.py
@@ -6,7 +6,7 @@ import torch
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
-from xgrammar.testing import _match_grammar_with_string, _regex_to_ebnf
+from xgrammar.testing import _is_grammar_accept_string, _regex_to_ebnf
 
 
 def test_basic():
@@ -15,8 +15,8 @@ def test_basic():
     expected_grammar = r"""root ::= "1" "2" "3"
 """
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, "123")
-    assert not _match_grammar_with_string(grammar_str, "1234")
+    assert _is_grammar_accept_string(grammar_str, "123")
+    assert not _is_grammar_accept_string(grammar_str, "1234")
 
 
 def test_unicode():
@@ -25,7 +25,7 @@ def test_unicode():
     expected_grammar = r"""root ::= "w" "w" "\u6211" "\U0001f601"
 """
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, regex)
+    assert _is_grammar_accept_string(grammar_str, regex)
 
 
 regex_expected_grammar_instance = [
@@ -60,7 +60,7 @@ regex_expected_grammar_instance = [
 def test_escape(regex: str, expected_grammar: str, instance: str):
     grammar_str = _regex_to_ebnf(regex)
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, instance)
+    assert _is_grammar_accept_string(grammar_str, instance)
 
 
 def test_escaped_char_class():
@@ -72,7 +72,7 @@ def test_escaped_char_class():
     expected_grammar = r"""root ::= [a-zA-Z0-9_] [a-zA-Z0-9_] [^a-zA-Z0-9_] [0-9] [^0-9] [\f\n\r\t\v\u0020\u00a0] [^[\f\n\r\t\v\u0020\u00a0]
 """
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, instance)
+    assert _is_grammar_accept_string(grammar_str, instance)
 
 
 def test_char_class():
@@ -82,7 +82,7 @@ def test_char_class():
     expected_grammar = r"""root ::= [-a-zA-Z+--]+
 """
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, instance)
+    assert _is_grammar_accept_string(grammar_str, instance)
 
 
 def test_boundary():
@@ -92,7 +92,7 @@ def test_boundary():
     expected_grammar = r"""root ::= "a" "b" "c"
 """
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, instance)
+    assert _is_grammar_accept_string(grammar_str, instance)
 
 
 def test_disjunction():
@@ -102,7 +102,7 @@ def test_disjunction():
     expected_grammar = r"""root ::= "a" "b" "c" | "d" "e" ( "f" | "g" )
 """
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, instance)
+    assert _is_grammar_accept_string(grammar_str, instance)
 
 
 def test_space():
@@ -112,7 +112,7 @@ def test_space():
     expected_grammar = r"""root ::= " " "a" "b" "c" " " | " " "d" "f" " " | " " "g" " "
 """
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, instance)
+    assert _is_grammar_accept_string(grammar_str, instance)
 
 
 def test_quantifier():
@@ -124,8 +124,8 @@ def test_quantifier():
 """
     # TODO(yixin): add tests for repetition range
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, instance)
-    assert _match_grammar_with_string(grammar_str, instance1)
+    assert _is_grammar_accept_string(grammar_str, instance)
+    assert _is_grammar_accept_string(grammar_str, instance1)
 
 
 def test_group():
@@ -135,7 +135,7 @@ def test_group():
     expected_grammar = r"""root ::= ( "a" | "b" ) ( "c" | "d" )
 """
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, instance)
+    assert _is_grammar_accept_string(grammar_str, instance)
 
 
 def test_any():
@@ -145,7 +145,7 @@ def test_any():
     expected_grammar = r"""root ::= [\u0000-\U0010FFFF]+ "a" [\u0000-\U0010FFFF]+
 """
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, instance)
+    assert _is_grammar_accept_string(grammar_str, instance)
 
 
 def test_ipv4():
@@ -159,7 +159,7 @@ def test_ipv4():
 """
     )
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, "123.45.67.89")
+    assert _is_grammar_accept_string(grammar_str, "123.45.67.89")
 
 
 date_time_instances_accepted = [
@@ -186,7 +186,7 @@ def test_date_time(instance: str, accepted: bool):
 """
     )
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, instance) == accepted
+    assert _is_grammar_accept_string(grammar_str, instance) == accepted
 
 
 date_instances_accepted = [
@@ -208,7 +208,7 @@ def test_date(instance: str, accepted: bool):
 """
     )
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, instance) == accepted
+    assert _is_grammar_accept_string(grammar_str, instance) == accepted
 
 
 time_instances_accepted = [
@@ -232,7 +232,7 @@ def test_time(instance: str, accepted: bool):
 """
     )
     assert grammar_str == expected_grammar
-    assert _match_grammar_with_string(grammar_str, instance) == accepted
+    assert _is_grammar_accept_string(grammar_str, instance) == accepted
 
 
 email_instances_accepted = [
@@ -261,7 +261,7 @@ def test_email(instance: str, accepted: bool):
         r"""[a-z0-9]([a-z0-9-]*[a-z0-9])?)$"""
     )
     grammar_str = _regex_to_ebnf(regex)
-    assert _match_grammar_with_string(grammar_str, instance) == accepted
+    assert _is_grammar_accept_string(grammar_str, instance) == accepted
 
 
 tokenizer_paths = ["meta-llama/Llama-2-7b-chat-hf", "meta-llama/Meta-Llama-3-8B-Instruct"]

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -1,0 +1,121 @@
+"""This test uses the optimized JSON grammar provided by the grammar library."""
+
+import sys
+import time
+
+import pytest
+import torch
+from triton.testing import do_bench
+
+import xgrammar as xgr
+from xgrammar.testing import _get_masked_tokens_from_bitmask
+
+
+def _bool_mask_to_bitmask(bool_mask: torch.Tensor) -> torch.Tensor:
+    bool_mask_int32 = bool_mask.to(torch.int32)
+    # Pad to multiple of 32
+    pad_size = (32 - bool_mask.shape[1] % 32) % 32
+    if pad_size > 0:
+        bool_mask_int32 = torch.nn.functional.pad(bool_mask_int32, (0, pad_size))
+    bool_mask_view = bool_mask_int32.view(bool_mask.shape[0], -1, 32)
+    # To avoid error for overflow, we construct int64 weights and convert to int32
+    weights = torch.tensor([1 << i for i in range(32)], dtype=torch.int64).to(torch.int32)
+    bitmask = (bool_mask_view * weights).sum(dim=2)
+    return bitmask.to(torch.int32)
+
+
+# token_mask_sizes = (1024, 32000, 32001, 32011)
+
+
+# @pytest.mark.parametrize("token_mask_size", token_mask_sizes)
+# @pytest.mark.parametrize("index", (0, 1))
+# def test_get_masked_tokens_from_bitmask(token_mask_size: int, index: int):
+#     bool_mask = torch.randint(0, 2, (2, token_mask_size), dtype=torch.bool)
+#     bitmask = _bool_mask_to_bitmask(bool_mask)
+#     expected = torch.where(~bool_mask[index])[0].tolist()
+#     assert _get_masked_tokens_from_bitmask(bitmask, token_mask_size, index) == expected
+
+
+# @pytest.mark.parametrize("is_cuda", (True, False))
+# def test_apply_token_bitmask_inplace(is_cuda: bool):
+#     neginf = float("-inf")
+#     bool_mask = torch.tensor([0, 1, 0, 1, 0, 1, 0, 1, 0, 1], dtype=torch.bool)
+#     logits = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0], dtype=torch.float32)
+#     expected = torch.where(bool_mask, logits, neginf)
+
+#     if is_cuda:
+#         logits_gpu = logits.to("cuda")
+#         bitmask = torch.tensor([0b1010101010], dtype=torch.int32).to("cuda")
+#         xgr.apply_token_bitmask_inplace(logits_gpu, bitmask)
+#         torch.cuda.synchronize()
+#         torch.testing.assert_close(logits_gpu, expected.to("cuda"))
+#     else:
+#         bitmask = torch.tensor([0b1010101010], dtype=torch.int32)
+#         xgr.apply_token_bitmask_inplace(logits, bitmask)
+#         torch.testing.assert_close(logits, expected)
+
+
+batch_size_vocab_size_masked_cnt_stride = [
+    (1, 128000, 1024, 1),
+    (1, 128000, 120000, 1),
+    (1, 128001, 120000, 1),
+    (1, 128010, 120000, 1),
+    (64, 128000, 1024, 1),
+    (64, 128000, 120000, 1),
+    (64, 128000, 1024, 4),
+    (64, 128000, 120000, 4),
+]
+
+
+@pytest.mark.parametrize(
+    "batch_size, vocab_size, masked_cnt, stride",
+    batch_size_vocab_size_masked_cnt_stride,
+)
+@pytest.mark.parametrize("is_cuda", (False,))
+def test_apply_token_bitmask_inplace_large(
+    batch_size: int, vocab_size: int, masked_cnt: int, stride: int, is_cuda: bool
+):
+
+    masked_batch_ids = list(range(0, batch_size, stride))
+    masked_positions = torch.randint(0, vocab_size, (batch_size, masked_cnt))
+    bool_mask = torch.ones((batch_size, vocab_size), dtype=torch.bool)
+    bool_mask.scatter_(1, masked_positions, False)
+
+    logits = torch.randn(batch_size, vocab_size, dtype=torch.float32)
+    logits_expected = logits.clone()
+    logits_expected[masked_batch_ids] = torch.masked_fill(
+        logits_expected[masked_batch_ids], ~bool_mask[masked_batch_ids], float("-inf")
+    )
+
+    bitmask = _bool_mask_to_bitmask(bool_mask)
+    if is_cuda:
+        logits_gpu = logits.to("cuda")
+        bitmask_gpu = bitmask.to("cuda")
+        torch.cuda.synchronize()
+        if stride == 1:
+            # Test logic without indices
+            f = lambda: xgr.apply_token_bitmask_inplace(logits_gpu, bitmask_gpu)
+        else:
+            f = lambda: xgr.apply_token_bitmask_inplace(
+                logits_gpu, bitmask_gpu, indices=masked_batch_ids
+            )
+        f()
+        torch.testing.assert_close(logits_gpu, logits_expected.to("cuda"))
+
+        dur = do_bench(f, warmup=100, rep=1000)
+        print(f"Time taken: {(dur) * 1e3} us")
+    else:
+        time_start = time.monotonic_ns()
+        if stride == 1:
+            # Test logic without indices
+            xgr.apply_token_bitmask_inplace(logits, bitmask)
+
+        else:
+            xgr.apply_token_bitmask_inplace(logits, bitmask, indices=masked_batch_ids)
+        time_end = time.monotonic_ns()
+        print(f"Time taken: {(time_end - time_start) / 1e3} us")
+        torch.testing.assert_close(logits, logits_expected)
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)


### PR DESCRIPTION
Previously the apply mask kernel computes:
```
for i in range(len(indices)):
    for j in range(vocab_size):
        if get_bitmask_value(bitmask, i, j) == 0:
            logits[indices[i], j] = -inf
```

This means the shape of the bitmask is `(len(indices), bitmask_size)`, where `len(indices)` represents the number of structured generation requests in a batch. However, this number can be different for different batches, and the shape of the bitmask also differs.

This PR makes the shape of the bitmask consist across batches to make it easier to allocate the bitmask. It fixes the shape of the bitmask to (batch_size, bitmask_size), and modifies the apply mask kernel to:

```
for batch_id in indices:
    for j in range(vocab_size):
        if get_bitmask_value(bitmask, batch_id, j) == 0:
            logits[batch_id, j] = -inf
```