### PR TITLE
[Fix] Fix broken rollback char count after accepting stop token

### DIFF
--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -314,6 +314,7 @@ bool GrammarMatcher::Impl::AcceptStopToken() {
     return false;
   }
   stack_tops_history_.PushHistory({});  // Terminate the matcher by setting the stack to empty
+  token_length_history.push_back(1);  // When rolling back a stop token, we need to rollback 1 state
   return true;
 }
 

--- a/tests/python/test_grammar_matcher.py
+++ b/tests/python/test_grammar_matcher.py
@@ -237,7 +237,7 @@ def test_reset():
 def test_termination():
     vocab = [
         # fmt: off
-        "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " ", '"a":true',
+        "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", " }", ", ", "6", ":", "\n", " ", '"a"', ':true',
         # fmt: on
     ]
     input_splitted = [
@@ -249,8 +249,9 @@ def test_termination():
         "6",
         ", ",
         " ",
-        '"a":true',
-        "}",
+        '"a"',
+        ":true",
+        " }",
         "</s>",
     ]
     input_ids = [vocab.index(t) for t in input_splitted]


### PR DESCRIPTION
In `GrammarMatcher::Impl::Rollback` (1), the number of chars to rollback for each token is determined by the `token_length_history` record.

However, `GrammarMatcher::Impl::AcceptStopToken` (2) does not push an amount into this history. This causes a straightforward bug where the wrong number of states are reverted when rolling back after the stop token is accepted.

I fixed the bug by appending "1" to the token length history for the stop token, since it also pushes a single `{}` stack element.

The `test_termination` does not catch this issue: it does in fact rollback too many characters, but the rolled back sequence is still an acceptable one because it removes _all of_ the second key/value pair text. By updating the test to separate this K/V into two tokens, if the value is rolled back the JSON is no longer valid.

Reviewers may run the updated test and see that it fails using the existing code. The updated code now passes and ensures a regression of this issue does not occur.

Relevant source code:
- (1) [GrammarMatcher:Impl::Rollback](https://github.com/mlc-ai/xgrammar/blob/792c92d9d48b1212561ea7dfb1379878210fe6b2/cpp/grammar_matcher.cc#L619)
```cpp
void GrammarMatcher::Impl::Rollback(int num_tokens) {
  XGRAMMAR_CHECK(num_tokens <= static_cast<int>(token_length_history.size()))
      << "Intended to rollback " << num_tokens << " tokens, but only the last "
      << token_length_history.size() << " steps of history are saved";
  while (num_tokens > 0) {
    int steps = token_length_history.back();
    RollbackChars(steps);
    token_length_history.pop_back();
    --num_tokens;
  }
}
```
- (2) [GrammarMatcher:Impl::AcceptStopToken](https://github.com/mlc-ai/xgrammar/blob/792c92d9d48b1212561ea7dfb1379878210fe6b2/cpp/grammar_matcher.cc#L309)
```cpp
bool GrammarMatcher::Impl::AcceptStopToken() {
  if (terminate_without_stop_token_) {
    return false;
  }
  if (!CanReachEnd()) {
    return false;
  }
  stack_tops_history_.PushHistory({});  // Terminate the matcher by setting the stack to empty
  return true;
}
```