### PR TITLE
Expose accept_string and print_internal_states

### DIFF
--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -164,6 +164,14 @@ NB_MODULE(xgrammar_bindings, m) {
           nb::arg("max_rollback_tokens")
       )
       .def("accept_token", &GrammarMatcher::AcceptToken, nb::call_guard<nb::gil_scoped_release>())
+      .def("accept_string", &GrammarMatcher::AcceptString, nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "accept_string",
+          [](GrammarMatcher& self, const nb::bytes& input_str, bool debug_print) {
+            return self.AcceptString(input_str.c_str(), debug_print);
+          },
+          nb::call_guard<nb::gil_scoped_release>()
+      )
       .def(
           "fill_next_token_bitmask",
           &GrammarMatcher_FillNextTokenBitmask,
@@ -179,18 +187,7 @@ NB_MODULE(xgrammar_bindings, m) {
       .def("reset", &GrammarMatcher::Reset, nb::call_guard<nb::gil_scoped_release>())
       .def_prop_ro("max_rollback_tokens", &GrammarMatcher::GetMaxRollbackTokens)
       .def_prop_ro("stop_token_ids", &GrammarMatcher::GetStopTokenIds)
-      .def(
-          "_debug_accept_string",
-          &GrammarMatcher::_DebugAcceptString,
-          nb::call_guard<nb::gil_scoped_release>()
-      )
-      .def(
-          "_debug_accept_string",
-          [](GrammarMatcher& self, const nb::bytes& input_str, bool debug_print) {
-            return self._DebugAcceptString(input_str.c_str(), debug_print);
-          },
-          nb::call_guard<nb::gil_scoped_release>()
-      );
+      .def("_debug_print_internal_state", &GrammarMatcher::_DebugPrintInternalState);
 
   auto pyTestingModule = m.def_submodule("testing");
   pyTestingModule

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -91,6 +91,16 @@ class GrammarMatcher {
   bool AcceptToken(int32_t token_id, bool debug_print = false);
 
   /*!
+   * \brief Accept a string and update the state of the matcher. The whole string is considered
+   * as one step in rollback. It is used to complement the functionality of AcceptToken, and
+   * AcceptToken should always be used to accept tokens.
+   * \param input_str The string to be accepted.
+   * \param debug_print Whether to print information about the internal state of the matcher.
+   * \return Whether the string is accepted.
+   */
+  bool AcceptString(const std::string& input_str, bool debug_print = false);
+
+  /*!
    * \brief Get the set of tokens that are acceptable for the next step and store them in a
    * bitmask.
    * \param next_token_bitmask The bitmask to store the result. The bitmask must be pre-allocated
@@ -127,7 +137,10 @@ class GrammarMatcher {
 
   const std::vector<int>& GetStopTokenIds() const;
 
-  bool _DebugAcceptString(const std::string& input_str, bool debug_print = false);
+  /*! \brief Print the internal state of the matcher. This is only used for debugging. The
+   * representation of the internal state is subject to change.
+   */
+  std::string _DebugPrintInternalState() const;
 
   XGRAMMAR_DEFINE_PIMPL_METHODS(GrammarMatcher);
 };

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -211,6 +211,16 @@ class GrammarMatcher(XGRObject):
     def accept_token(self, token_id: int, *, debug_print: bool = False) -> bool:
         """Accept one token and update the state of the matcher.
 
+        In the following cases, the matcher will not accept the token and return False:
+        1. The token does not match the grammar.
+        2. The matcher has terminated after accepting the stop token, but is trying to accept a
+           new token.
+        3. The token id is out of range.
+        4. The token is a special token.
+
+        The user should capture the return value and handle the cases where the token is not
+        accepted.
+
         Parameters
         ----------
         token_id : int
@@ -226,6 +236,27 @@ class GrammarMatcher(XGRObject):
             Whether the token is accepted.
         """
         return self._handle.accept_token(token_id, debug_print)
+
+    def accept_string(self, input_str: Union[str, bytes], *, debug_print: bool = False) -> bool:
+        """Accept a string and update the state of the matcher. The whole string is considered
+        as one step in rollback. It is used to complement the functionality of accept_token, and
+        accept_token should always be used to accept tokens.
+
+        Parameters
+        ----------
+        input_str : Union[str, bytes]
+            The string to be accepted.
+
+        debug_print : bool, default: False
+            Whether to print information about the internal state of the matcher. Helpful for
+            debugging.
+
+        Returns
+        -------
+        accepted : bool
+            Whether the string is accepted.
+        """
+        return self._handle.accept_string(input_str, debug_print)
 
     def fill_next_token_bitmask(
         self, bitmask: torch.Tensor, index: int = 0, *, debug_print: bool = False
@@ -325,24 +356,13 @@ class GrammarMatcher(XGRObject):
         """
         return self._handle.stop_token_ids
 
-    def _debug_accept_string(
-        self, input_str: Union[str, bytes], *, debug_print: bool = False
-    ) -> bool:
-        """Accept a string and update the state of the matcher. The whole string is considered
-        as one step in rollback. It is only used to complement the functionality of accept_token.
-
-        Parameters
-        ----------
-        input_str : Union[str, bytes]
-            The string to be accepted.
-
-        debug_print : bool, default: False
-            Whether to print information about the internal state of the matcher. Helpful for
-            debugging.
+    def _debug_print_internal_state(self) -> str:
+        """Print the internal state of the matcher. This is used for debugging. The
+        representation of the internal state is subject to change.
 
         Returns
         -------
-        accepted : bool
-            Whether the string is accepted.
+        internal_state : str
+            The internal state of the matcher.
         """
-        return self._handle._debug_accept_string(input_str, debug_print)
+        return self._handle._debug_print_internal_state()

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -101,6 +101,27 @@ def _ebnf_to_grammar_no_normalization(ebnf_string: str, root_rule_name: str = "r
     )
 
 
+def _get_matcher_from_grammar(grammar: Union[Grammar, str], **kwargs) -> GrammarMatcher:
+    """Create a GrammarMatcher from a grammar. The tokenizer info will be set to an empty
+    TokenizerInfo. The result matcher can only accept strings, and cannot accept tokens.
+
+    Parameters
+    ----------
+    grammar : Union[Grammar, str]
+        The grammar to create the matcher from. Can be either a Grammar object or a string
+        containing EBNF grammar.
+
+    Returns
+    -------
+    matcher : GrammarMatcher
+        The created grammar matcher.
+    """
+    tokenizer_info = TokenizerInfo([])
+    grammar_compiler = GrammarCompiler(tokenizer_info, cache_enabled=False)
+    compiled_grammar = grammar_compiler.compile_grammar(grammar)
+    return GrammarMatcher(compiled_grammar, terminate_without_stop_token=True, **kwargs)
+
+
 def _is_grammar_accept_string(
     grammar: Union[Grammar, str],
     input_str: str,
@@ -126,16 +147,12 @@ def _is_grammar_accept_string(
     bool
         True if the grammar accepts the string, False otherwise.
     """
-
-    if isinstance(grammar, str):
-        grammar = Grammar.from_ebnf(grammar)
-    grammar_compiler = GrammarCompiler(TokenizerInfo([]), cache_enabled=False)
-    compiled_grammar = grammar_compiler.compile_grammar(grammar)
-    matcher = GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+    grammar_matcher = _get_matcher_from_grammar(grammar)
 
     if print_time:
         start = time.monotonic_ns()
-    accepted = matcher._debug_accept_string(input_str, debug_print=debug_print)
+
+    accepted = grammar_matcher.accept_string(input_str, debug_print=debug_print)
 
     if print_time:
         end = time.monotonic_ns()
@@ -143,7 +160,7 @@ def _is_grammar_accept_string(
 
     if not accepted:
         return False
-    return matcher.is_terminated()
+    return grammar_matcher.is_terminated()
 
 
 def _get_masked_tokens_from_bitmask(

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -26,8 +26,8 @@ def test_compiled_grammar():
 
     def check_matcher(matcher: xgr.GrammarMatcher):
         assert not matcher.is_terminated()
-        assert not matcher._debug_accept_string('{ name: "John" }')
-        assert matcher._debug_accept_string('{"name": "John"}')
+        assert not matcher.accept_string('{ name: "John" }')
+        assert matcher.accept_string('{"name": "John"}')
         assert matcher.is_terminated()
 
     time_start = time.monotonic_ns()
@@ -55,8 +55,8 @@ def test_grammar_compiler_json(max_threads):
 
     def check_matcher(matcher: xgr.GrammarMatcher):
         assert not matcher.is_terminated()
-        assert not matcher._debug_accept_string('{ name: "John" }')
-        assert matcher._debug_accept_string('{"name": "John"}')
+        assert not matcher.accept_string('{ name: "John" }')
+        assert matcher.accept_string('{"name": "John"}')
         assert matcher.is_terminated()
 
     time_start = time.monotonic_ns()
@@ -122,7 +122,7 @@ def test_grammar_compiler_json_schema():
         matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
 
         assert not matcher.is_terminated()
-        assert matcher._debug_accept_string(instance_str)
+        assert matcher.accept_string(instance_str)
         assert matcher.is_terminated()
 
     check_with_fmt(False, None, (",", ":"), "1")
@@ -233,7 +233,7 @@ def test_grammar_compiler_json_schema_concurrent():
 
     def check_matcher(matcher: xgr.GrammarMatcher, instance_str: str):
         assert not matcher.is_terminated()
-        assert matcher._debug_accept_string(instance_str)
+        assert matcher.accept_string(instance_str)
         assert matcher.is_terminated()
 
     num_schemas = len(schema_instances)

--- a/tests/python/test_grammar_matcher_ebnf.py
+++ b/tests/python/test_grammar_matcher_ebnf.py
@@ -48,7 +48,6 @@ def test_repetition(input: str, accepted: bool):
 
 
 def test_utf8():
-
     # Test utf8-encoded string with EBNF grammar
     ebnf_grammar_str = "root ::= [，]+"
 
@@ -390,7 +389,7 @@ def test_fill_next_token_bitmask(
         # 4. accept_string
         print("Accepting char:", bytes([c]))
         time_start = time.monotonic_ns()
-        assert matcher._debug_accept_string(bytes([c]))
+        assert matcher.accept_string(bytes([c]))
         time_end = time.monotonic_ns()
         print(f"Time to accept_token: {(time_end - time_start) / 1e3} us")
 

--- a/tests/python/test_grammar_matcher_json.py
+++ b/tests/python/test_grammar_matcher_json.py
@@ -313,7 +313,7 @@ def test_fill_next_token_bitmask(
         # 4. accept_string
         print("Accepting char:", bytes([c]))
         time_start = time.monotonic_ns()
-        assert matcher._debug_accept_string(bytes([c]))
+        assert matcher.accept_string(bytes([c]))
         time_end = time.monotonic_ns()
         print(f"Time to accept_token: {(time_end - time_start) / 1e3} us")
 

--- a/tests/python/test_grammar_matcher_json_schema.py
+++ b/tests/python/test_grammar_matcher_json_schema.py
@@ -60,7 +60,7 @@ def test_json_schema_debug_accept_string():
     matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
 
     for c in instance_str:
-        assert matcher._debug_accept_string(c)
+        assert matcher.accept_string(c)
     assert matcher.accept_token(2)
     assert matcher.is_terminated()
 
@@ -72,7 +72,7 @@ def test_json_schema_find_jump_forward_string():
     for i, c in enumerate(instance_str):
         jump_forward_str = matcher.find_jump_forward_string()
         assert instance_str[i : i + len(jump_forward_str)] == jump_forward_str
-        assert matcher._debug_accept_string(c)
+        assert matcher.accept_string(c)
     assert matcher.find_jump_forward_string() == ""
 
 
@@ -106,7 +106,7 @@ def test_fill_next_token_bitmask(tokenizer_path: str):
         # 2. accept_string
         print("Accepting char:", bytes([c]))
         time_start = time.monotonic_ns()
-        assert matcher._debug_accept_string(bytes([c]))
+        assert matcher.accept_string(bytes([c]))
         time_end = time.monotonic_ns()
         print(f"Time to accept_token: {(time_end - time_start) / 1e3} us")
 
@@ -220,7 +220,7 @@ def test_fill_next_token_bitmask_intfloat_range(tokenizer_path: str, schema_clas
         time_end = time.monotonic_ns()
         print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
 
-        assert matcher._debug_accept_string(bytes([c]))
+        assert matcher.accept_string(bytes([c]))
 
     matcher.fill_next_token_bitmask(token_bitmask)
     rejected_token_ids = _get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size)
@@ -262,7 +262,7 @@ def test_mixed_type_range_schema(tokenizer_path: str):
             time_end = time.monotonic_ns()
             print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
 
-            assert matcher._debug_accept_string(bytes([c]))
+            assert matcher.accept_string(bytes([c]))
 
         matcher.fill_next_token_bitmask(token_bitmask)
         rejected_token_ids = _get_masked_tokens_from_bitmask(
@@ -310,7 +310,7 @@ def test_multiple_boundaries_schema(tokenizer_path: str):
             time_end = time.monotonic_ns()
             print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
 
-            assert matcher._debug_accept_string(bytes([c]))
+            assert matcher.accept_string(bytes([c]))
 
         matcher.fill_next_token_bitmask(token_bitmask)
         rejected_token_ids = _get_masked_tokens_from_bitmask(
@@ -372,7 +372,7 @@ def test_mask_generation_format(value: str, format: str):
         time_end = time.monotonic_ns()
         delta_us = (time_end - time_start) / 1e3
         print(f"Time for fill_next_token_bitmask: {delta_us} us before accepting char {bytes([c])}")
-        accepted = matcher._debug_accept_string(bytes([c]))
+        accepted = matcher.accept_string(bytes([c]))
         assert accepted
 
     time_start = time.monotonic_ns()

--- a/tests/python/test_grammar_matcher_regex.py
+++ b/tests/python/test_grammar_matcher_regex.py
@@ -150,7 +150,7 @@ def test_fill_next_token_bitmask(regex: str, input_str: str):
         print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
 
         time_start = time.monotonic_ns()
-        assert matcher._debug_accept_string(bytes([c]))
+        assert matcher.accept_string(bytes([c]))
         time_end = time.monotonic_ns()
         print(f"Time to accept char {chr(c)}: {(time_end - time_start) / 1e3} us")
 

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -113,7 +113,7 @@ rule2 ::= "dg"
         accepted_indices = list(set(range(tokenizer_info.vocab_size)) - set(rejected_indices))
         accepted_tokens = [tokens[id] for id in accepted_indices]
         if i < len(input_str):
-            assert matcher._debug_accept_string(c)
+            assert matcher.accept_string(c)
         assert accepted_tokens == expected_accepted_tokens[i]
 
 
@@ -277,7 +277,7 @@ def test_structural_tag_mask_gen():
         # 3. Test character acceptance
         print("Accepting char:", bytes([c]))
         time_start = time.monotonic_ns()
-        assert matcher._debug_accept_string(bytes([c]))
+        assert matcher.accept_string(bytes([c]))
         time_end = time.monotonic_ns()
         print(f"Time to accept_token: {(time_end - time_start) / 1e3} us")
 

--- a/tests/python/test_regex_converter.py
+++ b/tests/python/test_regex_converter.py
@@ -456,7 +456,7 @@ def test_mask_generation(tokenizer_path: str, regex: str, instance: str):
         matcher.fill_next_token_bitmask(token_bitmask)
         time_end = time.monotonic_ns()
         print(f"Time for fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
-        accepted = matcher._debug_accept_string(bytes([c]))
+        accepted = matcher.accept_string(bytes([c]))
         assert accepted
         print(f"Accepting {c}")
 


### PR DESCRIPTION
This PR exposes two internal functions of the GrammarMatcher:
1. accept_string: directly accept a string or byte sequence
2. _debug_print_internal_states: print the internal state for debugging

It also refines the logging info of GrammarMatcher.accept_token and GrammarMatcher.accept_string.

It also change the behavior of accept_token to return False when the token is out of boundary or special token. Previously it will throw RuntimeError.

Signed-off-by: Ubospica <ubospica@gmail.com>