### PR TITLE
[Feature] Support padding for logits and unequal batch size for logits and bitmask

### DIFF
--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -21,6 +21,7 @@
 #include "support/int_set.h"
 #include "support/logging.h"
 #include "testing.h"
+
 namespace xgrammar {
 
 /******************* Tool functions for token mask *******************/
@@ -69,31 +70,17 @@ void _DebugGetMaskedTokensFromBitmask(
 void ApplyTokenBitmaskInplaceCPU(
     DLTensor* logits, const DLTensor& bitmask, std::optional<std::vector<int>> indices
 ) {
+  // Check device and dim
   XGRAMMAR_CHECK(logits->device.device_type == kDLCPU)
       << "The provided logits's device is not valid: should be CPU";
   XGRAMMAR_CHECK(bitmask.device.device_type == kDLCPU)
       << "The provided bitmask's device is not valid: should be CPU";
-  int batch_size;
-  int vocab_size;
-  if (logits->ndim == 2) {
-    batch_size = logits->shape[0];
-    vocab_size = logits->shape[1];
-  } else {
-    batch_size = 1;
-    vocab_size = logits->shape[0];
-  }
-  int bitmask_size = GetBitmaskSize(vocab_size);
-  if (bitmask.ndim == 2) {
-    XGRAMMAR_CHECK(bitmask.shape[0] == batch_size)
-        << "The provided bitmask's batch size is not consistent with logits";
-    XGRAMMAR_CHECK(bitmask.shape[1] == bitmask_size)
-        << "The provided bitmask's bitmask size is not consistent with logits";
-  } else {
-    XGRAMMAR_CHECK(bitmask.ndim == 1)
-        << "The provided bitmask's shape is not valid: should be (batch_size, vocab_size)";
-    XGRAMMAR_CHECK(bitmask.shape[0] == bitmask_size)
-        << "The provided bitmask's bitmask size is not consistent with logits";
-  }
+  XGRAMMAR_CHECK(logits->ndim == 2 || logits->ndim == 1)
+      << "The provided logits's shape is not valid: should be 2D or 1D";
+  XGRAMMAR_CHECK(bitmask.ndim == 2 || bitmask.ndim == 1)
+      << "The provided bitmask's shape is not valid: should be 2D or 1D";
+
+  // Check type
   XGRAMMAR_CHECK(
       logits->dtype.code == kDLFloat && logits->dtype.bits == 32 && logits->dtype.lanes == 1
   ) << "The provided logits's dtype is not valid: should be float32";
@@ -101,6 +88,27 @@ void ApplyTokenBitmaskInplaceCPU(
       bitmask.dtype.code == kDLInt && bitmask.dtype.bits == 32 && bitmask.dtype.lanes == 1
   ) << "The provided bitmask's dtype is not valid: should be int32";
 
+  // Check shape
+  std::pair<int, int> logits_shape =
+      logits->ndim == 2
+          ? std::make_pair(static_cast<int>(logits->shape[0]), static_cast<int>(logits->shape[1]))
+          : std::make_pair(1, static_cast<int>(logits->shape[0]));
+  std::pair<int, int> bitmask_shape =
+      bitmask.ndim == 2
+          ? std::make_pair(static_cast<int>(bitmask.shape[0]), static_cast<int>(bitmask.shape[1]))
+          : std::make_pair(1, static_cast<int>(bitmask.shape[0]));
+
+  // logits may have extra paddings (in vLLM) so its vocab size can be larger than the bitmask's
+  // vocab size. So we are using >= instead of == here
+  XGRAMMAR_CHECK(GetBitmaskSize(logits_shape.second) >= bitmask_shape.second)
+      << "The provided logits's vocab size should be no less than the bitmask's vocab size "
+         "(converted from bitmask size). But got vocab size "
+      << logits_shape.second << " vs bitmask size " << bitmask_shape.second;
+
+  int vocab_size =
+      std::min(logits_shape.second, bitmask_shape.second * DynamicBitset::BITS_PER_BLOCK);
+
+  // Sort and deduplicate indices
   std::vector<int> indices_value;
   if (indices.has_value()) {
     indices_value = indices.value();
@@ -108,20 +116,30 @@ void ApplyTokenBitmaskInplaceCPU(
     indices_value.erase(
         std::unique(indices_value.begin(), indices_value.end()), indices_value.end()
     );
-    XGRAMMAR_CHECK(indices_value.back() < batch_size)
-        << "The provided indices is out of bounds: " << indices_value.back()
-        << " >= " << batch_size;
+    XGRAMMAR_CHECK(indices_value.front() >= 0)
+        << "The provided indices is negative: " << indices_value.front();
+    XGRAMMAR_CHECK(indices_value.back() < logits_shape.first)
+        << "The provided indices is larger than the logits's batch size: " << indices_value.back()
+        << " >= " << logits_shape.first;
+    XGRAMMAR_CHECK(static_cast<int>(indices_value.size()) <= bitmask_shape.first)
+        << "The provided indices is larger than the bitmask's batch size: " << indices_value.size()
+        << " >= " << bitmask_shape.first;
   } else {
-    indices_value.resize(batch_size);
-    for (int i = 0; i < batch_size; ++i) {
-      indices_value[i] = i;
+    XGRAMMAR_CHECK(logits_shape.first == bitmask_shape.first)
+        << "When indices is not provided, the logits's batch size should be equal to the "
+           "bitmask's batch size, but got "
+        << logits_shape.first << " vs " << bitmask_shape.first;
+    indices_value.reserve(logits_shape.first);
+    for (int i = 0; i < logits_shape.first; ++i) {
+      indices_value.push_back(i);
     }
   }
 
+  // Apply mask
   for (auto idx : indices_value) {
-    uint32_t* data_ptr = reinterpret_cast<uint32_t*>(bitmask.data) + idx * bitmask_size;
+    uint32_t* data_ptr = reinterpret_cast<uint32_t*>(bitmask.data) + idx * bitmask_shape.second;
     DynamicBitset bitset(vocab_size, data_ptr);
-    auto logits_ptr = reinterpret_cast<float*>(logits->data) + idx * vocab_size;
+    auto logits_ptr = reinterpret_cast<float*>(logits->data) + idx * logits_shape.second;
     for (int i = bitset.FindFirstZero(); i != -1; i = bitset.FindNextZero(i)) {
       logits_ptr[i] = -std::numeric_limits<float>::infinity();
     }

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -112,18 +112,6 @@ void ApplyTokenBitmaskInplaceCPU(
   std::vector<int> indices_value;
   if (indices.has_value()) {
     indices_value = indices.value();
-    std::sort(indices_value.begin(), indices_value.end());
-    indices_value.erase(
-        std::unique(indices_value.begin(), indices_value.end()), indices_value.end()
-    );
-    XGRAMMAR_CHECK(indices_value.front() >= 0)
-        << "The provided indices is negative: " << indices_value.front();
-    XGRAMMAR_CHECK(indices_value.back() < logits_shape.first)
-        << "The provided indices is larger than the logits's batch size: " << indices_value.back()
-        << " >= " << logits_shape.first;
-    XGRAMMAR_CHECK(static_cast<int>(indices_value.size()) <= bitmask_shape.first)
-        << "The provided indices is larger than the bitmask's batch size: " << indices_value.size()
-        << " >= " << bitmask_shape.first;
   } else {
     XGRAMMAR_CHECK(logits_shape.first == bitmask_shape.first)
         << "When indices is not provided, the logits's batch size should be equal to the "

--- a/cpp/support/dynamic_bitset.h
+++ b/cpp/support/dynamic_bitset.h
@@ -168,6 +168,8 @@ class DynamicBitset {
     return (data_[buffer_size_ - 1] & last_block_mask) == last_block_mask;
   }
 
+  static constexpr int BITS_PER_BLOCK = 32;
+
  private:
   static int LowestBit(uint32_t value) {
 #ifdef __GNUC__
@@ -203,7 +205,6 @@ class DynamicBitset {
     return position * BITS_PER_BLOCK + LowestBit(~data_[position]);
   }
 
-  static constexpr int BITS_PER_BLOCK = 32;
   // The size of the bitset.
   int size_;
   // The size of the buffer.

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu
@@ -31,8 +31,8 @@
 #define CUDART_INF_BF16 __ushort_as_bfloat16((unsigned short)0x7F80U)
 #endif
 
-constexpr int32_t kBitsPerMaskElement = 32;
-constexpr int32_t kThreadsPerBlock = 256;
+constexpr int32_t BITS_PER_BLOCK = 32;
+constexpr int32_t THREADS_PER_THREAD_BLOCK = 256;
 
 template <typename T>
 __device__ T NegativeInfinity() {
@@ -61,34 +61,35 @@ __device__ PackedT PackedNegativeInfinity() {
 }
 
 template <typename T, typename PackedT, int32_t kBitsPerThread>
-__global__ void __launch_bounds__(kThreadsPerBlock) LogitsBitmaskKernel(
+__global__ void __launch_bounds__(THREADS_PER_THREAD_BLOCK) LogitsBitmaskKernel(
     T* __restrict__ logits,
     const int32_t* __restrict__ bitmask,
     const int32_t* __restrict__ indices,
     int32_t vocab_size,
-    int32_t bitmask_size
+    int32_t logits_stride,
+    int32_t bitmask_stride
 ) {
   constexpr int kAlignment = sizeof(PackedT) / sizeof(T);
   constexpr uint32_t kPackedMask = (1 << kAlignment) - 1;
 
   const int batch_idx = (indices == nullptr) ? blockIdx.y : indices[blockIdx.y];
 
-  const int block_offset = blockIdx.x * kThreadsPerBlock * kBitsPerThread;
-  T* logits_gmem_ptr = logits + batch_idx * vocab_size + block_offset;
+  const int block_offset = blockIdx.x * THREADS_PER_THREAD_BLOCK * kBitsPerThread;
+  T* logits_gmem_ptr = logits + batch_idx * logits_stride + block_offset;
   const int32_t* bitmask_gmem_ptr =
-      bitmask + batch_idx * bitmask_size + block_offset / kBitsPerMaskElement;
-  const int bitmask_inner_idx = threadIdx.x % (kBitsPerMaskElement / kAlignment);
+      bitmask + batch_idx * bitmask_stride + block_offset / BITS_PER_BLOCK;
+  const int bitmask_inner_idx = threadIdx.x % (BITS_PER_BLOCK / kAlignment);
   T logits_reg[kAlignment];
 
 #pragma unroll
-  for (int offset = threadIdx.x * kAlignment; offset < kThreadsPerBlock * kBitsPerThread;
-       offset += kThreadsPerBlock * kAlignment) {
+  for (int offset = threadIdx.x * kAlignment; offset < THREADS_PER_THREAD_BLOCK * kBitsPerThread;
+       offset += THREADS_PER_THREAD_BLOCK * kAlignment) {
     if (block_offset + offset >= vocab_size) {
       break;
     }
 
     const uint32_t bitmask_val =
-        (~bitmask_gmem_ptr[offset / kBitsPerMaskElement] >> (bitmask_inner_idx * kAlignment)) &
+        (~bitmask_gmem_ptr[offset / BITS_PER_BLOCK] >> (bitmask_inner_idx * kAlignment)) &
         kPackedMask;
 
     if (bitmask_val == 0) {
@@ -122,32 +123,38 @@ void ApplyTokenBitmaskInplaceDispatchToBitsPerThread(
     const int32_t* __restrict__ bitmask,
     const int32_t* __restrict__ indices,
     int32_t vocab_size,
-    int32_t bitmask_size,
-    int32_t batch_size
+    int32_t logits_stride,
+    int32_t bitmask_stride,
+    int32_t num_rows
 ) {
   constexpr int kAlignment = sizeof(PackedT) / sizeof(T);
-  const int32_t num_blocks_per_row = CeilDiv(2048 / kThreadsPerBlock * 128, batch_size);
-  const int32_t num_bits_per_thread = CeilDiv(vocab_size, kThreadsPerBlock * num_blocks_per_row);
+  const int32_t num_blocks_per_row = CeilDiv(2048 / THREADS_PER_THREAD_BLOCK * 128, num_rows);
+  const int32_t num_bits_per_thread =
+      CeilDiv(vocab_size, THREADS_PER_THREAD_BLOCK * num_blocks_per_row);
 
-  const dim3 block(kThreadsPerBlock);
+  const dim3 block(THREADS_PER_THREAD_BLOCK);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
 
   if (num_bits_per_thread <= 4 && kAlignment <= 4) {
-    const dim3 grid(CeilDiv(vocab_size, kThreadsPerBlock * 4), batch_size);
-    LogitsBitmaskKernel<T, PackedT, 4>
-        <<<grid, block, 0, stream>>>(logits, bitmask, indices, vocab_size, bitmask_size);
+    const dim3 grid(CeilDiv(vocab_size, THREADS_PER_THREAD_BLOCK * 4), num_rows);
+    LogitsBitmaskKernel<T, PackedT, 4><<<grid, block, 0, stream>>>(
+        logits, bitmask, indices, vocab_size, logits_stride, bitmask_stride
+    );
   } else if (num_bits_per_thread <= 8 && kAlignment <= 8) {
-    const dim3 grid(CeilDiv(vocab_size, kThreadsPerBlock * 8), batch_size);
-    LogitsBitmaskKernel<T, PackedT, 8>
-        <<<grid, block, 0, stream>>>(logits, bitmask, indices, vocab_size, bitmask_size);
+    const dim3 grid(CeilDiv(vocab_size, THREADS_PER_THREAD_BLOCK * 8), num_rows);
+    LogitsBitmaskKernel<T, PackedT, 8><<<grid, block, 0, stream>>>(
+        logits, bitmask, indices, vocab_size, logits_stride, bitmask_stride
+    );
   } else if (num_bits_per_thread <= 16 && kAlignment <= 16) {
-    const dim3 grid(CeilDiv(vocab_size, kThreadsPerBlock * 16), batch_size);
-    LogitsBitmaskKernel<T, PackedT, 16>
-        <<<grid, block, 0, stream>>>(logits, bitmask, indices, vocab_size, bitmask_size);
+    const dim3 grid(CeilDiv(vocab_size, THREADS_PER_THREAD_BLOCK * 16), num_rows);
+    LogitsBitmaskKernel<T, PackedT, 16><<<grid, block, 0, stream>>>(
+        logits, bitmask, indices, vocab_size, logits_stride, bitmask_stride
+    );
   } else {
-    const dim3 grid(CeilDiv(vocab_size, kThreadsPerBlock * 32), batch_size);
-    LogitsBitmaskKernel<T, PackedT, 32>
-        <<<grid, block, 0, stream>>>(logits, bitmask, indices, vocab_size, bitmask_size);
+    const dim3 grid(CeilDiv(vocab_size, THREADS_PER_THREAD_BLOCK * 32), num_rows);
+    LogitsBitmaskKernel<T, PackedT, 32><<<grid, block, 0, stream>>>(
+        logits, bitmask, indices, vocab_size, logits_stride, bitmask_stride
+    );
   }
 }
 
@@ -157,16 +164,17 @@ void ApplyTokenBitmaskInplaceDispatchToPackedT(
     const int32_t* __restrict__ bitmask,
     const int32_t* __restrict__ indices,
     int32_t vocab_size,
-    int32_t bitmask_size,
-    int32_t batch_size
+    int32_t logits_stride,
+    int32_t bitmask_stride,
+    int32_t num_rows
 ) {
-  if (vocab_size % (sizeof(float4) / sizeof(T)) == 0) {
+  if (logits_stride % (sizeof(float4) / sizeof(T)) == 0) {
     ApplyTokenBitmaskInplaceDispatchToBitsPerThread<T, float4>(
-        logits, bitmask, indices, vocab_size, bitmask_size, batch_size
+        logits, bitmask, indices, vocab_size, logits_stride, bitmask_stride, num_rows
     );
   } else {
     ApplyTokenBitmaskInplaceDispatchToBitsPerThread<T, T>(
-        logits, bitmask, indices, vocab_size, bitmask_size, batch_size
+        logits, bitmask, indices, vocab_size, logits_stride, bitmask_stride, num_rows
     );
   }
 }
@@ -177,35 +185,62 @@ void ApplyTokenBitmaskInplace(
   TORCH_CHECK(logits.is_cuda(), "logits must be a CUDA tensor.");
   TORCH_CHECK(logits.is_contiguous(), "logits must be contiguous.");
   TORCH_CHECK(logits.dim() == 1 || logits.dim() == 2, "logits must be a 1D or 2D tensor.");
-  int32_t batch_size = 1;
-  int32_t vocab_size = logits.size(0);
-  if (logits.dim() == 2) {
-    batch_size = logits.size(0);
-    vocab_size = logits.size(1);
-  }
+  std::pair<int32_t, int32_t> logits_shape =
+      logits.dim() == 2
+          ? std::make_pair(
+                static_cast<int32_t>(logits.size(0)), static_cast<int32_t>(logits.size(1))
+            )
+          : std::make_pair(1, static_cast<int32_t>(logits.size(0)));
 
   TORCH_CHECK(bitmask.is_cuda(), "bitmask must be a CUDA tensor.");
   TORCH_CHECK(bitmask.is_contiguous(), "bitmask must be contiguous.");
   TORCH_CHECK(bitmask.dim() == 1 || bitmask.dim() == 2, "bitmask must be a 1D or 2D tensor.");
-  int32_t bitmask_batch_size = 1;
-  int32_t bitmask_size = bitmask.size(0);
-  if (bitmask.dim() == 2) {
-    bitmask_batch_size = bitmask.size(0);
-    bitmask_size = bitmask.size(1);
-  }
-  TORCH_CHECK(bitmask_batch_size == batch_size, "bitmask must have the batch size same to logits.");
+  std::pair<int32_t, int32_t> bitmask_shape =
+      bitmask.dim() == 2
+          ? std::make_pair(
+                static_cast<int32_t>(bitmask.size(0)), static_cast<int32_t>(bitmask.size(1))
+            )
+          : std::make_pair(1, static_cast<int32_t>(bitmask.size(0)));
+
+  TORCH_CHECK(bitmask.dtype() == torch::kInt32, "bitmask must be of type int32.");
+
   TORCH_CHECK(
-      bitmask_size == CeilDiv(vocab_size, kBitsPerMaskElement),
-      "bitmask must have the hidden size equal to CeilDiv(vocab_size, 32), but got vocab_size=",
-      vocab_size,
-      " and bitmask_size=",
-      bitmask_size
+      (logits_shape.second + BITS_PER_BLOCK - 1) / BITS_PER_BLOCK >= bitmask_shape.second,
+      "The provided logits's vocab size should be no less than the bitmask's vocab size "
+      "(converted from bitmask size). But got vocab size ",
+      logits_shape.second,
+      " vs bitmask size ",
+      bitmask_shape.second
   );
 
+  int vocab_size = std::min(logits_shape.second, bitmask_shape.second * BITS_PER_BLOCK);
+
+  int32_t num_rows = logits_shape.first;
   int32_t* indices_ptr = nullptr;
   if (indices) {
-    batch_size = indices->size(0);
+    TORCH_CHECK(indices->is_cuda(), "indices must be a CUDA tensor.");
+    TORCH_CHECK(indices->is_contiguous(), "indices must be contiguous.");
+    TORCH_CHECK(indices->dim() == 1, "indices must be a 1D tensor.");
+    TORCH_CHECK(indices->dtype() == torch::kInt32, "indices must be of type int32.");
+    TORCH_CHECK(
+        indices->size(0) <= bitmask_shape.first,
+        "indices must have the batch size no larger than bitmask's batch size."
+    );
+    TORCH_CHECK(
+        indices->index({0}).item<int32_t>() >= 0,
+        "indices must have the minimum value no less than 0."
+    );
+    TORCH_CHECK(
+        indices->index({indices->size(0) - 1}).item<int32_t>() < logits_shape.first,
+        "indices must have the maximum value no larger than logits's batch size."
+    );
+    num_rows = indices->size(0);
     indices_ptr = indices->data_ptr<int32_t>();
+  } else {
+    TORCH_CHECK(
+        logits_shape.first == bitmask_shape.first,
+        "logits and bitmask must have the same batch size."
+    );
   }
 
   switch (logits.scalar_type()) {
@@ -215,8 +250,9 @@ void ApplyTokenBitmaskInplace(
           bitmask.data_ptr<int32_t>(),
           indices_ptr,
           vocab_size,
-          bitmask_size,
-          batch_size
+          logits_shape.second,
+          bitmask_shape.second,
+          num_rows
       );
       break;
     }
@@ -226,8 +262,9 @@ void ApplyTokenBitmaskInplace(
           bitmask.data_ptr<int32_t>(),
           indices_ptr,
           vocab_size,
-          bitmask_size,
-          batch_size
+          logits_shape.second,
+          bitmask_shape.second,
+          num_rows
       );
       break;
     }
@@ -237,8 +274,9 @@ void ApplyTokenBitmaskInplace(
           bitmask.data_ptr<int32_t>(),
           indices_ptr,
           vocab_size,
-          bitmask_size,
-          batch_size
+          logits_shape.second,
+          bitmask_shape.second,
+          num_rows
       );
       break;
     }

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu
@@ -222,18 +222,6 @@ void ApplyTokenBitmaskInplace(
     TORCH_CHECK(indices->is_contiguous(), "indices must be contiguous.");
     TORCH_CHECK(indices->dim() == 1, "indices must be a 1D tensor.");
     TORCH_CHECK(indices->dtype() == torch::kInt32, "indices must be of type int32.");
-    TORCH_CHECK(
-        indices->size(0) <= bitmask_shape.first,
-        "indices must have the batch size no larger than bitmask's batch size."
-    );
-    TORCH_CHECK(
-        indices->index({0}).item<int32_t>() >= 0,
-        "indices must have the minimum value no less than 0."
-    );
-    TORCH_CHECK(
-        indices->index({indices->size(0) - 1}).item<int32_t>() < logits_shape.first,
-        "indices must have the maximum value no larger than logits's batch size."
-    );
     num_rows = indices->size(0);
     indices_ptr = indices->data_ptr<int32_t>();
   } else {

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py
@@ -73,5 +73,5 @@ def apply_token_bitmask_inplace_cuda(
     if isinstance(indices, list):
         indices = torch.tensor(indices, dtype=torch.int32, device=logits.device)
     if indices is not None:
-        indices = torch.unique(indices.to(logits.device))
+        indices = indices.to(logits.device)
     torch.ops.xgrammar.apply_token_bitmask_inplace_cuda(logits, bitmask, indices)

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py
@@ -72,4 +72,6 @@ def apply_token_bitmask_inplace_cuda(
 ) -> None:
     if isinstance(indices, list):
         indices = torch.tensor(indices, dtype=torch.int32, device=logits.device)
+    if indices is not None:
+        indices = torch.unique(indices.to(logits.device))
     torch.ops.xgrammar.apply_token_bitmask_inplace_cuda(logits, bitmask, indices)

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
@@ -110,16 +110,6 @@ def apply_token_bitmask_inplace_triton(
     num_rows = None
     if isinstance(indices, list) or isinstance(indices, torch.Tensor):
         indices = torch.tensor(indices, dtype=torch.int32, device=logits.device)
-        indices = torch.unique(indices)
-
-        assert (
-            indices.shape[0] <= bitmask_shape[0]
-        ), f"indices count ({indices.shape[0]}) exceeds bitmask batch size ({bitmask_shape[0]})"
-        assert indices.min() >= 0, f"negative index found: {indices.min()}"
-        assert (
-            indices.max() < logits_shape[0]
-        ), f"index {indices.max()} out of bounds for logits batch size {logits_shape[0]}"
-
         num_rows = indices.shape[0]
     else:
         assert (

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
@@ -16,27 +16,65 @@ def apply_token_bitmask_inplace_kernel(
     indices_ptr,
     num_rows,
     vocab_size,
-    bitmask_size,
+    logits_strides,
+    bitmask_strides,
     NUM_SMS: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
+    """Apply a bitmask to logits in-place using Triton. The bitmask is a 01 bitwise compressed tensor,
+    where 0 means the token is masked and 1 means the token is not masked. After applying the bitmask,
+    the masked logits will be set to -inf.
+
+    Parameters
+    ----------
+    logits_ptr : tl.tensor
+        Pointer to the logits tensor to apply the bitmask to.
+
+    bitmask_ptr : tl.tensor
+        Pointer to the bitmask tensor to apply.
+
+    indices_ptr : Optional[tl.tensor]
+        Optional pointer to indices tensor specifying which rows to apply the mask to.
+
+    num_rows : int
+        Number of rows to process. If indices_ptr is provided, this is the number of unique indices.
+
+    vocab_size : int
+        Size of the vocabulary dimension. If the logits does not have a vocab padding, this is the
+        same as the logits's second dimension. Otherwise, this is the actual size of the vocabulary.
+
+    logits_strides : int
+        Stride between rows in the logits tensor.
+
+    bitmask_strides : int
+        Stride between rows in the bitmask tensor.
+
+    NUM_SMS : int
+        Number of streaming multiprocessors to use.
+
+    BLOCK_SIZE : int
+        Size of processing blocks.
+    """
+
     pid = tl.program_id(0)
     num_blocks = tl.cdiv(vocab_size, BLOCK_SIZE)
     for work_id in tl.range(pid, num_rows * num_blocks, NUM_SMS):
-        block_offset = (work_id % num_blocks) * BLOCK_SIZE
         row_id = work_id // num_blocks
+        block_offset = (work_id % num_blocks) * BLOCK_SIZE
         batch_id = row_id if indices_ptr is None else tl.load(indices_ptr + row_id)
         offsets = block_offset + tl.arange(0, BLOCK_SIZE)
         bitmask_offsets = block_offset // 32 + tl.arange(0, BLOCK_SIZE // 32)
         vocab_mask = offsets < vocab_size
-        packed_bitmask_mask = bitmask_offsets < bitmask_size
+        packed_bitmask_mask = bitmask_offsets < bitmask_strides
         packed_bitmask = tl.load(
-            bitmask_ptr + batch_id * bitmask_size + bitmask_offsets, packed_bitmask_mask
+            bitmask_ptr + batch_id * bitmask_strides + bitmask_offsets, packed_bitmask_mask
         )
         bitmask = ((packed_bitmask[:, None] >> (tl.arange(0, 32)[None, :])) & 1) == 0
         bitmask = bitmask.reshape(BLOCK_SIZE)
 
-        tl.store(logits_ptr + batch_id * vocab_size + offsets, -float("inf"), vocab_mask & bitmask)
+        tl.store(
+            logits_ptr + batch_id * logits_strides + offsets, -float("inf"), vocab_mask & bitmask
+        )
 
 
 def apply_token_bitmask_inplace_triton(
@@ -44,25 +82,51 @@ def apply_token_bitmask_inplace_triton(
     bitmask: torch.Tensor,
     indices: Optional[Union[List[int], torch.Tensor]] = None,
 ):
-    def ceil_div(a, b):
-        return (a + b - 1) // b
-
     NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
     BLOCK_SIZE = 4096
+    BITS_PER_BLOCK = 32
+
+    # Check input dtype
+    assert bitmask.dtype == torch.int32, "bitmask must be of type int32"
+
     # Check input tensor shapes.
-    if logits.ndim == 2:
-        batch_size, vocab_size = logits.shape
-    elif logits.ndim == 1:
-        batch_size = 1
-        (vocab_size,) = logits.shape
-    else:
-        raise ValueError("Invalid logits tensor shape {}".format(logits.shape))
+    logits_shape = logits.shape
+    bitmask_shape = bitmask.shape
+    if logits.ndim == 1:
+        logits_shape = (1, logits_shape[0])
+    if bitmask.ndim == 1:
+        bitmask_shape = (1, bitmask_shape[0])
 
-    if isinstance(indices, list):
+    required_bitmask_width = (logits_shape[1] + BITS_PER_BLOCK - 1) // BITS_PER_BLOCK
+    assert required_bitmask_width >= bitmask_shape[1], (
+        f"Bitmask width too large: allow at most {required_bitmask_width} int32s for "
+        f"logits' width {logits_shape[1]}, but got {bitmask_shape[1]}"
+    )
+
+    vocab_size = min(logits_shape[1], bitmask_shape[1] * BITS_PER_BLOCK)
+
+    vocab_size = min(logits_shape[1], bitmask_shape[1] * BITS_PER_BLOCK)
+
+    num_rows = None
+    if isinstance(indices, list) or isinstance(indices, torch.Tensor):
         indices = torch.tensor(indices, dtype=torch.int32, device=logits.device)
+        indices = torch.unique(indices)
 
-    if isinstance(indices, torch.Tensor):
-        batch_size = indices.shape[0]
+        assert (
+            indices.shape[0] <= bitmask_shape[0]
+        ), f"indices count ({indices.shape[0]}) exceeds bitmask batch size ({bitmask_shape[0]})"
+        assert indices.min() >= 0, f"negative index found: {indices.min()}"
+        assert (
+            indices.max() < logits_shape[0]
+        ), f"index {indices.max()} out of bounds for logits batch size {logits_shape[0]}"
+
+        num_rows = indices.shape[0]
+    else:
+        assert (
+            logits_shape[0] == bitmask_shape[0]
+        ), f"batch size mismatch: logits {logits_shape[0]} vs bitmask {bitmask_shape[0]}"
+
+        num_rows = logits_shape[0]
 
     grid = (NUM_SMS,)
 
@@ -70,9 +134,10 @@ def apply_token_bitmask_inplace_triton(
         logits,
         bitmask,
         indices,
-        batch_size,
+        num_rows,
         vocab_size,
-        ceil_div(vocab_size, 32),
+        logits_shape[1],
+        bitmask_shape[1],
         NUM_SMS,
         BLOCK_SIZE,
         num_warps=BLOCK_SIZE // 32 // (16 // logits.element_size()),

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -114,6 +114,7 @@ def apply_token_bitmask_inplace(
         A list of indices to specify which logits in the batch to apply the bitmask to. If None,
         apply the bitmask to all logits in the batch.
     """
+    # dispatch to different implementations based on the device of logits and bitmask
     if bitmask.device != logits.device:
         raise ValueError(
             "logits and bitmask should be on the same device. "

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -95,12 +95,19 @@ def apply_token_bitmask_inplace(
                 if get_bitmask_value(bitmask, batch_id, j) == 0:
                     logits[batch_id, j] = -inf
 
+    When indices is specified, the batch sizes of logits and bitmask do not need to be the same.
+    As long as the indices are valid, the operation will be performed.
+
     The logits and bitmask should be on the same device. If both them are on CUDA, we launch a CUDA
     kernel to apply bitmask. If both them are on CPU, we use a CPU implementation. The CUDA kernel
     is optimized and should be preferred.
 
     In practice, the bitmask is allocated on CPU, and the logits is usually on GPU, so users should
     manually copy the bitmask to GPU before calling this function.
+
+    This method also supports additional padding on the vocabulary dimension of the logits. The
+    shape of logits can be (batch_size, vocab_size + padding). Then the vocab size will be
+    determined by the bitmask size.
 
     Parameters
     ----------

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -118,8 +118,8 @@ def apply_token_bitmask_inplace(
         The bitmask to apply.
 
     indices : Optional[List[int]], default: None
-        A list of indices to specify which logits in the batch to apply the bitmask to. If None,
-        apply the bitmask to all logits in the batch.
+        A list of indices to specify which logits in the batch to apply the bitmask to. Should be
+        unique. If None, apply the bitmask to all logits in the batch.
     """
     # dispatch to different implementations based on the device of logits and bitmask
     if bitmask.device != logits.device:

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -155,7 +155,8 @@ def _get_masked_tokens_from_bitmask(
 
 
 def _bool_mask_to_bitmask(bool_mask: torch.Tensor) -> torch.Tensor:
-    """Get the bitmask from bool mask.
+    """Get the bitmask from bool mask. If the bool mask does not align with the 32-bit block
+    size, it will add extra 1 paddings.
 
     Parameters
     ----------
@@ -172,7 +173,7 @@ def _bool_mask_to_bitmask(bool_mask: torch.Tensor) -> torch.Tensor:
     # Pad to multiple of 32
     pad_size = (32 - bool_mask.shape[1] % 32) % 32
     if pad_size > 0:
-        bool_mask_int32 = torch.nn.functional.pad(bool_mask_int32, (0, pad_size))
+        bool_mask_int32 = torch.nn.functional.pad(bool_mask_int32, (0, pad_size), value=1)
     bool_mask_view = bool_mask_int32.view(bool_mask.shape[0], -1, 32)
     # To avoid error for overflow, we construct int64 weights and convert to int32
     weights = torch.tensor(

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -154,7 +154,7 @@ def test_apply_token_bitmask_inplace_large(
         except ImportError:
             pytest.skip(reason="Triton is not installed")
     else:
-        indices = batch_indices.tolist() if stride == 1 else None
+        indices = batch_indices.tolist() if stride != 1 else None
         time_start = time.monotonic_ns()
         xgr.apply_token_bitmask_inplace(logits, bitmask, indices=indices)
         time_end = time.monotonic_ns()

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -219,7 +219,6 @@ logits_batch_size__bitmask_batch_size__vocab_size__indices = [
     (3, 3, 128, [0, 1]),
     (2, 3, 128, [0]),
     (3, 2, 130, [0]),
-    (3, 2, 130, [1, 1, 0, 0]),
 ]
 
 

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -2,6 +2,7 @@
 
 import sys
 import time
+from typing import List, Optional, Tuple
 
 import pytest
 import torch
@@ -64,7 +65,7 @@ def test_apply_token_bitmask_inplace(impl: str):
         torch.testing.assert_close(logits, expected)
 
 
-batch_size_vocab_size_masked_cnt_stride_logits_dtype = [
+batch_size__vocab_size__masked_cnt__stride__logits_dtype = [
     (1, 128000, 1024, 1, "float32"),
     (1, 128000, 120000, 1, "float32"),
     (1, 128001, 120000, 1, "float32"),
@@ -82,7 +83,7 @@ batch_size_vocab_size_masked_cnt_stride_logits_dtype = [
 
 @pytest.mark.parametrize(
     "batch_size, vocab_size, masked_cnt, stride, logits_dtype",
-    batch_size_vocab_size_masked_cnt_stride_logits_dtype,
+    batch_size__vocab_size__masked_cnt__stride__logits_dtype,
 )
 @pytest.mark.parametrize("impl", ("cpu", "cuda", "triton"))
 def test_apply_token_bitmask_inplace_large(
@@ -111,11 +112,11 @@ def test_apply_token_bitmask_inplace_large(
 
     bitmask = _bool_mask_to_bitmask(bool_mask)
 
-    masked_batch_ids = torch.arange(0, batch_size, stride, dtype=torch.int32)
+    batch_indices = torch.arange(0, batch_size, stride, dtype=torch.int32)
 
     logits_expected = logits.clone()
-    logits_expected[masked_batch_ids] = torch.masked_fill(
-        logits_expected[masked_batch_ids], ~bool_mask[masked_batch_ids], float("-inf")
+    logits_expected[batch_indices] = torch.masked_fill(
+        logits_expected[batch_indices], ~bool_mask[batch_indices], float("-inf")
     )
 
     bitmask = _bool_mask_to_bitmask(bool_mask)
@@ -125,24 +126,24 @@ def test_apply_token_bitmask_inplace_large(
 
         logits_gpu = logits.to("cuda")
         bitmask_gpu = bitmask.to("cuda")
-        masked_batch_ids_gpu = masked_batch_ids.to("cuda")
-        torch.cuda.synchronize()
-        kwargs = {} if stride == 1 else {"indices": masked_batch_ids_gpu}
+        indices = batch_indices.to("cuda") if stride != 1 else None
         if impl == "cuda":
 
             def f():
                 return xgr.kernels.apply_token_bitmask_inplace_kernels["cuda"](
-                    logits_gpu, bitmask_gpu, **kwargs
+                    logits_gpu, bitmask_gpu, indices=indices
                 )
 
         else:
 
             def f():
                 return xgr.kernels.apply_token_bitmask_inplace_kernels["triton"](
-                    logits_gpu, bitmask_gpu, **kwargs
+                    logits_gpu, bitmask_gpu, indices=indices
                 )
 
+        torch.cuda.synchronize()
         f()
+        torch.cuda.synchronize()
         torch.testing.assert_close(logits_gpu, logits_expected.to("cuda"))
 
         try:
@@ -153,14 +154,132 @@ def test_apply_token_bitmask_inplace_large(
         except ImportError:
             pytest.skip(reason="Triton is not installed")
     else:
-        kwargs = {} if stride == 1 else {"indices": masked_batch_ids.tolist()}
+        kwargs = {} if stride == 1 else {"indices": batch_indices.tolist()}
         time_start = time.monotonic_ns()
         xgr.apply_token_bitmask_inplace(logits, bitmask, **kwargs)
         time_end = time.monotonic_ns()
         exec_time = (time_end - time_start) / 1e3
         torch.testing.assert_close(logits, logits_expected)
 
-    print(f"Implementation: {impl}\t| Execution time (μs): {exec_time:.4f}")
+    print(
+        f"Batch: {batch_size:2} | Vocab: {vocab_size:6} | Masked: {masked_cnt:6} | "
+        f"Stride: {stride:1} | DType: {str(logits_dtype):15} | Impl: {impl:6} | "
+        f"Execution time (μs): {exec_time:.4f}"
+    )
+
+
+batch_size__logits_strides__vocab_size = [
+    # logits's vocab has extra paddings (vLLM)
+    (2, 161, 128),
+    (2, 161, 120),
+    # bitmask's vocab sizes do not align with the 32-bit block size
+    (2, 130, 130),
+]
+
+
+@pytest.mark.parametrize(
+    "batch_size, logits_strides, vocab_size", batch_size__logits_strides__vocab_size
+)
+@pytest.mark.parametrize("logits_dtype", ("float32", "float16", "bfloat16"))
+@pytest.mark.parametrize("impl", ("cpu", "cuda", "triton"))
+def test_apply_token_bitmask_inplace_special_shape(
+    batch_size: int, logits_strides: int, vocab_size: int, logits_dtype: str, impl: str
+):
+    if impl == "cpu" and logits_dtype != "float32":
+        pytest.skip(reason="cpu implementation supports float32 only")
+
+    logits_dtype = getattr(torch, logits_dtype)
+    logits = torch.ones(batch_size, logits_strides, dtype=logits_dtype)
+
+    bool_mask = torch.zeros(batch_size, vocab_size, dtype=torch.bool)
+    bitmask = _bool_mask_to_bitmask(bool_mask)
+
+    bool_mask_padded = torch.nn.functional.pad(bool_mask, (0, logits_strides - vocab_size), value=1)
+    logits_expected = logits.clone()
+    logits_expected[~bool_mask_padded] = float("-inf")
+
+    if impl in ["cuda", "triton"]:
+        logits_gpu = logits.to("cuda")
+        bitmask_gpu = bitmask.to("cuda")
+        if impl == "cuda":
+            xgr.kernels.apply_token_bitmask_inplace_kernels["cuda"](logits_gpu, bitmask_gpu)
+        else:
+            xgr.kernels.apply_token_bitmask_inplace_kernels["triton"](logits_gpu, bitmask_gpu)
+        torch.testing.assert_close(logits_gpu, logits_expected.to("cuda"))
+    else:
+        xgr.apply_token_bitmask_inplace(logits, bitmask)
+        torch.testing.assert_close(logits, logits_expected)
+
+
+logits_batch_size__bitmask_batch_size__vocab_size__indices = [
+    (3, 3, 128, [0, 1]),
+    (2, 3, 128, [0]),
+    (3, 2, 130, [0]),
+    (3, 2, 130, [1, 1, 0, 0]),
+]
+
+
+@pytest.mark.parametrize(
+    "logits_batch_size, bitmask_batch_size, vocab_size, indices",
+    logits_batch_size__bitmask_batch_size__vocab_size__indices,
+)
+@pytest.mark.parametrize("impl", ("cpu", "cuda", "triton"))
+def test_apply_token_bitmask_inplace_select_indices(
+    logits_batch_size: int, bitmask_batch_size: int, vocab_size: int, indices: List[int], impl: str
+):
+    logits = torch.ones(logits_batch_size, vocab_size, dtype=torch.float32)
+    bool_mask = torch.zeros(bitmask_batch_size, vocab_size, dtype=torch.bool)
+    bitmask = _bool_mask_to_bitmask(bool_mask)
+
+    logits_expected = logits.clone()
+    logits_expected[indices] = torch.masked_fill(
+        logits_expected[indices], ~bool_mask[indices], float("-inf")
+    )
+
+    if impl in ["cuda", "triton"]:
+        logits_gpu = logits.to("cuda")
+        bitmask_gpu = bitmask.to("cuda")
+        if impl == "cuda":
+            xgr.kernels.apply_token_bitmask_inplace_kernels["cuda"](
+                logits_gpu, bitmask_gpu, indices
+            )
+        else:
+            xgr.kernels.apply_token_bitmask_inplace_kernels["triton"](
+                logits_gpu, bitmask_gpu, indices
+            )
+        torch.testing.assert_close(logits_gpu, logits_expected.to("cuda"))
+    else:
+        xgr.apply_token_bitmask_inplace(logits, bitmask, indices=indices)
+        torch.testing.assert_close(logits, logits_expected)
+
+
+logits_shape__bitmask_shape__indices = [
+    ((2, 128), (1, 4), None),
+    ((2, 128), (2, 5), None),
+    ((2, 128), (1, 4), [0, 1]),
+    ((2, 128), (2, 5), [-1]),
+    ((2, 128), (3, 4), [2]),
+]
+
+
+@pytest.mark.parametrize(
+    "logits_shape, bitmask_shape, indices", logits_shape__bitmask_shape__indices
+)
+@pytest.mark.parametrize("impl", ("cpu", "cuda", "triton"))
+def test_apply_token_bitmask_inplace_invalid_shape(
+    logits_shape: Tuple[int], bitmask_shape: Tuple[int], indices: Optional[List[int]], impl: str
+):
+    device = "cpu" if impl == "cpu" else "cuda"
+    logits = torch.ones(logits_shape, dtype=torch.float32, device=device)
+    bitmask = torch.zeros(bitmask_shape, dtype=torch.int32, device=device)
+
+    with pytest.raises((RuntimeError, AssertionError)):
+        if impl == "cuda":
+            xgr.kernels.apply_token_bitmask_inplace_kernels["cuda"](logits, bitmask, indices)
+        elif impl == "triton":
+            xgr.kernels.apply_token_bitmask_inplace_kernels["triton"](logits, bitmask, indices)
+        else:
+            xgr.apply_token_bitmask_inplace(logits, bitmask, indices=indices)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -253,13 +253,7 @@ def test_apply_token_bitmask_inplace_select_indices(
         torch.testing.assert_close(logits, logits_expected)
 
 
-logits_shape__bitmask_shape__indices = [
-    ((2, 128), (1, 4), None),
-    ((2, 128), (2, 5), None),
-    ((2, 128), (1, 4), [0, 1]),
-    ((2, 128), (2, 5), [-1]),
-    ((2, 128), (3, 4), [2]),
-]
+logits_shape__bitmask_shape__indices = [((2, 128), (1, 4), None), ((2, 128), (2, 5), None)]
 
 
 @pytest.mark.parametrize(

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -154,9 +154,9 @@ def test_apply_token_bitmask_inplace_large(
         except ImportError:
             pytest.skip(reason="Triton is not installed")
     else:
-        kwargs = {} if stride == 1 else {"indices": batch_indices.tolist()}
+        indices = batch_indices.tolist() if stride == 1 else None
         time_start = time.monotonic_ns()
-        xgr.apply_token_bitmask_inplace(logits, bitmask, **kwargs)
+        xgr.apply_token_bitmask_inplace(logits, bitmask, indices=indices)
         time_end = time.monotonic_ns()
         exec_time = (time_end - time_start) / 1e3
         torch.testing.assert_close(logits, logits_expected)

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -187,6 +187,10 @@ def test_apply_token_bitmask_inplace_special_shape(
 ):
     if impl == "cpu" and logits_dtype != "float32":
         pytest.skip(reason="cpu implementation supports float32 only")
+    if impl == "cuda" and "cuda" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
+        pytest.skip(reason="CUDA is not installed")
+    if impl == "triton" and "triton" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
+        pytest.skip(reason="Triton is not installed")
 
     logits_dtype = getattr(torch, logits_dtype)
     logits = torch.ones(batch_size, logits_strides, dtype=logits_dtype)
@@ -227,6 +231,11 @@ logits_batch_size__bitmask_batch_size__vocab_size__indices = [
 def test_apply_token_bitmask_inplace_select_indices(
     logits_batch_size: int, bitmask_batch_size: int, vocab_size: int, indices: List[int], impl: str
 ):
+    if impl == "cuda" and "cuda" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
+        pytest.skip(reason="CUDA is not installed")
+    if impl == "triton" and "triton" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
+        pytest.skip(reason="Triton is not installed")
+
     logits = torch.ones(logits_batch_size, vocab_size, dtype=torch.float32)
     bool_mask = torch.zeros(bitmask_batch_size, vocab_size, dtype=torch.bool)
     bitmask = _bool_mask_to_bitmask(bool_mask)
@@ -263,6 +272,11 @@ logits_shape__bitmask_shape__indices = [((2, 128), (1, 4), None), ((2, 128), (2,
 def test_apply_token_bitmask_inplace_invalid_shape(
     logits_shape: Tuple[int], bitmask_shape: Tuple[int], indices: Optional[List[int]], impl: str
 ):
+    if impl == "cuda" and "cuda" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
+        pytest.skip(reason="CUDA is not installed")
+    if impl == "triton" and "triton" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
+        pytest.skip(reason="Triton is not installed")
+
     device = "cpu" if impl == "cpu" else "cuda"
     logits = torch.ones(logits_shape, dtype=torch.float32, device=device)
     bitmask = torch.zeros(bitmask_shape, dtype=torch.int32, device=device)

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -10,6 +10,8 @@ import torch
 import xgrammar as xgr
 from xgrammar.testing import _bool_mask_to_bitmask, _get_masked_tokens_from_bitmask
 
+_is_cuda_available = torch.cuda.is_available()
+
 
 def test_allocate_reset_token_bitmask():
     batch_size = 10
@@ -91,10 +93,8 @@ def test_apply_token_bitmask_inplace_large(
 ):
     if impl == "cpu" and logits_dtype != "float32":
         pytest.skip(reason="cpu implementation supports float32 only")
-    if impl == "cuda" and "cuda" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
+    if impl in ["cuda", "triton"] and not _is_cuda_available:
         pytest.skip(reason="CUDA is not installed")
-    if impl == "triton" and "triton" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
-        pytest.skip(reason="Triton is not installed")
 
     logits_dtype = getattr(torch, logits_dtype)
     logits = torch.randn(batch_size, vocab_size, dtype=logits_dtype)
@@ -187,10 +187,8 @@ def test_apply_token_bitmask_inplace_special_shape(
 ):
     if impl == "cpu" and logits_dtype != "float32":
         pytest.skip(reason="cpu implementation supports float32 only")
-    if impl == "cuda" and "cuda" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
+    if impl in ["cuda", "triton"] and not _is_cuda_available:
         pytest.skip(reason="CUDA is not installed")
-    if impl == "triton" and "triton" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
-        pytest.skip(reason="Triton is not installed")
 
     logits_dtype = getattr(torch, logits_dtype)
     logits = torch.ones(batch_size, logits_strides, dtype=logits_dtype)
@@ -230,10 +228,8 @@ logits_batch_size__bitmask_batch_size__vocab_size__indices = [
 def test_apply_token_bitmask_inplace_select_indices(
     logits_batch_size: int, bitmask_batch_size: int, vocab_size: int, indices: List[int], impl: str
 ):
-    if impl == "cuda" and "cuda" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
+    if impl in ["cuda", "triton"] and not _is_cuda_available:
         pytest.skip(reason="CUDA is not installed")
-    if impl == "triton" and "triton" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
-        pytest.skip(reason="Triton is not installed")
 
     logits = torch.ones(logits_batch_size, vocab_size, dtype=torch.float32)
     bool_mask = torch.zeros(bitmask_batch_size, vocab_size, dtype=torch.bool)
@@ -271,10 +267,8 @@ logits_shape__bitmask_shape__indices = [((2, 128), (1, 4), None), ((2, 128), (2,
 def test_apply_token_bitmask_inplace_invalid_shape(
     logits_shape: Tuple[int], bitmask_shape: Tuple[int], indices: Optional[List[int]], impl: str
 ):
-    if impl == "cuda" and "cuda" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
+    if impl in ["cuda", "triton"] and not _is_cuda_available:
         pytest.skip(reason="CUDA is not installed")
-    if impl == "triton" and "triton" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
-        pytest.skip(reason="Triton is not installed")
 
     device = "cpu" if impl == "cpu" else "cuda"
     logits = torch.ones(logits_shape, dtype=torch.float32, device=device)


### PR DESCRIPTION
This PR supports:
1. Padding on the vocabulary dimension for logits. vLLM could introduce such padding and this is not supported by the previous kernel.
2. Unequal batch size for logits and bitmask when indices are specified. When indices are not specified, we require the batch sizes for logits and bitmask the same. When indices are specified, we only require the indices larger than 
