### PR TITLE
[Fix] Fix test_json_schema_converter::test_non_strict and nanobind version issue

### DIFF
--- a/.github/workflows/tmate.yaml
+++ b/.github/workflows/tmate.yaml
@@ -29,6 +29,6 @@ jobs:
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 10
+        timeout-minutes: 30
         with:
           limit-access-to-actor: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
   "transformers>=4.38.0",
   "triton; platform_system == 'linux' and platform_machine == 'x86_64'",
   "ninja",
-  "nanobind>=2.0.0",
 ]
 dynamic = ["version"]
 
@@ -44,7 +43,7 @@ provider = "scikit_build_core.metadata.regex"
 input = "python/xgrammar/version.py"
 
 [build-system]
-requires = ["scikit-build-core>=0.10.0", "nanobind>=2.0.0"]
+requires = ["scikit-build-core>=0.10.0", "nanobind==2.5.0"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -93,8 +93,8 @@ class GrammarCompiler(XGRObject):
 
         Parameters
         ----------
-        schema : Union[str, Type[BaseModel]]
-            The schema string or Pydantic model.
+        schema : Union[str, Type[BaseModel], Dict[str, Any]]
+            The schema string or Pydantic model or JSON schema dict.
 
         indent : Optional[int], default: None
             The number of spaces for indentation. If None, the output will be in one line.

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -130,8 +130,8 @@ class Grammar(XGRObject):
 
         Parameters
         ----------
-        schema : Union[str, Type[BaseModel]]
-            The schema string or Pydantic model.
+        schema : Union[str, Type[BaseModel], Dict[str, Any]]
+            The schema string or Pydantic model or JSON schema dict.
 
         any_whitespace : bool, default: True
             Whether to use any whitespace. If True, the generated grammar will ignore the

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -1,19 +1,20 @@
 """Testing utilities."""
 
 import time
-from typing import List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import torch
+from pydantic import BaseModel
 
 from .base import _core
 from .compiler import CompiledGrammar, GrammarCompiler
-from .grammar import Grammar
+from .grammar import Grammar, _convert_schema_to_str
 from .matcher import GrammarMatcher, bitmask_dtype
 from .tokenizer_info import TokenizerInfo
 
 
 def _json_schema_to_ebnf(
-    schema: str,
+    schema: Union[str, Type[BaseModel], Dict[str, Any]],
     *,
     any_whitespace: bool = True,
     indent: Optional[int] = None,
@@ -24,8 +25,8 @@ def _json_schema_to_ebnf(
 
     Parameters
     ----------
-    schema : str
-        The schema string.
+    schema : Union[str, Type[BaseModel], Dict[str, Any]]
+        The schema string or Pydantic model or JSON schema dict.
 
     indent : Optional[int], default: None
         The number of spaces for indentation. If None, the output will be in one line.
@@ -48,8 +49,9 @@ def _json_schema_to_ebnf(
     bnf_string : str
         The BNF grammar string.
     """
+    schema_str = _convert_schema_to_str(schema)
     return _core.testing._json_schema_to_ebnf(
-        schema, any_whitespace, indent, separators, strict_mode
+        schema_str, any_whitespace, indent, separators, strict_mode
     )
 
 

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -280,16 +280,13 @@ def test_grammar_compiler_cache_unlimited():
     assert grammar_compiler.cache_limit_bytes == -1  # No limit (default, -1)
     assert grammar_compiler.get_cache_size_bytes() == 0  # No memory usage
     sum_single = 0
-    for i in range(100):
+    for i in range(10):
         schema = make_schema(f"name_{i}")
         compiled_grammar = grammar_compiler.compile_json_schema(schema, strict_mode=True)
         sum_single += compiled_grammar.memory_size_bytes
         memory_usage = grammar_compiler.get_cache_size_bytes()
         assert memory_usage == sum_single
-        if (i + 1) % 10 == 0:
-            print(
-                f"Cache memory usage after {i + 1} schemas: {memory_usage / MB:.3f} MB / unlimited"
-            )
+        print(f"Cache memory usage after {i + 1} schemas: {memory_usage / MB:.3f} MB / unlimited")
 
     old_size = grammar_compiler.get_cache_size_bytes()
     grammar_compiler.compile_json_schema(make_schema("name_0"), strict_mode=True)
@@ -309,22 +306,21 @@ def test_grammar_compiler_cache_limited():
 
     MB = 1024 * 1024
 
-    # with a 10MB limit
-    limit = int(1 * MB)
+    # with a 2MB limit
+    limit = int(2 * MB)
     grammar_compiler = xgr.GrammarCompiler(tokenizer_info, cache_limit_bytes=limit)
     assert grammar_compiler.cache_limit_bytes == limit
     assert grammar_compiler.get_cache_size_bytes() == 0
     sum_single = 0
-    for i in range(100):
+    for i in range(10):
         schema = make_schema(f"name_{i}")
         compiled_grammar = grammar_compiler.compile_json_schema(schema, strict_mode=True)
         sum_single += compiled_grammar.memory_size_bytes
         memory_usage = grammar_compiler.get_cache_size_bytes()
         assert 0 <= memory_usage <= min(sum_single, limit * 2)  # this is a rough estimate
-        if (i + 1) % 10 == 0:
-            print(
-                f"Cache memory usage after {i + 1} schemas: {memory_usage / MB:.3f} MB / {limit / MB:.3f} MB"
-            )
+        print(
+            f"Cache memory usage after {i + 1} schemas: {memory_usage / MB:.3f} MB / {limit / MB:.3f} MB"
+        )
 
     # Test clear_cache
     grammar_compiler.clear_cache()


### PR DESCRIPTION
test_json_schema_converter::test_non_strict was broken because pydantic 2.11 changes the converted json schema. This PR fixes the test. 

This PR also extends the timeout of tmate to 30min to help future CI debugging.

This PR also pins nanobind==2.5.0 in building system to avoid compilation error in 2.6.0.

This PR also reduces the time of test_grammar_compiler.py::test_grammar_compiler_cache_limited and test_grammar_compiler.py::test_grammar_compiler_cache_unlimited for faster CI.