### PR TITLE
Disable slow C++ test cases

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Configuring build Environment
         run: |
           sudo apt-get update
-          python -m pip install -U pip wheel
+          python -m pip install -U pip wheel setuptools
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/tests/cpp/test_thread_pool.cc
+++ b/tests/cpp/test_thread_pool.cc
@@ -37,30 +37,30 @@ TEST(XGramamrThreadPoolTest, FunctionalTest) {
   pool.Join();
 }
 
-TEST(XGramamrThreadPoolTest, PressureTest) {
-  const size_t num_threads = std::thread::hardware_concurrency();
-  ThreadPool pool(num_threads);
+// TEST(XGramamrThreadPoolTest, PressureTest) {
+//   const size_t num_threads = std::thread::hardware_concurrency();
+//   ThreadPool pool(num_threads);
 
-  const size_t num_tasks = 1000;
-  int counter = 0;
-  std::mutex counter_mutex;
+//   const size_t num_tasks = 1000;
+//   int counter = 0;
+//   std::mutex counter_mutex;
 
-  auto start_time = std::chrono::high_resolution_clock::now();
+//   auto start_time = std::chrono::high_resolution_clock::now();
 
-  for (size_t i = 0; i < num_tasks; ++i) {
-    pool.Execute([&counter, &counter_mutex, i]() {
-      std::this_thread::sleep_for(std::chrono::milliseconds(i % 50));
-      std::lock_guard<std::mutex> lock(counter_mutex);
-      counter++;
-    });
-  }
+//   for (size_t i = 0; i < num_tasks; ++i) {
+//     pool.Execute([&counter, &counter_mutex, i]() {
+//       std::this_thread::sleep_for(std::chrono::milliseconds(i % 50));
+//       std::lock_guard<std::mutex> lock(counter_mutex);
+//       counter++;
+//     });
+//   }
 
-  pool.Wait();
+//   pool.Wait();
 
-  auto end_time = std::chrono::high_resolution_clock::now();
+//   auto end_time = std::chrono::high_resolution_clock::now();
 
-  EXPECT_EQ(counter, static_cast<int>(num_tasks));
+//   EXPECT_EQ(counter, static_cast<int>(num_tasks));
 
-  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
-  std::cout << "Pressure test completed, time taken: " << duration.count() << " milliseconds.\n";
-}
+//   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+//   std::cout << "Pressure test completed, time taken: " << duration.count() << " milliseconds.\n";
+// }

--- a/tests/cpp/test_thread_safe_cache.cc
+++ b/tests/cpp/test_thread_safe_cache.cc
@@ -53,102 +53,105 @@ struct Computer0 {
 constexpr auto kUnlimited = std::size_t(-1);
 constexpr auto kOverheadRatio = 0.1;
 
-TEST(XGrammarParallelTest, CacheContention) {
-  XGRAMMAR_LOG_INFO << "Testing the contention performance of the cache (no eviction)";
-  constexpr auto kReadGroup = 8;
-  const auto kNumThreads = int(std::thread::hardware_concurrency()) * 4;
+// TEST(XGrammarParallelTest, CacheContention) {
+//   XGRAMMAR_LOG_INFO << "Testing the contention performance of the cache (no eviction)";
+//   constexpr auto kReadGroup = 8;
+//   const auto kNumThreads = int(std::thread::hardware_concurrency()) * 4;
 
-  // never evict
-  auto cache = ThreadSafeLRUCache<std::size_t, MockGrammar, Computer0, SizeEstimator>{kUnlimited};
+//   // never evict
+//   auto cache = ThreadSafeLRUCache<std::size_t, MockGrammar, Computer0,
+//   SizeEstimator>{kUnlimited};
 
-  auto futures = std::vector<std::future<std::size_t>>{};
-  futures.reserve(kNumThreads);
-  const auto tic = std::chrono::high_resolution_clock::now();
-  const auto target = tic + 1s;
+//   auto futures = std::vector<std::future<std::size_t>>{};
+//   futures.reserve(kNumThreads);
+//   const auto tic = std::chrono::high_resolution_clock::now();
+//   const auto target = tic + 1s;
 
-  for (int i = 0; i < kNumThreads; ++i) {
-    futures.push_back(std::async(std::launch::async, [=, &cache] {
-      std::this_thread::sleep_until(target);
-      auto sum = std::size_t{};
-      // write group: they should not compete with each other
-      for (int j = 0; j < kNumThreads; ++j) {
-        sum += cache.Get((i + j) % kNumThreads).uuid;
-      }
-      // read group: they should not compete with each other
-      for (int k = 0; k < kReadGroup; ++k) {
-        for (int j = 0; j < kNumThreads; ++j) {
-          sum += cache.Get((i + j) % kNumThreads).uuid;
-        }
-      }
-      return sum;
-    }));
-  }
+//   for (int i = 0; i < kNumThreads; ++i) {
+//     futures.push_back(std::async(std::launch::async, [=, &cache] {
+//       std::this_thread::sleep_until(target);
+//       auto sum = std::size_t{};
+//       // write group: they should not compete with each other
+//       for (int j = 0; j < kNumThreads; ++j) {
+//         sum += cache.Get((i + j) % kNumThreads).uuid;
+//       }
+//       // read group: they should not compete with each other
+//       for (int k = 0; k < kReadGroup; ++k) {
+//         for (int j = 0; j < kNumThreads; ++j) {
+//           sum += cache.Get((i + j) % kNumThreads).uuid;
+//         }
+//       }
+//       return sum;
+//     }));
+//   }
 
-  const auto kResult = std::size_t(kNumThreads) * (kNumThreads - 1) / 2 * (1 + kReadGroup);
-  for (int i = 0; i < kNumThreads; ++i) EXPECT_EQ(futures[i].get(), kResult);
+//   const auto kResult = std::size_t(kNumThreads) * (kNumThreads - 1) / 2 * (1 + kReadGroup);
+//   for (int i = 0; i < kNumThreads; ++i) EXPECT_EQ(futures[i].get(), kResult);
 
-  const auto toc = std::chrono::high_resolution_clock::now();
-  const auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(toc - tic);
+//   const auto toc = std::chrono::high_resolution_clock::now();
+//   const auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(toc - tic);
 
-  // remove 1s sleep time and computing sleep time
-  const auto overhead = dur - 1s - Computer0::kSleepTime;
+//   // remove 1s sleep time and computing sleep time
+//   const auto overhead = dur - 1s - Computer0::kSleepTime;
 
-  XGRAMMAR_LOG_INFO << "(1 write + " << kReadGroup << " reads) "
-                    << "* " << kNumThreads << " threads | "
-                    << "overhead = " << overhead.count() << "ms";
+//   XGRAMMAR_LOG_INFO << "(1 write + " << kReadGroup << " reads) "
+//                     << "* " << kNumThreads << " threads | "
+//                     << "overhead = " << overhead.count() << "ms";
 
-  if (overhead > kOverheadRatio * kNumThreads * Computer0::kSleepTime + 1s) {
-    XGRAMMAR_LOG(WARNING) << "The overhead is too high, maybe the cache holds the lock too long?";
-  }
-}
+//   if (overhead > kOverheadRatio * kNumThreads * Computer0::kSleepTime + 1s) {
+//     XGRAMMAR_LOG(WARNING) << "The overhead is too high, maybe the cache holds the lock too
+//     long?";
+//   }
+// }
 
-TEST(XGrammarParallelTest, CacheEviction) {
-  XGRAMMAR_LOG_INFO << "Testing the eviction performance of the cache (always evict)";
-  constexpr auto kInsertGroup = 8;
-  const auto kNumThreads = int(std::thread::hardware_concurrency()) * 4;
+// TEST(XGrammarParallelTest, CacheEviction) {
+//   XGRAMMAR_LOG_INFO << "Testing the eviction performance of the cache (always evict)";
+//   constexpr auto kInsertGroup = 8;
+//   const auto kNumThreads = int(std::thread::hardware_concurrency()) * 4;
 
-  // always evict
-  auto cache = ThreadSafeLRUCache<std::size_t, MockGrammar, Computer0, SizeEstimator>{0};
+//   // always evict
+//   auto cache = ThreadSafeLRUCache<std::size_t, MockGrammar, Computer0, SizeEstimator>{0};
 
-  auto futures = std::vector<std::future<std::size_t>>{};
-  futures.reserve(kNumThreads);
-  const auto tic = std::chrono::high_resolution_clock::now();
-  const auto target = tic + 1s;
+//   auto futures = std::vector<std::future<std::size_t>>{};
+//   futures.reserve(kNumThreads);
+//   const auto tic = std::chrono::high_resolution_clock::now();
+//   const auto target = tic + 1s;
 
-  for (int i = 0; i < kNumThreads; ++i) {
-    futures.push_back(std::async(std::launch::async, [=, &cache] {
-      std::this_thread::sleep_until(target);
-      auto sum = std::size_t{};
-      // each thread writes to a different key
-      for (int j = 0; j < kInsertGroup; ++j) {
-        sum += cache.Get(i * kInsertGroup + j).uuid;
-      }
-      return sum;
-    }));
-  }
+//   for (int i = 0; i < kNumThreads; ++i) {
+//     futures.push_back(std::async(std::launch::async, [=, &cache] {
+//       std::this_thread::sleep_until(target);
+//       auto sum = std::size_t{};
+//       // each thread writes to a different key
+//       for (int j = 0; j < kInsertGroup; ++j) {
+//         sum += cache.Get(i * kInsertGroup + j).uuid;
+//       }
+//       return sum;
+//     }));
+//   }
 
-  const auto kNumInsert = std::size_t(kNumThreads) * kInsertGroup;
-  const auto kResult = kNumInsert * (kNumInsert - 1) / 2;
+//   const auto kNumInsert = std::size_t(kNumThreads) * kInsertGroup;
+//   const auto kResult = kNumInsert * (kNumInsert - 1) / 2;
 
-  auto sum = std::size_t{};
-  for (int i = 0; i < kNumThreads; ++i) sum += futures[i].get();
-  EXPECT_EQ(sum, kResult);
+//   auto sum = std::size_t{};
+//   for (int i = 0; i < kNumThreads; ++i) sum += futures[i].get();
+//   EXPECT_EQ(sum, kResult);
 
-  const auto toc = std::chrono::high_resolution_clock::now();
-  const auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(toc - tic);
+//   const auto toc = std::chrono::high_resolution_clock::now();
+//   const auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(toc - tic);
 
-  // remove 1s sleep time and computing sleep time
-  const auto overhead = dur - 1s - Computer0::kSleepTime * kInsertGroup;
+//   // remove 1s sleep time and computing sleep time
+//   const auto overhead = dur - 1s - Computer0::kSleepTime * kInsertGroup;
 
-  XGRAMMAR_LOG_INFO << "(" << kInsertGroup << " writes) "
-                    << "* " << kNumThreads << " threads | "
-                    << "overhead = " << overhead.count() << "ms";
+//   XGRAMMAR_LOG_INFO << "(" << kInsertGroup << " writes) "
+//                     << "* " << kNumThreads << " threads | "
+//                     << "overhead = " << overhead.count() << "ms";
 
-  // shouldn't exceed compute + sleep time
-  if (overhead > kOverheadRatio * Computer0::kSleepTime * kNumThreads + 1s) {
-    XGRAMMAR_LOG(WARNING) << "The overhead is too high, maybe the cache holds the lock too long?";
-  }
-}
+//   // shouldn't exceed compute + sleep time
+//   if (overhead > kOverheadRatio * Computer0::kSleepTime * kNumThreads + 1s) {
+//     XGRAMMAR_LOG(WARNING) << "The overhead is too high, maybe the cache holds the lock too
+//     long?";
+//   }
+// }
 
 // A hook to ensure that the object will not be accessed after its destruction
 struct LifeSpanHook {
@@ -224,27 +227,27 @@ struct Computer1 {
   }
 };
 
-TEST(XGrammarParallelTest, CacheCorrectness) {
-  auto cache = ThreadSafeLRUCache<std::string, TestObject, Computer1, SizeEstimator>{kUnlimited};
+// TEST(XGrammarParallelTest, CacheCorrectness) {
+//   auto cache = ThreadSafeLRUCache<std::string, TestObject, Computer1, SizeEstimator>{kUnlimited};
 
-  const auto kNumThreads = int(std::thread::hardware_concurrency()) * 16;
-  auto futures = std::vector<std::future<std::string>>{};
-  futures.reserve(kNumThreads);
+//   const auto kNumThreads = int(std::thread::hardware_concurrency()) * 16;
+//   auto futures = std::vector<std::future<std::string>>{};
+//   futures.reserve(kNumThreads);
 
-  for (auto i = 0; i < kNumThreads; ++i) {
-    futures.push_back(std::async(std::launch::async, [&cache, i] {
-      return cache.Get(std::to_string(-i)).to_string();
-    }));
-  }
+//   for (auto i = 0; i < kNumThreads; ++i) {
+//     futures.push_back(std::async(std::launch::async, [&cache, i] {
+//       return cache.Get(std::to_string(-i)).to_string();
+//     }));
+//   }
 
-  // Wait the futures to block
-  std::this_thread::sleep_for(1s);
+//   // Wait the futures to block
+//   std::this_thread::sleep_for(1s);
 
-  cache.Clear();
+//   cache.Clear();
 
-  for (auto i = 0; i < kNumThreads; ++i) {
-    EXPECT_EQ(futures[i].get(), std::to_string(-i));
-  }
-}
+//   for (auto i = 0; i < kNumThreads; ++i) {
+//     EXPECT_EQ(futures[i].get(), std::to_string(-i));
+//   }
+// }
 
 }  // namespace


### PR DESCRIPTION
This PR disables slow C++ test cases. These tests should ideally disable in a configurable manner. cc @DarkSharpness