### PR TITLE
Structural Tag Parser

### DIFF
--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -14,6 +14,7 @@
 
 #include "../grammar_functor.h"
 #include "../json_schema_converter.h"
+#include "../parser_structural_tag.h"
 #include "../regex_converter.h"
 #include "../testing.h"
 #include "python_methods.h"
@@ -232,6 +233,14 @@ NB_MODULE(xgrammar_bindings, m) {
           },
           nb::arg("start").none(),
           nb::arg("end").none()
+      )
+      .def(
+          "_parser_structural_tag",
+          [](const std::string& input, const std::vector<std::string>& triggers) {
+            return parse_structural_tag(input, triggers);
+          },
+          nb::arg("input"),
+          nb::arg("triggers")
       );
 
   auto pyGrammarFunctorModule = pyTestingModule.def_submodule("grammar_functor");

--- a/cpp/parser_structural_tag.cc
+++ b/cpp/parser_structural_tag.cc
@@ -1,0 +1,160 @@
+/*!
+ *  Copyright (c) 2025 by Contributors
+ * \file xgrammar/parser_structural_tag.cc
+ */
+
+#include "parser_structural_tag.h"
+
+#include <algorithm>
+#include <iomanip>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include "picojson.h"
+#include "support/logging.h"
+
+namespace xgrammar {
+
+/**
+ * @brief Parse structural tags from input string
+ *
+ * @param input The LLM output string to parse
+ * @param triggers List of trigger strings that indicate the start of a structural tag
+ * @return std::pair<std::string, std::vector<std::tuple<std::string, std::string, std::string>>>
+ *         First element: Text outside structural tags, joined together
+ *         Second element: List of (start_tag, content, end_tag) tuples for valid structural tags
+ */
+std::pair<std::string, std::vector<std::tuple<std::string, std::string, std::string>>>
+parse_structural_tag(const std::string& input, const std::vector<std::string>& triggers) {
+  std::vector<std::tuple<std::string, std::string, std::string>> parsed_tags;
+  std::string non_tag_content;
+
+  size_t input_pos = 0;
+  const size_t input_length = input.length();
+  std::string_view input_view(input);
+
+  while (input_pos < input_length) {
+    bool trigger_matched = false;
+    std::string matched_trigger;
+
+    for (const auto& trigger : triggers) {
+      if (input_pos + trigger.length() <= input_length &&
+          input_view.substr(input_pos, trigger.length()) == trigger) {
+        trigger_matched = true;
+        matched_trigger = trigger;
+        break;
+      }
+    }
+
+    if (!trigger_matched) {
+      non_tag_content.push_back(input[input_pos]);
+      input_pos++;
+      continue;
+    }
+
+    size_t tag_start_pos = input_pos;
+    input_pos += matched_trigger.length();
+
+    bool is_complete_tag = matched_trigger.back() == '>';
+    size_t start_tag_end;
+
+    if (is_complete_tag) {
+      start_tag_end = tag_start_pos + matched_trigger.length() - 1;
+    } else {
+      start_tag_end = input.find('>', input_pos);
+      if (start_tag_end == std::string::npos) {
+        // Malformed tag: no closing '>' for start tag
+        input_pos = tag_start_pos + matched_trigger.length();
+        continue;
+      }
+    }
+
+    std::string start_tag = input.substr(tag_start_pos, start_tag_end - tag_start_pos + 1);
+
+    // Determine the end tag based on the trigger
+    std::string end_tag_prefix;
+    if (matched_trigger.substr(0, 1) == "<") {
+      if (is_complete_tag) {
+        // For tags like <ipython>, extract the tag name without the <>
+        end_tag_prefix = "</" + matched_trigger.substr(1, matched_trigger.length() - 2);
+      } else {
+        size_t tag_name_start = matched_trigger.find('=');
+        if (tag_name_start != std::string::npos) {
+          end_tag_prefix = "</" + matched_trigger.substr(1, tag_name_start - 1);
+        } else {
+          // tags without =
+          end_tag_prefix = "</" + matched_trigger.substr(1);
+        }
+      }
+    } else {
+      end_tag_prefix = "</" + matched_trigger.substr(1);
+    }
+
+    size_t content_start = start_tag_end + 1;
+    size_t end_tag_start = input.find(end_tag_prefix, content_start);
+
+    if (end_tag_start == std::string::npos) {
+      input_pos = start_tag_end + 1;
+      continue;
+    }
+
+    size_t end_tag_end = input.find('>', end_tag_start);
+    if (end_tag_end == std::string::npos) {
+      input_pos = start_tag_end + 1;
+      continue;
+    }
+
+    std::string content = input.substr(content_start, end_tag_start - content_start);
+    std::string end_tag = input.substr(end_tag_start, end_tag_end - end_tag_start + 1);
+
+    bool is_valid_json = false;
+
+    // Check if content is potentially JSON by looking for opening/closing brackets
+    if ((content.find('{') != std::string::npos && content.find('}') != std::string::npos) ||
+        (content.find('[') != std::string::npos && content.find(']') != std::string::npos)) {
+      int bracket_count = 0;
+      int square_bracket_count = 0;
+      bool potentially_valid = true;
+
+      for (char c : content) {
+        if (c == '{')
+          bracket_count++;
+        else if (c == '}') {
+          bracket_count--;
+          if (bracket_count < 0) {
+            potentially_valid = false;
+            break;
+          }
+        } else if (c == '[')
+          square_bracket_count++;
+        else if (c == ']') {
+          square_bracket_count--;
+          if (square_bracket_count < 0) {
+            potentially_valid = false;
+            break;
+          }
+        }
+      }
+
+      if (potentially_valid && bracket_count == 0 && square_bracket_count == 0) {
+        picojson::value v;
+        std::string err = picojson::parse(v, content);
+        is_valid_json = err.empty();
+      }
+    }
+
+    if (is_valid_json || matched_trigger.find("<function=") != 0) {
+      // For function tags, we require valid JSON. For other tags, we might be more lenient
+      parsed_tags.emplace_back(start_tag, content, end_tag);
+    }
+
+    input_pos = end_tag_end + 1;
+  }
+
+  return std::make_pair(non_tag_content, parsed_tags);
+}
+
+}  // namespace xgrammar

--- a/cpp/parser_structural_tag.h
+++ b/cpp/parser_structural_tag.h
@@ -1,0 +1,33 @@
+/*!
+ *  Copyright (c) 2025 by Contributors
+ * \file xgrammar/parser_structural_tag.h
+ */
+
+#ifndef XGRAMMAR_PARSER_STRUCTURAL_TAG_H_
+#define XGRAMMAR_PARSER_STRUCTURAL_TAG_H_
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace xgrammar {
+
+/**
+ * @brief Parse structural tags from input string
+ *
+ * This parser identifies structural tags in LLM output based on trigger strings.
+ * It extracts the start tag, content, and end tag for each valid structural element.
+ * For function tags with JSON content, it validates the JSON syntax using picojson.
+ *
+ * @param input The LLM output string to parse
+ * @param triggers List of trigger strings that indicate the start of a structural tag
+ * @return std::pair<std::string, std::vector<std::tuple<std::string, std::string, std::string>>>
+ *         First element: Text outside structural tags, joined together
+ *         Second element: List of (start_tag, content, end_tag) tuples for valid structural tags
+ */
+std::pair<std::string, std::vector<std::tuple<std::string, std::string, std::string>>>
+parse_structural_tag(const std::string& input, const std::vector<std::string>& triggers);
+
+}  // namespace xgrammar
+
+#endif  // XGRAMMAR_PARSER_STRUCTURAL_TAG_H_

--- a/tests/python/test_parser_structural_tag.py
+++ b/tests/python/test_parser_structural_tag.py
@@ -1,0 +1,253 @@
+import sys
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+import xgrammar as xgr
+from xgrammar.testing import parser_structural_tag
+
+
+def test_basic_function_tag():
+    """Test basic function tag with JSON content."""
+    input_str = '<function="get_weather">{"location": "Beijing"}</function>'
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == ""
+    assert len(parsed_tags) == 1
+    assert parsed_tags[0][0] == '<function="get_weather">'
+    assert parsed_tags[0][1] == {"location": "Beijing"}
+    assert parsed_tags[0][2] == "</function>"
+
+
+def test_function_tag_with_surrounding_text():
+    """Test function tag with surrounding text."""
+    input_str = 'I\'ll call the weather function: <function="get_weather">{"location": "Beijing"}</function> to get the weather for Beijing.'
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == "I'll call the weather function:  to get the weather for Beijing."
+    assert len(parsed_tags) == 1
+    assert parsed_tags[0][0] == '<function="get_weather">'
+    assert parsed_tags[0][1] == {"location": "Beijing"}
+    assert parsed_tags[0][2] == "</function>"
+
+
+def test_multiple_tags():
+    """Test multiple tags in one input."""
+    input_str = '<function="get_weather">{"location": "Beijing"}</function> I\'ll also check the time: <function="get_time">{"timezone": "Asia/Shanghai"}</function>'
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == " I'll also check the time: "
+    assert len(parsed_tags) == 2
+    assert parsed_tags[0][0] == '<function="get_weather">'
+    assert parsed_tags[0][1] == {"location": "Beijing"}
+    assert parsed_tags[0][2] == "</function>"
+    assert parsed_tags[1][0] == '<function="get_time">'
+    assert parsed_tags[1][1] == {"timezone": "Asia/Shanghai"}
+    assert parsed_tags[1][2] == "</function>"
+
+
+def test_malformed_tag_no_closing_tag():
+    """Test malformed tag with no closing tag."""
+    input_str = '<function="get_weather">{"location": "Beijing"}'
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert len(parsed_tags) == 0
+
+
+def test_invalid_json_content():
+    """Test tag with invalid JSON content."""
+    input_str = '<function="get_weather">{"location": "Beijing</function>'
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert len(parsed_tags) == 0
+
+
+def test_non_function_tag():
+    """Test non-function tag without requiring JSON validation."""
+    input_str = "<ipython>print('Hello world')</ipython>"
+    triggers = ["<ipython>"]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == ""
+    assert len(parsed_tags) == 1
+    assert parsed_tags[0][0] == "<ipython>"
+    # This shouldn't be parsed as JSON since it's not a function tag
+    assert parsed_tags[0][1] == "print('Hello world')"
+    assert parsed_tags[0][2] == "</ipython>"
+
+
+def test_mixed_tag_types():
+    """Test multiple tag types in the same input."""
+    input_str = 'Using different tags: <function="calc">{"operation": "add", "values": [1, 2]}</function> and <ipython>import math; print(math.pi)</ipython>'
+    triggers = ["<function=", "<ipython>"]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == "Using different tags:  and "
+    assert len(parsed_tags) == 2
+    assert parsed_tags[0][0] == '<function="calc">'
+    assert parsed_tags[0][1] == {"operation": "add", "values": [1, 2]}
+    assert parsed_tags[0][2] == "</function>"
+    assert parsed_tags[1][0] == "<ipython>"
+    assert parsed_tags[1][1] == "import math; print(math.pi)"
+    assert parsed_tags[1][2] == "</ipython>"
+
+
+def test_nested_structure_in_json():
+    """Test JSON content with nested structure."""
+    input_str = '<function="complex_data">{"user": {"name": "John", "age": 30}, "items": [1, 2, 3]}</function>'
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == ""
+    assert len(parsed_tags) == 1
+    assert parsed_tags[0][0] == '<function="complex_data">'
+    assert parsed_tags[0][1] == {"user": {"name": "John", "age": 30}, "items": [1, 2, 3]}
+    assert parsed_tags[0][2] == "</function>"
+
+
+def test_empty_json_object():
+    """Test function tag with empty JSON object."""
+    input_str = '<function="ping">{}</function>'
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == ""
+    assert len(parsed_tags) == 1
+    assert parsed_tags[0][0] == '<function="ping">'
+    assert parsed_tags[0][1] == {}
+    assert parsed_tags[0][2] == "</function>"
+
+
+def test_json_with_special_values():
+    """Test JSON with special values like null, true, false, numbers."""
+    input_str = '<function="test_values">{"null_value": null, "bool_true": true, "bool_false": false, "number": 42, "float": 3.14}</function>'
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == ""
+    assert len(parsed_tags) == 1
+    assert parsed_tags[0][0] == '<function="test_values">'
+    assert parsed_tags[0][1] == {
+        "null_value": None,
+        "bool_true": True,
+        "bool_false": False,
+        "number": 42,
+        "float": 3.14,
+    }
+    assert parsed_tags[0][2] == "</function>"
+
+
+def test_unicode_in_json():
+    """Test JSON with Unicode characters."""
+    input_str = '<function="translate">{"text": "こんにちは世界", "target": "español"}</function>'
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == ""
+    assert len(parsed_tags) == 1
+    assert parsed_tags[0][0] == '<function="translate">'
+    assert parsed_tags[0][1] == {"text": "こんにちは世界", "target": "español"}
+    assert parsed_tags[0][2] == "</function>"
+
+
+def test_empty_input():
+    """Test with empty input string."""
+    input_str = ""
+    triggers = ["<function=", "<ipython>"]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == ""
+    assert len(parsed_tags) == 0
+
+
+def test_no_tags_found():
+    """Test with input that doesn't contain any of the trigger strings."""
+    input_str = "This is just some regular text with no tags in it."
+    triggers = ["<function=", "<ipython>"]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == input_str
+    assert len(parsed_tags) == 0
+
+
+def test_whitespace_handling():
+    """Test with various whitespace in the input."""
+    input_str = """
+        <function="test">
+            {
+                "param": "value"
+            }
+        </function>
+    """
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    # Whitespace outside tags should be preserved
+    assert raw_text.strip() == ""
+    assert len(parsed_tags) == 1
+    assert parsed_tags[0][0] == '<function="test">'
+    assert parsed_tags[0][1] == {"param": "value"}
+    assert parsed_tags[0][2] == "</function>"
+
+
+def test_invalid_json_array():
+    """Test with invalid JSON array content."""
+    input_str = '<function="test">[1, 2, 3</function>'
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert len(parsed_tags) == 0
+
+
+def test_escaped_quotes_in_json():
+    """Test with escaped quotes in JSON content."""
+    input_str = '<function="message">{"text": "He said \\"Hello\\""}</function>'
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == ""
+    assert len(parsed_tags) == 1
+    assert parsed_tags[0][0] == '<function="message">'
+    assert parsed_tags[0][1] == {"text": 'He said "Hello"'}
+    assert parsed_tags[0][2] == "</function>"
+
+
+def test_code_tag():
+    """Test with a code tag."""
+    input_str = '<code>def hello():\n    print("Hello, world!")</code>'
+    triggers = ["<code>"]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == ""
+    assert len(parsed_tags) == 1
+    assert parsed_tags[0][0] == "<code>"
+    # This is not JSON, so it should be kept as a string
+    assert parsed_tags[0][1] == 'def hello():\n    print("Hello, world!")'
+    assert parsed_tags[0][2] == "</code>"
+
+
+def test_adjacent_tags():
+    """Test with tags that are adjacent with no text between them."""
+    input_str = (
+        '<function="first">{"value": 1}</function><function="second">{"value": 2}</function>'
+    )
+    triggers = ["<function="]
+    raw_text, parsed_tags = parser_structural_tag(input_str, triggers)
+
+    assert raw_text == ""
+    assert len(parsed_tags) == 2
+    assert parsed_tags[0][0] == '<function="first">'
+    assert parsed_tags[0][1] == {"value": 1}
+    assert parsed_tags[0][2] == "</function>"
+    assert parsed_tags[1][0] == '<function="second">'
+    assert parsed_tags[1][1] == {"value": 2}
+    assert parsed_tags[1][2] == "</function>"
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)


### PR DESCRIPTION
This PR implements a parser for the structural tag LLM outputs. It takes the LLM output string, as well as the triggers list as input, and returns the parsed string in format (non-tag-text, list of (start_tag, parsed_json_dict, end_tag)), it can parse any custom tag and xml style tag output. It will ignore invalid structural tags (invalid tag format, invalid json for function calling tags, missing end tag, etc.). 