### PR TITLE
[Feature] Optional Token Bitmask

### DIFF
--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -289,7 +289,8 @@ class GrammarMatcher::Impl : public GrammarMatcherBase {
       int32_t* bitmask_data_ptr,
       const DynamicBitset& accepted_bitset,
       const std::vector<int32_t>& rejected_indices,
-      bool can_reach_end
+      bool can_reach_end,
+      bool allow_special_token = false
   );
 
   /*!
@@ -489,13 +490,21 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
   // {-1} means the universal set, i.e. all tokens initially
   tmp_rejected_indices_.assign({-1});
 
+  // If there is a stack top that is a tag dispatch, we allow special tokens to be accepted
+  // because in function calling cases, only the part within the tag is constrained
+  bool have_tag_dispatch = false;
+
   for (auto top : latest_stack_tops) {
     auto cur_stack_element = persistent_stack_[top];
     auto cur_sequence = grammar_->GetRuleExpr(cur_stack_element.sequence_id);
-    if (cur_stack_element.parent_id == StackElement::kNoParent &&
-        cur_sequence.type != RuleExprType::kTagDispatch &&
+    if (cur_sequence.type != RuleExprType::kTagDispatch &&
+        cur_stack_element.parent_id == StackElement::kNoParent &&
         cur_stack_element.element_id == cur_sequence.size()) {
       continue;
+    }
+
+    if (cur_sequence.type == RuleExprType::kTagDispatch) {
+      have_tag_dispatch = true;
     }
 
     auto adaptive_token_mask_it = adaptive_token_mask_cache.find(cur_stack_element);
@@ -588,7 +597,13 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
 
   // Finally update the rejected_ids bitset
   bool can_reach_end = CanReachEnd();
-  SetTokenBitmask(bitmask_data_ptr, tmp_accepted_bitset_, tmp_rejected_indices_, can_reach_end);
+  SetTokenBitmask(
+      bitmask_data_ptr,
+      tmp_accepted_bitset_,
+      tmp_rejected_indices_,
+      can_reach_end,
+      have_tag_dispatch
+  );
   if (debug_print) {
     XGRAMMAR_LOG(INFO) << "Ended: " << can_reach_end
                        << ", filled bitmask: " << PrintBitmask(bitmask_data_ptr, tokenizer_info_);
@@ -701,7 +716,8 @@ void GrammarMatcher::Impl::SetTokenBitmask(
     int32_t* bitmask_data_ptr,
     const DynamicBitset& accepted_bitset,
     const std::vector<int32_t>& rejected_indices,
-    bool can_reach_end
+    bool can_reach_end,
+    bool allow_special_token
 ) {
   // next_token_bitmask = set(all accepted tokens) =
   // 1. all_tokens - (rejected_ids / accepted_ids)
@@ -717,6 +733,12 @@ void GrammarMatcher::Impl::SetTokenBitmask(
     // If rejected_indices is the universal set, the final accepted token set is just
     // accepted_indices
     next_token_bitset = accepted_bitset;
+
+    if (allow_special_token) {
+      for (int id : tokenizer_info_.GetSpecialTokenIds()) {
+        next_token_bitset.Set(id, true);
+      }
+    }
 
     if (can_reach_end) {
       // add end tokens
@@ -734,9 +756,10 @@ void GrammarMatcher::Impl::SetTokenBitmask(
         next_token_bitset.Set(id, false);
       }
     }
-
-    for (int id : tokenizer_info_.GetSpecialTokenIds()) {
-      next_token_bitset.Set(id, false);
+    if (!allow_special_token) {
+      for (int id : tokenizer_info_.GetSpecialTokenIds()) {
+        next_token_bitset.Set(id, false);
+      }
     }
     if (!can_reach_end) {
       for (int id : stop_token_ids_) {

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -302,7 +302,7 @@ class GrammarMatcher::Impl : public GrammarMatcherBase {
   bool IsStopTokenAccepted() const;
 
   /*! \brief Check if the token bitmask is all-true. */
-  bool CheckTokenBitmask(int32_t* bitmask_data_ptr);
+  bool IsTokenBitmaskAllTrue(int32_t* bitmask_data_ptr);
 
   std::string PrintBitmask(int32_t* bitmask_data_ptr, const TokenizerInfo& tokenizer_info);
 
@@ -461,7 +461,7 @@ std::string GrammarMatcher::Impl::PrintBitmask(
   return ss.str();
 }
 
-bool GrammarMatcher::Impl::CheckTokenBitmask(int32_t* bitmask_data_ptr) {
+bool GrammarMatcher::Impl::IsTokenBitmaskAllTrue(int32_t* bitmask_data_ptr) {
   DynamicBitset next_token_bitset(
       tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr)
   );
@@ -608,7 +608,7 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
     XGRAMMAR_LOG(INFO) << "Ended: " << can_reach_end
                        << ", filled bitmask: " << PrintBitmask(bitmask_data_ptr, tokenizer_info_);
   }
-  return !CheckTokenBitmask(bitmask_data_ptr);
+  return !IsTokenBitmaskAllTrue(bitmask_data_ptr);
 }
 
 std::string GrammarMatcher::Impl::FindJumpForwardString() {

--- a/cpp/pybind/python_methods.cc
+++ b/cpp/pybind/python_methods.cc
@@ -57,7 +57,7 @@ std::vector<pybind11::bytes> TokenizerInfo_GetDecodedVocab(const TokenizerInfo& 
   return py_result;
 }
 
-void GrammarMatcher_FillNextTokenBitmask(
+bool GrammarMatcher_FillNextTokenBitmask(
     GrammarMatcher& matcher,
     intptr_t token_bitmask_ptr,
     std::vector<int64_t> shape,
@@ -75,7 +75,7 @@ void GrammarMatcher_FillNextTokenBitmask(
       nullptr,
       0
   };
-  matcher.FillNextTokenBitmask(&bitmask_dltensor, index, debug_print);
+  return matcher.FillNextTokenBitmask(&bitmask_dltensor, index, debug_print);
 }
 
 std::vector<int> Matcher_DebugGetMaskedTokensFromBitmask(

--- a/cpp/pybind/python_methods.h
+++ b/cpp/pybind/python_methods.h
@@ -30,7 +30,7 @@ std::string TokenizerInfo_GetVocabType(const TokenizerInfo& tokenizer);
 
 std::vector<pybind11::bytes> TokenizerInfo_GetDecodedVocab(const TokenizerInfo& tokenizer);
 
-void GrammarMatcher_FillNextTokenBitmask(
+bool GrammarMatcher_FillNextTokenBitmask(
     GrammarMatcher& matcher,
     intptr_t token_bitmask_ptr,
     std::vector<int64_t> shape,

--- a/cpp/support/dynamic_bitset.h
+++ b/cpp/support/dynamic_bitset.h
@@ -148,6 +148,21 @@ class DynamicBitset {
     return count;
   }
 
+  bool All() const {
+    if (size_ == 0) return true;
+    // Check all complete blocks except the last one
+    for (int i = 0; i < buffer_size_ - 1; ++i) {
+      if (data_[i] != ~static_cast<uint32_t>(0)) {
+        return false;
+      }
+    }
+    // For the last block, create a mask for valid bits only
+    int remaining_bits = size_ % BITS_PER_BLOCK;
+    uint32_t last_block_mask = remaining_bits ? (static_cast<uint32_t>(1) << remaining_bits) - 1
+                                              : ~static_cast<uint32_t>(0);
+    return (data_[buffer_size_ - 1] & last_block_mask) == last_block_mask;
+  }
+
  private:
   static int LowestBit(uint32_t value) {
 #ifdef __GNUC__

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -92,8 +92,9 @@ class GrammarMatcher {
    * bitmask.
    * \param next_token_bitmask The bitmask to store the result. The bitmask must be pre-allocated
    * and with shape (GetBitmaskSize(),) and dtype int32.
+   * \return Whether the bitmask need to be applied (not all-true).
    */
-  void FillNextTokenBitmask(DLTensor* next_token_bitmask, int index = 0, bool debug_print = false);
+  bool FillNextTokenBitmask(DLTensor* next_token_bitmask, int index = 0, bool debug_print = false);
 
   /*!
    * \brief Find the jump-forward string for jump-forward decoding. This is the longest string that

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -206,7 +206,7 @@ class GrammarMatcher(XGRObject):
 
     def fill_next_token_bitmask(
         self, bitmask: torch.Tensor, index: int = 0, *, debug_print: bool = False
-    ) -> None:
+    ) -> bool:
         """Fill the bitmask for the next token prediction. The input bitmask can be generated
         by allocate_token_bitmask, and must be on CPU. bitmask[index] will be filled with the
         next token bitmask.
@@ -220,12 +220,21 @@ class GrammarMatcher(XGRObject):
 
         index : int, default: 0
             The batch id of the bitmask.
+
+        debug_print : bool, default: False
+            Whether to print information about generated bitmask. Helpful for debugging.
+
+        Returns
+        -------
+        need_apply : bool
+            Whether the bitmask need to be applied (not all-true). An optimization: if False,
+            this means the bitmask is already all-true, so no need to apply it.
         """
         if bitmask.device.type != "cpu":
             raise ValueError("bitmask should be on CPU.")
         if bitmask.dtype != bitmask_dtype:
             raise ValueError(f"bitmask should be of type {bitmask_dtype}.")
-        self._handle.fill_next_token_bitmask(
+        return self._handle.fill_next_token_bitmask(
             bitmask.data_ptr(), list(bitmask.shape), index, debug_print
         )
 

--- a/tests/python/test_grammar_matcher_json.py
+++ b/tests/python/test_grammar_matcher_json.py
@@ -294,7 +294,7 @@ def test_fill_next_token_bitmask(
     for i, c in enumerate(input_bytes):
         # 1. fill_next_token_bitmask
         time_start = time.monotonic_ns()
-        matcher.fill_next_token_bitmask(token_bitmask)
+        assert matcher.fill_next_token_bitmask(token_bitmask)
         time_end = time.monotonic_ns()
         print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
 

--- a/tests/python/test_grammar_matcher_tag_dispatch.py
+++ b/tests/python/test_grammar_matcher_tag_dispatch.py
@@ -271,9 +271,11 @@ def test_structural_tag_mask_gen():
     for c in input_bytes:
         # 1. Test token bitmask generation
         time_start = time.monotonic_ns()
-        matcher.fill_next_token_bitmask(token_bitmask)
+        need_apply = matcher.fill_next_token_bitmask(token_bitmask, debug_print=True)
         time_end = time.monotonic_ns()
         print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
+        if need_apply:
+            print("Need to apply token bitmask")
 
         # 2. Verify token bitmask correctness
         rejected_token_ids = _get_masked_tokens_from_bitmask(
@@ -298,6 +300,9 @@ def test_structural_tag_mask_gen():
     rejected_token_ids = _get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size)
     assert tokenizer.eos_token_id not in rejected_token_ids
 
+
+test_structural_tag_mask_gen()
+exit()
 
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_grammar_matcher_tag_dispatch.py
+++ b/tests/python/test_grammar_matcher_tag_dispatch.py
@@ -261,21 +261,29 @@ def test_structural_tag_mask_gen():
     print(f"Time to compile grammar and init GrammarMatcher: {(time_end - time_start) / 1e3} us")
 
     # Test input string
-    accepted_input = 'hhhh<function=g>{"arg3": 1.23, "arg4": ["a", "b", "c"]}</function>haha<function=f>{"arg1": "abc", "arg2": 1}</function>123'
+    accepted_input = (
+        'hhhh<function=g>{"arg3": 1.23, "arg4": ["a", "b", "c"]}</function>'
+        'haha<function=f>{"arg1": "abc", "arg2": 1}</function>123'
+    )
+    dont_apply_mask_indices = [
+        # fmt: off
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
+        77, 78, 119, 120, 121, 122
+        # fmt: on
+    ]
     input_bytes = accepted_input.encode("utf-8")
 
     # Set up token bitmask for validation
     token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
 
     # Process input character by character
-    for c in input_bytes:
+    for i, c in enumerate(input_bytes):
         # 1. Test token bitmask generation
         time_start = time.monotonic_ns()
-        need_apply = matcher.fill_next_token_bitmask(token_bitmask, debug_print=True)
+        need_apply = matcher.fill_next_token_bitmask(token_bitmask)
         time_end = time.monotonic_ns()
         print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
-        if need_apply:
-            print("Need to apply token bitmask")
+        assert need_apply == (i not in dont_apply_mask_indices)
 
         # 2. Verify token bitmask correctness
         rejected_token_ids = _get_masked_tokens_from_bitmask(
@@ -286,7 +294,7 @@ def test_structural_tag_mask_gen():
         assert token_id_for_next_char not in rejected_token_ids
 
         # 3. Test character acceptance
-        print("Accepting char:", bytes([c]))
+        # print("Accepting char:", bytes([c]))
         time_start = time.monotonic_ns()
         assert matcher._debug_accept_string(bytes([c]))
         time_end = time.monotonic_ns()
@@ -294,15 +302,13 @@ def test_structural_tag_mask_gen():
 
     # Final verification - check that EOS token is allowed
     time_start = time.monotonic_ns()
-    matcher.fill_next_token_bitmask(token_bitmask)
+    need_apply = matcher.fill_next_token_bitmask(token_bitmask)
     time_end = time.monotonic_ns()
+    assert need_apply == (len(input_bytes) not in dont_apply_mask_indices)
     print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
     rejected_token_ids = _get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size)
     assert tokenizer.eos_token_id not in rejected_token_ids
 
-
-test_structural_tag_mask_gen()
-exit()
 
 if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
Sometimes the bitmask is all-true, which means the mask don't need to be applied. This is especially common for function calling cases because we only constrain the part within the tag, and for the part out of tag, all tokens are allowed.


This PR introduces a bool return value for `FillNextTokenBitmask` to represent if the filled bitmask need to applied. If false, user can skip applying the bitmask.

This PR also updates the logic for TagDispatch, so that when the stack top is at an tag dispatch rule (corresponding to the part out of tag), the special tokens are allowed.