### PR TITLE
Add MLX Metal GPU kernel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,6 @@ repos:
     rev: 6.0.0
     hooks:
       - id: isort
-        args: [--profile, black]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v19.1.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
     rev: 6.0.0
     hooks:
       - id: isort
+        args: [--profile, black]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v19.1.7

--- a/python/xgrammar/contrib/mlxlm.py
+++ b/python/xgrammar/contrib/mlxlm.py
@@ -4,6 +4,8 @@ Usage:
 """
 
 import argparse
+import itertools
+import timeit
 
 import mlx.core as mx
 import torch
@@ -27,9 +29,9 @@ def apply_token_bitmask_inplace_mlx(bitmask: torch.Tensor, logits: mx.array) -> 
     Returns:
         mx.array: The masked logits where invalid tokens have their logits set to -inf
     """
-    # If Metal implementation is available, use it
-    if "metal" in xgrammar.kernels.apply_token_bitmask_inplace_kernels:
-        return xgrammar.kernels.apply_token_bitmask_inplace_kernels["metal"](bitmask, logits)
+    # # If Metal implementation is available, use it
+    # if "metal" in xgrammar.kernels.apply_token_bitmask_inplace_kernels:
+    #     return xgrammar.kernels.apply_token_bitmask_inplace_kernels["metal"](bitmask, logits)
 
     # Otherwise, fall back to the naive implementation
     vocab_size = logits.shape[-1]
@@ -47,6 +49,10 @@ def apply_token_bitmask_inplace_mlx(bitmask: torch.Tensor, logits: mx.array) -> 
     return logits + mx.array(logits_mask.numpy())
 
 
+g_bitmasks = []
+g_logits = []
+
+
 class XGrammarLogitsProcessor:
     def __init__(self, grammar: xgrammar.CompiledGrammar, max_rollback_tokens: int = 16):
         self.matcher = xgrammar.GrammarMatcher(grammar, max_rollback_tokens=max_rollback_tokens)
@@ -60,7 +66,11 @@ class XGrammarLogitsProcessor:
             self.matcher.reset()
             self.matcher.accept_token(last_token)
         if not self.matcher.is_terminated():
+            global g_bitmasks
+            global g_logits
             self.matcher.fill_next_token_bitmask(self.bitmask)
+            g_bitmasks.append(self.bitmask)
+            g_logits.append(logits)
             return apply_token_bitmask_inplace_mlx(self.bitmask, logits)
         return logits
 
@@ -75,11 +85,23 @@ def parse_args():
     return parser.parse_args()
 
 
+@mx.compile
+def apply_bitmask_compiled(bitmask, logits, vocab_size):
+    bitmap = mx.array(
+        [l[::-1] for l in itertools.product(*[[float("-inf"), 0]] * 8)], dtype=logits.dtype
+    )
+    bitmask = bitmask.view(mx.uint8)
+    return logits[..., :vocab_size] + bitmap[bitmask].flatten(-2)[..., :vocab_size]
+
+
 def main():
     args = parse_args()
     model, _ = mlx_load(args.model)
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     mx.random.seed(args.seed)
+
+    vocab_size = xgrammar.TokenizerInfo.from_huggingface(tokenizer).vocab_size
+
     with_logits_processor = mlx_generate(
         model=model,
         tokenizer=tokenizer,
@@ -104,6 +126,23 @@ def main():
         verbose=False,
     )
     assert without_logits_processor == with_logits_processor
+
+    global g_bitmasks
+    global g_logits
+    for i in range(min(3, len(g_logits))):
+        execution_time = timeit.timeit(
+            lambda: mx.eval(
+                apply_bitmask_compiled(
+                    mx.array(g_bitmasks[i].detach().numpy()), g_logits[i], vocab_size
+                )
+            ),
+            number=10,
+        )
+        print(f"apply_bitmask_compiled: {execution_time / 10} seconds")
+        execution_time = timeit.timeit(
+            lambda: mx.eval(apply_token_bitmask_inplace_mlx(g_bitmasks[i], g_logits[i])), number=10
+        )
+        print(f"apply_token_bitmask_inplace_mlx: {execution_time / 10} seconds")
 
 
 if __name__ == "__main__":

--- a/python/xgrammar/kernels/__init__.py
+++ b/python/xgrammar/kernels/__init__.py
@@ -32,9 +32,7 @@ except ImportError:
 
 try:
     from .apply_token_bitmask_inplace_metal import apply_token_bitmask_inplace_metal  # isort: skip
-    # Note: The MLX Metal implementation has reversed parameter order (bitmask, logits)
-    # and works with MLX arrays directly instead of PyTorch tensors.
-    # Both logits and indices parameters are expected to be MLX arrays.
+
     apply_token_bitmask_inplace_kernels["metal"] = apply_token_bitmask_inplace_metal
 except ImportError:
     # If MLX is not installed, we can still use the CPU, CUDA, and Triton implementations.

--- a/python/xgrammar/kernels/__init__.py
+++ b/python/xgrammar/kernels/__init__.py
@@ -29,3 +29,13 @@ try:
 except ImportError:
     # If triton is not installed, we can still use the CPU and CUDA implementations.
     pass
+
+try:
+    from .apply_token_bitmask_inplace_metal import apply_token_bitmask_inplace_metal  # isort: skip
+    # Note: The MLX Metal implementation has reversed parameter order (bitmask, logits)
+    # and works with MLX arrays directly instead of PyTorch tensors.
+    # Both logits and indices parameters are expected to be MLX arrays.
+    apply_token_bitmask_inplace_kernels["metal"] = apply_token_bitmask_inplace_metal
+except ImportError:
+    # If MLX is not installed, we can still use the CPU, CUDA, and Triton implementations.
+    pass

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_metal.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_metal.py
@@ -1,0 +1,117 @@
+from typing import List, Optional, Union
+
+import torch
+
+try:
+    import mlx.core as mx
+    from mlx.core.fast import metal_kernel
+except ImportError as err:
+    raise ImportError("MLX is not installed") from err
+
+
+def apply_token_bitmask_inplace_metal(bitmask: torch.Tensor, logits: mx.array) -> mx.array:
+    """Apply a bitmask to logits using Metal. The bitmask is a 01 bitwise compressed tensor,
+    where 0 means the token is masked and 1 means the token is not masked. After applying the bitmask,
+    the masked logits will be set to -inf.
+
+    Parameters
+    ----------
+    bitmask : torch.Tensor
+        The bitmask tensor to apply. Should be of type int32.
+
+    logits : mx.array
+        The logits tensor to apply the bitmask to.
+
+    Returns
+    -------
+    mx.array
+        The masked logits where invalid tokens have their logits set to -inf.
+    """
+    # Check input dtype
+    assert bitmask.dtype == torch.int32, "bitmask must be of type int32"
+
+    # Convert PyTorch bitmask to MLX array
+    bitmask_mx = mx.array(bitmask.detach().cpu().numpy())
+
+    # Ensure 2D tensors for logits and bitmask
+    logits = logits.reshape((1, logits.size)) if len(logits.shape) == 1 else logits
+    bitmask_mx = (
+        bitmask_mx.reshape((1, bitmask_mx.size)) if len(bitmask_mx.shape) == 1 else bitmask_mx
+    )
+
+    # Vocabulary size is from logits shape
+    vocab_size = logits.shape[1]
+
+    # Check bitmask size
+    bits_per_int32 = 32
+    required_bitmask_width = (vocab_size + bits_per_int32 - 1) // bits_per_int32
+    assert bitmask_mx.shape[1] >= required_bitmask_width, (
+        f"Bitmask width too small: need at least {required_bitmask_width} int32s for "
+        f"logits' width {vocab_size}, but got {bitmask_mx.shape[1]}"
+    )
+
+    # Check batch sizes match
+    assert (
+        logits.shape[0] == bitmask_mx.shape[0]
+    ), f"Batch size mismatch: logits {logits.shape[0]} vs bitmask {bitmask_mx.shape[0]}"
+    batch_size = logits.shape[0]
+
+    # Define the Metal kernel source
+    source = """
+    // Get thread position in grid
+    uint token_idx = thread_position_in_grid.x;
+    uint batch_idx = thread_position_in_grid.y;
+
+    // Get actual scalar values from input parameters
+    int logits_stride_val = logits_stride[0];
+    int bitmask_stride_val = bitmask_stride[0];
+
+    // Calculate bitmask position
+    int bitmask_block_idx = token_idx / 32;
+    int bit_position = token_idx % 32;
+
+    // Calculate logits index
+    int logits_idx = batch_idx * logits_stride_val + token_idx;
+
+    // Always copy the value first
+    result[logits_idx] = logits[logits_idx];
+
+    // Apply mask if within bitmask bounds
+    if (bitmask_block_idx < bitmask_stride_val) {
+        int packed_bitmask = bitmask[batch_idx * bitmask_stride_val + bitmask_block_idx];
+        bool is_masked = ((packed_bitmask >> bit_position) & 1) == 0;
+
+        if (is_masked) {
+            result[logits_idx] = -INFINITY;
+        }
+    }
+    """
+
+    # Compile and execute the kernel
+    kernel = metal_kernel(
+        name="apply_token_bitmask",
+        source=source,
+        input_names=["logits", "bitmask", "logits_stride", "bitmask_stride"],
+        output_names=["result"],
+    )
+
+    # Prepare inputs and execute kernel
+    inputs = [
+        logits,
+        bitmask_mx,
+        mx.array([vocab_size], dtype=mx.int32),
+        mx.array([bitmask_mx.shape[1]], dtype=mx.int32),
+    ]
+
+    # Calculate thread group size - for Metal, 256 threads per group is typically good
+    threads_per_group = 256
+
+    outputs = kernel(
+        inputs=inputs,
+        output_shapes=[logits.shape],
+        output_dtypes=[logits.dtype],
+        grid=(vocab_size, batch_size, 1),  # Launch one thread per token-row pair
+        threadgroup=(threads_per_group, 1, 1),  # Use optimal thread group size
+    )
+
+    return outputs[0]

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -37,12 +37,14 @@ def test_get_masked_tokens_from_bitmask(token_mask_size: int, index: int):
     assert _get_masked_tokens_from_bitmask(bitmask, token_mask_size, index) == expected
 
 
-@pytest.mark.parametrize("impl", ("cpu", "cuda", "triton"))
+@pytest.mark.parametrize("impl", ("cpu", "cuda", "triton", "metal"))
 def test_apply_token_bitmask_inplace(impl: str):
     if impl == "cuda" and "cuda" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
         pytest.skip(reason="CUDA is not installed")
     if impl == "triton" and "triton" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
         pytest.skip(reason="Triton is not installed")
+    if impl == "metal" and "metal" not in xgr.kernels.apply_token_bitmask_inplace_kernels:
+        pytest.skip(reason="Metal is not installed")
 
     neginf = float("-inf")
     bool_mask = torch.tensor([0, 1, 0, 1, 0, 1, 0, 1, 0, 1], dtype=torch.bool)
@@ -61,6 +63,15 @@ def test_apply_token_bitmask_inplace(impl: str):
             xgr.kernels.apply_token_bitmask_inplace_kernels["triton"](logits_gpu, bitmask)
         torch.cuda.synchronize()
         torch.testing.assert_close(logits_gpu, expected.to("cuda"))
+    elif impl == "metal":
+        # Import MLX only when needed for the Metal test
+        import mlx.core as mx
+
+        bitmask = torch.tensor([0b1010101010], dtype=torch.int32)
+        logits_mx = mx.array(logits.numpy())
+        result_mx = xgr.kernels.apply_token_bitmask_inplace_kernels["metal"](bitmask, logits_mx)
+        expected_mx = mx.array(expected.numpy())
+        assert mx.allclose(result_mx, expected_mx)
     else:
         bitmask = torch.tensor([0b1010101010], dtype=torch.int32)
         xgr.apply_token_bitmask_inplace(logits, bitmask)


### PR DESCRIPTION
## Motivation

The goal of this PR is to enable XGrammar to work with MLX, in addition to its existing support for PyTorch.

## Approach 1: ✅ The Merged

https://github.com/mlc-ai/xgrammar/pull/273

@Ubospica has merged my initial implementation in [PR #273](https://github.com/mlc-ai/xgrammar/pull/273).

This version converts the bitmask generated by the pushdown automaton from a torch.Tensor to a mx.array float mask before applying it to logits: mx.array returned from an LLM via mlx-lm.

While functional, this approach is likely less efficient than the CUDA/Triton version, for two reasons:

1. It expands the bitmask into a float mask.
2. It applies the mask out-of-place, creating a new tensor instead of modifying logits in-place.

## Approach 2: ⛔ The Blocked

https://github.com/mlc-ai/xgrammar/pull/283

As an improvement, I submitted [PR #283](https://github.com/mlc-ai/xgrammar/pull/283), which added custom MLX kernels for ARM CPU and Metal GPU using CMake.

However, building the Metal kernel this way turned out to be very complex—likely due to the intricate relationship between CMakeLists.txt and the pip build backend.

@Ubospica kindly suggested exploring [mlx.core.fast.metal_kernel](https://ml-explore.github.io/mlx/build/html/python/_autosummary/mlx.core.fast.metal_kernel.html), which supports JIT-compilation of Metal kernels—similar to how torch.utils.cpp_extension.load_inline works for CUDA.

## Approach 3: 🟡 The Imperfect

https://github.com/mlc-ai/xgrammar/pull/285

This PR adopts @Ubospica’s suggestion. It works as expected with the following:

```shell
pip uninstall -y xgrammar && pip install .[test]
pytest -v tests/python/test_token_bitmask_operations.py::test_apply_token_bitmask_inplace
```

Result:

```plaintext
PASSED tests/python/test_token_bitmask_operations.py::test_apply_token_bitmask_inplace[cpu]
PASSED tests/python/test_token_bitmask_operations.py::test_apply_token_bitmask_inplace[metal]
SKIPPED [1] tests/python/test_token_bitmask_operations.py:43: CUDA is not installed
SKIPPED [1] tests/python/test_token_bitmask_operations.py:45: Triton is not installed
```

However, `mlx.core.fast.metal_kernel` allocates a new output tensor instead of performing the operation in-place. This behavior is reasonable—MLX follows a functional programming paradigm similar to JAX, where tensors are immutable. This differs from PyTorch, which allows in-place operations.

## Approach 4: 🚀 The Promising

https://github.com/mlc-ai/xgrammar/pull/287

After discussing with Awni Hannun and Angelos Katharopoulos, they suggested a much better direction:

1. Don’t perform the masking in-place.
2. Expand the bitmask into a float mask (as in Approach 1).
3. Use mx.compile to optimize and accelerate this expand-and-apply process.

Angelos even provided a brilliant and fully compiled implementation:

```python
@mx.compile
def apply_bitmask(bitmask, logits):
    bitmap = mx.array(
        [l[::-1] for l in product(*[[float("-inf"), 0]]*8)],
        dtype=logits.dtype,
    )
    bitmask = bitmask.view(mx.uint8)
    return logits + bitmap[bitmask].flatten(-2)[..., :logits.shape[-1]]
```

My Interpretation of Angelos’ Code:
1. `bitmap` is a (256, 8) array. Each row represents one of the 256 combinations of 8 bits, mapping bits to -inf or 0.
2. `bitmask.view(mx.uint8)` casts the uint32 tensor into uint8 without changing the byte order. (Apple Silicon is little-endian.)
3. As `bitmask` has shape (batch_size, ceil_div(vocab_size, 32)/8), then `bitmap[bitmask]` becomes `(batch_size, ceil_div(vocab_size, 32)/8, 8)`. After `flatten(-2)`, we get a float mask of shape `(batch_size, vocab_size_padded)`.
4. `[..., :logits.shape[-1]]` truncates the padding to match the actual vocabulary size.

## Performance Comparison

Angelos benchmarked approach 4 against my original (non-compiled) Approach 1:

```
In [3]: %timeit mx.eval(apply_token_bitmask_inplace_mlx(bitmask_torch, logits))
255 ms ± 2.47 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: %timeit mx.eval(apply_bitmask(bitmask_mlx, logits))
225 µs ± 15.5 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

**Result: The compiled version is over 1000× faster.**