### PR TITLE
Fix torch extension build cflags on Windows

### DIFF
--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py
@@ -16,6 +16,7 @@
 from contextlib import suppress
 from typing import List, Optional, Union
 
+import platform
 import torch
 import torch.utils.cpp_extension
 

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py
@@ -74,7 +74,9 @@ def _load_torch_ops() -> None:
     torch_op_file_path = Path(__file__).with_suffix(".cu")
     with open(torch_op_file_path) as f:
         source = f.read()
-    cflags = ["-O3", "-Wno-switch-bool"]
+    cflags = ["-O3"]
+    if platform.system() != "Windows":
+        cflags.append("-Wno-switch-bool")
     cuda_cflags = ["-O3", "-std=c++17", "--threads", "4", "-use_fast_math"]
     # Use the safer cpp_extension.load_inline instead of cpp_extension.load
     torch.utils.cpp_extension.load_inline(

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import platform
 from contextlib import suppress
 from typing import List, Optional, Union
 
-import platform
 import torch
 import torch.utils.cpp_extension
 


### PR DESCRIPTION
This PR fixes an error when compiling the cpp extension on Windows caused by -Wno-switch-bool, which is not available on MSVC.