### PR TITLE
fix(fsm): fix error of dangling-reference in gcc-13

### DIFF
--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -208,8 +208,9 @@ inline std::ostream& operator<<(std::ostream& os, const FSM& fsm) {
   os << "], edges=[\n";
   for (int i = 0; i < fsm.NumNodes(); ++i) {
     os << i << ": [";
+    const auto& edges = fsm.edges_[i];
     for (int j = 0; j < static_cast<int>(fsm.edges_[i].size()); ++j) {
-      const auto& edge = fsm.edges_[i][j];
+      const auto& edge = edges[j];
       if (edge.min_ch == edge.max_ch) {
         os << "(" << edge.min_ch << ")->" << edge.target;
       } else {
@@ -236,8 +237,9 @@ inline std::ostream& operator<<(std::ostream& os, const CompactFSM& fsm) {
   os << "], edges=[\n";
   for (int i = 0; i < fsm.NumNodes(); ++i) {
     os << i << ": [";
+    const auto& edges = fsm.edges_[i];
     for (int j = 0; j < static_cast<int>(fsm.edges_[i].size()); ++j) {
-      const auto& edge = fsm.edges_[i][j];
+      const auto& edge = edges[j];
       if (edge.min_ch == edge.max_ch) {
         os << "(" << edge.min_ch << ")->" << edge.target;
       } else {


### PR DESCRIPTION
When compiling with `gcc-13.2.0`, we encountered a false-positive "dangling-reference" warning.

To mitigate this issue, we now construct the object outside the inner loop to prevent the false positive.

For more details on this gcc bug, refer to [this article](https://trofi.github.io/posts/264-gcc-s-new-Wdangling-reference-warning.html).