### PR TITLE
test lazy character class

### DIFF
--- a/tests/python/test_grammar_matcher_regex.py
+++ b/tests/python/test_grammar_matcher_regex.py
@@ -86,6 +86,8 @@ test_advanced_regex_string_instance_is_accepted = [
     (r"[a-z0-9]+", "ABC", False),
     (r"[^abc]+", "def", True),
     (r"[^abc]+", "aaa", False),
+    # Lazy character class
+    (r"[abc]+?abc", "aabc", True),
     # Quantifiers
     (r"a*b+c?", "b", True),
     (r"a*b+c?", "aaabbc", True),


### PR DESCRIPTION
There is an issue with the compiler and lazy character classes.

The test I have added will raise the following exception:
`RuntimeError: [12:25:32] /workspace/cpp/grammar_parser.cc:78: EBNF parse error at line 1, column 16: Expect element`