### PR TITLE
[Fix] Rollback safely when token acceptance fails

### DIFF
--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -314,6 +314,7 @@ bool GrammarMatcher::Impl::AcceptStopToken() {
     return false;
   }
   stack_tops_history_.PushHistory({});  // Terminate the matcher by setting the stack to empty
+  token_length_history.push_back(1);  // When rolling back a stop token, we need to rollback 1 state
   return true;
 }
 

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -373,6 +373,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
         XGRAMMAR_LOG(INFO) << "The token is rejected at position " << pos << ", character "
                            << PrintAsEscapedUTF8(char_value);
       }
+      RollbackChars(pos);
       return false;
     }
     ++pos;

--- a/tests/python/test_grammar_matcher.py
+++ b/tests/python/test_grammar_matcher.py
@@ -237,7 +237,7 @@ def test_reset():
 def test_termination():
     vocab = [
         # fmt: off
-        "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", "}", ", ", "6", ":", "\n", " ", '"a":true',
+        "<s>", "</s>", "a", "abc", 'b"', '"', ':"', "{", " }", ", ", "6", ":", "\n", " ", '"a"', ':true',
         # fmt: on
     ]
     input_splitted = [
@@ -249,8 +249,9 @@ def test_termination():
         "6",
         ", ",
         " ",
-        '"a":true',
-        "}",
+        '"a"',
+        ":true",
+        " }",
         "</s>",
     ]
     input_ids = [vocab.index(t) for t in input_splitted]


### PR DESCRIPTION
In `GrammarMatcher::Impl::AcceptToken`, if a char is not accepted, the matcher state is left broken because the partially-advanced token state remains in the matcher.

The below function, `GrammarMatcher::Impl::_DebugAcceptString`, handles this case correctly. I'm not sure why it isn't present in AcceptToken.

If this behaviour is not deliberate, please accept this fix so that AcceptToken can handle rejections gracefully.