### PR TITLE
[Fix] Fix compilation error with virtual overloaded function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,8 @@ else()
     set(CMAKE_CXX_FLAGS "-Ofast ${CMAKE_CXX_FLAGS}")
   endif()
 
-  set(CMAKE_CXX_FLAGS
-      "-Wall -Wextra -Werror -Wno-pedantic -Wno-unused-parameter -flto=auto ${CMAKE_CXX_FLAGS}"
+  set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -Wno-pedantic -Wno-unused-parameter \
+-Woverloaded-virtual -flto=auto ${CMAKE_CXX_FLAGS}"
   )
 endif()
 

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -394,6 +394,9 @@ class GrammarUnionFunctorImpl : public SubGrammarAdder {
     builder_.UpdateRuleBody(root_rule_id, builder_.AddChoices(new_root_choices));
     return builder_.Get(root_rule_id);
   }
+
+  // Avoid hiding the original Apply(const Grammar&)
+  Grammar Apply(const Grammar& grammar) override { XGRAMMAR_LOG(FATAL) << "Not implemented"; }
 };
 
 class GrammarConcatFunctorImpl : public SubGrammarAdder {
@@ -418,6 +421,9 @@ class GrammarConcatFunctorImpl : public SubGrammarAdder {
 
     return builder_.Get(root_rule_id);
   }
+
+  // Avoid hiding the original Apply(const Grammar&)
+  Grammar Apply(const Grammar& grammar) override { XGRAMMAR_LOG(FATAL) << "Not implemented"; }
 };
 
 /*************************** Forward grammar functors to their impl ***************************/


### PR DESCRIPTION
This PR fixes the problem in #149 about the hidden overloaded function `Apply`. This will cause a compilation error.