### PR TITLE
Add module xgrammar.contrib.mlxlm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ test = [
   # https://github.com/huggingface/transformers/issues/36906
   "transformers<4.50.0; platform_system == 'Darwin'",
 ]
+apple-silicon = ["mlx-lm"]
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"

--- a/python/xgrammar/contrib/mlxlm.py
+++ b/python/xgrammar/contrib/mlxlm.py
@@ -17,6 +17,9 @@ import xgrammar
 def apply_token_bitmask_inplace_mlx(bitmask: torch.Tensor, logits: mx.array) -> mx.array:
     """This is an easy mimic of the apply_token_bitmask_inplace function.
 
+    NOTE: This function works with only the case of batch size is 1, which is common for on-device
+          applications.
+
     Args:
         bitmask (torch.Tensor): Created by calling xgrammar.allocate_token_bitmask.
         logits (mx.array): Passed in from mlx_generate.

--- a/python/xgrammar/contrib/mlxlm.py
+++ b/python/xgrammar/contrib/mlxlm.py
@@ -1,0 +1,107 @@
+"""
+Usage:
+    python xgrammar.py --model mlx-community/Qwen2.5-Coder-32B-Instruct-3bit
+"""
+
+import argparse
+import mlx.core as mx
+from mlx_lm.generate import generate as mlx_generate
+from mlx_lm.utils import load as mlx_load
+from transformers import AutoTokenizer
+import xgrammar
+import torch
+
+
+def apply_token_bitmask_inplace_mlx(
+    bitmask: torch.Tensor, logits: mx.array
+) -> mx.array:
+    """This is an easy mimic of the apply_token_bitmask_inplace function.
+
+    Args:
+        bitmask (torch.Tensor): Created by calling xgrammar.allocate_token_bitmask.
+        logits (mx.array): Passed in from mlx_generate.
+
+    Returns:
+        mx.array: The masked logits where invalid tokens have their logits set to -inf
+    """
+    vocab_size = logits.shape[-1]
+    # Create mask as torch tensor for mutability
+    logits_mask = torch.zeros(logits.shape, dtype=torch.float32)
+    for i in range(bitmask.size(0)):
+        mask_int = bitmask[0][i].item()  # batch size is 1
+        for bit in range(32):
+            token_idx = i * 32 + bit
+            if token_idx >= vocab_size:
+                break
+            is_valid = (mask_int >> bit) & 1
+            logits_mask[0][token_idx] = 0.0 if is_valid else float("-inf")
+    # Convert to mx.array only so we can add it to logits
+    return logits + mx.array(logits_mask.numpy())
+
+
+class XGrammarLogitsProcessor:
+    def __init__(
+        self,
+        grammar: xgrammar.CompiledGrammar,
+        max_rollback_tokens: int = 16,
+    ):
+        self.matcher = xgrammar.GrammarMatcher(
+            grammar, max_rollback_tokens=max_rollback_tokens
+        )
+        self.vocab_size = grammar.tokenizer_info.vocab_size
+        self.bitmask = xgrammar.allocate_token_bitmask(1, self.vocab_size)
+
+    def __call__(self, tokens: mx.array, logits: mx.array) -> mx.array:
+        assert tokens.size > 0  # In the first call, tokens.size == #tokens in prompt
+        last_token = tokens[-1].item()
+        acc = (
+            self.matcher.accept_token(last_token)
+            if not self.matcher.is_terminated()
+            else False
+        )
+        if not acc:
+            self.matcher.reset()
+            self.matcher.accept_token(last_token)
+        if not self.matcher.is_terminated():
+            self.matcher.fill_next_token_bitmask(self.bitmask)
+            return apply_token_bitmask_inplace_mlx(self.bitmask, logits)
+        return logits
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, required=True)
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default="Generate a simple example JSON. No text. Only the JSON",
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    model, _ = mlx_load(args.model)
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    mx.random.seed(args.seed)
+    generated_text = mlx_generate(
+        model=model,
+        tokenizer=tokenizer,
+        prompt=tokenizer.apply_chat_template(
+            [{"role": "user", "content": args.prompt}], add_generation_prompt=True
+        ),
+        verbose=False,
+        logits_processors=[
+            XGrammarLogitsProcessor(
+                grammar=xgrammar.GrammarCompiler(
+                    tokenizer_info=xgrammar.TokenizerInfo.from_huggingface(tokenizer)
+                ).compile_builtin_json_grammar()
+            )
+        ],
+    )
+    print(generated_text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
After a chat with @Ubospica , I am filing this PR to fix https://github.com/mlc-ai/xgrammar/issues/270

This module provides a logit processor for mlx_lm, just like hf.py provides one for Hugging Face Transformers.

This module is runnable and works demonstrating that XGrammar runs on Apple Silicon via MLX and mlx-lm, just like it works on CUDA via PyTorch and Hugging Face Transformers.

You can run this module like the following

```shell
python -m mlxlm \
 --model mlx-community/Qwen2.5-Coder-3B-Instruct-4bit \
 --prompt "Generate a very simple example JSON. No text. Only the JSON."
```

It generates a grammar-verified JSON like the following:

```json
{
  "name": "John Doe",
  "age": 30,
  "city": "New York"
}
```

### Optional Dependency

This pull request adds mlx-lm as an optional dependency `apple-silicon`. To run this demo modules, you need to install XGrammar from source code:

```shell
pip install -e .[apple-silicon]
```

### Next Steps

1. Currently, this demo module expand the bitmask generated from the pushdown automaton of XGrammar into a float array before adding it to the vocabulary logits generated by the LLM. We should add a Apple Silicon GPU kernel for MLX, just like the CUDA, Triton and CPU kernels for PyTorch.  In this way, we don't expand the bitmask and saves application time.

2. Currently, XGrammar generates the bitmask as a PyTorch tensor and this demo module converts it into an MLX array. I haven't benchmarked the cost of the conversion. If it is high, we may consider enabling XGrammar generating the bitmask as an MLX array optionally.
