### PR TITLE
[Fix] Fix regex converter

### DIFF
--- a/cpp/grammar_matcher_base.cc
+++ b/cpp/grammar_matcher_base.cc
@@ -189,7 +189,10 @@ void GrammarMatcherBase::ExpandEquivalentStackElements(
       XGRAMMAR_DCHECK(cur_rule_body.type == RuleExprType::kChoices);
       for (auto sequence_id : cur_rule_body) {
         auto ref_rule_sequence = grammar_->GetRuleExpr(sequence_id);
-        if (ref_rule_sequence.type == RuleExprType::kEmptyStr) {
+        if (ref_rule_sequence.type == RuleExprType::kEmptyStr &&
+            cur_stack_element.parent_id != StackElement::kNoParent) {
+          // If the empty string is in a root rule, it indicates the end of the grammar and we
+          // just add it as a stack top to indicate the matching ends.
           continue;
         }
         auto new_stack_element =

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -12,6 +12,7 @@
 #include "grammar_builder.h"
 #include "grammar_data_structure.h"
 #include "support/encoding.h"
+#include "support/logging.h"
 
 namespace xgrammar {
 
@@ -75,6 +76,7 @@ class EBNFParser {
 
   // Report a parsing error with the given message and the line and column number.
   [[noreturn]] void ReportParseError(const std::string& msg) {
+    PrintTrace();
     XGRAMMAR_LOG(FATAL) << "EBNF parse error at line " + std::to_string(cur_line_) + ", column " +
                                std::to_string(cur_column_) + ": " + msg;
   }

--- a/cpp/support/cpptrace.h
+++ b/cpp/support/cpptrace.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2024 by Contributors
  * \file xgrammar/support/cpptrace.h
  * \details This file is an encapsulation of the cpptrace library. It helps debugging. This file
- * can only be included when XGRAMMAR_ENABLE_CPPTRACE is set to ON, and only support Linux and
+ * takes effect only when XGRAMMAR_ENABLE_CPPTRACE is set to 1, and only support Linux and
  * RelWithDebugInfo or Debug build.
  */
 #ifndef XGRAMMAR_SUPPORT_CPPTRACE_H_

--- a/cpp/support/logging.h
+++ b/cpp/support/logging.h
@@ -12,6 +12,8 @@
 #include <sstream>
 #include <string>
 
+#include "cpptrace.h"
+
 /*!
  * \brief Whether or not customize the logging output.
  *  If log customize is enabled, the user must implement


### PR DESCRIPTION
This PR fixes these issues in regex converter:
- Adds validation for empty character classes [] which are now properly rejected
- Implements support for non-capturing groups (?:...) and named capturing groups (?<name>...)
- Adds proper error handling for unmatched parentheses
- Implements support for empty alternatives in groups like (a|)
- Adds validation for unsupported regex features with clear error messages:
  - Lookaheads ((?=...), (?!...))
  - Lookbehinds ((?<=...), (?<!...))
  - Inline modifiers ((?i))
