### PR TITLE
[Feature] Structural tag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@
 #     pre-commit autoupdate
 #
 # See https://github.com/pre-commit/pre-commit
-# Note the pre-commit hooks shoule only be used for formatting, but not for linting.
+# Note the pre-commit hooks should only be used for formatting, but not for linting.
 # For linting consider using CI.
 repos:
   # Standard hooks

--- a/cpp/compiled_grammar_data_structure.h
+++ b/cpp/compiled_grammar_data_structure.h
@@ -66,6 +66,11 @@ struct AdaptiveTokenMask {
       const std::vector<int32_t>& rejected_indices,
       const std::vector<int32_t>& uncertain_indices
   );
+
+  static std::string PrintTokenByIds(
+      const std::vector<int32_t>& token_ids, const TokenizerInfo& tokenizer_info, int max_print_num
+  );
+  std::string Print(const TokenizerInfo& tokenizer_info) const;
 };
 
 /*!

--- a/cpp/compiled_grammar_data_structure.h
+++ b/cpp/compiled_grammar_data_structure.h
@@ -67,9 +67,6 @@ struct AdaptiveTokenMask {
       const std::vector<int32_t>& uncertain_indices
   );
 
-  static std::string PrintTokenByIds(
-      const std::vector<int32_t>& token_ids, const TokenizerInfo& tokenizer_info, int max_print_num
-  );
   std::string Print(const TokenizerInfo& tokenizer_info) const;
 };
 

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -1,0 +1,298 @@
+/*!
+ *  Copyright (c) 2023 by Contributors
+ * \file xgrammar/fsm.h
+ */
+#ifndef XGRAMMAR_FSM_H_
+#define XGRAMMAR_FSM_H_
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include "support/csr_array.h"
+
+namespace xgrammar {
+
+class CompactFSM;
+
+/*!
+ * \brief A finite state machine (FSM) implementation that supports character ranges on transitions.
+ */
+class FSM {
+ public:
+  /*! \brief Constructs an FSM with the specified number of nodes. */
+  FSM(int num_nodes = 0) : edges_(num_nodes) {}
+
+  /********************** Accessors **********************/
+
+  /*!
+   * \brief Transitions from a given state based on an input character.
+   * \param from The source state to transition from.
+   * \param character The input character.
+   * \return The target state if a valid transition exists, -1 otherwise.
+   */
+  int Transition(int from, int16_t character) const {
+    auto& edges = edges_[from];
+    for (const auto& edge : edges) {
+      if (edge.min_ch <= character && edge.max_ch >= character) {
+        return edge.target;
+      }
+    }
+    return -1;
+  }
+
+  /*! \brief Returns the start node of the FSM. */
+  int StartNode() const { return start_node_; }
+
+  /*!
+   * \brief Checks if a given node is an end/accepting state.
+   * \param node The node to check.
+   * \return True if the node is an end state, false otherwise.
+   */
+  bool IsEndNode(int node) const {
+    return std::any_of(end_nodes_.begin(), end_nodes_.end(), [node](int end_node) {
+      return end_node == node;
+    });
+  }
+
+  /*! \brief Returns the total number of nodes in the FSM. */
+  int NumNodes() const { return edges_.size(); }
+
+  /********************** Modifiers **********************/
+
+  /*!
+   * \brief Adds a transition edge between states with a character range.
+   * \param from The source state.
+   * \param to The target state.
+   * \param min_ch The minimum character in the range (inclusive).
+   * \param max_ch The maximum character in the range (inclusive).
+   */
+  void AddEdge(int from, int to, int16_t min_ch, int16_t max_ch) {
+    edges_[from].push_back({min_ch, max_ch, to});
+  }
+
+  /*!
+   * \brief Adds a new node to the FSM.
+   * \return The index of the newly added node.
+   */
+  int AddNode() {
+    edges_.emplace_back();
+    return edges_.size() - 1;
+  }
+
+  /*!
+   * \brief Sets the start node of the FSM.
+   * \param node The node to set as the start node.
+   */
+  void SetStartNode(int node) { start_node_ = node; }
+
+  /*!
+   * \brief Adds an end/accepting node to the FSM.
+   * \param node The node to add as an end node.
+   */
+  void AddEndNode(int node) { end_nodes_.push_back(node); }
+
+  /*! \brief Converts this FSM to a more compact representation. */
+  CompactFSM ToCompact();
+
+  friend std::ostream& operator<<(std::ostream& os, const FSM& fsm);
+
+ private:
+  /*! \brief Represents a transition edge in the FSM. */
+  struct Edge {
+    /*! \brief Minimum character in range (inclusive). */
+    int16_t min_ch;
+    /*! \brief Maximum character in range (inclusive). */
+    int16_t max_ch;
+    /*! \brief Target state. */
+    int32_t target;
+  };
+
+  /*! \brief Adjacency list of edges for each node. */
+  std::vector<std::vector<Edge>> edges_;
+  /*! \brief Start node index. */
+  int start_node_ = -1;
+  /*! \brief List of end/accepting nodes. */
+  std::vector<int> end_nodes_;
+
+  friend class CompactFSM;
+};
+
+/*!
+ * \brief A memory-efficient version of FSM that uses CSR format for edge storage.
+ */
+class CompactFSM {
+ public:
+  /*! \brief Default constructor. */
+  CompactFSM() = default;
+
+  /********************** Accessors **********************/
+
+  /*!
+   * \brief Transitions from a given state based on an input character.
+   * \param from The source state to transition from.
+   * \param character The input character.
+   * \return The target state if a valid transition exists, -1 otherwise.
+   */
+  int Transition(int from, int16_t character) const {
+    auto edges = edges_[from];
+    // TODO(yixin): test correctness for both cases
+    if (edges.size() <= 16) {
+      for (const auto& edge : edges) {
+        if (edge.min_ch > character) {
+          return -1;
+        } else if (edge.max_ch >= character) {
+          return edge.target;
+        }
+      }
+      return -1;
+    } else {
+      auto it = std::lower_bound(
+          edges.begin(),
+          edges.end(),
+          character,
+          [](const Edge& edge, int16_t character) { return edge.min_ch <= character; }
+      );
+      if (it != edges.end() && it->min_ch <= character) {
+        return it->target;
+      }
+      return -1;
+    }
+  }
+
+  /*! \brief Returns the start node of the FSM. */
+  int StartNode() const { return start_node_; }
+
+  /*!
+   * \brief Checks if a given node is an end/accepting state.
+   * \param node The node to check.
+   * \return True if the node is an end state, false otherwise.
+   */
+  bool IsEndNode(int node) const {
+    return std::any_of(end_nodes_.begin(), end_nodes_.end(), [node](int end_node) {
+      return end_node == node;
+    });
+  }
+
+  /*! \brief Returns the total number of nodes in the FSM. */
+  int NumNodes() const { return edges_.Size(); }
+
+  friend std::ostream& operator<<(std::ostream& os, const CompactFSM& fsm);
+
+ private:
+  using Edge = FSM::Edge;
+
+  /*! \brief Edges stored in CSR format. */
+  CSRArray<Edge> edges_;
+  /*! \brief Start node index. */
+  int start_node_ = -1;
+  /*! \brief List of end/accepting nodes. */
+  std::vector<int> end_nodes_;
+
+  friend class FSM;
+};
+
+inline std::ostream& operator<<(std::ostream& os, const FSM& fsm) {
+  os << "FSM(num_nodes=" << fsm.NumNodes() << ", start=" << fsm.StartNode() << ", end=[";
+  for (int i = 0; i < static_cast<int>(fsm.end_nodes_.size()); ++i) {
+    os << fsm.end_nodes_[i];
+    if (i < static_cast<int>(fsm.end_nodes_.size()) - 1) {
+      os << ", ";
+    }
+  }
+  os << "], edges=[\n";
+  for (int i = 0; i < fsm.NumNodes(); ++i) {
+    os << i << ": [";
+    for (int j = 0; j < static_cast<int>(fsm.edges_[i].size()); ++j) {
+      const auto& edge = fsm.edges_[i][j];
+      if (edge.min_ch == edge.max_ch) {
+        os << "(" << edge.min_ch << ")->" << edge.target;
+      } else {
+        os << "(" << edge.min_ch << ", " << edge.max_ch << ")->" << edge.target;
+      }
+      if (j < static_cast<int>(fsm.edges_[i].size()) - 1) {
+        os << ", ";
+      }
+    }
+    os << "]\n";
+  }
+  os << "])";
+  return os;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const CompactFSM& fsm) {
+  os << "CompactFSM(num_nodes=" << fsm.NumNodes() << ", start=" << fsm.StartNode() << ", end=[";
+  for (int i = 0; i < static_cast<int>(fsm.end_nodes_.size()); ++i) {
+    os << fsm.end_nodes_[i];
+    if (i < static_cast<int>(fsm.end_nodes_.size()) - 1) {
+      os << ", ";
+    }
+  }
+  os << "], edges=[\n";
+  for (int i = 0; i < fsm.NumNodes(); ++i) {
+    os << i << ": [";
+    for (int j = 0; j < static_cast<int>(fsm.edges_[i].size()); ++j) {
+      const auto& edge = fsm.edges_[i][j];
+      if (edge.min_ch == edge.max_ch) {
+        os << "(" << edge.min_ch << ")->" << edge.target;
+      } else {
+        os << "(" << edge.min_ch << ", " << edge.max_ch << ")->" << edge.target;
+      }
+      if (j < static_cast<int>(fsm.edges_[i].size()) - 1) {
+        os << ", ";
+      }
+    }
+    os << "]\n";
+  }
+  os << "])";
+  return os;
+}
+
+/*!
+ * \brief Converts an FSM to its compact representation.
+ * \return A CompactFSM with the same transitions but more efficient memory usage.
+ */
+inline CompactFSM FSM::ToCompact() {
+  CompactFSM compact_fsm;
+  compact_fsm.start_node_ = start_node_;
+  compact_fsm.end_nodes_ = end_nodes_;
+  for (int i = 0; i < static_cast<int>(edges_.size()); ++i) {
+    std::sort(edges_[i].begin(), edges_[i].end(), [](const Edge& a, const Edge& b) {
+      return a.min_ch < b.min_ch;
+    });
+    compact_fsm.edges_.Insert(edges_[i]);
+  }
+  return compact_fsm;
+}
+
+inline FSM BuildTrie(
+    const std::vector<std::string>& patterns, std::vector<int32_t>* end_nodes = nullptr
+) {
+  FSM fsm(1);
+  fsm.SetStartNode(0);
+  if (end_nodes) {
+    end_nodes->clear();
+  }
+  for (const auto& pattern : patterns) {
+    int current_node = 0;
+    for (const auto& ch : pattern) {
+      int16_t ch_int16 = static_cast<int16_t>(static_cast<uint8_t>(ch));
+      int next_node = fsm.Transition(current_node, ch_int16);
+      if (next_node == -1) {
+        next_node = fsm.AddNode();
+        fsm.AddEdge(current_node, next_node, ch_int16, ch_int16);
+      }
+      current_node = next_node;
+    }
+    fsm.AddEndNode(current_node);
+    if (end_nodes) {
+      end_nodes->push_back(current_node);
+    }
+  }
+  return fsm;
+}
+
+}  // namespace xgrammar
+
+#endif  // XGRAMMAR_FSM_H_

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -26,6 +26,8 @@ class FSM {
 
   /********************** Accessors **********************/
 
+  inline static constexpr int NO_TRANSITION = -1;
+
   /*!
    * \brief Transitions from a given state based on an input character.
    * \param from The source state to transition from.
@@ -39,7 +41,7 @@ class FSM {
         return edge.target;
       }
     }
-    return -1;
+    return NO_TRANSITION;
   }
 
   /*! \brief Returns the start node of the FSM. */
@@ -129,6 +131,8 @@ class CompactFSM {
 
   /********************** Accessors **********************/
 
+  inline static constexpr int NO_TRANSITION = -1;
+
   /*!
    * \brief Transitions from a given state based on an input character.
    * \param from The source state to transition from.
@@ -141,12 +145,12 @@ class CompactFSM {
     if (edges.size() <= 16) {
       for (const auto& edge : edges) {
         if (edge.min_ch > character) {
-          return -1;
+          return NO_TRANSITION;
         } else if (edge.max_ch >= character) {
           return edge.target;
         }
       }
-      return -1;
+      return NO_TRANSITION;
     } else {
       auto it = std::lower_bound(
           edges.begin(),
@@ -157,7 +161,7 @@ class CompactFSM {
       if (it != edges.end() && it->min_ch <= character) {
         return it->target;
       }
-      return -1;
+      return NO_TRANSITION;
     }
   }
 
@@ -279,7 +283,7 @@ inline FSM BuildTrie(
     for (const auto& ch : pattern) {
       int16_t ch_int16 = static_cast<int16_t>(static_cast<uint8_t>(ch));
       int next_node = fsm.Transition(current_node, ch_int16);
-      if (next_node == -1) {
+      if (next_node == FSM::NO_TRANSITION) {
         next_node = fsm.AddNode();
         fsm.AddEdge(current_node, next_node, ch_int16, ch_int16);
       }

--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -11,6 +11,7 @@
 #include "grammar_serializer.h"
 #include "json_schema_converter.h"
 #include "regex_converter.h"
+#include "structural_tag.h"
 
 namespace xgrammar {
 
@@ -34,6 +35,12 @@ Grammar Grammar::FromJSONSchema(
 }
 
 Grammar Grammar::FromRegex(const std::string& regex) { return FromEBNF(RegexToEBNF(regex)); }
+
+Grammar Grammar::FromStructuralTag(
+    const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
+) {
+  return FromEBNF(StructuralTagToEBNF(tags, triggers));
+}
 
 // Optimized json grammar for the speed of the grammar matcher
 const std::string kJSONGrammarString = R"(

--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -39,7 +39,7 @@ Grammar Grammar::FromRegex(const std::string& regex) { return FromEBNF(RegexToEB
 Grammar Grammar::FromStructuralTag(
     const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
 ) {
-  return FromEBNF(StructuralTagToEBNF(tags, triggers));
+  return StructuralTagToGrammar(tags, triggers);
 }
 
 // Optimized json grammar for the speed of the grammar matcher

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -79,6 +79,20 @@ class GrammarBuilder {
   }
 
   /*!
+   * \brief Add a RuleExpr for string stored in bytes.
+   * \param str The string to be added.
+   */
+  int32_t AddByteString(const std::string& str) {
+    std::vector<int32_t> bytes;
+    bytes.reserve(str.size());
+    for (char c : str) {
+      bytes.push_back(static_cast<int32_t>(c));
+    }
+    return AddRuleExpr({RuleExprType::kByteString, bytes.data(), static_cast<int32_t>(bytes.size())}
+    );
+  }
+
+  /*!
    * \brief One element of a character class, containing a lower and a upper bound. Both bounds are
    * inclusive.
    */

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -13,6 +13,7 @@
 #include "support/encoding.h"
 #include "support/thread_pool.h"
 #include "support/thread_safe_cache.h"
+#include "testing.h"
 
 namespace xgrammar {
 
@@ -45,27 +46,6 @@ AdaptiveTokenMask::AdaptiveTokenMask(
   }
 
   this->uncertain_indices = uncertain_indices;
-}
-
-std::string AdaptiveTokenMask::PrintTokenByIds(
-    const std::vector<int32_t>& token_ids, const TokenizerInfo& tokenizer_info, int max_print_num
-) {
-  std::stringstream ss;
-  const auto& sorted_decoded_vocab = tokenizer_info.GetDecodedVocab();
-  ss << "[";
-  int print_num = std::min(static_cast<int>(token_ids.size()), max_print_num);
-  for (int i = 0; i < print_num; ++i) {
-    ss << "#" << token_ids[i] << " <" << PrintAsEscapedUTF8(sorted_decoded_vocab[token_ids[i]])
-       << ">";
-    if (i < print_num - 1) {
-      ss << ", ";
-    }
-  }
-  if (static_cast<int>(token_ids.size()) > max_print_num) {
-    ss << ", ...";
-  }
-  ss << "]";
-  return ss.str();
 }
 
 std::string AdaptiveTokenMask::Print(const TokenizerInfo& tokenizer_info) const {

--- a/cpp/grammar_data_structure.h
+++ b/cpp/grammar_data_structure.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "fsm.h"
 #include "support/logging.h"
 
 namespace xgrammar {
@@ -161,12 +162,20 @@ class Grammar::Impl {
  public:
   /******************* Aux information for matching *******************/
 
+  /*! \brief The fsm for the root tag dispatch rule. If the grammar does not have a root tag
+   * dispatch rule, it is not built. */
+  std::optional<CompactFSM> root_tag_dispatch_fsm = std::nullopt;
+
+  /*! \brief The map from the end nodes of the root tag dispatch fsm to the rule ids. */
+  std::unordered_map<int32_t, int32_t> tag_dispatch_end_node_to_rule_id;
+
   /*! \brief The ids of the rules that are allowed to be empty. */
   std::vector<int32_t> allow_empty_rule_ids;
 
   friend class GrammarBuilder;
   friend class GrammarSerializer;
   friend class GrammarDeserializer;
+  friend class GrammarCompiler;
 };
 
 }  // namespace xgrammar

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -420,7 +420,7 @@ class GrammarUnionFunctorImpl : public SubGrammarAdder {
   }
 
   // Avoid hiding the original Apply(const Grammar&)
-  Grammar Apply(const Grammar& grammar) override { XGRAMMAR_LOG(FATAL) << "Should not be called"; }
+  Grammar Apply(const Grammar& grammar) final { XGRAMMAR_LOG(FATAL) << "Should not be called"; }
 };
 
 /*!
@@ -454,7 +454,7 @@ class GrammarConcatFunctorImpl : public SubGrammarAdder {
   }
 
   // Avoid hiding the original Apply(const Grammar&)
-  Grammar Apply(const Grammar& grammar) override { XGRAMMAR_LOG(FATAL) << "Should not be called"; }
+  Grammar Apply(const Grammar& grammar) final { XGRAMMAR_LOG(FATAL) << "Should not be called"; }
 };
 
 /*!
@@ -604,6 +604,79 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
   }
 };
 
+class StructuralTagGrammarCreatorImpl : public SubGrammarAdder {
+ public:
+  Grammar Apply(
+      const std::vector<std::string>& triggers,
+      const std::vector<std::vector<std::pair<StructuralTagItem, Grammar>>>& tag_groups
+  ) {
+    XGRAMMAR_CHECK(triggers.size() == tag_groups.size())
+        << "Number of triggers must match number of tag groups";
+
+    builder_ = GrammarBuilder();
+    auto root_rule_id = builder_.AddEmptyRule("root");
+
+    // Create rules for each trigger group
+    std::vector<std::pair<int32_t, int32_t>> trigger_rule_pairs;
+    trigger_rule_pairs.reserve(triggers.size());
+    for (size_t i = 0; i < triggers.size(); i++) {
+      // Skip empty trigger groups
+      if (tag_groups[i].empty()) {
+        continue;
+      }
+
+      auto rule_name = "trigger_rule_" + std::to_string(i);
+      auto rule_id = builder_.AddEmptyRule(rule_name);
+
+      // Convert trigger string to byte string expr
+      auto trigger_expr_id = builder_.AddByteString(triggers[i]);
+
+      // Create choices for each tag in this trigger group
+      std::vector<int32_t> choices;
+      choices.reserve(tag_groups[i].size());
+      for (const auto& [tag, schema_grammar] : tag_groups[i]) {
+        // Create sequence: start_suffix + schema + end
+        std::vector<int32_t> seq_elements;
+        seq_elements.reserve(3);
+
+        // Add start suffix (everything after trigger)
+        XGRAMMAR_DCHECK(tag.start.size() >= triggers[i].size())
+            << "Tag start must be at least as long as trigger";
+        if (tag.start.size() > triggers[i].size()) {
+          seq_elements.push_back(builder_.AddByteString(tag.start.substr(triggers[i].size())));
+        }
+
+        // Create and visit schema grammar for this tag
+        auto schema_rule_id = VisitSubGrammar(schema_grammar);
+        seq_elements.push_back(builder_.AddRuleRef(schema_rule_id));
+
+        // Add end string
+        if (!tag.end.empty()) {
+          seq_elements.push_back(builder_.AddByteString(tag.end));
+        }
+
+        choices.push_back(builder_.AddSequence(seq_elements));
+      }
+
+      builder_.UpdateRuleBody(rule_id, builder_.AddChoices(choices));
+      trigger_rule_pairs.emplace_back(trigger_expr_id, rule_id);
+    }
+
+    // Create root TagDispatch rule
+    std::vector<std::pair<int32_t, int32_t>> tag_dispatch_data;
+    tag_dispatch_data.reserve(trigger_rule_pairs.size());
+    for (const auto& [trigger_id, rule_id] : trigger_rule_pairs) {
+      tag_dispatch_data.emplace_back(trigger_id, rule_id);
+    }
+
+    builder_.UpdateRuleBody(root_rule_id, builder_.AddTagDispatch(tag_dispatch_data));
+    return builder_.Get(root_rule_id);
+  }
+
+  // Avoid hiding the original Apply(const Grammar&)
+  Grammar Apply(const Grammar& grammar) final { XGRAMMAR_LOG(FATAL) << "Should not be called"; }
+};
+
 /*************************** Forward grammar functors to their impl ***************************/
 
 Grammar GrammarNormalizer::Apply(const Grammar& grammar) {
@@ -620,6 +693,13 @@ Grammar GrammarConcatFunctor::Apply(const std::vector<Grammar>& grammars) {
 
 std::vector<int32_t> AllowEmptyRuleAnalyzer::Apply(const Grammar& grammar) {
   return AllowEmptyRuleAnalyzerImpl().Apply(grammar);
+}
+
+Grammar StructuralTagGrammarCreator::Apply(
+    const std::vector<std::string>& triggers,
+    const std::vector<std::vector<std::pair<StructuralTagItem, Grammar>>>& tag_groups
+) {
+  return StructuralTagGrammarCreatorImpl().Apply(triggers, tag_groups);
 }
 
 }  // namespace xgrammar

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -522,6 +522,9 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
     for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
       auto rule = base_grammar_->GetRule(i);
       auto rule_expr = base_grammar_->GetRuleExpr(rule.body_expr_id);
+      if (rule_expr.type == RuleExprType::kTagDispatch) {
+        empty_rule_id_set->insert(i);
+      }
       XGRAMMAR_DCHECK(rule_expr.type == RuleExprType::kChoices);
       if (base_grammar_->GetRuleExpr(rule_expr[0]).type == RuleExprType::kEmptyStr) {
         empty_rule_id_set->insert(i);

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -262,6 +262,23 @@ class AllowEmptyRuleAnalyzer {
   static std::vector<int32_t> Apply(const Grammar& grammar);
 };
 
+/*!
+ * \brief Create a grammar that recognizes structural tags based on their triggers. See
+ * StructuralTagToGrammar() for more details.
+ *
+ * \param triggers The trigger strings that identify each tag group
+ * \param tag_groups The tags and their schema grammars, grouped by trigger. tag_groups[i][j] is the
+ * j-th tag that matches triggers[i], and its corresponding schema grammar.
+ * \return A grammar that matches all the tagged patterns.
+ */
+class StructuralTagGrammarCreator {
+ public:
+  static Grammar Apply(
+      const std::vector<std::string>& triggers,
+      const std::vector<std::vector<std::pair<StructuralTagItem, Grammar>>>& tag_groups
+  );
+};
+
 }  // namespace xgrammar
 
 #endif  // XGRAMMAR_GRAMMAR_FUNCTOR_H_

--- a/cpp/grammar_matcher_base.cc
+++ b/cpp/grammar_matcher_base.cc
@@ -21,6 +21,10 @@ namespace xgrammar {
 bool GrammarMatcherBase::CheckIfAccepted(const StackElement& stack_element, uint8_t char_value)
     const {
   auto current_sequence = grammar_->GetRuleExpr(stack_element.sequence_id);
+  if (current_sequence.type == Grammar::Impl::RuleExprType::kTagDispatch) {
+    XGRAMMAR_DCHECK(stack_element.element_id != -1);
+    return true;
+  }
   auto current_element = grammar_->GetRuleExpr(current_sequence[stack_element.element_id]);
   if (current_element.type == RuleExprType::kCharacterClass ||
       current_element.type == RuleExprType::kCharacterClassStar) {

--- a/cpp/grammar_matcher_base.cc
+++ b/cpp/grammar_matcher_base.cc
@@ -266,9 +266,8 @@ void GrammarMatcherBase::ExpandEquivalentStackElements(
 
 bool GrammarMatcherBase::AcceptChar(uint8_t char_value, bool debug_print) {
   if (debug_print) {
-    XGRAMMAR_LOG(INFO) << "Matching char: " << static_cast<int>(char_value) << " \""
+    XGRAMMAR_LOG(INFO) << "Trying to accept char: " << static_cast<int>(char_value) << " \""
                        << PrintAsEscapedUTF8(char_value) << "\"";
-    XGRAMMAR_LOG(INFO) << "Previous stack: " << PrintStackState();
   }
   const auto& prev_stack_tops = stack_tops_history_.GetLatest();
 

--- a/cpp/grammar_matcher_base.h
+++ b/cpp/grammar_matcher_base.h
@@ -57,7 +57,7 @@ class GrammarMatcherBase {
   void DiscardEarliestChars(int discard_cnt);
 
   /*! \brief Print the stack state. */
-  std::string PrintStackState(int steps_behind_latest = 0) const;
+  std::string PrintStackState(int steps_before_latest = 0) const;
 
  protected:
   /*!

--- a/cpp/grammar_matcher_base.h
+++ b/cpp/grammar_matcher_base.h
@@ -60,8 +60,14 @@ class GrammarMatcherBase {
   std::string PrintStackState(int steps_behind_latest = 0) const;
 
  protected:
-  // Push an initial stack state according to the given stack element.
-  // If init_stack_element is kInvalidStackElement, init the stack with the root rule.
+  /*!
+   * \brief Push an initial stack state according to the given stack element.
+   * \param init_stack_element The initial stack element. If kInvalidStackElement, init the stack
+   * with the root rule.
+   * \param expand_init_stack_element Whether to expand the initial stack element to all equivalent
+   * locations. See ExpandEquivalentStackElements. Only meaningful when init_stack_element is not
+   * kInvalidStackElement.
+   */
   void PushInitialState(StackElement init_stack_element, bool expand_init_stack_element);
 
   // Check if the character is accepted by the current stack element.
@@ -94,7 +100,7 @@ class GrammarMatcherBase {
    * current stack element does not exist in the persistent stack, pass -1. This is used to avoid
    * inserting the same stack element again.
    * \param consider_parent Whether to consider the parent position if the current position is
-   * at the end of the rule.
+   * at the end of the rule. Only used in its self recursion.
    */
   void ExpandEquivalentStackElements(
       StackElement cur_stack_element,

--- a/cpp/grammar_matcher_base.h
+++ b/cpp/grammar_matcher_base.h
@@ -68,7 +68,7 @@ class GrammarMatcherBase {
    * locations. See ExpandEquivalentStackElements. Only meaningful when init_stack_element is not
    * kInvalidStackElement.
    */
-  void PushInitialState(StackElement init_stack_element, bool expand_init_stack_element);
+  void PushInitialState(const StackElement& init_stack_element, bool expand_init_stack_element);
 
   // Check if the character is accepted by the current stack element.
   bool CheckIfAccepted(const StackElement& stack_element, uint8_t char_value) const;
@@ -76,7 +76,7 @@ class GrammarMatcherBase {
   /*!
    * \brief Move to the next position in the current rule, and return the updated stack element.
    */
-  StackElement MoveToNextPosition(StackElement stack_element);
+  StackElement MoveToNextPosition(const StackElement& stack_element);
 
   /*!
    * \brief Return the updated stack element after accepting the character.
@@ -103,7 +103,7 @@ class GrammarMatcherBase {
    * at the end of the rule. Only used in its self recursion.
    */
   void ExpandEquivalentStackElements(
-      StackElement cur_stack_element,
+      const StackElement& cur_stack_element,
       std::vector<int32_t>* new_stack_tops,
       int32_t cur_stack_element_id = -1,
       bool consider_parent = true

--- a/cpp/grammar_matcher_base.h
+++ b/cpp/grammar_matcher_base.h
@@ -68,18 +68,13 @@ class GrammarMatcherBase {
   bool CheckIfAccepted(const StackElement& stack_element, uint8_t char_value) const;
 
   /*!
-   * \brief Move to the next position in the grammar. It could be the next position in the current
-   * rule, or the next position in the parent rule if the current position is at the end of the
-   * rule. Does not change the underlying persistent stack.
-   * \param stack_element The current stack element.
-   * \param consider_parent Whether to consider the parent position if the current position is
-   * at the end of the rule.
-   * \returns (success, next_stack_element), indicating if the iteration is successful and the
-   * next stack element.
+   * \brief Move to the next position in the current rule, and return the updated stack element.
    */
   StackElement MoveToNextPosition(StackElement stack_element);
 
-  // Return the updated stack element after accepting the char
+  /*!
+   * \brief Return the updated stack element after accepting the character.
+   */
   StackElement AdvanceStackElementWithChar(const StackElement& stack_element, uint8_t char_value);
 
   /*!
@@ -95,11 +90,11 @@ class GrammarMatcherBase {
    * (rule=A, position="c"), since B and [a-z]* can be empty.
    * \param cur_stack_element The current stack element.
    * \param new_stack_tops The vector to store the new stack tops.
-   * \param is_inner_recursion Whether this is an inner recursion. The inner recursion will not
-   * consider the parent rule.
-   * \param first_id_if_inserted An optimization. When cur_stack_element is already inserted to
-   * the state tree, pass its id to avoid inserting it again. -1 (ignore it) by default.
-   * \return Whether the end of the rule can be reached. Useful for inner recursion.
+   * \param cur_stack_element_id The id in the persistent stack of the current stack element. If the
+   * current stack element does not exist in the persistent stack, pass -1. This is used to avoid
+   * inserting the same stack element again.
+   * \param consider_parent Whether to consider the parent position if the current position is
+   * at the end of the rule.
    */
   void ExpandEquivalentStackElements(
       StackElement cur_stack_element,

--- a/cpp/persistent_stack.h
+++ b/cpp/persistent_stack.h
@@ -330,7 +330,11 @@ inline bool PersistentStack::IsEndOfGrammar(const StackElement& stack_element) c
     return false;
   }
   auto seq_expr = grammar_->GetRuleExpr(stack_element.sequence_id);
-  return seq_expr.size() == stack_element.element_id;
+  if (seq_expr.type == Grammar::Impl::RuleExprType::kTagDispatch) {
+    return stack_element.element_id != -1;
+  } else {
+    return seq_expr.size() == stack_element.element_id;
+  }
 }
 
 inline std::string PersistentStack::PrintNode(int32_t id) const {

--- a/cpp/persistent_stack.h
+++ b/cpp/persistent_stack.h
@@ -193,10 +193,10 @@ class PersistentStack {
   }
 
   /*! \brief Print the given stack_element to a string. */
-  std::string PrintNode(const StackElement& stack_element) const;
+  std::string PrintStackElement(const StackElement& stack_element) const;
 
   /*! \brief Print the stack_element associated with the given id to a string. */
-  std::string PrintNode(int32_t id) const;
+  std::string PrintStackElement(int32_t id) const;
 
   /*! \brief Print the stack with the given top id to a string. */
   std::string PrintStackByTopId(int32_t top_id) const;
@@ -337,11 +337,11 @@ inline bool PersistentStack::IsEndOfGrammar(const StackElement& stack_element) c
   }
 }
 
-inline std::string PersistentStack::PrintNode(int32_t id) const {
-  return "id: " + std::to_string(id) + ", " + PrintNode(node_buffer_[id]);
+inline std::string PersistentStack::PrintStackElement(int32_t id) const {
+  return "id: " + std::to_string(id) + ", " + PrintStackElement(node_buffer_[id]);
 }
 
-inline std::string PersistentStack::PrintNode(const StackElement& stack_element) const {
+inline std::string PersistentStack::PrintStackElement(const StackElement& stack_element) const {
   std::stringstream ss;
   ss << "StackElement: rule " << stack_element.rule_id;
   if (stack_element.rule_id != -1) {
@@ -352,7 +352,8 @@ inline std::string PersistentStack::PrintNode(const StackElement& stack_element)
   ss << ", element id: " << stack_element.element_id;
 
   auto sequence = grammar_->GetRuleExpr(stack_element.sequence_id);
-  if (stack_element.element_id < static_cast<int32_t>(sequence.size())) {
+  if (sequence.type != Grammar::Impl::RuleExprType::kTagDispatch &&
+      stack_element.element_id < static_cast<int32_t>(sequence.size())) {
     auto element = grammar_->GetRuleExpr(sequence[stack_element.element_id]);
     if (element.type == Grammar::Impl::RuleExprType::kByteString) {
       ss << ", element in string: " << stack_element.element_in_string;
@@ -376,7 +377,7 @@ inline std::string PersistentStack::PrintStackByTopId(int32_t top_id) const {
   }
   ss << "{\n";
   for (auto it = stack.rbegin(); it != stack.rend(); ++it) {
-    ss << PrintNode(*it) << "\n";
+    ss << PrintStackElement(*it) << "\n";
   }
   ss << "}";
   return ss.str();

--- a/cpp/persistent_stack.h
+++ b/cpp/persistent_stack.h
@@ -434,7 +434,7 @@ inline std::string StackTopsHistory::PrintHistory(int steps_ago) const {
   const auto& latest_tops =
       stack_tops_history_[static_cast<int64_t>(stack_tops_history_.size()) - 1 - steps_ago];
   std::stringstream ss;
-  ss << "Stacks tops size: " << latest_tops.size() << std::endl;
+  ss << "Num of stacks: " << latest_tops.size() << std::endl;
   int cnt = 0;
   for (auto id : latest_tops) {
     ss << "Stack #" << cnt << ": " << persistent_stack_->PrintStackByTopId(id) << "\n";

--- a/cpp/pybind/pybind.cc
+++ b/cpp/pybind/pybind.cc
@@ -34,6 +34,7 @@ PYBIND11_MODULE(xgrammar_bindings, m) {
       .def_static("from_ebnf", &Grammar::FromEBNF)
       .def_static("from_json_schema", &Grammar::FromJSONSchema)
       .def_static("from_regex", &Grammar::FromRegex)
+      .def_static("from_structural_tag", &Grammar_FromStructuralTag)
       .def_static("builtin_json_grammar", &Grammar::BuiltinJSONGrammar)
       .def_static("union", &Grammar::Union)
       .def_static("concat", &Grammar::Concat);

--- a/cpp/pybind/pybind.cc
+++ b/cpp/pybind/pybind.cc
@@ -56,6 +56,11 @@ PYBIND11_MODULE(xgrammar_bindings, m) {
           py::call_guard<py::gil_scoped_release>()
       )
       .def(
+          "compile_structural_tag",
+          &GrammarCompiler_CompileStructuralTag,
+          py::call_guard<py::gil_scoped_release>()
+      )
+      .def(
           "compile_grammar",
           &GrammarCompiler::CompileGrammar,
           py::call_guard<py::gil_scoped_release>()

--- a/cpp/pybind/python_methods.cc
+++ b/cpp/pybind/python_methods.cc
@@ -131,4 +131,18 @@ std::vector<int32_t> GetAllowEmptyRuleIds(const CompiledGrammar& compiled_gramma
   return compiled_grammar.GetGrammar()->allow_empty_rule_ids;
 }
 
+Grammar Grammar_FromStructuralTag(
+    const std::vector<std::tuple<std::string, std::string, std::string>>& tags,
+    const std::vector<std::string>& triggers
+) {
+  std::vector<StructuralTagItem> tags_objects;
+  tags_objects.reserve(tags.size());
+  for (const auto& tag : tags) {
+    tags_objects.emplace_back(
+        StructuralTagItem{std::get<0>(tag), std::get<1>(tag), std::get<2>(tag)}
+    );
+  }
+  return Grammar::FromStructuralTag(tags_objects, triggers);
+}
+
 }  // namespace xgrammar

--- a/cpp/pybind/python_methods.cc
+++ b/cpp/pybind/python_methods.cc
@@ -149,4 +149,19 @@ Grammar Grammar_FromStructuralTag(
   return Grammar::FromStructuralTag(tags_objects, triggers);
 }
 
+CompiledGrammar GrammarCompiler_CompileStructuralTag(
+    GrammarCompiler& compiler,
+    const std::vector<std::tuple<std::string, std::string, std::string>>& tags,
+    const std::vector<std::string>& triggers
+) {
+  std::vector<StructuralTagItem> tags_objects;
+  tags_objects.reserve(tags.size());
+  for (const auto& tag : tags) {
+    tags_objects.emplace_back(
+        StructuralTagItem{std::get<0>(tag), std::get<1>(tag), std::get<2>(tag)}
+    );
+  }
+  return compiler.CompileStructuralTag(tags_objects, triggers);
+}
+
 }  // namespace xgrammar

--- a/cpp/pybind/python_methods.cc
+++ b/cpp/pybind/python_methods.cc
@@ -58,7 +58,11 @@ std::vector<pybind11::bytes> TokenizerInfo_GetDecodedVocab(const TokenizerInfo& 
 }
 
 void GrammarMatcher_FillNextTokenBitmask(
-    GrammarMatcher& matcher, intptr_t token_bitmask_ptr, std::vector<int64_t> shape, int32_t index
+    GrammarMatcher& matcher,
+    intptr_t token_bitmask_ptr,
+    std::vector<int64_t> shape,
+    int32_t index,
+    bool debug_print
 ) {
   XGRAMMAR_CHECK(shape.size() == 1 || shape.size() == 2) << "token_bitmask tensor must be 1D or 2D";
 
@@ -71,7 +75,7 @@ void GrammarMatcher_FillNextTokenBitmask(
       nullptr,
       0
   };
-  matcher.FillNextTokenBitmask(&bitmask_dltensor, index);
+  matcher.FillNextTokenBitmask(&bitmask_dltensor, index, debug_print);
 }
 
 std::vector<int> Matcher_DebugGetMaskedTokensFromBitmask(

--- a/cpp/pybind/python_methods.h
+++ b/cpp/pybind/python_methods.h
@@ -12,6 +12,7 @@
 
 #include <optional>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -46,6 +47,11 @@ void Kernels_ApplyTokenBitmaskInplaceCPU(
 );
 
 std::vector<int32_t> GetAllowEmptyRuleIds(const CompiledGrammar& compiled_grammar);
+
+Grammar Grammar_FromStructuralTag(
+    const std::vector<std::tuple<std::string, std::string, std::string>>& tags,
+    const std::vector<std::string>& triggers
+);
 
 }  // namespace xgrammar
 

--- a/cpp/pybind/python_methods.h
+++ b/cpp/pybind/python_methods.h
@@ -57,6 +57,12 @@ Grammar Grammar_FromStructuralTag(
     const std::vector<std::string>& triggers
 );
 
+CompiledGrammar GrammarCompiler_CompileStructuralTag(
+    GrammarCompiler& compiler,
+    const std::vector<std::tuple<std::string, std::string, std::string>>& tags,
+    const std::vector<std::string>& triggers
+);
+
 }  // namespace xgrammar
 
 #endif  // XGRAMMAR_PYBIND_PYTHON_METHODS_H_

--- a/cpp/pybind/python_methods.h
+++ b/cpp/pybind/python_methods.h
@@ -31,7 +31,11 @@ std::string TokenizerInfo_GetVocabType(const TokenizerInfo& tokenizer);
 std::vector<pybind11::bytes> TokenizerInfo_GetDecodedVocab(const TokenizerInfo& tokenizer);
 
 void GrammarMatcher_FillNextTokenBitmask(
-    GrammarMatcher& matcher, intptr_t token_bitmask_ptr, std::vector<int64_t> shape, int32_t index
+    GrammarMatcher& matcher,
+    intptr_t token_bitmask_ptr,
+    std::vector<int64_t> shape,
+    int32_t index,
+    bool debug_print
 );
 
 std::vector<int> Matcher_DebugGetMaskedTokensFromBitmask(

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -8,11 +8,12 @@
 #include <string>
 #include <string_view>
 
+#include "grammar_functor.h"
 #include "support/logging.h"
 
 namespace xgrammar {
 
-std::string StructuralTagToEBNF(
+Grammar StructuralTagToGrammar(
     const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
 ) {
   // Step 1: handle triggers. Triggers should not be mutually inclusive
@@ -20,16 +21,42 @@ std::string StructuralTagToEBNF(
   std::sort(sorted_triggers.begin(), sorted_triggers.end());
   for (int i = 0; i < static_cast<int>(sorted_triggers.size()) - 1; ++i) {
     XGRAMMAR_CHECK(
-        std::string_view(sorted_triggers[i + 1]).substr(0, sorted_triggers[i].size()) ==
-        sorted_triggers[i]
+        sorted_triggers[i + 1].size() < sorted_triggers[i].size() ||
+        std::string_view(sorted_triggers[i + 1]).substr(0, sorted_triggers[i].size()) !=
+            sorted_triggers[i]
     ) << "Triggers should not be mutually inclusive, but "
       << sorted_triggers[i] << " is a prefix of " << sorted_triggers[i + 1];
   }
 
   // Step 2: For each tag, find the trigger that is a prefix of the tag.begin
+  // Convert the schema to grammar at the same time
+  std::vector<std::vector<std::pair<StructuralTagItem, Grammar>>> tag_groups(triggers.size());
+  for (const auto& tag : tags) {
+    bool found = false;
+    for (int i = 0; i < static_cast<int>(sorted_triggers.size()); ++i) {
+      const auto& trigger = sorted_triggers[i];
+      if (trigger.size() <= tag.start.size() &&
+          std::string_view(tag.start).substr(0, trigger.size()) == trigger) {
+        auto schema_grammar = Grammar::FromJSONSchema(tag.schema, true);
+        tag_groups[i].push_back(std::make_pair(tag, schema_grammar));
+        found = true;
+        break;
+      }
+    }
+    XGRAMMAR_CHECK(found) << "Tag " << tag.start << " does not match any trigger";
+  }
 
-  std::vector<std::vector<StructuralTagItem>> sorted_tags_groups;
-  return "";
+  // Step 3: Combine the tags to form a grammar
+  // root ::= TagDispatch((trigger1, rule1), (trigger2, rule2), ...)
+  // Suppose tag1 and tag2 matches trigger1, then
+  // rule1 ::= (tag1.start[trigger1.size():] + ToEBNF(tag1.schema) + tag1.end) |
+  //            (tag2.start[trigger1.size():] + ToEBNF(tag2.schema) + tag2.end) | ...
+  //
+  // Suppose tag3 matches trigger2, then
+  // rule2 ::= (tag3.start[trigger2.size():] + ToEBNF(tag3.schema) + tag3.end)
+  //
+  // ...
+  return StructuralTagGrammarCreator::Apply(sorted_triggers, tag_groups);
 }
 
 }  // namespace xgrammar

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -1,0 +1,35 @@
+/*!
+ *  Copyright (c) 2024 by Contributors
+ * \file xgrammar/structural_tag.cc
+ */
+#include "structural_tag.h"
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+
+#include "support/logging.h"
+
+namespace xgrammar {
+
+std::string StructuralTagToEBNF(
+    const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
+) {
+  // Step 1: handle triggers. Triggers should not be mutually inclusive
+  std::vector<std::string> sorted_triggers(triggers.begin(), triggers.end());
+  std::sort(sorted_triggers.begin(), sorted_triggers.end());
+  for (int i = 0; i < static_cast<int>(sorted_triggers.size()) - 1; ++i) {
+    XGRAMMAR_CHECK(
+        std::string_view(sorted_triggers[i + 1]).substr(0, sorted_triggers[i].size()) ==
+        sorted_triggers[i]
+    ) << "Triggers should not be mutually inclusive, but "
+      << sorted_triggers[i] << " is a prefix of " << sorted_triggers[i + 1];
+  }
+
+  // Step 2: For each tag, find the trigger that is a prefix of the tag.begin
+
+  std::vector<std::vector<StructuralTagItem>> sorted_tags_groups;
+  return "";
+}
+
+}  // namespace xgrammar

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -1,0 +1,22 @@
+/*!
+ *  Copyright (c) 2024 by Contributors
+ * \file xgrammar/structural_tag.h
+ * \brief The header for the definition of the structural tag.
+ */
+#ifndef XGRAMMAR_STRUCTURAL_TAG_H_
+#define XGRAMMAR_STRUCTURAL_TAG_H_
+
+#include <xgrammar/xgrammar.h>
+
+#include <string>
+#include <vector>
+
+namespace xgrammar {
+
+std::string StructuralTagToEBNF(
+    const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
+);
+
+}  // namespace xgrammar
+
+#endif  // XGRAMMAR_STRUCTURAL_TAG_H_

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -13,7 +13,7 @@
 
 namespace xgrammar {
 
-std::string StructuralTagToEBNF(
+Grammar StructuralTagToGrammar(
     const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
 );
 

--- a/cpp/support/csr_array.h
+++ b/cpp/support/csr_array.h
@@ -1,0 +1,270 @@
+/*!
+ * Copyright (c) 2024 by Contributors
+ * \file xgrammar/support/csr_array.h
+ */
+#ifndef XGRAMMAR_SUPPORT_CSR_ARRAY_H_
+#define XGRAMMAR_SUPPORT_CSR_ARRAY_H_
+
+#include <picojson.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "logging.h"
+
+namespace xgrammar {
+
+// TODO(yixin): consider renaming to CompactVector
+
+/*!
+ * \brief This class implements a Compressed Sparse Row (CSR) array data structure. It stores
+ * a 2D array in a compressed format, where each row can have a variable number of elements, and
+ * all rows are stored contiguously in memory. The inserted row is immutable.
+ *
+ * \note Inserting new rows into the CSRArray will invalidate the existing Row objects.
+ *
+ * \tparam DataType The type of elements stored in the CSRArray.
+ *
+ * \details
+ * The CSRArray stores elements of type DataType in a compressed format,
+ * where each row can have a variable number of elements. It uses two vectors:
+ * - data_: stores all elements contiguously
+ * - indptr_: stores the starting index of each row in data_. Its last element is the size of data_
+ *            representing the ending index.
+ *
+ * This structure allows efficient storage and access for sparse data.
+ */
+template <typename DataType = int32_t>
+class CSRArray {
+ public:
+  /*! \brief Default constructor. */
+  CSRArray() = default;
+
+  /****************** Accessors ******************/
+
+  /*! \brief Get the number of rows in the CSRArray. */
+  int32_t Size() const { return static_cast<int32_t>(indptr_.size()) - 1; }
+
+  /*!
+   * \brief Struct representing a row in the CSRArray.
+   */
+  struct Row {
+    /*! \brief Pointer to the data of the row. */
+    const DataType* data;
+    /*! \brief Length of the row data. */
+    int32_t data_len;
+
+    /*!
+     * \brief Access an element in the row.
+     * \param i Index of the element to access.
+     * \return Reference to the element at index i.
+     */
+    const DataType& operator[](int32_t i) const {
+      XGRAMMAR_DCHECK(i >= 0 && i < data_len)
+          << "Index " << i << " of the CSRArray Row is out of bound";
+      return data[i];
+    }
+
+    /*! \brief Get the beginning iterator of the row. */
+    const DataType* begin() const { return data; }
+    /*! \brief Get the end iterator of the row. */
+    const DataType* end() const { return data + data_len; }
+    /*! \brief Get the size of the row. */
+    int32_t size() const { return data_len; }
+
+    friend std::ostream& operator<<(std::ostream& os, const Row& row) {
+      os << "[";
+      for (auto i = 0; i < row.data_len; ++i) {
+        if (i > 0) {
+          os << ", ";
+        }
+        os << row[i];
+      }
+      os << "]";
+      return os;
+    }
+  };
+
+  /*!
+   * \brief Access a row in the CSRArray.
+   * \param i Index of the row to access.
+   * \return Row struct representing the i-th row.
+   */
+  Row operator[](int32_t i) const;
+
+  /****************** Modifiers ******************/
+
+  /*!
+   * \brief Insert a new row of data into the CSRArray.
+   * \param data Pointer to the data to be inserted.
+   * \param data_len Length of the data to be inserted.
+   * \return The index of the newly inserted row.
+   */
+  int32_t Insert(const DataType* new_data, int32_t new_data_len);
+
+  /*!
+   * \brief Insert a new row of data into the CSRArray from a vector.
+   * \param data Vector containing the data to be inserted.
+   * \return The index of the newly inserted row.
+   */
+  int32_t Insert(const std::vector<DataType>& new_data);
+
+  /*!
+   * \brief Insert a new row of data into the CSRArray from a Row struct.
+   * \param row The Row struct containing the data to be inserted.
+   * \return The index of the newly inserted row.
+   */
+  int32_t Insert(const Row& row) { return Insert(row.data, row.data_len); }
+
+  /*!
+   * \brief Insert a new row of non-contiguous data into the CSRArray. This method inserts a
+   * single element followed by a sequence of elements. This is useful in the GrammarExpr data
+   * structure.
+   * \param data_1 The first element to be inserted.
+   * \param data_2 Pointer to the remaining data to be inserted.
+   * \param data_2_len Length of the remaining data to be inserted.
+   * \return The index of the newly inserted row.
+   */
+  int32_t InsertNonContiguous(DataType data_1, const DataType* data_2, int32_t data_2_len);
+
+  /****************** Internal Accessors ******************/
+
+  /*! \brief Get a pointer to the underlying data array. */
+  const DataType* data() const { return data_.data(); }
+  /*! \brief Get a pointer to the underlying index pointer array. */
+  const int32_t* indptr() const { return indptr_.data(); }
+
+  /****************** Serialization ******************/
+
+  /*!
+   * \brief Serialize the CSRArray to a JSON string.
+   * \return A JSON value representation of the CSRArray.
+   */
+  picojson::value Serialize() const;
+
+  /*!
+   * \brief Deserialize a JSON string to create a CSRArray.
+   * \param v The JSON value to deserialize.
+   * \return A new CSRArray object created from the deserialized data.
+   * \throws xgrammar::InternalError if the JSON parsing fails or if the required fields are
+   * missing.
+   */
+  static CSRArray Deserialize(const picojson::value& v);
+
+  friend std::ostream& operator<<(std::ostream& os, const CSRArray& csr_array) {
+    os << "CSRArray([";
+    for (auto i = 0; i < csr_array.Size(); ++i) {
+      if (i > 0) {
+        os << ", ";
+      }
+      os << csr_array[i];
+    }
+    os << "])";
+    return os;
+  }
+
+ private:
+  /*! \brief Vector storing all elements contiguously. */
+  std::vector<DataType> data_;
+  /*! \brief Vector storing the starting index of each row in data_. */
+  std::vector<int32_t> indptr_{0};
+};
+
+template <typename DataType>
+inline typename CSRArray<DataType>::Row CSRArray<DataType>::operator[](int32_t i) const {
+  XGRAMMAR_DCHECK(i >= 0 && i < Size()) << "CSRArray index " << i << " is out of bound";
+  int32_t start = indptr_[i];
+  int32_t end = indptr_[i + 1];
+  return {data_.data() + start, end - start};
+}
+
+template <typename DataType>
+inline int32_t CSRArray<DataType>::Insert(const DataType* new_data, int32_t new_data_len) {
+  // TODO(yixin): whether to add a additional data_len
+  // If the new data is already in the CSRArray, we need to copy it to the new memory location.
+  if (new_data >= data_.data() && new_data < data_.data() + data_.size()) {
+    std::vector<DataType> new_data_copied(new_data, new_data + new_data_len);
+    data_.insert(data_.end(), new_data_copied.begin(), new_data_copied.end());
+  } else {
+    data_.insert(data_.end(), new_data, new_data + new_data_len);
+  }
+  indptr_.push_back(static_cast<int32_t>(data_.size()));
+  return static_cast<int32_t>(indptr_.size()) - 2;
+}
+
+template <typename DataType>
+inline int32_t CSRArray<DataType>::Insert(const std::vector<DataType>& new_data) {
+  data_.insert(data_.end(), new_data.begin(), new_data.end());
+  indptr_.push_back(static_cast<int32_t>(data_.size()));
+  return static_cast<int32_t>(indptr_.size()) - 2;
+}
+
+template <typename DataType>
+inline int32_t CSRArray<DataType>::InsertNonContiguous(
+    DataType data_1, const DataType* data_2, int32_t data_2_len
+) {
+  if (data_2 >= data_.data() && data_2 < data_.data() + data_.size()) {
+    std::vector<DataType> new_data_copied(data_2, data_2 + data_2_len);
+    data_.push_back(data_1);
+    data_.insert(data_.end(), new_data_copied.begin(), new_data_copied.end());
+  } else {
+    data_.push_back(data_1);
+    data_.insert(data_.end(), data_2, data_2 + data_2_len);
+  }
+  indptr_.push_back(static_cast<int32_t>(data_.size()));
+  return static_cast<int32_t>(indptr_.size()) - 2;
+}
+
+template <typename DataType>
+inline picojson::value CSRArray<DataType>::Serialize() const {
+  // Serialize data_
+  picojson::array data_json;
+  for (const auto& item : data_) {
+    data_json.push_back(picojson::value(static_cast<int64_t>(item)));
+  }
+
+  // Serialize indptr_
+  picojson::array indptr_json;
+  for (const auto& item : indptr_) {
+    indptr_json.push_back(picojson::value(static_cast<int64_t>(item)));
+  }
+
+  // Serialize the object
+  picojson::object obj;
+  obj["data"] = picojson::value(data_json);
+  obj["indptr"] = picojson::value(indptr_json);
+
+  return picojson::value(obj);
+}
+
+template <typename DataType>
+inline CSRArray<DataType> CSRArray<DataType>::Deserialize(const picojson::value& v) {
+  XGRAMMAR_CHECK(v.is<picojson::object>())
+      << "Failed to deserialize CSRArray: expected a JSON object";
+
+  picojson::object obj = v.get<picojson::object>();
+  XGRAMMAR_CHECK(obj.find("data") != obj.end() && obj["data"].is<picojson::array>())
+      << "Failed to parse data in CSRArray";
+  XGRAMMAR_CHECK(obj.find("indptr") != obj.end() && obj["indptr"].is<picojson::array>())
+      << "Failed to parse indptr in CSRArray";
+
+  CSRArray csr_array;
+
+  // Deserialize data_
+  csr_array.data_.clear();
+  for (const auto& item : obj["data"].get<picojson::array>()) {
+    csr_array.data_.push_back(static_cast<DataType>(item.get<int64_t>()));
+  }
+
+  // Deserialize indptr_
+  csr_array.indptr_.clear();
+  for (const auto& item : obj["indptr"].get<picojson::array>()) {
+    csr_array.indptr_.push_back(static_cast<int32_t>(item.get<int64_t>()));
+  }
+
+  return csr_array;
+}
+
+}  // namespace xgrammar
+
+#endif  // XGRAMMAR_SUPPORT_CSR_ARRAY_H_

--- a/cpp/support/dynamic_bitset.h
+++ b/cpp/support/dynamic_bitset.h
@@ -140,6 +140,14 @@ class DynamicBitset {
     return result < size_ ? result : -1;
   }
 
+  int Count() const {
+    int count = 0;
+    for (int i = 0; i < buffer_size_; ++i) {
+      count += PopCount(data_[i]);
+    }
+    return count;
+  }
+
  private:
   static int LowestBit(uint32_t value) {
 #ifdef __GNUC__
@@ -151,6 +159,14 @@ class DynamicBitset {
                                                         16, 7,  26, 12, 18, 6,  11, 5,  10, 9};
     return MultiplyDeBruijnBitPosition[((uint32_t)((value & -value) * 0x077CB531U)) >> 27];
 #endif  // __GNUC__
+  }
+
+  static int PopCount(uint32_t value) {
+#if defined(__GNUC__) || defined(_MSC_VER)
+    return __builtin_popcount(value);
+#else
+    XGRAMMAR_LOG(FATAL) << "PopCount is not supported on this platform";
+#endif
   }
 
   int DoFindZeroFrom(int first_block) const {

--- a/cpp/support/logging.h
+++ b/cpp/support/logging.h
@@ -6,6 +6,10 @@
 #ifndef XGRAMMAR_SUPPORT_LOGGING_H_
 #define XGRAMMAR_SUPPORT_LOGGING_H_
 
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
 #include <ctime>
 #include <iomanip>
 #include <iostream>

--- a/cpp/support/utils.h
+++ b/cpp/support/utils.h
@@ -10,6 +10,12 @@
 #include <functional>
 #include <tuple>
 
+// Define __builtin_popcount for MSVC
+#ifdef _MSC_VER
+#include <intrin.h>
+#define __builtin_popcount __popcnt
+#endif
+
 namespace xgrammar {
 
 /*!

--- a/cpp/support/utils.h
+++ b/cpp/support/utils.h
@@ -64,6 +64,17 @@ struct hash<std::tuple<Args...>> {
   }
 };
 
+template <typename T>
+struct hash<std::vector<T>> {
+  size_t operator()(const std::vector<T>& vec) const {
+    uint32_t seed = 0;
+    for (const auto& item : vec) {
+      xgrammar::HashCombineBinary(seed, std::hash<T>{}(item));
+    }
+    return seed;
+  }
+};
+
 }  // namespace std
 
 #endif  // XGRAMMAR_SUPPORT_UTILS_H_

--- a/cpp/testing.cc
+++ b/cpp/testing.cc
@@ -1,0 +1,36 @@
+/*!
+ *  Copyright (c) 2024 by Contributors
+ * \file xgrammar/structural_tag.cc
+ */
+#include <xgrammar/xgrammar.h>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "support/encoding.h"
+
+namespace xgrammar {
+
+std::string PrintTokenByIds(
+    const std::vector<int32_t>& token_ids, const TokenizerInfo& tokenizer_info, int max_print_num
+) {
+  std::stringstream ss;
+  const auto& sorted_decoded_vocab = tokenizer_info.GetDecodedVocab();
+  ss << "[";
+  int print_num = std::min(static_cast<int>(token_ids.size()), max_print_num);
+  for (int i = 0; i < print_num; ++i) {
+    ss << "#" << token_ids[i] << " <" << PrintAsEscapedUTF8(sorted_decoded_vocab[token_ids[i]])
+       << ">";
+    if (i < print_num - 1) {
+      ss << ", ";
+    }
+  }
+  if (static_cast<int>(token_ids.size()) > max_print_num) {
+    ss << ", ...";
+  }
+  ss << "]";
+  return ss.str();
+}
+
+}  // namespace xgrammar

--- a/cpp/testing.h
+++ b/cpp/testing.h
@@ -1,0 +1,22 @@
+/*!
+ *  Copyright (c) 2024 by Contributors
+ * \file xgrammar/testing.h
+ * \brief The header testing utilities.
+ */
+#ifndef XGRAMMAR_TESTING_H_
+#define XGRAMMAR_TESTING_H_
+
+#include <xgrammar/xgrammar.h>
+
+#include <string>
+#include <vector>
+
+namespace xgrammar {
+
+std::string PrintTokenByIds(
+    const std::vector<int32_t>& token_ids, const TokenizerInfo& tokenizer_info, int max_print_num
+);
+
+}  // namespace xgrammar
+
+#endif  // XGRAMMAR_TESTING_H_

--- a/cpp/tokenizer_info.cc
+++ b/cpp/tokenizer_info.cc
@@ -345,14 +345,15 @@ TokenizerInfo::Impl::Impl(
 )
     : vocab_type_(vocab_type),
       vocab_size_(vocab_size.value_or(encoded_vocab.size())),
-      prepend_space_in_tokenization_(prepend_space_in_tokenization),
-      stop_token_ids_(stop_token_ids.value_or(std::vector<int32_t>())) {
+      prepend_space_in_tokenization_(prepend_space_in_tokenization) {
   decoded_vocab_.reserve(encoded_vocab.size());
   sorted_decoded_vocab_.reserve(encoded_vocab.size());
   for (int i = 0; i < static_cast<int>(encoded_vocab.size()); ++i) {
     const std::string& token = TokenDecoder::DecodeToken(encoded_vocab[i], vocab_type_);
     decoded_vocab_.push_back(token);
-    if (!stop_token_ids && DETECTION_STOP_TOKENS.count(token)) {
+    if ((!stop_token_ids && DETECTION_STOP_TOKENS.count(token)) ||
+        (stop_token_ids &&
+         std::find(stop_token_ids->begin(), stop_token_ids->end(), i) != stop_token_ids->end())) {
       stop_token_ids_.push_back(i);
     } else if (IsSpecialToken(token)) {
       special_token_ids_.push_back(i);

--- a/grammar_functor.cc
+++ b/grammar_functor.cc
@@ -1,0 +1,89 @@
+class StructuralTagGrammarCreatorImpl : public SubGrammarAdder {
+ public:
+  Grammar Apply(
+      const std::vector<Grammar>& schema_grammars,
+      const std::vector<std::string>& triggers,
+      const std::vector<std::vector<StructuralTagItem>>& tag_groups
+  ) {
+    XGRAMMAR_CHECK(triggers.size() == tag_groups.size())
+        << "Number of triggers must match number of tag groups";
+
+    builder_ = GrammarBuilder();
+    auto root_rule_id = builder_.AddEmptyRule("root");
+
+    // Create rules for each trigger group
+    std::vector<std::pair<int32_t, int32_t>> trigger_rule_pairs;
+    for (size_t i = 0; i < triggers.size(); i++) {
+      auto rule_name = "trigger_rule" + std::to_string(i);
+      auto rule_id = builder_.AddEmptyRule(rule_name);
+
+      // Convert trigger string to byte string expr
+      std::vector<int32_t> trigger_bytes;
+      trigger_bytes.reserve(triggers[i].size());
+      for (char c : triggers[i]) {
+        trigger_bytes.push_back(static_cast<int32_t>(c));
+      }
+      auto trigger_expr_id = builder_.AddByteString(trigger_bytes);
+
+      // Create choices for each tag in this trigger group
+      std::vector<int32_t> choices;
+      for (const auto& tag : tag_groups[i]) {
+        XGRAMMAR_CHECK(
+            tag.schema_idx >= 0 && tag.schema_idx < static_cast<int>(schema_grammars.size())
+        ) << "Invalid schema index: "
+          << tag.schema_idx;
+        XGRAMMAR_CHECK(tag.start.substr(0, triggers[i].size()) == triggers[i])
+            << "Tag start must begin with trigger";
+
+        // Visit the schema grammar for this tag
+        auto schema_rule_id = VisitSubGrammar(schema_grammars[tag.schema_idx]);
+
+        // Create sequence: start_suffix + schema + end
+        std::vector<int32_t> seq_elements;
+
+        // Add start suffix (everything after trigger)
+        if (tag.start.size() > triggers[i].size()) {
+          std::string suffix = tag.start.substr(triggers[i].size());
+          std::vector<int32_t> suffix_bytes;
+          suffix_bytes.reserve(suffix.size());
+          for (char c : suffix) {
+            suffix_bytes.push_back(static_cast<int32_t>(c));
+          }
+          seq_elements.push_back(builder_.AddByteString(suffix_bytes));
+        }
+
+        // Add schema reference
+        seq_elements.push_back(builder_.AddRuleRef(schema_rule_id));
+
+        // Add end string
+        if (!tag.end.empty()) {
+          std::vector<int32_t> end_bytes;
+          end_bytes.reserve(tag.end.size());
+          for (char c : tag.end) {
+            end_bytes.push_back(static_cast<int32_t>(c));
+          }
+          seq_elements.push_back(builder_.AddByteString(end_bytes));
+        }
+
+        choices.push_back(builder_.AddSequence(seq_elements));
+      }
+
+      builder_.UpdateRuleBody(rule_id, builder_.AddChoices(choices));
+      trigger_rule_pairs.emplace_back(trigger_expr_id, rule_id);
+    }
+
+    // Create root TagDispatch rule
+    std::vector<int32_t> tag_dispatch_data;
+    tag_dispatch_data.reserve(trigger_rule_pairs.size() * 2);
+    for (const auto& [trigger_id, rule_id] : trigger_rule_pairs) {
+      tag_dispatch_data.push_back(trigger_id);
+      tag_dispatch_data.push_back(rule_id);
+    }
+
+    builder_.UpdateRuleBody(root_rule_id, builder_.AddTagDispatch(tag_dispatch_data));
+    return builder_.Get(root_rule_id);
+  }
+
+  // Avoid hiding the original Apply(const Grammar&)
+  Grammar Apply(const Grammar& grammar) override { XGRAMMAR_LOG(FATAL) << "Should not be called"; }
+};

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -61,6 +61,11 @@ class GrammarCompiler {
   /*! \brief Get the compiled grammar for a grammar. */
   CompiledGrammar CompileGrammar(const Grammar& grammar);
 
+  /*! \brief Get the compiled grammar for a structural tag. */
+  CompiledGrammar CompileStructuralTag(
+      const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
+  );
+
   // /*! \brief Get the compiled grammar for a structural tag grammar. */
   // CompiledGrammar CompileStructuralTag(const std::vector<StructuralTagItem>& tags, const
   // std::vector<std::string>& triggers);

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -58,7 +58,12 @@ class GrammarCompiler {
   /*! \brief Get the compiled grammar for pure JSON. */
   CompiledGrammar CompileBuiltinJSONGrammar();
 
+  /*! \brief Get the compiled grammar for a grammar. */
   CompiledGrammar CompileGrammar(const Grammar& grammar);
+
+  // /*! \brief Get the compiled grammar for a structural tag grammar. */
+  // CompiledGrammar CompileStructuralTag(const std::vector<StructuralTagItem>& tags, const
+  // std::vector<std::string>& triggers);
 
   /*! \brief Clear the internal cache of compiled grammars. */
   void ClearCache();

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -20,6 +20,10 @@ struct StructuralTagItem {
   std::string start;
   std::string schema;
   std::string end;
+
+  bool operator==(const StructuralTagItem& other) const {
+    return start == other.start && schema == other.schema && end == other.end;
+  }
 };
 
 /*!

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -16,6 +16,12 @@
 
 namespace xgrammar {
 
+struct StructuralTagItem {
+  std::string start;
+  std::string schema;
+  std::string end;
+};
+
 /*!
  * \brief This class stores the abstract syntax tree (AST) of the Backus-Naur Form (BNF) grammar.
  * The BNF definition here is standard BNF, and the characters are represented using regex-style
@@ -108,6 +114,14 @@ class Grammar {
    * \param regex The regular expression string.
    */
   static Grammar FromRegex(const std::string& regex);
+
+  /*!
+   * \brief Construct a grammar from a regular expression string.
+   * \param regex The regular expression string.
+   */
+  static Grammar FromStructuralTag(
+      const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
+  );
 
   /*!
    * \brief Get the grammar of standard JSON format. We have built-in support for JSON.

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -93,7 +93,7 @@ class GrammarMatcher {
    * \param next_token_bitmask The bitmask to store the result. The bitmask must be pre-allocated
    * and with shape (GetBitmaskSize(),) and dtype int32.
    */
-  void FillNextTokenBitmask(DLTensor* next_token_bitmask, int index = 0);
+  void FillNextTokenBitmask(DLTensor* next_token_bitmask, int index = 0, bool debug_print = false);
 
   /*!
    * \brief Find the jump-forward string for jump-forward decoding. This is the longest string that

--- a/python/xgrammar/__init__.py
+++ b/python/xgrammar/__init__.py
@@ -1,7 +1,7 @@
 from . import testing
 from .compiler import CompiledGrammar, GrammarCompiler
 from .contrib import hf
-from .grammar import Grammar
+from .grammar import Grammar, StructuralTagItem
 from .matcher import (
     GrammarMatcher,
     allocate_token_bitmask,

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple, Type, Union, overload
 from pydantic import BaseModel
 
 from .base import XGRObject, _core
-from .grammar import Grammar
+from .grammar import Grammar, StructuralTagItem
 from .tokenizer_info import TokenizerInfo
 
 

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple, Type, Union, overload
 from pydantic import BaseModel
 
 from .base import XGRObject, _core
-from .grammar import Grammar, StructuralTagItem
+from .grammar import Grammar, StructuralTagItem, _handle_pydantic_schema
 from .tokenizer_info import TokenizerInfo
 
 
@@ -101,21 +101,10 @@ class GrammarCompiler(XGRObject):
         compiled_grammar : CompiledGrammar
             The compiled grammar.
         """
-        if isinstance(schema, type) and issubclass(schema, BaseModel):
-            if hasattr(schema, "model_json_schema"):
-                # pydantic 2.x
-                schema = json.dumps(schema.model_json_schema())
-            elif hasattr(schema, "schema_json"):
-                # pydantic 1.x
-                schema = json.dumps(schema.schema_json())
-            else:
-                raise ValueError(
-                    "The schema should have a model_json_schema or json_schema method."
-                )
-
+        schema_str = _handle_pydantic_schema(schema)
         return CompiledGrammar._create_from_handle(
             self._handle.compile_json_schema(
-                schema, any_whitespace, indent, separators, strict_mode
+                schema_str, any_whitespace, indent, separators, strict_mode
             )
         )
 
@@ -129,11 +118,28 @@ class GrammarCompiler(XGRObject):
         """
         return CompiledGrammar._create_from_handle(self._handle.compile_builtin_json_grammar())
 
-    def compile_structural_tag_grammar(
+    def compile_structural_tag(
         self, tags: List[StructuralTagItem], triggers: List[str]
     ) -> CompiledGrammar:
+        """Compile a grammar from structural tags. See Grammar.from_structural_tag() for more
+        details.
+
+        Parameters
+        ----------
+        tags : List[StructuralTagItem]
+            The structural tags.
+
+        triggers : List[str]
+            The triggers.
+
+        Returns
+        -------
+        compiled_grammar : CompiledGrammar
+            The compiled grammar.
+        """
+        tags_tuple = [(tag.start, _handle_pydantic_schema(tag.schema_), tag.end) for tag in tags]
         return CompiledGrammar._create_from_handle(
-            self._handle.compile_structural_tag_grammar(tags, triggers)
+            self._handle.compile_structural_tag(tags_tuple, triggers)
         )
 
     @overload

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -1,7 +1,7 @@
 """Compiling grammar for efficient token mask generation."""
 
 import json
-from typing import Optional, Tuple, Type, Union, overload
+from typing import List, Optional, Tuple, Type, Union, overload
 
 from pydantic import BaseModel
 
@@ -128,6 +128,13 @@ class GrammarCompiler(XGRObject):
             The compiled grammar.
         """
         return CompiledGrammar._create_from_handle(self._handle.compile_builtin_json_grammar())
+
+    def compile_structural_tag_grammar(
+        self, tags: List[StructuralTagItem], triggers: List[str]
+    ) -> CompiledGrammar:
+        return CompiledGrammar._create_from_handle(
+            self._handle.compile_structural_tag_grammar(tags, triggers)
+        )
 
     @overload
     def compile_grammar(self, ebnf_string: str, *, root_rule_name: str = "root") -> CompiledGrammar:

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -9,6 +9,20 @@ from .base import XGRObject, _core
 
 
 class StructuralTagItem(BaseModel):
+    """A structural tag item. See Grammar.from_structural_tag() for more details.
+
+    Attributes
+    ----------
+    start : str
+        The start tag.
+
+    schema_ : Union[str, Type[BaseModel]]
+        The schema.
+
+    end : str
+        The end tag.
+    """
+
     start: str
     schema_: Union[str, Type[BaseModel]] = Field(alias="schema")
     end: str
@@ -163,6 +177,54 @@ class Grammar(XGRObject):
 
     @staticmethod
     def from_structural_tag(tags: List[StructuralTagItem], triggers: List[str]) -> "Grammar":
+        """Create a grammar from structural tags. The structural tag handles the dispatching
+        of different grammars based on the tags and triggers.
+
+        The tags parameter is used to specify the output pattern. It is especially useful for LLM
+        function calling, where the pattern is:
+        <function=func_name>{"arg1": ..., "arg2": ...}</function>.
+        This pattern consists of three parts: a start tag (<function=func_name>), a parameter list
+        according to some schema ({"arg1": ..., "arg2": ...}), and an end tag (</function>). This
+        pattern can be described in a StructuralTagItem with a start tag, a schema, and an end tag.
+        The structural tag is able to handle multiple such patterns by passing them into multiple
+        tags.
+
+        The triggers parameter is used to trigger the dispatching of different grammars. The trigger
+        should be a prefix of a provided start tag. When the trigger is encountered, the
+        corresponding tag should be used to constrain the following output. There can be multiple
+        tags matching the same trigger. Then if the trigger is encountered, the following output
+        should match one of the tags. For example, in function calling, the triggers can be
+        ["<function="]. Then if "<function=" is encountered, the following output must match one
+        of the tags (e.g. <function=get_weather>{"city": "Beijing"}</function>).
+
+
+        The corrrespondance of tags and triggers is automatically determined: all tags with the
+        same trigger will be grouped together. User should make sure any trigger is not a prefix
+        of another trigger: then the corrrespondance of tags and triggers will be ambiguous.
+
+        Parameters
+        ----------
+        tags : List[StructuralTagItem]
+            The structural tags.
+
+        triggers : List[str]
+            The triggers.
+
+        Examples
+        --------
+        >>> class Schema1(BaseModel):
+        >>>     arg1: str
+        >>>     arg2: int
+        >>> class Schema2(BaseModel):
+        >>>     arg3: float
+        >>>     arg4: List[str]
+        >>> tags = [
+        >>>     StructuralTagItem(start="<function=f>", schema=Schema1, end="</function>"),
+        >>>     StructuralTagItem(start="<function=g>", schema=Schema2, end="</function>"),
+        >>> ]
+        >>> triggers = ["<function="]
+        >>> grammar = Grammar.from_structural_tag(tags, triggers)
+        """
         tags_tuple = [(tag.start, _handle_pydantic_schema(tag.schema_), tag.end) for tag in tags]
         return Grammar._create_from_handle(_core.Grammar.from_structural_tag(tags_tuple, triggers))
 

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -3,14 +3,14 @@
 import json
 from typing import List, Optional, Tuple, Type, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .base import XGRObject, _core
 
 
 class StructuralTagItem(BaseModel):
     start: str
-    schema: Union[str, Type[BaseModel]]
+    schema_: Union[str, Type[BaseModel]] = Field(alias="schema")
     end: str
 
 
@@ -163,7 +163,7 @@ class Grammar(XGRObject):
 
     @staticmethod
     def from_structural_tag(tags: List[StructuralTagItem], triggers: List[str]) -> "Grammar":
-        tags_tuple = [(tag.start, _handle_pydantic_schema(tag.schema), tag.end) for tag in tags]
+        tags_tuple = [(tag.start, _handle_pydantic_schema(tag.schema_), tag.end) for tag in tags]
         return Grammar._create_from_handle(_core.Grammar.from_structural_tag(tags_tuple, triggers))
 
     @staticmethod

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -204,7 +204,9 @@ class GrammarMatcher(XGRObject):
         """
         return self._handle.accept_token(token_id, debug_print)
 
-    def fill_next_token_bitmask(self, bitmask: torch.Tensor, index: int = 0) -> None:
+    def fill_next_token_bitmask(
+        self, bitmask: torch.Tensor, index: int = 0, *, debug_print: bool = False
+    ) -> None:
         """Fill the bitmask for the next token prediction. The input bitmask can be generated
         by allocate_token_bitmask, and must be on CPU. bitmask[index] will be filled with the
         next token bitmask.
@@ -223,7 +225,9 @@ class GrammarMatcher(XGRObject):
             raise ValueError("bitmask should be on CPU.")
         if bitmask.dtype != bitmask_dtype:
             raise ValueError(f"bitmask should be of type {bitmask_dtype}.")
-        self._handle.fill_next_token_bitmask(bitmask.data_ptr(), list(bitmask.shape), index)
+        self._handle.fill_next_token_bitmask(
+            bitmask.data_ptr(), list(bitmask.shape), index, debug_print
+        )
 
     def find_jump_forward_string(self) -> str:
         """Find the jump-forward string for jump-forward decoding. This is the longest string that

--- a/scripts/release_new_version.sh
+++ b/scripts/release_new_version.sh
@@ -10,8 +10,8 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-# Fetch and checkout main branch
-git fetch origin main
+# Pull and checkout main branch
+git pull origin main
 git checkout main
 git tag $1 HEAD
 git push origin $1

--- a/tests/cpp/test_fsm.cc
+++ b/tests/cpp/test_fsm.cc
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+
+#include "fsm.h"
+
+using namespace xgrammar;
+
+TEST(XGrammarFSMTest, BuildTrieTest) {
+  std::vector<std::string> patterns = {"hello", "hi", "哈哈", "哈", "hili", "good"};
+  auto fsm = BuildTrie(patterns);
+
+  // Test1: The printed result of FSM
+  std::stringstream ss;
+  ss << fsm;
+  std::string fsm_str = ss.str();
+  std::string fsm_str_expected = R"(FSM(num_nodes=19, start=0, end=[5, 6, 12, 9, 14, 18], edges=[
+0: [(104)->1, (229)->7, (103)->15]
+1: [(101)->2, (105)->6]
+2: [(108)->3]
+3: [(108)->4]
+4: [(111)->5]
+5: []
+6: [(108)->13]
+7: [(147)->8]
+8: [(136)->9]
+9: [(229)->10]
+10: [(147)->11]
+11: [(136)->12]
+12: []
+13: [(105)->14]
+14: []
+15: [(111)->16]
+16: [(111)->17]
+17: [(100)->18]
+18: []
+]))";
+
+  EXPECT_EQ(fsm_str, fsm_str_expected);
+
+  // Test2: The printed result of CompactFSM
+  auto compact_fsm = fsm.ToCompact();
+  ss.str("");
+  ss << compact_fsm;
+  std::string compact_fsm_str = ss.str();
+  std::string compact_fsm_str_expected =
+      R"(CompactFSM(num_nodes=19, start=0, end=[5, 6, 12, 9, 14, 18], edges=[
+0: [(103)->15, (104)->1, (229)->7]
+1: [(101)->2, (105)->6]
+2: [(108)->3]
+3: [(108)->4]
+4: [(111)->5]
+5: []
+6: [(108)->13]
+7: [(147)->8]
+8: [(136)->9]
+9: [(229)->10]
+10: [(147)->11]
+11: [(136)->12]
+12: []
+13: [(105)->14]
+14: []
+15: [(111)->16]
+16: [(111)->17]
+17: [(100)->18]
+18: []
+]))";
+
+  EXPECT_EQ(compact_fsm_str, compact_fsm_str_expected);
+
+  // Test3: Walk through the FSM
+  int state = fsm.StartNode();
+  EXPECT_EQ(state, 0);
+
+  // Test "hello"
+  state = fsm.StartNode();
+  EXPECT_EQ(fsm.Transition(state, 'h'), 1);
+  EXPECT_EQ(fsm.Transition(1, 'e'), 2);
+  EXPECT_EQ(fsm.Transition(2, 'l'), 3);
+  EXPECT_EQ(fsm.Transition(3, 'l'), 4);
+  EXPECT_EQ(fsm.Transition(4, 'o'), 5);
+  EXPECT_TRUE(fsm.IsEndNode(5));
+
+  // Test "hil"
+  state = fsm.StartNode();
+  EXPECT_EQ(fsm.Transition(state, 'h'), 1);
+  EXPECT_EQ(fsm.Transition(1, 'i'), 6);
+  EXPECT_EQ(fsm.Transition(6, 'l'), 13);
+  EXPECT_FALSE(fsm.IsEndNode(13));
+
+  // Test walk failure
+  state = fsm.StartNode();
+  EXPECT_EQ(fsm.Transition(state, 'g'), 15);
+  EXPECT_EQ(fsm.Transition(15, 'o'), 16);
+  EXPECT_EQ(fsm.Transition(16, 'e'), -1);
+}

--- a/tests/python/test_grammar_matcher.py
+++ b/tests/python/test_grammar_matcher.py
@@ -197,7 +197,7 @@ def test_rollback():
         result_after_rollback.append(new_token_bitmask2)
         assert matcher.accept_token(i_2)
         for l, r in zip(orig_result, result_after_rollback):
-            torch.testing.assert_allclose(l, r)
+            torch.testing.assert_close(l, r)
 
 
 def test_reset():
@@ -231,7 +231,7 @@ def test_reset():
         assert matcher.accept_token(i)
 
     for l, r in zip(orig_result, result_after_reset):
-        torch.testing.assert_allclose(l, r)
+        torch.testing.assert_close(l, r)
 
 
 def test_termination():

--- a/tests/python/test_grammar_matcher_json.py
+++ b/tests/python/test_grammar_matcher_json.py
@@ -2,7 +2,7 @@
 
 import sys
 import time
-from typing import List, Optional
+from typing import List
 
 import pytest
 import torch

--- a/tests/python/test_grammar_matcher_tag_dispatch.py
+++ b/tests/python/test_grammar_matcher_tag_dispatch.py
@@ -2,13 +2,12 @@
 a unoptimized, non-simplified EBNF string. This is to test the robustness of the grammar matcher.
 """
 
+import json
 import sys
 import time
 from typing import List
 
 import pytest
-import torch
-from aiohttp import TraceResponseChunkReceivedParams
 from pydantic import BaseModel
 from transformers import AutoTokenizer
 
@@ -220,11 +219,19 @@ def test_structural_tag_mask_gen():
 
     # Set up grammar from schemas
     tags = [
-        xgr.StructuralTagItem(start="<function=f>", schema=Schema1, end="</function>"),
-        xgr.StructuralTagItem(start="<function=g>", schema=Schema2, end="</function>"),
+        xgr.StructuralTagItem(
+            start="<function=f>", schema=json.dumps(Schema1.model_json_schema()), end="</function>"
+        ),
+        xgr.StructuralTagItem(
+            start="<function=g>", schema=json.dumps(Schema2.model_json_schema()), end="</function>"
+        ),
     ]
     triggers = ["<function=f", "<function=g"]
+    start = time.monotonic_ns()
     grammar = xgr.Grammar.from_structural_tag(tags, triggers)
+    end = time.monotonic_ns()
+    print(f"Time to init grammar: {(end - start) / 1e3} us")
+    exit()
 
     # Set up tokenizer
     tokenizer_id = "meta-llama/Llama-3.1-8B-Instruct"
@@ -281,5 +288,7 @@ def test_structural_tag_mask_gen():
     assert tokenizer.eos_token_id not in rejected_token_ids
 
 
+test_structural_tag_mask_gen()
+exit()
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_grammar_matcher_tag_dispatch.py
+++ b/tests/python/test_grammar_matcher_tag_dispatch.py
@@ -3,15 +3,12 @@ a unoptimized, non-simplified EBNF string. This is to test the robustness of the
 """
 
 import sys
-import time
 from typing import List
 
 import pytest
-import torch
-from transformers import AutoTokenizer
 
 import xgrammar as xgr
-from xgrammar.testing import _is_grammar_accept_string
+from xgrammar.testing import _get_masked_tokens_from_bitmask, _is_grammar_accept_string
 
 
 def test_simple():
@@ -26,6 +23,7 @@ rule2 ::= "efg"
     assert _is_grammar_accept_string(grammar, "tag1abcdqqqqtag2efg")
     assert not _is_grammar_accept_string(grammar, "tag1abc")
     assert not _is_grammar_accept_string(grammar, "tag1abce")
+    assert not _is_grammar_accept_string(grammar, "ttag1abd")
 
 
 def test_complex_rule():
@@ -39,6 +37,69 @@ rule2 ::= "efg" [t]*
     assert _is_grammar_accept_string(grammar, "tag1abcdppppptag2efg")
     assert _is_grammar_accept_string(grammar, "tag2efgtttttag1abc")
 
+
+def test_tag_dispatch_mask_generation_correctness():
+    grammar_str = """root ::= TagDispatch(("tag1", rule1), ("tag2", rule2))
+rule1 ::= "abc"
+rule2 ::= "dg"
+"""
+    tokens = [
+        # fmt: off
+        "a", "b", "c", "d", "g", "t", "1", "2", "1a", "2d", "2a", "2dgt",
+        "2dgtag1a", "2dgtag1b", "tag1a", "tag1b", "c哈哈t", "q", "abcdef"
+        # fmt: on
+    ]
+    input_str = "tag1abcqqtag2dgq"
+    expected_accepted_tokens = [
+        # fmt: off
+        ['a', 'b', 'c', 'd', 'g', 't', '1', '2', '1a', '2d', '2a', '2dgt', '2dgtag1a', 'tag1a', 'c哈哈t', 'q', 'abcdef'],
+        ['a', 'b', 'c', 'd', 'g', 't', '1', '2', '1a', '2d', '2a', '2dgt', '2dgtag1a', 'tag1a', 'c哈哈t', 'q', 'abcdef'],
+        ['a', 'b', 'c', 'd', 'g', 't', '1', '2', '1a', '2d', '2a', '2dgt', '2dgtag1a', 'tag1a', 'c哈哈t', 'q', 'abcdef'],
+        ['a', 'b', 'c', 'd', 'g', 't', '1', '2', '1a', '2d', '2dgt', '2dgtag1a', 'tag1a', 'c哈哈t', 'q', 'abcdef'],
+        ['a', 'abcdef'],
+        ['b'],
+        ['c哈哈t', 'c'],
+        ['a', 'b', 'c', 'd', 'g', 't', '1', '2', '1a', '2d', '2a', '2dgt', '2dgtag1a', 'tag1a', 'c哈哈t', 'q', 'abcdef'],
+        ['a', 'b', 'c', 'd', 'g', 't', '1', '2', '1a', '2d', '2a', '2dgt', '2dgtag1a', 'tag1a', 'c哈哈t', 'q', 'abcdef'],
+        ['a', 'b', 'c', 'd', 'g', 't', '1', '2', '1a', '2d', '2a', '2dgt', '2dgtag1a', 'tag1a', 'c哈哈t', 'q', 'abcdef'],
+        ['a', 'b', 'c', 'd', 'g', 't', '1', '2', '1a', '2d', '2a', '2dgt', '2dgtag1a', 'tag1a', 'c哈哈t', 'q', 'abcdef'],
+        ['a', 'b', 'c', 'd', 'g', 't', '1', '2', '1a', '2d', '2a', '2dgt', '2dgtag1a', 'tag1a', 'c哈哈t', 'q', 'abcdef'],
+        ['a', 'b', 'c', 'd', 'g', 't', '1', '2', '1a', '2d', '2dgt', '2dgtag1a', 'tag1a', 'c哈哈t', 'q', 'abcdef'],
+        ['d'],
+        ['g'],
+        ['a', 'b', 'c', 'd', 'g', 't', '1', '2', '1a', '2d', '2a', '2dgt', '2dgtag1a', 'tag1a', 'c哈哈t', 'q', 'abcdef'],
+        ['a', 'b', 'c', 'd', 'g', 't', '1', '2', '1a', '2d', '2a', '2dgt', '2dgtag1a', 'tag1a', 'c哈哈t', 'q', 'abcdef']
+        # fmt: on
+    ]
+
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    tokenizer_info = xgr.TokenizerInfo(tokens)
+    compiler = xgr.GrammarCompiler(tokenizer_info)
+    compiled_grammar = compiler.compile_grammar(grammar)
+    matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+    mask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+
+    # pad a dummy char to check the final bitmask after accepting the input string
+    for i, c in enumerate(input_str + "0"):
+        matcher.fill_next_token_bitmask(mask)
+        rejected_indices = _get_masked_tokens_from_bitmask(mask, tokenizer_info.vocab_size)
+        accepted_indices = list(set(range(tokenizer_info.vocab_size)) - set(rejected_indices))
+        accepted_tokens = [tokens[id] for id in accepted_indices]
+        if i < len(input_str):
+            assert matcher._debug_accept_string(c)
+        assert accepted_tokens == expected_accepted_tokens[i]
+
+
+# def test_tag_dispatch_mask_generation_real():
+#     grammar_str = """root ::= TagDispatch(("<function=func1>", rule1), ("<function=func2>", rule2))
+# rule1 ::= "abc"
+# rule2 ::= "def"
+# """
+#     grammar = xgr.Grammar.from_ebnf(grammar_str)
+#     tokenizer_info = xgr.TokenizerInfo(tokens)
+#     compiler = xgr.GrammarCompiler(tokenizer_info)
+#     compiled_grammar = compiler.compile_grammar(grammar)
+#     matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
 
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_grammar_matcher_tag_dispatch.py
+++ b/tests/python/test_grammar_matcher_tag_dispatch.py
@@ -15,17 +15,29 @@ from xgrammar.testing import _is_grammar_accept_string
 
 
 def test_simple():
-    grammar_str = """root ::= TagDispatch(("a", rule1), ("b", rule2))
+    grammar_str = """root ::= TagDispatch(("tag1", rule1), ("tag2", rule2))
 rule1 ::= "abcd"
 rule2 ::= "efg"
 """
 
     grammar = xgr.Grammar.from_ebnf(grammar_str)
-    assert _is_grammar_accept_string(grammar, "aabcd")
-    assert _is_grammar_accept_string(grammar, "aabcdbefg")
-    assert _is_grammar_accept_string(grammar, "aabcdqqqq")
-    assert not _is_grammar_accept_string(grammar, "aabc")
-    assert not _is_grammar_accept_string(grammar, "aabce")
+    assert _is_grammar_accept_string(grammar, "tag1abcd")
+    assert _is_grammar_accept_string(grammar, "tag1abcdtag2efg")
+    assert _is_grammar_accept_string(grammar, "tag1abcdqqqqtag2efg")
+    assert not _is_grammar_accept_string(grammar, "tag1abc")
+    assert not _is_grammar_accept_string(grammar, "tag1abce")
+
+
+def test_complex_rule():
+    grammar_str = """root ::= TagDispatch(("tag1", rule1), ("tag2", rule2))
+rule1 ::= "abcd" [p]*
+rule2 ::= "efg" [t]*
+"""
+
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    assert _is_grammar_accept_string(grammar, "tag1abcd")
+    assert _is_grammar_accept_string(grammar, "tag1abcdppppptag2efg")
+    assert _is_grammar_accept_string(grammar, "tag2efgtttttag1abc")
 
 
 if __name__ == "__main__":

--- a/tests/python/test_grammar_matcher_tag_dispatch.py
+++ b/tests/python/test_grammar_matcher_tag_dispatch.py
@@ -1,0 +1,32 @@
+"""This test is adopted from test_builtin_grammar_json.py, but the grammar is parsed from
+a unoptimized, non-simplified EBNF string. This is to test the robustness of the grammar matcher.
+"""
+
+import sys
+import time
+from typing import List
+
+import pytest
+import torch
+from transformers import AutoTokenizer
+
+import xgrammar as xgr
+from xgrammar.testing import _is_grammar_accept_string
+
+
+def test_simple():
+    grammar_str = """root ::= TagDispatch(("a", rule1), ("b", rule2))
+rule1 ::= "abcd"
+rule2 ::= "efg"
+"""
+
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    assert _is_grammar_accept_string(grammar, "aabcd")
+    assert _is_grammar_accept_string(grammar, "aabcdbefg")
+    assert _is_grammar_accept_string(grammar, "aabcdqqqq")
+    assert not _is_grammar_accept_string(grammar, "aabc")
+    assert not _is_grammar_accept_string(grammar, "aabce")
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)

--- a/tests/python/test_grammar_matcher_tag_dispatch.py
+++ b/tests/python/test_grammar_matcher_tag_dispatch.py
@@ -231,7 +231,7 @@ def test_structural_tag_mask_gen():
     grammar = xgr.Grammar.from_structural_tag(tags, triggers)
     end = time.monotonic_ns()
     print(f"Time to init grammar: {(end - start) / 1e3} us")
-    exit()
+    # exit()
 
     # Set up tokenizer
     tokenizer_id = "meta-llama/Llama-3.1-8B-Instruct"
@@ -288,7 +288,8 @@ def test_structural_tag_mask_gen():
     assert tokenizer.eos_token_id not in rejected_token_ids
 
 
-test_structural_tag_mask_gen()
-exit()
+# test_structural_tag_mask_gen()
+# exit()
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_grammar_matcher_tag_dispatch.py
+++ b/tests/python/test_grammar_matcher_tag_dispatch.py
@@ -3,9 +3,14 @@ a unoptimized, non-simplified EBNF string. This is to test the robustness of the
 """
 
 import sys
+import time
 from typing import List
 
 import pytest
+import torch
+from aiohttp import TraceResponseChunkReceivedParams
+from pydantic import BaseModel
+from transformers import AutoTokenizer
 
 import xgrammar as xgr
 from xgrammar.testing import _get_masked_tokens_from_bitmask, _is_grammar_accept_string
@@ -100,6 +105,181 @@ rule2 ::= "dg"
 #     compiler = xgr.GrammarCompiler(tokenizer_info)
 #     compiled_grammar = compiler.compile_grammar(grammar)
 #     matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+
+
+def test_structural_tag():
+    class Schema1(BaseModel):
+        arg1: str
+        arg2: int
+
+    class Schema2(BaseModel):
+        arg3: float
+        arg4: List[str]
+
+    tags = [
+        xgr.StructuralTagItem(start="<function=f1>", schema=Schema1, end="</function>"),
+        xgr.StructuralTagItem(start="<function=f2>", schema=Schema1, end="</function>"),
+        xgr.StructuralTagItem(start="<function=g>", schema=Schema2, end="</function>"),
+    ]
+    # in real cases, we should use one trigger: "<function=" and dispatch to two tags
+    # but here we use two triggers for testing such cases
+    triggers = ["<function=f", "<function=g"]
+
+    grammar = xgr.Grammar.from_structural_tag(tags, triggers)
+
+    expected_grammar = r"""root ::= TagDispatch(("<function=f", trigger_rule_0), ("<function=g", trigger_rule_1))
+trigger_rule_0 ::= (("1>" root_1 "</function>") | ("2>" root_2 "</function>"))
+basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_choice basic_number_3 basic_number_6))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]"))
+basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}"))
+root_1 ::= (("{" [ \n\t]* "\"arg1\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "," [ \n\t]* "\"arg2\"" [ \n\t]* ":" [ \n\t]* basic_integer [ \n\t]* "}"))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
+basic_number_3 ::= ("" | ("." basic_number_2))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
+basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
+basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
+basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
+basic_number_choice ::= (("0") | (basic_number_1 [1-9] [0-9]*))
+basic_escape_1 ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub_1 ::= (("\"") | ([^\"\\\r\n] basic_string_sub_1) | ("\\" basic_escape_1 basic_string_sub_1)) (=([ \n\t]* [,}\]:]))
+basic_any_1 ::= ((basic_number_7) | (basic_string_1) | (basic_boolean_1) | (basic_null_1) | (basic_array_2) | (basic_object_2))
+basic_integer_2 ::= (("0") | (basic_integer_1_1 [1-9] [0-9]*))
+basic_number_7 ::= ((basic_number_choice_1 basic_number_3_1 basic_number_6_1))
+basic_string_1 ::= (("\"" basic_string_sub_1))
+basic_boolean_1 ::= (("true") | ("false"))
+basic_null_1 ::= (("null"))
+basic_array_2 ::= (("[" [ \n\t]* basic_any_1 basic_array_1_1 [ \n\t]* "]"))
+basic_object_2 ::= (("{" [ \n\t]* basic_string_1 [ \n\t]* ":" [ \n\t]* basic_any_1 basic_object_1_1 [ \n\t]* "}"))
+root_2 ::= (("{" [ \n\t]* "\"arg1\"" [ \n\t]* ":" [ \n\t]* basic_string_1 [ \n\t]* "," [ \n\t]* "\"arg2\"" [ \n\t]* ":" [ \n\t]* basic_integer_2 [ \n\t]* "}"))
+basic_integer_1_1 ::= ("" | ("-"))
+basic_number_1_1 ::= ("" | ("-"))
+basic_number_2_1 ::= (([0-9] basic_number_2_1) | ([0-9]))
+basic_number_3_1 ::= ("" | ("." basic_number_2_1))
+basic_number_4_1 ::= ("" | ([+\-]))
+basic_number_5_1 ::= (([0-9] basic_number_5_1) | ([0-9]))
+basic_number_6_1 ::= ("" | ([eE] basic_number_4_1 basic_number_5_1))
+basic_array_1_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any_1 basic_array_1_1))
+basic_object_1_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string_1 [ \n\t]* ":" [ \n\t]* basic_any_1 basic_object_1_1))
+basic_number_choice_1 ::= (("0") | (basic_number_1_1 [1-9] [0-9]*))
+trigger_rule_1 ::= ((">" root_3 "</function>"))
+basic_escape_2 ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub_2 ::= (("\"") | ([^\"\\\r\n] basic_string_sub_2) | ("\\" basic_escape_2 basic_string_sub_2)) (=([ \n\t]* [,}\]:]))
+basic_any_2 ::= ((basic_number_8) | (basic_string_2) | (basic_boolean_2) | (basic_null_2) | (basic_array_3) | (basic_object_3))
+basic_integer_3 ::= (("0") | (basic_integer_1_2 [1-9] [0-9]*))
+basic_number_8 ::= ((basic_number_choice_2 basic_number_3_2 basic_number_6_2))
+basic_string_2 ::= (("\"" basic_string_sub_2))
+basic_boolean_2 ::= (("true") | ("false"))
+basic_null_2 ::= (("null"))
+basic_array_3 ::= (("[" [ \n\t]* basic_any_2 basic_array_1_2 [ \n\t]* "]"))
+basic_object_3 ::= (("{" [ \n\t]* basic_string_2 [ \n\t]* ":" [ \n\t]* basic_any_2 basic_object_1_2 [ \n\t]* "}"))
+root_prop_1 ::= (("[" [ \n\t]* basic_string_2 root_prop_1_1 [ \n\t]* "]"))
+root_3 ::= (("{" [ \n\t]* "\"arg3\"" [ \n\t]* ":" [ \n\t]* basic_number_8 [ \n\t]* "," [ \n\t]* "\"arg4\"" [ \n\t]* ":" [ \n\t]* root_prop_1 [ \n\t]* "}"))
+basic_integer_1_2 ::= ("" | ("-"))
+basic_number_1_2 ::= ("" | ("-"))
+basic_number_2_2 ::= (([0-9] basic_number_2_2) | ([0-9]))
+basic_number_3_2 ::= ("" | ("." basic_number_2_2))
+basic_number_4_2 ::= ("" | ([+\-]))
+basic_number_5_2 ::= (([0-9] basic_number_5_2) | ([0-9]))
+basic_number_6_2 ::= ("" | ([eE] basic_number_4_2 basic_number_5_2))
+basic_array_1_2 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any_2 basic_array_1_2))
+basic_object_1_2 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string_2 [ \n\t]* ":" [ \n\t]* basic_any_2 basic_object_1_2))
+root_prop_1_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string_2 root_prop_1_1))
+basic_number_choice_2 ::= (("0") | (basic_number_1_2 [1-9] [0-9]*))
+"""
+    assert str(grammar) == expected_grammar
+
+    accepted_inputs = [
+        '<function=f1>{"arg1": "abc", "arg2": 1}</function>',
+        '<function=g>{"arg3": 1.23, "arg4": ["a", "b", "c"]}</function>',
+        '<function=f2>{"arg1": "abc", "arg2": 1}</function><function=g>{"arg3": 1.23, "arg4": ["a", "b", "c"]}</function>',
+        'hhhh<function=g>{"arg3": 1.23, "arg4": ["a", "b", "c"]}</function>haha<function=f1>{"arg1": "abc", "arg2": 1}</function>123',
+    ]
+    for input in accepted_inputs:
+        assert _is_grammar_accept_string(grammar, input, print_time=True)
+
+
+def test_structural_tag_mask_gen():
+    # Define schemas for the test
+    class Schema1(BaseModel):
+        arg1: str
+        arg2: int
+
+    class Schema2(BaseModel):
+        arg3: float
+        arg4: List[str]
+
+    # Set up grammar from schemas
+    tags = [
+        xgr.StructuralTagItem(start="<function=f>", schema=Schema1, end="</function>"),
+        xgr.StructuralTagItem(start="<function=g>", schema=Schema2, end="</function>"),
+    ]
+    triggers = ["<function=f", "<function=g"]
+    grammar = xgr.Grammar.from_structural_tag(tags, triggers)
+
+    # Set up tokenizer
+    tokenizer_id = "meta-llama/Llama-3.1-8B-Instruct"
+    tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer_id,
+        use_fast=True,
+        trust_remote_code=True,
+    )
+    tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
+
+    # Compile grammar and create matcher
+    compiler = xgr.GrammarCompiler(tokenizer_info)
+    time_start = time.monotonic_ns()
+    matcher = xgr.GrammarMatcher(compiler.compile_grammar(grammar))
+    time_end = time.monotonic_ns()
+    print(f"Time to compile grammar and init GrammarMatcher: {(time_end - time_start) / 1e3} us")
+
+    # Test input string
+    accepted_input = 'hhhh<function=g>{"arg3": 1.23, "arg4": ["a", "b", "c"]}</function>haha<function=f>{"arg1": "abc", "arg2": 1}</function>123'
+    input_bytes = accepted_input.encode("utf-8")
+
+    # Set up token bitmask for validation
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+
+    # Process input character by character
+    for c in input_bytes:
+        # 1. Test token bitmask generation
+        time_start = time.monotonic_ns()
+        matcher.fill_next_token_bitmask(token_bitmask)
+        time_end = time.monotonic_ns()
+        print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
+
+        # 2. Verify token bitmask correctness
+        rejected_token_ids = _get_masked_tokens_from_bitmask(
+            token_bitmask, tokenizer_info.vocab_size
+        )
+        # This checking does not support non-ascii characters for now
+        token_id_for_next_char = tokenizer.convert_tokens_to_ids(chr(c))
+        assert token_id_for_next_char not in rejected_token_ids
+
+        # 3. Test character acceptance
+        print("Accepting char:", bytes([c]))
+        time_start = time.monotonic_ns()
+        assert matcher._debug_accept_string(bytes([c]))
+        time_end = time.monotonic_ns()
+        print(f"Time to accept_token: {(time_end - time_start) / 1e3} us")
+
+    # Final verification - check that EOS token is allowed
+    time_start = time.monotonic_ns()
+    matcher.fill_next_token_bitmask(token_bitmask)
+    time_end = time.monotonic_ns()
+    print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
+    rejected_token_ids = _get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size)
+    assert tokenizer.eos_token_id not in rejected_token_ids
+
 
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_tokenizer_info.py
+++ b/tests/python/test_tokenizer_info.py
@@ -223,16 +223,7 @@ def test_customized_tokenizer_info(tokenizer_path: str):
     assert tokenizer_info.special_token_ids[-5:] == [original_vocab_size + i for i in range(5)]
 
 
-@pytest.mark.parametrize("tokenizer_path", ["meta-llama/Llama-2-7b-chat-hf"])
-def test_special_token_detection(
-    tokenizer_path: str,
-    tokenizer_info_storage: Dict[str, Tuple[PreTrainedTokenizerBase, xgr.TokenizerInfo]],
-):
-    tokenizer = AutoTokenizer.from_pretrained(
-        tokenizer_path,
-        use_fast=True,
-        trust_remote_code=True,
-    )
+def test_special_token_detection():
     vocab_dict = {
         "": 0,
         "<s>": 1,
@@ -247,7 +238,7 @@ def test_special_token_detection(
         list(vocab_dict.keys()),
         '{"vocab_type":"BYTE_FALLBACK","vocab_size":8,"prepend_space_in_tokenization":true,"stop_token_ids":[2]}',
     )
-    expected_special_tokens = {0, 1, 2, 3, 5}
+    expected_special_tokens = {0, 1, 3, 5}
     assert set(tokenizer_info.special_token_ids) == expected_special_tokens
 
 


### PR DESCRIPTION
This PR 
- Supports the parsing and mask generation algorithm for TagDispatch in GrammarMatcherBase and GrammarMatcher
- Refactors GrammarMatcherBase and GrammarMatcher along the way
- Designs the CSRArray and FSM data structures which are useful in later architecture
- Supports the structural tag feature with the above backend support.

Description of the structural tag:

The structural tag handles the dispatching
of different grammars based on the tags and triggers: it initially allows any output,
until a trigger is encountered, then dispatch to the corresponding tag; when the end tag
is encountered, the grammar will allow any following output, until the next trigger is
encountered.

The tags parameter is used to specify the output pattern. It is especially useful for LLM
function calling, where the pattern is:
<function=func_name>{"arg1": ..., "arg2": ...}</function>.
This pattern consists of three parts: a start tag (<function=func_name>), a parameter list
according to some schema ({"arg1": ..., "arg2": ...}), and an end tag (</function>). This
pattern can be described in a StructuralTagItem with a start tag, a schema, and an end tag.
The structural tag is able to handle multiple such patterns by passing them into multiple
tags.

The triggers parameter is used to trigger the dispatching of different grammars. The trigger
should be a prefix of a provided start tag. When the trigger is encountered, the
corresponding tag should be used to constrain the following output. There can be multiple
tags matching the same trigger. Then if the trigger is encountered, the following output
should match one of the tags. For example, in function calling, the triggers can be
["<function="]. Then if "<function=" is encountered, the following output must match one
of the tags (e.g. `<function=get_weather>{"city": "Beijing"}</function>`).

The corrrespondence of tags and triggers is automatically determined: all tags with the
same trigger will be grouped together. User should make sure any trigger is not a prefix
of another trigger: then the corrrespondence of tags and triggers will be ambiguous.

To use this grammar in grammar-guided generation, the GrammarMatcher constructed from
structural tag will generate a mask for each token. When the trigger is not encountered,
the mask will likely be all-1 and not have to be used (fill_next_token_bitmask returns
False, meaning no token is masked). When a trigger is encountered, the mask should be
enforced (fill_next_token_bitmask will return True, meaning some token is masked) to the
output logits.

The benefit of this method is the token boundary between tags and triggers is automatically
handled. The user does not need to worry about the token boundary.