### PR TITLE
Add MLX kernel to support Apple Silicon

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -57,15 +57,7 @@ jobs:
             ~/.cache/huggingface
           key: huggingface-${{ matrix.os }}-python-${{ matrix.python }}
 
-      - name: Build XGrammar for Apple Silicon
-        if: ${{ runner.os == 'macOS' && runner.arch == 'arm64' }}
-        run: |
-          echo "set(XGRAMMAR_BUILD_CXX_TESTS ON)" >> cmake/config.cmake
-          python -m pip install --upgrade pip
-          pip install -v ".[test,apple-silicon]"
-
-      - name: Build XGrammar for non-Apple Silicon
-        if: ${{ runner.os != 'macOS' || runner.arch != 'arm64' }}
+      - name: Build xgrammar from source
         run: |
           echo "set(XGRAMMAR_BUILD_CXX_TESTS ON)" >> cmake/config.cmake
           python -m pip install --upgrade pip

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -57,7 +57,15 @@ jobs:
             ~/.cache/huggingface
           key: huggingface-${{ matrix.os }}-python-${{ matrix.python }}
 
-      - name: Build xgrammar from source
+      - name: Build XGrammar for Apple Silicon
+        if: ${{ runner.os == 'macOS' && runner.arch == 'arm64' }}
+        run: |
+          echo "set(XGRAMMAR_BUILD_CXX_TESTS ON)" >> cmake/config.cmake
+          python -m pip install --upgrade pip
+          pip install -v ".[test,apple-silicon]"
+
+      - name: Build XGrammar for non-Apple Silicon
+        if: ${{ runner.os != 'macOS' || runner.arch != 'arm64' }}
         run: |
           echo "set(XGRAMMAR_BUILD_CXX_TESTS ON)" >> cmake/config.cmake
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
   "tiktoken",
   "torch>=1.10.0",
   "transformers>=4.38.0",
-  "triton; platform_system == 'linux' and platform_machine == 'x86_64'",
+  "triton; platform_system == 'Linux' and platform_machine == 'x86_64'",
+  "mlx-lm; platform_system == 'Darwin' and platform_machine == 'arm64'",
   "ninja",
 ]
 dynamic = ["version"]
@@ -37,7 +38,6 @@ test = [
   # https://github.com/huggingface/transformers/issues/36906
   "transformers<4.50.0; platform_system == 'Darwin'",
 ]
-apple-silicon = ["mlx-lm"]
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"

--- a/python/xgrammar/contrib/mlxlm.py
+++ b/python/xgrammar/contrib/mlxlm.py
@@ -6,7 +6,6 @@ Usage:
 import argparse
 
 import mlx.core as mx
-import torch
 from mlx_lm.generate import generate as mlx_generate
 from mlx_lm.utils import load as mlx_load
 from transformers import AutoTokenizer

--- a/python/xgrammar/contrib/mlxlm.py
+++ b/python/xgrammar/contrib/mlxlm.py
@@ -12,34 +12,7 @@ from mlx_lm.utils import load as mlx_load
 from transformers import AutoTokenizer
 
 import xgrammar
-
-
-def apply_token_bitmask_inplace_mlx(bitmask: torch.Tensor, logits: mx.array) -> mx.array:
-    """This is an easy mimic of the apply_token_bitmask_inplace function.
-
-    NOTE: This function works with only the case of batch size is 1, which is common for on-device
-          applications.
-
-    Args:
-        bitmask (torch.Tensor): Created by calling xgrammar.allocate_token_bitmask.
-        logits (mx.array): Passed in from mlx_generate.
-
-    Returns:
-        mx.array: The masked logits where invalid tokens have their logits set to -inf
-    """
-    vocab_size = logits.shape[-1]
-    # Create mask as torch tensor for mutability
-    logits_mask = torch.zeros(logits.shape, dtype=torch.float32)
-    for i in range(bitmask.size(1)):
-        mask_int = bitmask[0][i].item()  # batch size is 1
-        for bit in range(32):
-            token_idx = i * 32 + bit
-            if token_idx >= vocab_size:
-                break
-            is_valid = (mask_int >> bit) & 1
-            logits_mask[0][token_idx] = 0.0 if is_valid else float("-inf")
-    # Convert to mx.array only so we can add it to logits
-    return logits + mx.array(logits_mask.numpy())
+from xgrammar.kernels import apply_token_bitmask_inplace_kernels
 
 
 class XGrammarLogitsProcessor:
@@ -57,7 +30,9 @@ class XGrammarLogitsProcessor:
             self.matcher.accept_token(last_token)
         if not self.matcher.is_terminated():
             self.matcher.fill_next_token_bitmask(self.bitmask)
-            return apply_token_bitmask_inplace_mlx(self.bitmask, logits)
+            return apply_token_bitmask_inplace_kernels["metal"](
+                mx.array(self.bitmask.numpy()), logits, self.vocab_size
+            )
         return logits
 
 
@@ -100,6 +75,7 @@ def main():
         verbose=False,
     )
     assert without_logits_processor == with_logits_processor
+    print(without_logits_processor)
 
 
 if __name__ == "__main__":

--- a/python/xgrammar/kernels/__init__.py
+++ b/python/xgrammar/kernels/__init__.py
@@ -30,13 +30,13 @@ except ImportError:
     # If triton is not installed, we can still use the CPU and CUDA implementations.
     pass
 
-# MLX implementation
 try:
     import mlx.core as mx
 
     from .apply_token_bitmask_mlx import apply_token_bitmask_mlx
 
-    # Note: We're adding this to a new dictionary since it's not an in-place operation
+    # Note: MLX arrays, like JAX arrays, are immutable.  Therefore, in-place operations are not
+    #       allowed. Here we reuse the variable apply_token_bitmask_inplace_kernels.
     apply_token_bitmask_inplace_kernels["metal"] = apply_token_bitmask_mlx
 except ImportError:
     # If MLX is not installed, we don't register the MLX implementation

--- a/python/xgrammar/kernels/__init__.py
+++ b/python/xgrammar/kernels/__init__.py
@@ -29,3 +29,15 @@ try:
 except ImportError:
     # If triton is not installed, we can still use the CPU and CUDA implementations.
     pass
+
+# MLX implementation
+try:
+    import mlx.core as mx
+
+    from .apply_token_bitmask_mlx import apply_token_bitmask_mlx
+
+    # Note: We're adding this to a new dictionary since it's not an in-place operation
+    apply_token_bitmask_inplace_kernels["metal"] = apply_token_bitmask_mlx
+except ImportError:
+    # If MLX is not installed, we don't register the MLX implementation
+    pass

--- a/python/xgrammar/kernels/apply_token_bitmask_mlx.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_mlx.py
@@ -1,0 +1,25 @@
+"""MLX kernel for applying token bitmasks."""
+
+import itertools
+
+import mlx.core as mx
+
+
+@mx.compile
+def apply_token_bitmask_mlx(bitmask: mx.array, logits: mx.array, vocab_size: int):
+    """Apply a token bitmask to logits using MLX for Metal GPUs.
+
+    Args:
+        bitmask: A tensor of shape (batch_size, (vocab_size + 31) // 32) containing
+            the bitmask. Each bit in the bitmask determines whether the corresponding
+            token is allowed (1) or not (0).
+        logits: A tensor of shape (batch_size, vocab_size) containing the logits.
+
+    Returns:
+        The logits with -inf for tokens that are not allowed.
+    """
+    bitmap = mx.array(
+        [l[::-1] for l in itertools.product(*[[float("-inf"), 0]] * 8)], dtype=logits.dtype
+    )
+    bitmask = bitmask.view(mx.uint8)
+    return logits[..., :vocab_size] + bitmap[bitmask].flatten(-2)[..., :vocab_size]


### PR DESCRIPTION
As described in https://github.com/mlc-ai/xgrammar/pull/285#issue-2961934829, there are four ways to implement apply_token_bitmask for Apple Silicon in MLX. This PR is approach 4, which is from Angelos Katharopoulos. Kudos to Angelos!

Also, as described in https://github.com/mlc-ai/xgrammar/pull/285#issuecomment-2768166617, this approach is the simplest and the most performant option.  After the merge of this PR, I will close the rest PRs implementing other approaches:

- https://github.com/mlc-ai/xgrammar/pull/283
- https://github.com/mlc-ai/xgrammar/pull/285

For our reference, I am highlighting the experiment report at https://github.com/mlc-ai/xgrammar/pull/285#issuecomment-2768166617 with content copied to the following:

- Manually written Metal GPU kernel compiled with `mx.fast.metal_kernel`:  0.0002715208800509572 seconds
- Python-code compiled with `mx.compile`:  0.00022429581731557845 seconds
- Naive Python implementation:  0.31162573751062156 seconds
