### PR TITLE
[Maintain] Support Python 3.13 for Manylinux

### DIFF
--- a/scripts/build_xgrammar_wheel_manylinux.sh
+++ b/scripts/build_xgrammar_wheel_manylinux.sh
@@ -39,7 +39,7 @@ function audit_xgrammar_wheel() {
 }
 
 XGRAMMAR_PYTHON_DIR="/workspace/python"
-PYTHON_VERSIONS_CPU=("3.9" "3.10" "3.11" "3.12")
+PYTHON_VERSIONS_CPU=("3.9" "3.10" "3.11" "3.12" "3.13")
 
 while [[ $# -gt 0 ]]; do
     arg="$1"


### PR DESCRIPTION
This PR supports Python 3.13 for linux wheels. Other platforms are upcoming.