### PR TITLE
Update JSON Schema Converter to support int64 values

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -106,9 +106,9 @@ class IndentManager {
  private:
   bool any_whitespace_;
   bool enable_newline_;
-  int indent_;
+  int64_t indent_;
   std::string separator_;
-  int total_indent_;
+  int64_t total_indent_;
   std::vector<bool> is_first_;
   friend class JSONSchemaConverter;
 };
@@ -201,7 +201,7 @@ class JSONSchemaConverter {
   std::string Convert();
 
   /*! \brief Generate the regex for integer range. Public for testing. */
-  static std::string GenerateRangeRegex(std::optional<int> start, std::optional<int> end);
+  static std::string GenerateRangeRegex(std::optional<int64_t> start, std::optional<int64_t> end);
 
   /*! \brief Generate the regex for float range. Public for testing. */
   static std::string GenerateFloatRangeRegex(
@@ -241,9 +241,9 @@ class JSONSchemaConverter {
   /*! \brief Helpers for GenerateRangeRegex and GenerateFloatRangeRegex */
   static std::string MakePatternForDigitRange(char start, char end, int remainingDigits);
 
-  static std::vector<std::string> GenerateNumberPatterns(int lower, int upper);
+  static std::vector<std::string> GenerateNumberPatterns(int64_t lower, int64_t upper);
 
-  static std::string GenerateSubRangeRegex(int lower, int upper);
+  static std::string GenerateSubRangeRegex(int64_t lower, int64_t upper);
 
   static std::string FormatFloat(double value, int precision);
 
@@ -319,8 +319,8 @@ class JSONSchemaConverter {
     std::vector<picojson::value> prefix_item_schemas;
     bool allow_additional_items;
     picojson::value additional_item_schema;
-    int min_items;
-    int max_items;
+    int64_t min_items;
+    int64_t max_items;
   };
 
   Result<ArraySpec> ParseArraySchema(const picojson::object& schema);
@@ -418,7 +418,7 @@ class JSONSchemaConverter {
       const std::string& prop_name,
       const picojson::value& prop_schema,
       const std::string& rule_name,
-      int idx
+      int64_t idx
   );
 
   /*! \brief Get the pattern for the additional/unevaluated properties in the object schema. */
@@ -637,7 +637,7 @@ std::string JSONSchemaConverter::GetSchemaCacheIndex(const picojson::value& sche
     std::sort(sorted_kv.begin(), sorted_kv.end(), [](const auto& lhs, const auto& rhs) {
       return lhs.first < rhs.first;
     });
-    int idx = 0;
+    int64_t idx = 0;
     for (const auto& [key, value] : sorted_kv) {
       if (idx != 0) {
         result += ",";
@@ -648,7 +648,7 @@ std::string JSONSchemaConverter::GetSchemaCacheIndex(const picojson::value& sche
     return result + "}";
   } else if (schema.is<picojson::array>()) {
     std::string result = "[";
-    int idx = 0;
+    int64_t idx = 0;
     for (const auto& item : schema.get<picojson::array>()) {
       if (idx != 0) {
         result += ",";
@@ -801,7 +801,7 @@ std::string JSONSchemaConverter::VisitEnum(
 ) {
   XGRAMMAR_CHECK(schema.count("enum"));
   std::string result = "";
-  int idx = 0;
+  int64_t idx = 0;
   for (auto value : schema.at("enum").get<picojson::array>()) {
     if (idx != 0) {
       result += " | ";
@@ -832,7 +832,7 @@ std::string JSONSchemaConverter::VisitAnyOf(
 ) {
   XGRAMMAR_CHECK(schema.count("anyOf") || schema.count("oneOf"));
   std::string result = "";
-  int idx = 0;
+  int64_t idx = 0;
   auto anyof_schema = schema.count("anyOf") ? schema.at("anyOf") : schema.at("oneOf");
   XGRAMMAR_CHECK(anyof_schema.is<picojson::array>()) << "anyOf or oneOf must be an array";
   for (auto anyof_schema : anyof_schema.get<picojson::array>()) {
@@ -891,18 +891,18 @@ std::string JSONSchemaConverter::MakePatternForDigitRange(
   return oss.str();
 }
 
-std::vector<std::string> JSONSchemaConverter::GenerateNumberPatterns(int lower, int upper) {
+std::vector<std::string> JSONSchemaConverter::GenerateNumberPatterns(int64_t lower, int64_t upper) {
   std::vector<std::string> patterns;
 
   int lower_len = static_cast<int>(std::to_string(lower).size());
   int upper_len = static_cast<int>(std::to_string(upper).size());
 
   for (int len = lower_len; len <= upper_len; ++len) {
-    const int digit_min = static_cast<int>(std::pow(10, len - 1));
-    const int digit_max = static_cast<int>(std::pow(10, len)) - 1;
+    const int64_t digit_min = static_cast<int64_t>(std::pow(10, len - 1));
+    const int64_t digit_max = static_cast<int64_t>(std::pow(10, len)) - 1;
 
-    int start = (len == lower_len) ? lower : digit_min;
-    int end = (len == upper_len) ? upper : digit_max;
+    int64_t start = (len == lower_len) ? lower : digit_min;
+    int64_t end = (len == upper_len) ? upper : digit_max;
 
     std::string start_str = std::to_string(start);
     std::string end_str = std::to_string(end);
@@ -1101,7 +1101,7 @@ std::vector<std::string> JSONSchemaConverter::GenerateNumberPatterns(int lower, 
   return patterns;
 }
 
-std::string JSONSchemaConverter::GenerateSubRangeRegex(int lower, int upper) {
+std::string JSONSchemaConverter::GenerateSubRangeRegex(int64_t lower, int64_t upper) {
   std::vector<std::string> patterns = GenerateNumberPatterns(lower, upper);
   std::ostringstream oss;
   for (size_t i = 0; i < patterns.size(); ++i) {
@@ -1114,7 +1114,7 @@ std::string JSONSchemaConverter::GenerateSubRangeRegex(int lower, int upper) {
 }
 
 std::string JSONSchemaConverter::GenerateRangeRegex(
-    std::optional<int> start, std::optional<int> end
+    std::optional<int64_t> start, std::optional<int64_t> end
 ) {
   std::vector<std::string> parts;
   std::ostringstream result;
@@ -1210,16 +1210,16 @@ std::string JSONSchemaConverter::GenerateRangeRegex(
   }
 
   if (start && end) {
-    int range_start = start.value();
-    int range_end = end.value();
+    int64_t range_start = start.value();
+    int64_t range_end = end.value();
 
     if (range_start > range_end) {
       return "^()$";  // Invalid input
     }
 
     if (range_start < 0) {
-      int neg_start = range_start;
-      int neg_end = std::min(-1, range_end);
+      int64_t neg_start = range_start;
+      int64_t neg_end = std::min(static_cast<int64_t>(-1), range_end);
       parts.push_back("-" + GenerateSubRangeRegex(-neg_end, -neg_start));
     }
 
@@ -1228,7 +1228,7 @@ std::string JSONSchemaConverter::GenerateRangeRegex(
     }
 
     if (range_end > 0) {
-      int pos_start = std::max(1, range_start);
+      int64_t pos_start = std::max(static_cast<int64_t>(1), range_start);
       parts.push_back(GenerateSubRangeRegex(pos_start, range_end));
     }
   }
@@ -1246,6 +1246,11 @@ std::string JSONSchemaConverter::GenerateRangeRegex(
 }
 
 std::string JSONSchemaConverter::FormatFloat(double value, int precision = 6) {
+  // Special handling for integer values to avoid float representation issues
+  if (value == static_cast<int64_t>(value)) {
+    return std::to_string(static_cast<int64_t>(value));
+  }
+
   std::ostringstream oss;
   oss << std::fixed << std::setprecision(precision) << value;
   std::string result = oss.str();
@@ -1277,8 +1282,8 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
 
   std::vector<std::string> parts;
 
-  int startInt = 0;
-  int endInt = 0;
+  int64_t startInt = 0;
+  int64_t endInt = 0;
   double startFrac = 0.0;
   double endFrac = 0.0;
   bool isStartNegative = false;
@@ -1286,13 +1291,13 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
 
   if (start) {
     isStartNegative = start.value() < 0;
-    startInt = static_cast<int>(floor(start.value()));
+    startInt = static_cast<int64_t>(floor(start.value()));
     startFrac = start.value() - startInt;
   }
 
   if (end) {
     isEndNegative = end.value() < 0;
-    endInt = static_cast<int>(floor(end.value()));
+    endInt = static_cast<int64_t>(floor(end.value()));
     endFrac = end.value() - endInt;
   }
 
@@ -1351,7 +1356,7 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
     }
 
     // For all integers > startInt
-    if (startInt < INT_MAX - 1) {
+    if (startInt < INT64_MAX - 1) {
       std::string intRangeRegex = GenerateRangeRegex(startInt + 1, std::nullopt);
       intRangeRegex = intRangeRegex.substr(1, intRangeRegex.length() - 2);
       parts.push_back(intRangeRegex + "(\\.\\d{1," + std::to_string(precision) + "})?");
@@ -1412,7 +1417,7 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
     }
 
     // For all integers < endInt
-    if (endInt > INT_MIN + 1) {
+    if (endInt > INT64_MIN + 1) {
       std::string intRangeRegex = GenerateRangeRegex(std::nullopt, endInt - 1);
       intRangeRegex = intRangeRegex.substr(1, intRangeRegex.length() - 2);
       parts.push_back(intRangeRegex + "(\\.\\d{1," + std::to_string(precision) + "})?");
@@ -1644,39 +1649,40 @@ std::string JSONSchemaConverter::VisitInteger(
   std::string range_regex = "";
   if (schema.count("minimum") || schema.count("maximum") || schema.count("exclusiveMinimum") ||
       schema.count("exclusiveMaximum")) {
-    std::optional<int> start, end;
+    std::optional<int64_t> start, end;
     if (schema.count("minimum")) {
       XGRAMMAR_CHECK(schema.at("minimum").is<double>() || schema.at("minimum").is<int64_t>())
           << "minimum must be a number";
       double start_double = schema.at("minimum").get<double>();
-      XGRAMMAR_CHECK(start_double == static_cast<int>(start_double))
+      XGRAMMAR_CHECK(start_double == static_cast<int64_t>(start_double))
           << "minimum must be an integer";
-      start = static_cast<int>(start_double);
+      start = static_cast<int64_t>(start_double);
     }
     if (schema.count("exclusiveMinimum")) {
       XGRAMMAR_CHECK(
           schema.at("exclusiveMinimum").is<double>() || schema.at("exclusiveMinimum").is<int64_t>()
       ) << "exclusiveMinimum must be a number";
       double start_double = schema.at("exclusiveMinimum").get<double>();
-      XGRAMMAR_CHECK(start_double == static_cast<int>(start_double))
+      XGRAMMAR_CHECK(start_double == static_cast<int64_t>(start_double))
           << "exclusiveMinimum must be an integer";
-      start = static_cast<int>(start_double);
+      start = static_cast<int64_t>(start_double) + 1;  // Exclusive minimum means start + 1
     }
     if (schema.count("maximum")) {
       XGRAMMAR_CHECK(schema.at("maximum").is<double>() || schema.at("maximum").is<int64_t>())
           << "maximum must be a number";
       double end_double = schema.at("maximum").get<double>();
-      XGRAMMAR_CHECK(end_double == static_cast<int>(end_double)) << "maximum must be an integer";
-      end = static_cast<int>(end_double);
+      XGRAMMAR_CHECK(end_double == static_cast<int64_t>(end_double))
+          << "maximum must be an integer";
+      end = static_cast<int64_t>(end_double);
     }
     if (schema.count("exclusiveMaximum")) {
       XGRAMMAR_CHECK(
           schema.at("exclusiveMaximum").is<double>() || schema.at("exclusiveMaximum").is<int64_t>()
       ) << "exclusiveMaximum must be a number";
       double end_double = schema.at("exclusiveMaximum").get<double>();
-      XGRAMMAR_CHECK(end_double == static_cast<int>(end_double))
+      XGRAMMAR_CHECK(end_double == static_cast<int64_t>(end_double))
           << "exclusiveMaximum must be an integer";
-      end = static_cast<int>(end_double);
+      end = static_cast<int64_t>(end_double) - 1;  // Exclusive maximum means end - 1
     }
     XGRAMMAR_CHECK(!(start && end) || *start <= *end)
         << "Invalid range, start value greater than end value";
@@ -1714,7 +1720,10 @@ std::string JSONSchemaConverter::VisitNumber(
       XGRAMMAR_CHECK(
           schema.at("exclusiveMinimum").is<double>() || schema.at("exclusiveMinimum").is<int64_t>()
       ) << "exclusiveMinimum must be a number";
-      start = schema.at("exclusiveMinimum").get<double>();
+      double exclusive_min = schema.at("exclusiveMinimum").get<double>();
+      // For exclusive minimum with floats, we can't easily add 1, so we'll handle that
+      // in the regex generation if needed
+      start = exclusive_min;
     }
     if (schema.count("maximum")) {
       XGRAMMAR_CHECK(schema.at("maximum").is<double>() || schema.at("maximum").is<int64_t>())
@@ -1725,7 +1734,10 @@ std::string JSONSchemaConverter::VisitNumber(
       XGRAMMAR_CHECK(
           schema.at("exclusiveMaximum").is<double>() || schema.at("exclusiveMaximum").is<int64_t>()
       ) << "exclusiveMaximum must be a number";
-      end = schema.at("exclusiveMaximum").get<double>();
+      double exclusive_max = schema.at("exclusiveMaximum").get<double>();
+      // For exclusive maximum with floats, we can't easily subtract 1, so we'll handle that
+      // in the regex generation if needed
+      end = exclusive_max;
     }
     XGRAMMAR_CHECK(!(start && end) || *start <= *end)
         << "Invalid range, start value greater than end value";
@@ -1924,8 +1936,8 @@ std::string JSONSchemaConverter::VisitString(
     return "\"\\\"\" " + converted_regex + " \"\\\"\"";
   }
   if (schema.count("minLength") || schema.count("maxLength")) {
-    int min_length = schema.count("minLength") ? schema.at("minLength").get<int64_t>() : 0;
-    int max_length = schema.count("maxLength") ? schema.at("maxLength").get<int64_t>() : -1;
+    int64_t min_length = schema.count("minLength") ? schema.at("minLength").get<int64_t>() : 0;
+    int64_t max_length = schema.count("maxLength") ? schema.at("maxLength").get<int64_t>() : -1;
     XGRAMMAR_CHECK(max_length == -1 || min_length <= max_length)
         << "In string schema, minLength " << min_length << " is greater than " << "maxLength "
         << max_length;
@@ -1964,8 +1976,8 @@ Result<JSONSchemaConverter::ArraySpec> JSONSchemaConverter::ParseArraySchema(
   std::vector<picojson::value> prefix_item_schemas;
   bool allow_additional_items = true;
   picojson::value additional_item_schema;
-  int min_items = 0;
-  int max_items = -1;
+  int64_t min_items = 0;
+  int64_t max_items = -1;
 
   if (schema.count("prefixItems")) {
     if (!schema.at("prefixItems").is<picojson::array>()) {
@@ -2028,7 +2040,7 @@ Result<JSONSchemaConverter::ArraySpec> JSONSchemaConverter::ParseArraySchema(
           std::make_shared<InvalidSchemaError>("minItems must be an integer")
       );
     }
-    min_items = std::max(0, static_cast<int>(schema.at("minItems").get<int64_t>()));
+    min_items = std::max(static_cast<int64_t>(0), schema.at("minItems").get<int64_t>());
   }
 
   if (schema.count("minContains")) {
@@ -2037,7 +2049,7 @@ Result<JSONSchemaConverter::ArraySpec> JSONSchemaConverter::ParseArraySchema(
           std::make_shared<InvalidSchemaError>("minContains must be an integer")
       );
     }
-    min_items = std::max(min_items, static_cast<int>(schema.at("minContains").get<int64_t>()));
+    min_items = std::max(min_items, schema.at("minContains").get<int64_t>());
   }
 
   if (schema.count("maxItems")) {
@@ -2057,7 +2069,7 @@ Result<JSONSchemaConverter::ArraySpec> JSONSchemaConverter::ParseArraySchema(
     ));
   }
 
-  if (max_items != -1 && max_items < static_cast<int>(prefix_item_schemas.size())) {
+  if (max_items != -1 && max_items < static_cast<int64_t>(prefix_item_schemas.size())) {
     return Result<ArraySpec>::Err(std::make_shared<UnsatisfiableSchemaError>(
         "maxItems is less than the number of prefixItems: " + std::to_string(max_items) + " < " +
         std::to_string(prefix_item_schemas.size())
@@ -2066,14 +2078,14 @@ Result<JSONSchemaConverter::ArraySpec> JSONSchemaConverter::ParseArraySchema(
 
   if (!allow_additional_items) {
     // [len, len] must be in [min, max]
-    if (static_cast<int>(prefix_item_schemas.size()) < min_items) {
+    if (static_cast<int64_t>(prefix_item_schemas.size()) < min_items) {
       return Result<ArraySpec>::Err(std::make_shared<UnsatisfiableSchemaError>(
           "minItems is greater than the number of prefixItems, but additional items are not "
           "allowed: " +
           std::to_string(min_items) + " > " + std::to_string(prefix_item_schemas.size())
       ));
     }
-    if (max_items != -1 && static_cast<int>(prefix_item_schemas.size()) > max_items) {
+    if (max_items != -1 && static_cast<int64_t>(prefix_item_schemas.size()) > max_items) {
       return Result<ArraySpec>::Err(std::make_shared<UnsatisfiableSchemaError>(
           "maxItems is less than the number of prefixItems, but additional items are not "
           "allowed: " +
@@ -2109,7 +2121,7 @@ std::string JSONSchemaConverter::VisitArray(
 
   // 1. Handle prefix items
   if (array_spec.prefix_item_schemas.size() > 0) {
-    for (int i = 0; i < static_cast<int>(array_spec.prefix_item_schemas.size()); ++i) {
+    for (int64_t i = 0; i < static_cast<int64_t>(array_spec.prefix_item_schemas.size()); ++i) {
       XGRAMMAR_DCHECK(
           array_spec.prefix_item_schemas[i].is<picojson::object>() ||
           array_spec.prefix_item_schemas[i].is<bool>()
@@ -2130,19 +2142,19 @@ std::string JSONSchemaConverter::VisitArray(
 
   // 3. Construct the result with given format
   // clang-format off
-  /*
-   * prefix empty, additional items not allowed: [empty_separator]
-   * prefix empty, additional items allowed:
-   *   if min == 0, max == 0:
-   *     [empty_separator]
-   *   if min == 0, max > 0:
-   *     ([start_separator additional_rule_name (mid_separator additional_rule_name){0, max - 1}) end_separator] | [empty_separator]
-   *   if min > 0:
-   *     ([start_separator additional_rule_name (mid_separator additional_rule_name){min - 1, max - 1}) end_separator]
-   * prefix non-empty, additional items not allowed: [start_separator item0 mid_separator item1 end_separator]
-   * prefix non-empty, additional items allowed:
-   *   [start_separator item0 mid_separator item1 (mid_separator additional_rule_name){max(0, min - len(prefix)), max - len(prefix)} end_separator]
-   */
+   /*
+    * prefix empty, additional items not allowed: [empty_separator]
+    * prefix empty, additional items allowed:
+    *   if min == 0, max == 0:
+    *     [empty_separator]
+    *   if min == 0, max > 0:
+    *     ([start_separator additional_rule_name (mid_separator additional_rule_name){0, max - 1}) end_separator] | [empty_separator]
+    *   if min > 0:
+    *     ([start_separator additional_rule_name (mid_separator additional_rule_name){min - 1, max - 1}) end_separator]
+    * prefix non-empty, additional items not allowed: [start_separator item0 mid_separator item1 end_separator]
+    * prefix non-empty, additional items allowed:
+    *   [start_separator item0 mid_separator item1 (mid_separator additional_rule_name){max(0, min - len(prefix)), max - len(prefix)} end_separator]
+    */
   // clang-format on
   std::string result;
   const std::string& left_bracket = EBNFScriptCreator::Str("[");
@@ -2187,7 +2199,7 @@ std::string JSONSchemaConverter::VisitArray(
     }
   } else {
     std::vector<std::string> prefix_part;
-    for (int i = 0; i < static_cast<int>(item_rule_names.size()); ++i) {
+    for (int64_t i = 0; i < static_cast<int64_t>(item_rule_names.size()); ++i) {
       if (i > 0) {
         prefix_part.push_back(mid_separator);
       }
@@ -2199,7 +2211,10 @@ std::string JSONSchemaConverter::VisitArray(
           {left_bracket, start_separator, prefix_part_str, end_separator, right_bracket}
       );
     } else {
-      int min_items = std::max(0, array_spec.min_items - static_cast<int>(item_rule_names.size()));
+      int64_t min_items = std::max(
+          static_cast<int64_t>(0),
+          array_spec.min_items - static_cast<int64_t>(item_rule_names.size())
+      );
       return EBNFScriptCreator::Concat(
           {left_bracket,
            start_separator,
@@ -2209,7 +2224,7 @@ std::string JSONSchemaConverter::VisitArray(
                min_items,
                array_spec.max_items == -1
                    ? -1
-                   : array_spec.max_items - static_cast<int>(item_rule_names.size())
+                   : array_spec.max_items - static_cast<int64_t>(item_rule_names.size())
            ),
            end_separator,
            right_bracket}
@@ -2222,7 +2237,7 @@ std::string JSONSchemaConverter::GetPropertyPattern(
     const std::string& prop_name,
     const picojson::value& prop_schema,
     const std::string& rule_name,
-    int idx
+    int64_t idx  // Changed to int64_t
 ) {
   // the outer quote is for the string in EBNF grammar, and the inner quote is for
   // the string in JSON
@@ -2256,7 +2271,7 @@ std::string JSONSchemaConverter::GetPartialRuleForPropertiesAllOptional(
   std::string res = "";
 
   std::vector<std::string> prop_patterns;
-  int idx = 0;
+  int64_t idx = 0;  // Changed to int64_t
   for (const auto& [prop_name, prop_schema] : properties) {
     prop_patterns.push_back(GetPropertyPattern(prop_name, prop_schema, rule_name, idx));
     ++idx;
@@ -2271,7 +2286,8 @@ std::string JSONSchemaConverter::GetPartialRuleForPropertiesAllOptional(
         GetOtherPropertyPattern(kBasicString, additional, rule_name, additional_suffix);
     std::string last_rule_body = "(" + mid_sep + " " + additional_prop_pattern + ")*";
     std::string last_rule_name =
-        rule_name + "_part_" + std::to_string(static_cast<int>(properties.size()) - 1);
+        rule_name + "_part_" +
+        std::to_string(static_cast<int64_t>(properties.size()) - 1);  // Changed to int64_t
     last_rule_name = ebnf_script_creator_.AddRule(last_rule_name, last_rule_body);
     rule_names.back() = last_rule_name;
   } else {
@@ -2279,7 +2295,7 @@ std::string JSONSchemaConverter::GetPartialRuleForPropertiesAllOptional(
   }
 
   // construct 0~(len(properties) - 2) rules
-  for (int i = properties.size() - 2; i >= 0; --i) {
+  for (int64_t i = properties.size() - 2; i >= 0; --i) {  // Changed to int64_t
     const std::string& prop_pattern = prop_patterns[i + 1];
     const std::string& last_rule_name = rule_names[i + 1];
     std::string cur_rule_body =
@@ -2290,7 +2306,7 @@ std::string JSONSchemaConverter::GetPartialRuleForPropertiesAllOptional(
   }
 
   // construct the root rule
-  for (int i = 0; i < static_cast<int>(properties.size()); ++i) {
+  for (int64_t i = 0; i < static_cast<int64_t>(properties.size()); ++i) {  // Changed to int64_t
     if (i != 0) {
       res += " | ";
     }
@@ -2312,19 +2328,21 @@ std::string JSONSchemaConverter::GetPartialRuleForPropertiesContainRequired(
     const std::string& rule_name
 ) {
   // Find the index of the first required property
-  int first_required_idx = properties.size();
-  for (int i = 0; i < static_cast<int>(properties.size()); ++i) {
+  int64_t first_required_idx = properties.size();                          // Changed to int64_t
+  for (int64_t i = 0; i < static_cast<int64_t>(properties.size()); ++i) {  // Changed to int64_t
     if (required.count(properties[i].first)) {
       first_required_idx = i;
       break;
     }
   }
-  XGRAMMAR_CHECK(first_required_idx < static_cast<int>(properties.size()));
+  XGRAMMAR_CHECK(
+      first_required_idx < static_cast<int64_t>(properties.size())
+  );  // Changed to int64_t
 
   std::string res = NextSeparator();
 
   // Handle the properties before the first required property
-  for (int i = 0; i < first_required_idx; ++i) {
+  for (int64_t i = 0; i < first_required_idx; ++i) {  // Changed to int64_t
     const auto& [prop_name, prop_schema] = properties[i];
     XGRAMMAR_CHECK(!prop_schema.is<bool>() || prop_schema.get<bool>());
     std::string property_pattern = GetPropertyPattern(prop_name, prop_schema, rule_name, i);
@@ -2338,7 +2356,8 @@ std::string JSONSchemaConverter::GetPartialRuleForPropertiesContainRequired(
   res += " " + property_pattern;
 
   // Handle the properties after the first required property
-  for (int i = first_required_idx + 1; i < static_cast<int>(properties.size()); ++i) {
+  for (int64_t i = first_required_idx + 1; i < static_cast<int64_t>(properties.size());
+       ++i) {  // Changed to int64_t
     const auto& [prop_name, prop_schema] = properties[i];
     XGRAMMAR_CHECK(!prop_schema.is<bool>() || prop_schema.get<bool>());
     std::string property_pattern = GetPropertyPattern(prop_name, prop_schema, rule_name, i);
@@ -2511,7 +2530,7 @@ std::string JSONSchemaToEBNF(
 }
 
 // Wrapper function for testing
-std::string GenerateRangeRegex(std::optional<int> start, std::optional<int> end) {
+std::string GenerateRangeRegex(std::optional<int64_t> start, std::optional<int64_t> end) {
   return JSONSchemaConverter::GenerateRangeRegex(start, end);
 }
 

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -70,7 +70,7 @@ std::string JSONSchemaToEBNF(
  * \param end The end of the range (inclusive). If null assume infinity.
  * \returns The regex pattern that matches integers/floats in the given range.
  */
-std::string GenerateRangeRegex(std::optional<int> start, std::optional<int> end);
+std::string GenerateRangeRegex(std::optional<int64_t> start, std::optional<int64_t> end);
 
 std::string GenerateFloatRangeRegex(std::optional<double> start, std::optional<double> end);
 

--- a/tests/python/test_grammar_matcher_json_schema.py
+++ b/tests/python/test_grammar_matcher_json_schema.py
@@ -4,7 +4,7 @@ import time
 from typing import Dict, List, Tuple
 
 import pytest
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, conint
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
@@ -132,6 +132,10 @@ class LargeRangeSchema(BaseModel):
     value: int = Field(ge=-99999, le=99999)
 
 
+class LargeRangeSchemaStartZero(BaseModel):
+    value: int = Field(ge=0, le=20_000_000_000)
+
+
 class FloatRangeSchema(BaseModel):
     value: float = Field(ge=0.0, le=1.0)
 
@@ -177,6 +181,10 @@ class MixedTypeRangeSchema(BaseModel):
         (LargeRangeSchema, 0),
         (LargeRangeSchema, 5678),
         (LargeRangeSchema, 99999),
+        (LargeRangeSchemaStartZero, 20000000000),
+        (LargeRangeSchemaStartZero, 0),
+        (LargeRangeSchemaStartZero, 10000000000),
+        (LargeRangeSchemaStartZero, 19999999999),
         # Float test cases
         (FloatRangeSchema, 0.0),
         (FloatRangeSchema, 0.5),
@@ -209,7 +217,7 @@ def test_fill_next_token_bitmask_intfloat_range(tokenizer_path: str, schema_clas
     compiled_grammar = compiler.compile_json_schema(schema_class)
     matcher = xgr.GrammarMatcher(compiled_grammar)
     time_end = time.monotonic_ns()
-    print(f"Time to init GrammarMatcher: {(time_end - time_start) / 1e3} us")
+    # print(f"Time to init GrammarMatcher: {(time_end - time_start) / 1e3} us")
 
     token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
 
@@ -218,7 +226,7 @@ def test_fill_next_token_bitmask_intfloat_range(tokenizer_path: str, schema_clas
         time_start = time.monotonic_ns()
         matcher.fill_next_token_bitmask(token_bitmask)
         time_end = time.monotonic_ns()
-        print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
+        # print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
 
         assert matcher._debug_accept_string(bytes([c]))
 


### PR DESCRIPTION
This pull request allows the json schema converter to support 64 bit values (previously only supported up to 32 bit), which would cause serving engines to crash in production when values exceeded 32 bits. 