### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -38,7 +38,7 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.arch }}
           CIBW_BUILD: ${{ matrix.build }}
-          CIBW_TEST_SKIP: True
+          CIBW_TEST_SKIP: '*'
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -51,6 +51,13 @@ jobs:
           cache: 'pip'
           python-version: ${{ matrix.python }}
 
+      - name: Cache huggingface
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/huggingface
+          key: ${{ runner.os }}-huggingface-${{ matrix.python }}
+
       - name: Build xgrammar from source
         run: |
           echo "set(XGRAMMAR_BUILD_CXX_TESTS ON)" >> cmake/config.cmake

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v3
-        with:
-          cache: 'pip'
 
       - name: Pre-commit
         uses: pre-commit/action@v3.0.1
@@ -49,9 +47,6 @@ jobs:
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5
-        with:
-          cache: 'pip'
-          python-version: ${{ matrix.python }}
 
       - name: Cache huggingface
         uses: actions/cache@v4

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -64,6 +64,7 @@ jobs:
       - name: Run Python tests
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_HUB_DOWNLOAD_TIMEOUT: 60
         if: env.HF_TOKEN != ''
         run: |
           pytest

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -2,6 +2,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   pre_check:
@@ -56,7 +58,7 @@ jobs:
         with:
           path: |
             ~/.cache/huggingface
-          key: ${{ runner.os }}-huggingface-${{ matrix.python }}
+          key: ${{ matrix.os }}-huggingface-${{ matrix.python }}
 
       - name: Build xgrammar from source
         run: |

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -16,7 +16,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
 
       - name: Pre-commit
         uses: pre-commit/action@v3.0.1
@@ -47,6 +47,8 @@ jobs:
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
 
       - name: Cache huggingface
         uses: actions/cache@v4

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           path: |
             ~/.cache/huggingface
-          key: ${{ matrix.os }}-huggingface-${{ matrix.python }}
+          key: huggingface-${{ matrix.os }}-python-${{ matrix.python }}
 
       - name: Build xgrammar from source
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "transformers>=4.38.0",
   "triton; platform_system == 'linux' and platform_machine == 'x86_64'",
   "ninja",
+  "nanobind>=2.0.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,14 @@ Homepage = "https://xgrammar.mlc.ai/"
 GitHub = "https://github.com/mlc-ai/xgrammar"
 
 [project.optional-dependencies]
-test = ["pytest", "protobuf", "huggingface-hub[cli]"]
+test = [
+  "pytest",
+  "protobuf",
+  "huggingface-hub[cli]",
+  # transformers==4.50.0 has error on MacOS.
+  # https://github.com/huggingface/transformers/issues/36906
+  "transformers<4.50.0; platform_system == 'Darwin'",
+]
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"

--- a/tests/python/test_tokenizer_info.py
+++ b/tests/python/test_tokenizer_info.py
@@ -58,7 +58,6 @@ def test_build_tokenizer_info(
 ):
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_fast=True, trust_remote_code=True)
     tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
-    print(f"{tokenizer_info.vocab_type}, {tokenizer_info.add_prefix_space}")
     tokenizer_info_storage[tokenizer_path] = (tokenizer, tokenizer_info)
 
 


### PR DESCRIPTION
This PR fixes the CI errors. It 
- sets longer timeout
- correctly skips tests for wheel building
- avoids caching pip, but cache huggingface
- downgrade transformers library on macos