### PR TITLE
[Fix] Fix compatibility for apply_token_bitmask_inplace

### DIFF
--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu
@@ -23,6 +23,14 @@
 #include <ATen/cuda/CUDAContext.h>
 // clang-format on
 
+#ifndef CUDART_INF_FP16
+#define CUDART_INF_FP16 __ushort_as_half((unsigned short)0x7C00U)
+#endif
+
+#ifndef CUDART_INF_BF16
+#define CUDART_INF_BF16 __ushort_as_bfloat16((unsigned short)0x7F80U)
+#endif
+
 constexpr int32_t kBitsPerMaskElement = 32;
 constexpr int32_t kThreadsPerBlock = 256;
 

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu
@@ -27,207 +27,207 @@ int32_t constexpr kBitsPerMaskElement = 32;
 int32_t constexpr kThreadsPerBlock = 256;
 
 template <typename T>
-__device__ T negativeInfinity() {
+__device__ T NegativeInfinity() {
   return -INFINITY;
 }
 
 template <>
-__device__ __half negativeInfinity<__half>() {
+__device__ __half NegativeInfinity<__half>() {
   return -CUDART_INF_FP16;
 }
 
 template <>
-__device__ __nv_bfloat16 negativeInfinity<__nv_bfloat16>() {
+__device__ __nv_bfloat16 NegativeInfinity<__nv_bfloat16>() {
   return -CUDART_INF_BF16;
 }
 
 template <typename T, typename PackedT>
-__device__ PackedT packedNegativeInfinity() {
+__device__ PackedT PackedNegativeInfinity() {
   int constexpr kAlignment = sizeof(PackedT) / sizeof(T);
   T packed[kAlignment];
 #pragma unroll
   for (int i = 0; i < kAlignment; i++) {
-    packed[i] = negativeInfinity<T>();
+    packed[i] = NegativeInfinity<T>();
   }
   return *reinterpret_cast<PackedT*>(packed);
 }
 
 template <typename T, typename PackedT, int32_t kBitsPerThread>
-__global__ void __launch_bounds__(kThreadsPerBlock) logitsBitmaskKernel(
+__global__ void __launch_bounds__(kThreadsPerBlock) LogitsBitmaskKernel(
     T* __restrict__ logits,
     int32_t const* __restrict__ bitmask,
     int32_t const* __restrict__ indices,
-    int32_t vocabSize,
-    int32_t bitmaskSize
+    int32_t vocab_size,
+    int32_t bitmask_size
 ) {
   int constexpr kAlignment = sizeof(PackedT) / sizeof(T);
   uint32_t constexpr kPackedMask = (1 << kAlignment) - 1;
 
-  int const batchIdx = (indices == nullptr) ? blockIdx.y : indices[blockIdx.y];
+  int const batch_idx = (indices == nullptr) ? blockIdx.y : indices[blockIdx.y];
 
-  int const blockOffset = blockIdx.x * kThreadsPerBlock * kBitsPerThread;
-  T* logitsGmemPtr = logits + batchIdx * vocabSize + blockOffset;
-  int32_t const* bitmaskGmemPtr =
-      bitmask + batchIdx * bitmaskSize + blockOffset / kBitsPerMaskElement;
-  int const bitmaskInnerIdx = threadIdx.x % (kBitsPerMaskElement / kAlignment);
-  T logitsReg[kAlignment];
+  int const block_offset = blockIdx.x * kThreadsPerBlock * kBitsPerThread;
+  T* logits_gmem_ptr = logits + batch_idx * vocab_size + block_offset;
+  int32_t const* bitmask_gmem_ptr =
+      bitmask + batch_idx * bitmask_size + block_offset / kBitsPerMaskElement;
+  int const bitmask_inner_idx = threadIdx.x % (kBitsPerMaskElement / kAlignment);
+  T logits_reg[kAlignment];
 
 #pragma unroll
   for (int offset = threadIdx.x * kAlignment; offset < kThreadsPerBlock * kBitsPerThread;
        offset += kThreadsPerBlock * kAlignment) {
-    if (blockOffset + offset >= vocabSize) {
+    if (block_offset + offset >= vocab_size) {
       break;
     }
 
-    uint32_t const bitmaskVal =
-        (~bitmaskGmemPtr[offset / kBitsPerMaskElement] >> (bitmaskInnerIdx * kAlignment)) &
+    uint32_t const bitmask_val =
+        (~bitmask_gmem_ptr[offset / kBitsPerMaskElement] >> (bitmask_inner_idx * kAlignment)) &
         kPackedMask;
 
-    if (bitmaskVal == 0) {
+    if (bitmask_val == 0) {
       continue;
     }
 
-    if (bitmaskVal == kPackedMask) {
-      *reinterpret_cast<PackedT*>(logitsGmemPtr + offset) = packedNegativeInfinity<T, PackedT>();
+    if (bitmask_val == kPackedMask) {
+      *reinterpret_cast<PackedT*>(logits_gmem_ptr + offset) = PackedNegativeInfinity<T, PackedT>();
       continue;
     }
 
-    *reinterpret_cast<PackedT*>(logitsReg) = *reinterpret_cast<PackedT*>(logitsGmemPtr + offset);
+    *reinterpret_cast<PackedT*>(logits_reg) = *reinterpret_cast<PackedT*>(logits_gmem_ptr + offset);
 #pragma unroll
     for (int i = 0; i < kAlignment; i++) {
-      if (((bitmaskVal >> i) & 1)) {
-        logitsReg[i] = negativeInfinity<T>();
+      if (((bitmask_val >> i) & 1)) {
+        logits_reg[i] = NegativeInfinity<T>();
       }
     }
-    *reinterpret_cast<PackedT*>(logitsGmemPtr + offset) = *reinterpret_cast<PackedT*>(logitsReg);
+    *reinterpret_cast<PackedT*>(logits_gmem_ptr + offset) = *reinterpret_cast<PackedT*>(logits_reg);
   }
 }
 
 template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
-auto constexpr ceilDiv(T numerator, T denominator) {
+auto constexpr CeilDiv(T numerator, T denominator) {
   return (numerator + denominator - 1) / denominator;
 }
 
 template <typename T, typename PackedT>
-void applyTokenBitmaskInplaceDispatchToBitsPerThread(
+void ApplyTokenBitmaskInplaceDispatchToBitsPerThread(
     T* __restrict__ logits,
     int32_t const* __restrict__ bitmask,
     int32_t const* __restrict__ indices,
-    int32_t vocabSize,
-    int32_t bitmaskSize,
-    int32_t batchSize
+    int32_t vocab_size,
+    int32_t bitmask_size,
+    int32_t batch_size
 ) {
   int constexpr kAlignment = sizeof(PackedT) / sizeof(T);
-  int32_t const numBlocksPerRow = ceilDiv(2048 / kThreadsPerBlock * 128, batchSize);
-  int32_t const numBitsPerThread = ceilDiv(vocabSize, kThreadsPerBlock * numBlocksPerRow);
+  int32_t const num_blocks_per_row = CeilDiv(2048 / kThreadsPerBlock * 128, batch_size);
+  int32_t const num_bits_per_thread = CeilDiv(vocab_size, kThreadsPerBlock * num_blocks_per_row);
 
   dim3 const block(kThreadsPerBlock);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
 
-  if (numBitsPerThread <= 4 && kAlignment <= 4) {
-    dim3 const grid(ceilDiv(vocabSize, kThreadsPerBlock * 4), batchSize);
-    logitsBitmaskKernel<T, PackedT, 4>
-        <<<grid, block, 0, stream>>>(logits, bitmask, indices, vocabSize, bitmaskSize);
-  } else if (numBitsPerThread <= 8 && kAlignment <= 8) {
-    dim3 const grid(ceilDiv(vocabSize, kThreadsPerBlock * 8), batchSize);
-    logitsBitmaskKernel<T, PackedT, 8>
-        <<<grid, block, 0, stream>>>(logits, bitmask, indices, vocabSize, bitmaskSize);
-  } else if (numBitsPerThread <= 16 && kAlignment <= 16) {
-    dim3 const grid(ceilDiv(vocabSize, kThreadsPerBlock * 16), batchSize);
-    logitsBitmaskKernel<T, PackedT, 16>
-        <<<grid, block, 0, stream>>>(logits, bitmask, indices, vocabSize, bitmaskSize);
+  if (num_bits_per_thread <= 4 && kAlignment <= 4) {
+    dim3 const grid(CeilDiv(vocab_size, kThreadsPerBlock * 4), batch_size);
+    LogitsBitmaskKernel<T, PackedT, 4>
+        <<<grid, block, 0, stream>>>(logits, bitmask, indices, vocab_size, bitmask_size);
+  } else if (num_bits_per_thread <= 8 && kAlignment <= 8) {
+    dim3 const grid(CeilDiv(vocab_size, kThreadsPerBlock * 8), batch_size);
+    LogitsBitmaskKernel<T, PackedT, 8>
+        <<<grid, block, 0, stream>>>(logits, bitmask, indices, vocab_size, bitmask_size);
+  } else if (num_bits_per_thread <= 16 && kAlignment <= 16) {
+    dim3 const grid(CeilDiv(vocab_size, kThreadsPerBlock * 16), batch_size);
+    LogitsBitmaskKernel<T, PackedT, 16>
+        <<<grid, block, 0, stream>>>(logits, bitmask, indices, vocab_size, bitmask_size);
   } else {
-    dim3 const grid(ceilDiv(vocabSize, kThreadsPerBlock * 32), batchSize);
-    logitsBitmaskKernel<T, PackedT, 32>
-        <<<grid, block, 0, stream>>>(logits, bitmask, indices, vocabSize, bitmaskSize);
+    dim3 const grid(CeilDiv(vocab_size, kThreadsPerBlock * 32), batch_size);
+    LogitsBitmaskKernel<T, PackedT, 32>
+        <<<grid, block, 0, stream>>>(logits, bitmask, indices, vocab_size, bitmask_size);
   }
 }
 
 template <typename T>
-void applyTokenBitmaskInplaceDispatchToPackedT(
+void ApplyTokenBitmaskInplaceDispatchToPackedT(
     T* __restrict__ logits,
     int32_t const* __restrict__ bitmask,
     int32_t const* __restrict__ indices,
-    int32_t vocabSize,
-    int32_t bitmaskSize,
-    int32_t batchSize
+    int32_t vocab_size,
+    int32_t bitmask_size,
+    int32_t batch_size
 ) {
-  if (vocabSize % (sizeof(float4) / sizeof(T)) == 0) {
-    applyTokenBitmaskInplaceDispatchToBitsPerThread<T, float4>(
-        logits, bitmask, indices, vocabSize, bitmaskSize, batchSize
+  if (vocab_size % (sizeof(float4) / sizeof(T)) == 0) {
+    ApplyTokenBitmaskInplaceDispatchToBitsPerThread<T, float4>(
+        logits, bitmask, indices, vocab_size, bitmask_size, batch_size
     );
   } else {
-    applyTokenBitmaskInplaceDispatchToBitsPerThread<T, T>(
-        logits, bitmask, indices, vocabSize, bitmaskSize, batchSize
+    ApplyTokenBitmaskInplaceDispatchToBitsPerThread<T, T>(
+        logits, bitmask, indices, vocab_size, bitmask_size, batch_size
     );
   }
 }
 
-void applyTokenBitmaskInplace(
+void ApplyTokenBitmaskInplace(
     at::Tensor logits, at::Tensor bitmask, at::optional<at::Tensor> indices = at::nullopt
 ) {
   TORCH_CHECK(logits.is_cuda(), "logits must be a CUDA tensor.");
   TORCH_CHECK(logits.is_contiguous(), "logits must be contiguous.");
   TORCH_CHECK(logits.dim() == 1 || logits.dim() == 2, "logits must be a 1D or 2D tensor.");
-  int32_t batchSize = 1;
-  int32_t vocabSize = logits.size(0);
+  int32_t batch_size = 1;
+  int32_t vocab_size = logits.size(0);
   if (logits.dim() == 2) {
-    batchSize = logits.size(0);
-    vocabSize = logits.size(1);
+    batch_size = logits.size(0);
+    vocab_size = logits.size(1);
   }
 
   TORCH_CHECK(bitmask.is_cuda(), "bitmask must be a CUDA tensor.");
   TORCH_CHECK(bitmask.is_contiguous(), "bitmask must be contiguous.");
   TORCH_CHECK(bitmask.dim() == 1 || bitmask.dim() == 2, "bitmask must be a 1D or 2D tensor.");
-  int32_t bitmaskBatchSize = 1;
-  int32_t bitmaskSize = bitmask.size(0);
+  int32_t bitmask_batch_size = 1;
+  int32_t bitmask_size = bitmask.size(0);
   if (bitmask.dim() == 2) {
-    bitmaskBatchSize = bitmask.size(0);
-    bitmaskSize = bitmask.size(1);
+    bitmask_batch_size = bitmask.size(0);
+    bitmask_size = bitmask.size(1);
   }
-  TORCH_CHECK(bitmaskBatchSize == batchSize, "bitmask must have the batch size same to logits.");
+  TORCH_CHECK(bitmask_batch_size == batch_size, "bitmask must have the batch size same to logits.");
   TORCH_CHECK(
-      bitmaskSize == ceilDiv(vocabSize, kBitsPerMaskElement),
-      "bitmask must have the hidden size equal to ceilDiv(vocabSize, 32)."
+      bitmask_size == CeilDiv(vocab_size, kBitsPerMaskElement),
+      "bitmask must have the hidden size equal to CeilDiv(vocabSize, 32)."
   );
 
   int32_t* indices_ptr = nullptr;
   if (indices) {
-    batchSize = indices->size(0);
+    batch_size = indices->size(0);
     indices_ptr = indices->data_ptr<int32_t>();
   }
 
   switch (logits.scalar_type()) {
     case torch::kFloat32: {
-      applyTokenBitmaskInplaceDispatchToPackedT(
+      ApplyTokenBitmaskInplaceDispatchToPackedT(
           logits.data_ptr<float>(),
           bitmask.data_ptr<int32_t>(),
           indices_ptr,
-          vocabSize,
-          bitmaskSize,
-          batchSize
+          vocab_size,
+          bitmask_size,
+          batch_size
       );
       break;
     }
     case torch::kFloat16: {
-      applyTokenBitmaskInplaceDispatchToPackedT(
+      ApplyTokenBitmaskInplaceDispatchToPackedT(
           reinterpret_cast<__half*>(logits.data_ptr<torch::Half>()),
           bitmask.data_ptr<int32_t>(),
           indices_ptr,
-          vocabSize,
-          bitmaskSize,
-          batchSize
+          vocab_size,
+          bitmask_size,
+          batch_size
       );
       break;
     }
     case torch::kBFloat16: {
-      applyTokenBitmaskInplaceDispatchToPackedT(
+      ApplyTokenBitmaskInplaceDispatchToPackedT(
           reinterpret_cast<__nv_bfloat16*>(logits.data_ptr<torch::BFloat16>()),
           bitmask.data_ptr<int32_t>(),
           indices_ptr,
-          vocabSize,
-          bitmaskSize,
-          batchSize
+          vocab_size,
+          bitmask_size,
+          batch_size
       );
       break;
     }
@@ -244,5 +244,5 @@ TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
 }
 
 TORCH_LIBRARY_IMPL(TORCH_EXTENSION_NAME, CUDA, m) {
-  m.impl("apply_token_bitmask_inplace_cuda", &applyTokenBitmaskInplace);
+  m.impl("apply_token_bitmask_inplace_cuda", &ApplyTokenBitmaskInplace);
 }

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py
@@ -58,13 +58,17 @@ _remove_torch_nvcc_flags()
 _load_torch_ops()
 
 
-@torch.library.register_fake("xgrammar::apply_token_bitmask_inplace_cuda")
-def _(
-    logits: torch.Tensor,
-    bitmask: torch.Tensor,
-    indices: Optional[torch.Tensor] = None,
-) -> None:
-    pass
+_is_register_fake_available = hasattr(torch, "library") and hasattr(torch.library, "register_fake")
+
+if _is_register_fake_available:
+
+    @torch.library.register_fake("xgrammar::apply_token_bitmask_inplace_cuda")
+    def _(
+        logits: torch.Tensor,
+        bitmask: torch.Tensor,
+        indices: Optional[torch.Tensor] = None,
+    ) -> None:
+        pass
 
 
 def apply_token_bitmask_inplace_cuda(


### PR DESCRIPTION
This PR enhances the compatibility of apply_token_bitmask_inplace_cuda, introduced in #186, for cuda<12.4, >12, torch > 1.10. It solves the compilation error in SGLang CI.

It also renames the vars in `python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu` to the naming convention of xgrammar.