### PR TITLE
[Style] Remove unused headers

### DIFF
--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -5,7 +5,6 @@
 
 #include <xgrammar/grammar.h>
 
-#include "grammar_data_structure.h"
 #include "grammar_functor.h"
 #include "grammar_parser.h"
 #include "grammar_serializer.h"

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -10,7 +10,6 @@
 #include "grammar_data_structure.h"
 #include "grammar_functor.h"
 #include "grammar_matcher_base.h"
-#include "support/encoding.h"
 #include "support/thread_pool.h"
 #include "support/thread_safe_cache.h"
 #include "testing.h"

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -8,6 +8,7 @@
 #include <xgrammar/xgrammar.h>
 
 #include <algorithm>
+#include <queue>
 #include <unordered_set>
 #include <vector>
 

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -9,12 +9,10 @@
 
 #include <xgrammar/xgrammar.h>
 
-#include <queue>
 #include <string>
 
 #include "grammar_builder.h"
 #include "grammar_data_structure.h"
-#include "grammar_serializer.h"
 
 namespace xgrammar {
 

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -8,19 +8,16 @@
 
 #include <xgrammar/matcher.h>
 
-#include <chrono>
-#include <queue>
-
 #include "compiled_grammar_data_structure.h"
 #include "grammar_data_structure.h"
 #include "grammar_matcher_base.h"
-#include "grammar_serializer.h"
 #include "persistent_stack.h"
 #include "support/dynamic_bitset.h"
 #include "support/encoding.h"
 #include "support/int_set.h"
 #include "support/logging.h"
 #include "testing.h"
+
 namespace xgrammar {
 
 /******************* Tool functions for token mask *******************/

--- a/cpp/grammar_matcher_base.h
+++ b/cpp/grammar_matcher_base.h
@@ -8,7 +8,6 @@
 
 #include <xgrammar/grammar.h>
 
-#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -7,8 +7,6 @@
 
 #include <picojson.h>
 
-#include <memory>
-
 #include "grammar_builder.h"
 #include "grammar_data_structure.h"
 #include "support/encoding.h"

--- a/cpp/grammar_parser.h
+++ b/cpp/grammar_parser.h
@@ -9,8 +9,6 @@
 
 #include <xgrammar/xgrammar.h>
 
-#include "support/logging.h"
-
 namespace xgrammar {
 
 /*!

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -7,10 +7,7 @@
 #include <picojson.h>
 
 #include <iostream>
-#include <map>
-#include <memory>
 #include <optional>
-#include <queue>
 #include <sstream>
 #include <string>
 #include <unordered_set>

--- a/cpp/regex_converter.cc
+++ b/cpp/regex_converter.cc
@@ -5,10 +5,8 @@
 #include "regex_converter.h"
 
 #include <iostream>
-#include <optional>
 #include <string>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include "support/encoding.h"

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -5,7 +5,6 @@
 #include "structural_tag.h"
 
 #include <algorithm>
-#include <chrono>
 #include <string>
 #include <string_view>
 

--- a/cpp/support/encoding.h
+++ b/cpp/support/encoding.h
@@ -8,7 +8,6 @@
 // TODO(yixin): enhance performance
 
 #include <cstdint>
-#include <iostream>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/cpp/support/logging.h
+++ b/cpp/support/logging.h
@@ -12,8 +12,6 @@
 #include <sstream>
 #include <string>
 
-#include "cpptrace.h"
-
 /*!
  * \brief Whether or not customize the logging output.
  *  If log customize is enabled, the user must implement

--- a/cpp/support/thread_pool.h
+++ b/cpp/support/thread_pool.h
@@ -172,7 +172,7 @@ class ThreadPool {
   int unfinished_task_count_ = 0;
 };
 
-void ParallelFor(int low, int high, int num_threads, std::function<void(int)> f) {
+inline void ParallelFor(int low, int high, int num_threads, std::function<void(int)> f) {
   if (high - low == 1) {
     f(low);
     return;

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -9,7 +9,6 @@
 
 #include <xgrammar/object.h>
 
-#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>

--- a/include/xgrammar/object.h
+++ b/include/xgrammar/object.h
@@ -7,8 +7,8 @@
 #ifndef XGRAMMAR_OBJECT_H_
 #define XGRAMMAR_OBJECT_H_
 
-#include <memory>
-#include <utility>
+#include <memory>   // IWYU pragma: keep
+#include <utility>  // IWYU pragma: keep
 
 namespace xgrammar {
 


### PR DESCRIPTION
Currently, there are many headers in C++ files that are not used directly. We remove all of them (thanks to clangd).

Moreover, it seems that an `inline` is missing in `cpp/support/thread_pool.h`, which may lead to a potential violation of ODR in the future.

Maybe this PR should be merged only after a C++ test ci is ready to ensure correctness.
