### PR TITLE
[fix]fix the handling for '\?'.

### DIFF
--- a/cpp/support/encoding.cc
+++ b/cpp/support/encoding.cc
@@ -41,7 +41,7 @@ std::string PrintAsEscapedUTF8(
   static const std::unordered_map<TCodepoint, std::string> kCodepointToEscape = {
       {'\'', "\\\'"},
       {'\"', "\\\""},
-      {'\?', "\\\?"},
+      {'\?', "\\?"},
       {'\\', "\\\\"},
       {'\a', "\\a"},
       {'\b', "\\b"},
@@ -167,7 +167,7 @@ std::pair<TCodepoint, int32_t> ParseNextUTF8OrEscaped(
   static const std::unordered_map<char, TCodepoint> kEscapeToCodepoint = {
       {'\'', '\''},
       {'\"', '\"'},
-      {'\?', '\?'},
+      {'?', '\?'},
       {'\\', '\\'},
       {'a', '\a'},
       {'b', '\b'},

--- a/cpp/support/encoding.h
+++ b/cpp/support/encoding.h
@@ -114,7 +114,7 @@ std::pair<TCodepoint, int32_t> HandleEscape(
   static const std::unordered_map<char, TCodepoint> kEscapeToCodepoint = {
       {'\'', '\''},
       {'\"', '\"'},
-      {'\?', '\?'},
+      {'?', '\?'},
       {'\\', '\\'},
       {'a', '\a'},
       {'b', '\b'},


### PR DESCRIPTION
It's a minor bug. When handling escape characters, it can't handle `\?` correctly at present. This PR fixed the problem.