### PR TITLE
update ci for hf token

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Run benchmark
         id: benchmark
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python examples/benchmark/cibench_grammar_compile_mask_gen.py --num_iters 3 --num_warmup 2 --datasets all | tee benchmark_output.txt
 


### PR DESCRIPTION
Adds hf token so the benchmark can correctly run the Llama-3.1-8B-Instruct tokenizer