### PR TITLE
[Fix] Switch release compilation flag from -Ofast to -O3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS "/Wall ${CMAKE_CXX_FLAGS}")
 else()
   if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CMAKE_CXX_FLAGS "-Ofast ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "-O3 ${CMAKE_CXX_FLAGS}")
   endif()
 
   set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -Wno-pedantic -Wno-unused-parameter \


### PR DESCRIPTION
This switches the optimization level from -Ofast to -O3. 

The motivation is that `-Ofast` causes a change in the global floating point behaviour in python.
Currently we see the following surprising behavior, where the if statement changes from False to True after importing xgrammar. 
```python
smallest_subnormal_double = 2.0 ** (-1074)
print("equal" if smallest_subnormal_double == 0.0 else "not equal") # prints non-equal

import xgrammar
print("equal" if smallest_subnormal_double == 0.0 else "not equal") # prints equal
```
(Python 3.12.7, linux, x86-64, xgrammar==0.1.11)

Note, I get this issue with version `0.1.11`, but not with `0.1.16`. 
I don't understand why to be honest, but I expect the underlying issue to be present with `-Ofast`

There's a blog post with more information here:
https://moyix.blogspot.com/2022/09/someones-been-messing-with-my-subnormals.html