### PR TITLE
[FunctionCalling] Support TagDispatch

### DIFF
--- a/cpp/compiled_grammar_data_structure.h
+++ b/cpp/compiled_grammar_data_structure.h
@@ -15,7 +15,7 @@
 #include <vector>
 
 // matcher_data_structure.h is included to use StackElement
-#include "grammar_matcher_data_structure.h"
+#include "persistent_stack.h"
 #include "support/dynamic_bitset.h"
 #include "support/utils.h"
 

--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -18,7 +18,7 @@ std::string Grammar::ToString() const { return GrammarPrinter(*this).ToString();
 
 Grammar Grammar::FromEBNF(const std::string& ebnf_string, const std::string& root_rule_name) {
   auto grammar = ParseEBNF(ebnf_string, root_rule_name);
-  grammar = GrammarNormalizer().Apply(grammar);
+  //   grammar = GrammarNormalizer().Apply(grammar);
   return grammar;
 }
 

--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -18,7 +18,7 @@ std::string Grammar::ToString() const { return GrammarPrinter(*this).ToString();
 
 Grammar Grammar::FromEBNF(const std::string& ebnf_string, const std::string& root_rule_name) {
   auto grammar = ParseEBNF(ebnf_string, root_rule_name);
-  //   grammar = GrammarNormalizer().Apply(grammar);
+  grammar = GrammarNormalizer().Apply(grammar);
   return grammar;
 }
 

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -138,6 +138,21 @@ class GrammarBuilder {
     );
   }
 
+  /*!
+   * \brief Add a RuleExpr for tag dispatch.
+   * \param tag_dispatch_list A list of pairs of tag_expr_id and rule_id.
+   */
+  int32_t AddTagDispatch(const std::vector<std::pair<int32_t, int32_t>>& tag_dispatch_list) {
+    std::vector<int32_t> data;
+    data.reserve(tag_dispatch_list.size() * 2);
+    for (const auto& [tag_expr_id, rule_id] : tag_dispatch_list) {
+      data.push_back(tag_expr_id);
+      data.push_back(rule_id);
+    }
+    return AddRuleExpr({RuleExprType::kTagDispatch, data.data(), static_cast<int32_t>(data.size())}
+    );
+  }
+
   size_t NumRuleExprs() const { return grammar_->NumRuleExprs(); }
   /*! \brief Get the rule_expr with the given id. */
   RuleExpr GetRuleExpr(int32_t rule_expr_id) { return grammar_->GetRuleExpr(rule_expr_id); }

--- a/cpp/grammar_data_structure.h
+++ b/cpp/grammar_data_structure.h
@@ -106,6 +106,9 @@ class Grammar::Impl {
     kSequence,
     // data format: [rule_expr_id0, rule_expr_id1, ...]
     kChoices,
+    // data format: [tag_expr0, rule_id0, tag_expr1, rule_id1, ...]
+    // tag_expr should be a byte string, and rule_id should be a rule id
+    kTagDispatch,
   };
 
   /*! \brief The object representing a rule expr. */

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -1,6 +1,6 @@
 /*!
  *  Copyright (c) 2024 by Contributors
- * \file xgrammar/matcher.cc
+ * \file xgrammar/grammar_matcher.cc
  * \brief This source file implement the matcher class, especially the logic related to LLM tokens,
  * like accepting tokens, leveraging the token mask cache to generate the mask, etc. matcher_base.cc
  * implements the basic matching algorithm from strings to grammar.
@@ -14,8 +14,8 @@
 #include "compiled_grammar_data_structure.h"
 #include "grammar_data_structure.h"
 #include "grammar_matcher_base.h"
-#include "grammar_matcher_data_structure.h"
 #include "grammar_serializer.h"
+#include "persistent_stack.h"
 #include "support/dynamic_bitset.h"
 #include "support/encoding.h"
 #include "support/int_set.h"

--- a/cpp/grammar_matcher_base.cc
+++ b/cpp/grammar_matcher_base.cc
@@ -1,6 +1,6 @@
 /*!
  *  Copyright (c) 2024 by Contributors
- * \file xgrammar/matcher_base.cc
+ * \file xgrammar/grammar_matcher_base.cc
  * \brief This source file implements the basic matching algorithm from strings to grammar.
  * matcher.cc will handle the logic related to LLM tokens, like accepting tokens, leveraging the
  * token mask cache to generate the mask, etc.
@@ -12,7 +12,7 @@
 #include <vector>
 
 #include "grammar_data_structure.h"
-#include "grammar_matcher_data_structure.h"
+#include "persistent_stack.h"
 #include "support/encoding.h"
 
 namespace xgrammar {

--- a/cpp/grammar_matcher_base.h
+++ b/cpp/grammar_matcher_base.h
@@ -3,8 +3,8 @@
  * \file xgrammar/grammar_matcher_base.h
  * \brief The base class of GrammarMatcher. It implements a character-based matching automata.
  */
-#ifndef XGRAMMAR_MATCHER_BASE_H_
-#define XGRAMMAR_MATCHER_BASE_H_
+#ifndef XGRAMMAR_GRAMMAR_MATCHER_BASE_H_
+#define XGRAMMAR_GRAMMAR_MATCHER_BASE_H_
 
 #include <xgrammar/grammar.h>
 
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include "grammar_data_structure.h"
-#include "grammar_matcher_data_structure.h"
+#include "persistent_stack.h"
 
 namespace xgrammar {
 
@@ -125,4 +125,4 @@ class GrammarMatcherBase {
 
 }  // namespace xgrammar
 
-#endif  // XGRAMMAR_MATCHER_BASE_H_
+#endif  // XGRAMMAR_GRAMMAR_MATCHER_BASE_H_

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -528,13 +528,18 @@ std::pair<int32_t, int32_t> EBNFParser::ParseTagDispatchElement() {
 }
 
 // TagDispatch:
-// rule ::= TagDispatch(("tag1", rule1), ("tag2", rule2), ...)
+// root ::= TagDispatch(("tag1", rule1), ("tag2", rule2), ...)
 int32_t EBNFParser::ParseTagDispatchOrChoices() {
   auto prev_cursor = std::make_tuple(cur_, cur_line_, cur_column_, in_parentheses_);
   auto first_identifier = ParseIdentifier(true);
   if (first_identifier.empty() || first_identifier != "TagDispatch") {
     std::tie(cur_, cur_line_, cur_column_, in_parentheses_) = prev_cursor;
     return ParseChoices();
+  }
+
+  // TODO(yixin): Make tagdispatch general
+  if (cur_rule_name_ != root_rule_name_) {
+    ReportParseError("TagDispatch should only be used in the root rule");
   }
 
   ConsumeSpace();

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -18,13 +18,14 @@ namespace xgrammar {
 class EBNFParser {
  public:
   /*! \brief The logic of parsing the grammar string. */
-  Grammar Parse(std::string ebnf_string, std::string root_rule_name);
+  Grammar Parse(const std::string& ebnf_string, const std::string& root_rule_name);
 
  private:
   using Rule = Grammar::Impl::Rule;
+  using RuleExprType = Grammar::Impl::RuleExprType;
 
   // Parsing different parts of the grammar
-  std::string ParseName(bool accept_empty = false);
+  std::string ParseIdentifier(bool accept_empty = false);
   int32_t ParseCharacterClass();
   int32_t ParseString();
   int32_t ParseRuleRef();
@@ -35,6 +36,8 @@ class EBNFParser {
   int32_t ParseLookaheadAssertion();
   int32_t ParseSequence();
   int32_t ParseChoices();
+  std::pair<int32_t, int32_t> ParseTagDispatchElement();
+  int32_t ParseTagDispatchOrChoices();
   Rule ParseRule();
 
   // Helper functions
@@ -89,6 +92,9 @@ class EBNFParser {
   // A sequence expression cannot contain newline, unless it is in parentheses.
   bool in_parentheses_ = false;
 
+  // The name of the root rule
+  std::string root_rule_name_;
+
   inline static constexpr int64_t MAX_INTEGER_IN_GRAMMAR = 1e10;
 };
 
@@ -118,7 +124,7 @@ bool EBNFParser::IsNameChar(TCodepoint c, bool first_char) {
 }
 
 // name should be a char string (not a utf8 string)
-std::string EBNFParser::ParseName(bool accept_empty) {
+std::string EBNFParser::ParseIdentifier(bool accept_empty) {
   auto start = cur_;
   bool first_char = true;
   while (Peek() && IsNameChar(Peek(), first_char)) {
@@ -196,12 +202,12 @@ int32_t EBNFParser::ParseCharacterClass() {
 
 // parse a c style string with utf8 support
 int32_t EBNFParser::ParseString() {
+  if (Peek() != '\"') {
+    ReportParseError("Expect \" in string literal");
+  }
+  Consume();
   std::vector<int32_t> codepoints;
-  while (Peek() && Peek() != '\"') {
-    if (Peek() == '\r' || Peek() == '\n') {
-      ReportParseError("There should be no newline character in a string literal");
-    }
-
+  while (Peek() && Peek() != '\"' && Peek() != '\n' && Peek() != '\r') {
     auto [codepoint, len] = ParseNextUTF8OrEscaped(cur_);
     if (codepoint == CharHandlingError::kInvalidUTF8) {
       ReportParseError("Invalid utf8 sequence");
@@ -212,6 +218,11 @@ int32_t EBNFParser::ParseString() {
     Consume(len);
     codepoints.push_back(codepoint);
   }
+  if (Peek() != '\"') {
+    ReportParseError("Expect \" in string literal");
+  }
+  Consume();
+
   if (codepoints.empty()) {
     return builder_.AddEmptyStr();
   }
@@ -230,7 +241,7 @@ int32_t EBNFParser::ParseString() {
 }
 
 int32_t EBNFParser::ParseRuleRef() {
-  std::string name = ParseName();
+  std::string name = ParseIdentifier();
   auto rule_id = builder_.GetRuleId(name);
   if (rule_id == -1) {
     ReportParseError("Rule \"" + name + "\" is not defined");
@@ -264,13 +275,7 @@ int32_t EBNFParser::ParseElement() {
       return rule_expr_id;
     }
     case '\"': {
-      Consume();
-      auto rule_expr_id = ParseString();
-      if (Peek() != '\"') {
-        ReportParseError("Expect \"");
-      }
-      Consume();
-      return rule_expr_id;
+      return ParseString();
     }
     default: {
       if (IsNameChar(Peek(), true)) {
@@ -481,6 +486,81 @@ int32_t EBNFParser::ParseChoices() {
   return builder_.AddChoices(choices);
 }
 
+std::pair<int32_t, int32_t> EBNFParser::ParseTagDispatchElement() {
+  if (Peek() != '(') {
+    ReportParseError("Expect ( in tag dispatch element");
+  }
+  Consume();
+  ConsumeSpace();
+
+  // Parse tag (a string literal)
+  auto tag_id = ParseString();
+  if (builder_.GetRuleExpr(tag_id).type == RuleExprType::kEmptyStr) {
+    ReportParseError("Tag cannot be empty");
+  }
+
+  ConsumeSpace();
+  if (Peek() != ',') {
+    ReportParseError("Expect , in tag dispatch element");
+  }
+  Consume();
+  ConsumeSpace();
+
+  // Parse rule name (should refer to a rule in the grammar)
+  auto rule_name = ParseIdentifier(false);
+
+  // The rule cannot be the root rule and should be defined in the grammar
+  if (rule_name == root_rule_name_) {
+    ReportParseError("The root rule \"" + rule_name + "\" cannot be used as a tag");
+  }
+  auto rule_id = builder_.GetRuleId(rule_name);
+  if (rule_id == -1) {
+    ReportParseError("Rule \"" + rule_name + "\" is not defined");
+  }
+
+  ConsumeSpace();
+  if (Peek() != ')') {
+    ReportParseError("Expect ) in tag dispatch element");
+  }
+  Consume();
+
+  return {tag_id, rule_id};
+}
+
+// TagDispatch:
+// rule ::= TagDispatch(("tag1", rule1), ("tag2", rule2), ...)
+int32_t EBNFParser::ParseTagDispatchOrChoices() {
+  auto prev_cursor = std::make_tuple(cur_, cur_line_, cur_column_, in_parentheses_);
+  auto first_identifier = ParseIdentifier(true);
+  if (first_identifier.empty() || first_identifier != "TagDispatch") {
+    std::tie(cur_, cur_line_, cur_column_, in_parentheses_) = prev_cursor;
+    return ParseChoices();
+  }
+
+  ConsumeSpace();
+  if (Peek() != '(') {
+    ReportParseError("Expect ( after TagDispatch");
+  }
+  Consume();
+  ConsumeSpace();
+  std::vector<std::pair<int32_t, int32_t>> tag_dispatch_list;
+  while (true) {
+    auto tag_dispatch = ParseTagDispatchElement();
+    tag_dispatch_list.push_back(tag_dispatch);
+    ConsumeSpace();
+    if (Peek() == ',') {
+      Consume();
+      ConsumeSpace();
+    } else if (Peek() == ')') {
+      Consume();
+      break;
+    } else {
+      ReportParseError("Expect , or ) in macro function TagDispatch");
+    }
+  }
+  return builder_.AddTagDispatch(tag_dispatch_list);
+}
+
 int32_t EBNFParser::ParseLookaheadAssertion() {
   if (Peek() != '(' || Peek(1) != '=') {
     return -1;
@@ -500,7 +580,7 @@ int32_t EBNFParser::ParseLookaheadAssertion() {
 }
 
 EBNFParser::Rule EBNFParser::ParseRule() {
-  std::string name = ParseName();
+  std::string name = ParseIdentifier();
   cur_rule_name_ = name;
   ConsumeSpace();
   if (Peek() != ':' || Peek(1) != ':' || Peek(2) != '=') {
@@ -508,7 +588,7 @@ EBNFParser::Rule EBNFParser::ParseRule() {
   }
   Consume(3);
   ConsumeSpace();
-  auto body_id = ParseChoices();
+  auto body_id = ParseTagDispatchOrChoices();
   ConsumeSpace();
   auto lookahead_id = ParseLookaheadAssertion();
   return {name, body_id, lookahead_id};
@@ -517,7 +597,7 @@ EBNFParser::Rule EBNFParser::ParseRule() {
 void EBNFParser::BuildRuleNameToId() {
   ConsumeSpace();
   while (Peek()) {
-    auto name = ParseName(true);
+    auto name = ParseIdentifier(true);
     ConsumeSpace(false);
     if (Peek() == ':' && Peek(1) == ':' && Peek(2) == '=') {
       if (name.empty()) {
@@ -544,7 +624,8 @@ void EBNFParser::ResetStringIterator(const char* cur) {
   in_parentheses_ = false;
 }
 
-Grammar EBNFParser::Parse(std::string ebnf_string, std::string root_rule_name) {
+Grammar EBNFParser::Parse(const std::string& ebnf_string, const std::string& root_rule_name) {
+  root_rule_name_ = root_rule_name;
   ResetStringIterator(ebnf_string.c_str());
   BuildRuleNameToId();
 
@@ -571,7 +652,7 @@ Grammar EBNFParser::Parse(std::string ebnf_string, std::string root_rule_name) {
   return builder_.Get(root_rule_name);
 }
 
-Grammar ParseEBNF(std::string ebnf_string, std::string root_rule_name) {
+Grammar ParseEBNF(const std::string& ebnf_string, const std::string& root_rule_name) {
   EBNFParser parser;
   return parser.Parse(ebnf_string, root_rule_name);
 }

--- a/cpp/grammar_parser.h
+++ b/cpp/grammar_parser.h
@@ -27,7 +27,7 @@ namespace xgrammar {
  * \param root_rule_name The name of the root rule. Default is "root".
  * \return The parsed grammar.
  */
-Grammar ParseEBNF(std::string ebnf_string, std::string root_rule_name = "root");
+Grammar ParseEBNF(const std::string& ebnf_string, const std::string& root_rule_name = "root");
 
 }  // namespace xgrammar
 

--- a/cpp/grammar_serializer.cc
+++ b/cpp/grammar_serializer.cc
@@ -40,6 +40,8 @@ std::string GrammarPrinter::PrintRuleExpr(const RuleExpr& rule_expr) {
       return PrintSequence(rule_expr);
     case RuleExprType::kChoices:
       return PrintChoices(rule_expr);
+    case RuleExprType::kTagDispatch:
+      return PrintTagDispatch(rule_expr);
     default:
       XGRAMMAR_LOG(FATAL) << "Unexpected RuleExpr type: " << static_cast<int>(rule_expr.type);
   }
@@ -115,6 +117,19 @@ std::string GrammarPrinter::PrintChoices(const RuleExpr& rule_expr) {
     result += PrintRuleExpr(rule_expr[i]);
     if (i + 1 != rule_expr.data_len) {
       result += " | ";
+    }
+  }
+  result += ")";
+  return result;
+}
+
+std::string GrammarPrinter::PrintTagDispatch(const RuleExpr& rule_expr) {
+  std::string result = "TagDispatch(";
+  for (int i = 0; i < rule_expr.data_len; i += 2) {
+    result +=
+        "(" + PrintRuleExpr(rule_expr[i]) + ", " + grammar_->GetRule(rule_expr[i + 1]).name + ")";
+    if (i + 2 != rule_expr.data_len) {
+      result += ", ";
     }
   }
   result += ")";

--- a/cpp/grammar_serializer.h
+++ b/cpp/grammar_serializer.h
@@ -58,6 +58,8 @@ class GrammarPrinter {
   std::string PrintSequence(const RuleExpr& rule_expr);
   /*! \brief Print a RuleExpr for rule_expr choices. */
   std::string PrintChoices(const RuleExpr& rule_expr);
+  /*! \brief Print a RuleExpr for tag dispatch. */
+  std::string PrintTagDispatch(const RuleExpr& rule_expr);
 
   Grammar grammar_;
 };

--- a/cpp/persistent_stack.h
+++ b/cpp/persistent_stack.h
@@ -1,10 +1,10 @@
 /*!
  *  Copyright (c) 2024 by Contributors
- * \file xgrammar/matcher_data_structure.h
- * \brief The header for the definition of the data structures used in the grammar matcher.
+ * \file xgrammar/persistent_stack.h
+ * \brief The header for the definition of the persistent stack and stack elements.
  */
-#ifndef XGRAMMAR_MATCHER_DATA_STRUCTURE_H_
-#define XGRAMMAR_MATCHER_DATA_STRUCTURE_H_
+#ifndef XGRAMMAR_PERSISTENT_STACK_H_
+#define XGRAMMAR_PERSISTENT_STACK_H_
 
 #include <xgrammar/xgrammar.h>
 
@@ -444,4 +444,4 @@ inline void StackTopsHistory::CheckWellFormed() const {
 
 }  // namespace xgrammar
 
-#endif  // XGRAMMAR_MATCHER_DATA_STRUCTURE_H_
+#endif  // XGRAMMAR_PERSISTENT_STACK_H_

--- a/tests/python/test_grammar_parser.py
+++ b/tests/python/test_grammar_parser.py
@@ -284,6 +284,21 @@ d_1 ::= ("" | ("d"))
     assert output_string_1 == output_string_2
 
 
+def test_tag_dispatch_roundtrip():
+    """Checks the printed result can be parsed, and the parsing-printing process is idempotent."""
+    before = r"""root ::= TagDispatch(("tag1", rule1), ("tag2", rule2), ("tag3", rule3))
+rule1 ::= (("a"))
+rule2 ::= (("b"))
+rule3 ::= (("c"))
+"""
+    grammar_1 = xgr.Grammar.from_ebnf(before)
+    output_string_1 = str(grammar_1)
+    grammar_2 = xgr.Grammar.from_ebnf(output_string_1)
+    output_string_2 = str(grammar_2)
+    assert before == output_string_1
+    assert output_string_1 == output_string_2
+
+
 def test_error():
     with pytest.raises(
         RuntimeError,
@@ -355,8 +370,7 @@ def test_error_tag_dispatch():
     # Test empty tag
     with pytest.raises(RuntimeError):
         xgr.Grammar.from_ebnf(
-            """
-root ::= TagDispatch(("", rule1))
+            """root ::= TagDispatch(("", rule1))
 rule1 ::= "a"
 """
         )
@@ -364,33 +378,38 @@ rule1 ::= "a"
     # Test undefined rule
     with pytest.raises(RuntimeError):
         xgr.Grammar.from_ebnf(
-            """
-root ::= TagDispatch(("tag1", undefined_rule))
+            """root ::= TagDispatch(("tag1", undefined_rule))
 """
         )
 
     # Test using root rule as tag target
     with pytest.raises(RuntimeError):
         xgr.Grammar.from_ebnf(
-            """
-root ::= TagDispatch(("tag1", root))
+            """root ::= TagDispatch(("tag1", root))
 """
         )
 
     # Test invalid TagDispatch syntax
     with pytest.raises(RuntimeError):
         xgr.Grammar.from_ebnf(
-            """
-root ::= TagDispatch("tag1", rule1)
+            """root ::= TagDispatch("tag1", rule1)
 rule1 ::= "a"
 """
         )
 
     with pytest.raises(RuntimeError):
         xgr.Grammar.from_ebnf(
-            """
-root ::= TagDispatch(("tag1" rule1))
+            """root ::= TagDispatch(("tag1" rule1))
 rule1 ::= "a"
+"""
+        )
+
+    # Test TagDispatch in non-root rule
+    with pytest.raises(RuntimeError):
+        xgr.Grammar.from_ebnf(
+            """root ::= rule1
+rule1 ::= TagDispatch(("tag1", rule2))
+rule2 ::= "a"
 """
         )
 


### PR DESCRIPTION
This PR supports TagDispatch. Its grammar is:
```
rule ::= TagDispatch(("tag1", rule1), ("tag2", rule2), ...)
```
And its semantic is: allowing any input at start. When input matches tag1, let the following input match rule1 until rule1 finishes. The same for rule1 and tag2. When the rule finished, get to start, allow any input, and check tag again. 

Its backend is not supported yet.