### PR TITLE
[Maintain] Add no-sort to toml fmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,4 +72,4 @@ repos:
     rev: v2.14.0
     hooks:
       - id: pretty-format-toml
-        args: [--autofix, --indent, "2"]
+        args: [--autofix, --indent, "2", "--no-sort"]


### PR DESCRIPTION
This PR avoids sorting the toml file.