### PR TITLE
[Fix] Fix problems in regex converter

### DIFF
--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -34,7 +34,13 @@ Grammar Grammar::FromJSONSchema(
   return FromEBNF(ebnf_string);
 }
 
-Grammar Grammar::FromRegex(const std::string& regex) { return FromEBNF(RegexToEBNF(regex)); }
+Grammar Grammar::FromRegex(const std::string& regex, bool print_converted_ebnf) {
+  auto ebnf_string = RegexToEBNF(regex);
+  if (print_converted_ebnf) {
+    XGRAMMAR_LOG(INFO) << "Converted EBNF: " << ebnf_string << std::endl;
+  }
+  return FromEBNF(ebnf_string);
+}
 
 Grammar Grammar::FromStructuralTag(
     const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -33,7 +33,7 @@ class EBNFParser {
   int32_t ParseElement();
   int64_t ParseInteger();
   std::pair<int64_t, int64_t> ParseRepetitionRange();
-  int32_t ParseQuantifier();
+  int32_t ParseElementWithQuantifier();
   int32_t ParseLookaheadAssertion();
   int32_t ParseSequence();
   int32_t ParseChoices();
@@ -42,7 +42,8 @@ class EBNFParser {
   Rule ParseRule();
 
   // Helper functions
-  // Helper for ParseQuantifier
+
+  // Helper for ParseElementWithQuantifier
   int32_t HandleStarQuantifier(int32_t rule_expr_id);
   int32_t HandlePlusQuantifier(int32_t rule_expr_id);
   int32_t HandleQuestionQuantifier(int32_t rule_expr_id);
@@ -76,7 +77,6 @@ class EBNFParser {
 
   // Report a parsing error with the given message and the line and column number.
   [[noreturn]] void ReportParseError(const std::string& msg) {
-    PrintTrace();
     XGRAMMAR_LOG(FATAL) << "EBNF parse error at line " + std::to_string(cur_line_) + ", column " +
                                std::to_string(cur_column_) + ": " + msg;
   }
@@ -256,6 +256,11 @@ int32_t EBNFParser::ParseElement() {
     case '(': {
       Consume();
       ConsumeSpace();
+      if (Peek() == ')') {
+        // Special case: ( )
+        Consume();
+        return builder_.AddEmptyStr();
+      }
       auto prev_in_parentheses = in_parentheses_;
       in_parentheses_ = true;
       auto rule_expr_id = ParseChoices();
@@ -437,7 +442,7 @@ int32_t EBNFParser::HandleRepetitionRange(int32_t rule_expr_id, int64_t lower, i
   return builder_.AddSequence(elements);
 }
 
-int32_t EBNFParser::ParseQuantifier() {
+int32_t EBNFParser::ParseElementWithQuantifier() {
   int32_t rule_expr_id = ParseElement();
   ConsumeSpace(in_parentheses_);
   if (Peek() != '*' && Peek() != '+' && Peek() != '?' && Peek() != '{') {
@@ -470,7 +475,7 @@ int32_t EBNFParser::ParseQuantifier() {
 int32_t EBNFParser::ParseSequence() {
   std::vector<int32_t> elements;
   do {
-    elements.push_back(ParseQuantifier());
+    elements.push_back(ParseElementWithQuantifier());
     ConsumeSpace(in_parentheses_);
   } while (Peek() && Peek() != '|' && Peek() != ')' && Peek() != '\n' && Peek() != '\r' &&
            (Peek() != '(' || Peek(1) != '='));

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -288,7 +288,9 @@ int32_t EBNFParser::ParseElement() {
       if (IsNameChar(Peek(), true)) {
         return ParseRuleRef();
       }
-      ReportParseError("Expect element");
+      ReportParseError(
+          "Expect element, but got character: " + std::string(1, static_cast<char>(Peek()))
+      );
     }
   }
 }

--- a/cpp/regex_converter.cc
+++ b/cpp/regex_converter.cc
@@ -332,8 +332,17 @@ std::string RegexConverter::Convert() {
     } else if (*current_ == '*' || *current_ == '+' || *current_ == '?') {
       result_ebnf_ += static_cast<char>(*current_);
       ++current_;
+      if (current_ != end_ && *current_ == '?') {
+        // Ignore the non-greedy modifier because our grammar handles all repetition numbers
+        // non-deterministically.
+        ++current_;
+      }
     } else if (*current_ == '{') {
       result_ebnf_ += HandleRepetitionRange();
+      if (current_ != end_ && *current_ == '?') {
+        // Still ignore the non-greedy modifier.
+        ++current_;
+      }
     } else if (*current_ == '|') {
       AddEBNFSegment("|");
       ++current_;

--- a/cpp/regex_converter.cc
+++ b/cpp/regex_converter.cc
@@ -337,11 +337,19 @@ std::string RegexConverter::Convert() {
         // non-deterministically.
         ++current_;
       }
+      if (current_ != end_ &&
+          (*current_ == '{' || *current_ == '*' || *current_ == '+' || *current_ == '?')) {
+        RaiseError("Two consecutive repetition modifiers are not allowed.");
+      }
     } else if (*current_ == '{') {
       result_ebnf_ += HandleRepetitionRange();
       if (current_ != end_ && *current_ == '?') {
         // Still ignore the non-greedy modifier.
         ++current_;
+      }
+      if (current_ != end_ &&
+          (*current_ == '{' || *current_ == '*' || *current_ == '+' || *current_ == '?')) {
+        RaiseError("Two consecutive repetition modifiers are not allowed.");
       }
     } else if (*current_ == '|') {
       AddEBNFSegment("|");
@@ -358,7 +366,7 @@ std::string RegexConverter::Convert() {
     }
   }
   if (parenthesis_level_ != 0) {
-    RaiseError("The paranthesis is not closed.");
+    RaiseError("The parenthesis is not closed.");
   }
   return result_ebnf_;
 }

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -116,8 +116,10 @@ class Grammar {
   /*!
    * \brief Construct a grammar from a regular expression string.
    * \param regex The regular expression string.
+   * \param print_converted_ebnf This method will convert the regex to EBNF first. If this is true,
+   * the converted EBNF string will be printed. For debugging purpose. Default: false.
    */
-  static Grammar FromRegex(const std::string& regex);
+  static Grammar FromRegex(const std::string& regex, bool print_converted_ebnf = false);
 
   /*!
    * \brief Construct a grammar from a regular expression string.

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -155,13 +155,17 @@ class Grammar(XGRObject):
         )
 
     @staticmethod
-    def from_regex(regex_string: str) -> "Grammar":
+    def from_regex(regex_string: str, *, print_converted_ebnf: bool = False) -> "Grammar":
         """Create a grammar from a regular expression string.
 
         Parameters
         ----------
         regex_string : str
             The regular expression pattern to create the grammar from.
+
+        print_converted_ebnf : bool, default: False
+            This method will convert the regex pattern to EBNF first. If this is true, the converted
+            EBNF string will be printed. For debugging purpose. Default: False.
 
         Returns
         -------
@@ -173,7 +177,9 @@ class Grammar(XGRObject):
         RuntimeError
             When parsing the regex pattern fails, with details about the parsing error.
         """
-        return Grammar._create_from_handle(_core.Grammar.from_regex(regex_string))
+        return Grammar._create_from_handle(
+            _core.Grammar.from_regex(regex_string, print_converted_ebnf)
+        )
 
     @staticmethod
     def from_structural_tag(tags: List[StructuralTagItem], triggers: List[str]) -> "Grammar":

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -165,7 +165,7 @@ class Grammar(XGRObject):
 
         print_converted_ebnf : bool, default: False
             This method will convert the regex pattern to EBNF first. If this is true, the converted
-            EBNF string will be printed. For debugging purpose. Default: False.
+            EBNF string will be printed. For debugging purposes. Default: False.
 
         Returns
         -------

--- a/tests/python/test_grammar_matcher_regex.py
+++ b/tests/python/test_grammar_matcher_regex.py
@@ -61,9 +61,7 @@ test_regex_refuse_regex_input_refused = (
     r"a{,3}",  # Invalid range
     r"a{3,2}",  # Invalid range (max < min)
     r"[z-a]",  # Invalid range (max < min)
-    r"a??",  # Invalid repetition
     r"a++",  # Invalid repetition
-    r"(?:a)",  # Non-capturing groups not supported
     r"(?=a)",  # Lookahead not supported
     r"(?!a)",  # Negative lookahead not supported
 )

--- a/tests/python/test_grammar_parser.py
+++ b/tests/python/test_grammar_parser.py
@@ -185,6 +185,26 @@ root_choice ::= (("b") | ("cd"))
     assert after == expected
 
 
+def test_empty_parentheses():
+    before = """root ::= "a" ( ) "b"
+"""
+    expected = """root ::= (("ab"))
+"""
+    grammar = xgr.Grammar.from_ebnf(before)
+    after = str(grammar)
+    assert after == expected
+
+    before = """root ::= "a" rule1
+rule1 ::= ( )
+"""
+    expected = """root ::= (("a" rule1))
+rule1 ::= ("")
+"""
+    grammar = xgr.Grammar.from_ebnf(before)
+    after = str(grammar)
+    assert after == expected
+
+
 def test_tag_dispatch():
     before = """root ::= TagDispatch(("tag1", rule1), ("tag2", rule2), ("tag3", rule3))
 rule1 ::= "a"

--- a/tests/python/test_grammar_parser.py
+++ b/tests/python/test_grammar_parser.py
@@ -74,8 +74,7 @@ d_1_choice ::= (("bcd") | ("pq"))
     after = str(grammar)
     assert after == expected
 
-
-def test_star_quantifier_bugfix():
+    # Here rule1 can be empty
     before = """root ::= [a]* [b]* rule1
 rule1 ::= [abc]* [def]*
 """
@@ -85,6 +84,32 @@ rule1 ::= (([abc]* [def]*))
     grammar = xgr.Grammar.from_ebnf(before)
     after = str(grammar)
     assert after == expected
+
+
+def test_consecutive_quantifiers():
+    grammar_str = """root ::= "a"{1,3}{1,3}
+"""
+    with pytest.raises(
+        RuntimeError,
+        match="EBNF parse error at line 1, column 18: Expect element, but got character: {",
+    ):
+        xgr.Grammar.from_ebnf(grammar_str)
+
+    grammar_str = """root ::= "a"++
+"""
+    with pytest.raises(
+        RuntimeError,
+        match="EBNF parse error at line 1, column 14: Expect element, but got character: +",
+    ):
+        xgr.Grammar.from_ebnf(grammar_str)
+
+    grammar_str = """root ::= "a"??
+"""
+    with pytest.raises(
+        RuntimeError,
+        match="EBNF parse error at line 1, column 14: Expect element, but got character: ?",
+    ):
+        xgr.Grammar.from_ebnf(grammar_str)
 
 
 def test_repetition_range():

--- a/tests/python/test_regex_converter.py
+++ b/tests/python/test_regex_converter.py
@@ -352,6 +352,47 @@ def test_empty_alternative():
     assert not _is_grammar_accept_string(grammar_str, "abd")
 
 
+def test_non_greedy_quantifier():
+    regex = "a{1,3}?"
+    grammar_str = _regex_to_ebnf(regex)
+    expected_grammar = r"""root ::= "a"{1,3}
+"""
+    assert grammar_str == expected_grammar
+    assert _is_grammar_accept_string(grammar_str, "a")
+    assert _is_grammar_accept_string(grammar_str, "aa")
+    assert _is_grammar_accept_string(grammar_str, "aaa")
+    assert not _is_grammar_accept_string(grammar_str, "aaaa")
+
+    regex = "a+?"
+    grammar_str = _regex_to_ebnf(regex)
+    expected_grammar = r"""root ::= "a"+
+"""
+    assert grammar_str == expected_grammar
+    assert _is_grammar_accept_string(grammar_str, "a")
+    assert _is_grammar_accept_string(grammar_str, "aa")
+    assert _is_grammar_accept_string(grammar_str, "aaa")
+    assert not _is_grammar_accept_string(grammar_str, "")
+
+    regex = "a*?"
+    grammar_str = _regex_to_ebnf(regex)
+    expected_grammar = r"""root ::= "a"*
+"""
+    assert grammar_str == expected_grammar
+    assert _is_grammar_accept_string(grammar_str, "a")
+    assert _is_grammar_accept_string(grammar_str, "aa")
+    assert _is_grammar_accept_string(grammar_str, "aaa")
+    assert _is_grammar_accept_string(grammar_str, "")
+
+    regex = "a??"
+    grammar_str = _regex_to_ebnf(regex)
+    expected_grammar = r"""root ::= "a"?
+"""
+    assert grammar_str == expected_grammar
+    assert _is_grammar_accept_string(grammar_str, "a")
+    assert _is_grammar_accept_string(grammar_str, "")
+    assert not _is_grammar_accept_string(grammar_str, "aa")
+
+
 tokenizer_paths = ["meta-llama/Llama-2-7b-chat-hf", "meta-llama/Meta-Llama-3-8B-Instruct"]
 regex_instances = [
     (r".+a.+", "bbbabb"),

--- a/tests/python/test_regex_converter.py
+++ b/tests/python/test_regex_converter.py
@@ -128,6 +128,24 @@ def test_quantifier():
     assert _is_grammar_accept_string(grammar_str, instance1)
 
 
+def test_consecutive_quantifiers():
+    regex = "a{1,3}?{1,3}"
+    with pytest.raises(RuntimeError, match="Two consecutive repetition modifiers are not allowed."):
+        _regex_to_ebnf(regex)
+
+    regex = "a???"
+    with pytest.raises(RuntimeError, match="Two consecutive repetition modifiers are not allowed."):
+        _regex_to_ebnf(regex)
+
+    regex = "a++"
+    with pytest.raises(RuntimeError, match="Two consecutive repetition modifiers are not allowed."):
+        _regex_to_ebnf(regex)
+
+    regex = "a+?{1,3}"
+    with pytest.raises(RuntimeError, match="Two consecutive repetition modifiers are not allowed."):
+        _regex_to_ebnf(regex)
+
+
 def test_group():
     regex = r"(a|b)(c|d)"
     instance = "ac"
@@ -308,7 +326,7 @@ def test_unmatched_parentheses():
         _regex_to_ebnf(regex)
 
     regex = "abc((a)"
-    with pytest.raises(RuntimeError, match="Unmatched '\\)'"):
+    with pytest.raises(RuntimeError, match="The parenthesis is not closed."):
         _regex_to_ebnf(regex)
 
 

--- a/tests/python/test_regex_converter.py
+++ b/tests/python/test_regex_converter.py
@@ -307,7 +307,30 @@ def test_unmatched_parentheses():
     with pytest.raises(RuntimeError, match="Unmatched '\\)'"):
         _regex_to_ebnf(regex)
 
-    # Test empty alternative with closing parenthesis
+    regex = "abc((a)"
+    with pytest.raises(RuntimeError, match="Unmatched '\\)'"):
+        _regex_to_ebnf(regex)
+
+
+def test_empty_parentheses():
+    regex = "()"
+    grammar_str = _regex_to_ebnf(regex)
+    print(grammar_str)
+    expected_grammar = r"""root ::= ( )
+"""
+    assert grammar_str == expected_grammar
+    assert _is_grammar_accept_string(grammar_str, "")
+
+    regex = "a()b"
+    grammar_str = _regex_to_ebnf(regex)
+    print(grammar_str)
+    expected_grammar = r"""root ::= "a" ( ) "b"
+"""
+    assert grammar_str == expected_grammar
+    assert _is_grammar_accept_string(grammar_str, "ab")
+
+
+def test_empty_alternative():
     regex = "(a|)"
     grammar_str = _regex_to_ebnf(regex)
     expected_grammar = r"""root ::= ( "a" | "" )
@@ -317,7 +340,7 @@ def test_unmatched_parentheses():
     assert _is_grammar_accept_string(grammar_str, "")
     assert not _is_grammar_accept_string(grammar_str, "b")
 
-    # Test unmatched opening parenthesis
+    # Nested case
     regex = "ab(c|)"
     grammar_str = _regex_to_ebnf(regex)
     print(grammar_str)


### PR DESCRIPTION
This PR supports the empty parentheses `()` and non-greedy modifier `?` in regex. It also forbids consecutive quantifiers (e.g. `++`, `{1,2}{1,2}`) in the regex and EBNF.

It also provides a `print_converted_ebnf` parameter for `Grammar.from_regex`, helping debugging.