### PR TITLE
feat: Set and get max_recursion_depth

### DIFF
--- a/cpp/grammar_matcher_base.cc
+++ b/cpp/grammar_matcher_base.cc
@@ -16,6 +16,7 @@
 #include "grammar_data_structure.h"
 #include "persistent_stack.h"
 #include "support/encoding.h"
+#include "support/recursion_guard.h"
 #include "support/utils.h"
 
 namespace xgrammar {
@@ -171,6 +172,7 @@ void GrammarMatcherBase::ExpandEquivalentStackElements(
     int32_t cur_stack_element_id,
     bool consider_parent
 ) {
+  RecursionGuard guard(&expand_equivalent_stack_elements_recursion_depth_);
   auto f_add_current_stack_element = [&]() {
     if (cur_stack_element_id != -1) {
       return cur_stack_element_id;
@@ -295,8 +297,10 @@ bool GrammarMatcherBase::AcceptChar(uint8_t char_value, bool debug_print) {
     auto new_stack_element = AdvanceStackElementWithChar(cur_stack_element, char_value);
 
     if (new_stack_element == cur_stack_element) {
+      RecursionGuard::ResetRecursionDepth(&expand_equivalent_stack_elements_recursion_depth_);
       ExpandEquivalentStackElements(new_stack_element, &tmp_new_stack_tops_, prev_top);
     } else {
+      RecursionGuard::ResetRecursionDepth(&expand_equivalent_stack_elements_recursion_depth_);
       ExpandEquivalentStackElements(new_stack_element, &tmp_new_stack_tops_);
     }
   }
@@ -349,11 +353,13 @@ void GrammarMatcherBase::PushInitialState(
         grammar_->GetRootRuleId(), kUnexpandedRuleStartSequenceId, 0, StackElement::kNoParent
     );
     tmp_new_stack_tops_.clear();
+    RecursionGuard::ResetRecursionDepth(&expand_equivalent_stack_elements_recursion_depth_);
     ExpandEquivalentStackElements(init_stack_element, &tmp_new_stack_tops_);
     stack_tops_history_.PushHistory(tmp_new_stack_tops_);
   } else {
     if (expand_init_stack_element) {
       tmp_new_stack_tops_.clear();
+      RecursionGuard::ResetRecursionDepth(&expand_equivalent_stack_elements_recursion_depth_);
       ExpandEquivalentStackElements(init_stack_element, &tmp_new_stack_tops_);
       stack_tops_history_.PushHistory(tmp_new_stack_tops_);
     } else {

--- a/cpp/grammar_matcher_base.h
+++ b/cpp/grammar_matcher_base.h
@@ -119,6 +119,8 @@ class GrammarMatcherBase {
   // Temporary data for AcceptChar, PushInitialState, etc to store new stacks.
   // They are stored here to avoid repeated allocation.
   std::vector<int32_t> tmp_new_stack_tops_;
+
+  int expand_equivalent_stack_elements_recursion_depth_ = 0;
 };
 
 }  // namespace xgrammar

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -15,6 +15,7 @@
 #include "../grammar_functor.h"
 #include "../json_schema_converter.h"
 #include "../regex_converter.h"
+#include "../support/recursion_guard.h"
 #include "../testing.h"
 #include "python_methods.h"
 
@@ -250,4 +251,17 @@ NB_MODULE(xgrammar_bindings, m) {
       nb::arg("indices").none(),
       nb::call_guard<nb::gil_scoped_release>()
   );
+
+  auto pyConfigModule = m.def_submodule("config");
+  pyConfigModule
+      .def(
+          "set_max_recursion_depth",
+          &RecursionGuard::SetMaxRecursionDepth,
+          nb::call_guard<nb::gil_scoped_release>()
+      )
+      .def(
+          "get_max_recursion_depth",
+          &RecursionGuard::GetMaxRecursionDepth,
+          nb::call_guard<nb::gil_scoped_release>()
+      );
 }

--- a/cpp/support/recursion_guard.cc
+++ b/cpp/support/recursion_guard.cc
@@ -5,7 +5,7 @@
 #include <string_view>
 #include <system_error>
 
-#include "support/logging.h"
+#include "logging.h"
 
 namespace xgrammar {
 

--- a/cpp/support/recursion_guard.cc
+++ b/cpp/support/recursion_guard.cc
@@ -1,0 +1,45 @@
+#include "recursion_guard.h"
+
+#include <charconv>
+#include <cstdlib>
+#include <string_view>
+#include <system_error>
+
+#include "support/logging.h"
+
+namespace xgrammar {
+
+int RecursionGuard::LoadMaxRecursionDepthFromEnv() {
+  const char* env_value = std::getenv(kMaxRecursionDepthEnvVar);
+  if (env_value == nullptr) {
+    return kDefaultMaxRecursionDepth;
+  }
+
+  int value = 0;
+  std::string_view sv(env_value);
+
+  // Convert the string to an integer
+  auto result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
+
+  // Check if the conversion is successful
+  if (result.ec == std::errc::invalid_argument || result.ec == std::errc::result_out_of_range ||
+      result.ptr != sv.data() + sv.size() || value <= 0) {
+    XGRAMMAR_LOG(WARNING) << "Env variable XGRAMMAR_MAX_RECURSION_DEPTH is not a valid "
+                             "integer or out of range: '"
+                          << env_value << "', using default " << kDefaultMaxRecursionDepth;
+    return kDefaultMaxRecursionDepth;
+  }
+
+  // Check if the value is too large
+  if (value > kMaxReasonableDepth) {
+    XGRAMMAR_LOG(WARNING) << "Env variable XGRAMMAR_MAX_RECURSION_DEPTH too large: " << value
+                          << ", clamping to " << kMaxReasonableDepth;
+    return kMaxReasonableDepth;
+  }
+
+  return value;
+}
+
+std::atomic<int> RecursionGuard::max_recursion_depth_{LoadMaxRecursionDepthFromEnv()};
+
+}  // namespace xgrammar

--- a/cpp/support/recursion_guard.h
+++ b/cpp/support/recursion_guard.h
@@ -1,0 +1,110 @@
+#ifndef XGRAMMAR_SUPPORT_RECURSION_GUARD_H_
+#define XGRAMMAR_SUPPORT_RECURSION_GUARD_H_
+
+#include <atomic>
+
+#include "logging.h"
+
+namespace xgrammar {
+
+/*!
+ * \brief Thread-safe recursion guard to prevent stack overflow
+ *
+ * This class provides a RAII-style guard that tracks recursion depth
+ * and prevents excessive recursion that could lead to stack overflow.
+ * It uses atomic operations for thread safety and supports configurable
+ * maximum recursion depth.
+ */
+class RecursionGuard {
+ public:
+  /*!
+   * \brief Constructor that increments recursion depth
+   * \param current_recursion_depth Pointer to the current recursion depth counter
+   * \throws Logs fatal error if max recursion depth is exceeded
+   */
+  explicit RecursionGuard(int* current_recursion_depth)
+      : current_depth_ptr_(current_recursion_depth) {
+    XGRAMMAR_DCHECK(current_depth_ptr_ != nullptr);
+
+    int current_depth = ++(*current_depth_ptr_);
+    int max_depth = max_recursion_depth_.load(std::memory_order_relaxed);
+
+    if (current_depth > max_depth) {
+      XGRAMMAR_LOG(FATAL) << "RecursionGuard: Maximum recursion depth exceeded. "
+                          << "Current depth: " << current_depth << ", Max allowed: " << max_depth;
+    }
+  }
+
+  /*!
+   * \brief Reset the recursion depth to 0
+   * \param current_recursion_depth Pointer to the current recursion depth counter
+   */
+  static void ResetRecursionDepth(int* current_recursion_depth) {
+    XGRAMMAR_DCHECK(current_recursion_depth != nullptr);
+    *current_recursion_depth = 0;
+  }
+
+  /*!
+   * \brief Destructor that decrements recursion depth
+   */
+  ~RecursionGuard() {
+    XGRAMMAR_DCHECK(current_depth_ptr_ != nullptr);
+    --(*current_depth_ptr_);
+  }
+
+  /*!
+   * \brief Get the maximum allowed recursion depth
+   * \return Current maximum recursion depth limit
+   */
+  static int GetMaxRecursionDepth() { return max_recursion_depth_.load(std::memory_order_relaxed); }
+
+  /*!
+   * \brief Set the maximum allowed recursion depth
+   * \param max_depth New maximum recursion depth limit (must be positive)
+   */
+  static void SetMaxRecursionDepth(int max_depth) {
+    if (max_depth <= 0 || max_depth > kMaxReasonableDepth) {
+      XGRAMMAR_LOG(FATAL
+      ) << "RecursionGuard: Maximum recursion depth must be positive and less than "
+        << kMaxReasonableDepth << ", got: " << max_depth;
+    }
+    max_recursion_depth_.store(max_depth, std::memory_order_relaxed);
+  }
+
+ private:
+  /*!
+   * \brief Get the maximum allowed recursion depth from the environment variable. Used to
+   * initialize max_recursion_depth_.
+   * \return Current maximum recursion depth limit
+   */
+  static int LoadMaxRecursionDepthFromEnv();
+
+  /*!
+   * \brief Pointer to the recursion depth counter
+   */
+  int* current_depth_ptr_;
+
+  /*!
+   * \brief Thread-safe global configuration
+   */
+  static std::atomic<int> max_recursion_depth_;
+
+  /*!
+   * \brief Environment variable name for the maximum recursion depth
+   */
+  inline constexpr static char kMaxRecursionDepthEnvVar[] = "XGRAMMAR_MAX_RECURSION_DEPTH";
+
+  /*!
+   * \brief Default maximum recursion depth
+   */
+  inline constexpr static int kDefaultMaxRecursionDepth = 10000;
+
+  /*!
+   * \brief Maximum reasonable recursion depth
+   */
+  inline constexpr static int kMaxReasonableDepth = 1000000;
+};
+
+}  // namespace xgrammar
+
+#endif  // XGRAMMAR_SUPPORT_RECURSION_GUARD_H_

--- a/python/xgrammar/__init__.py
+++ b/python/xgrammar/__init__.py
@@ -1,5 +1,6 @@
 from . import testing
 from .compiler import CompiledGrammar, GrammarCompiler
+from .config import get_max_recursion_depth, max_recursion_depth, set_max_recursion_depth
 from .contrib import hf
 from .grammar import Grammar, StructuralTagItem
 from .matcher import (

--- a/python/xgrammar/config.py
+++ b/python/xgrammar/config.py
@@ -11,7 +11,7 @@ def get_max_recursion_depth() -> int:
     The maximum recursion depth is determined in the following order:
     1. Manually set via set_max_recursion_depth()
     2. XGRAMMAR_MAX_RECURSION_DEPTH environment variable (if set and is a valid integer <= 1000000)
-    3. Default value of 1000000
+    3. Default value of 10000
 
     Returns
     -------

--- a/python/xgrammar/config.py
+++ b/python/xgrammar/config.py
@@ -1,0 +1,52 @@
+"""Global configuration for XGrammar."""
+
+from contextlib import contextmanager
+
+from .base import _core
+
+
+def get_max_recursion_depth() -> int:
+    """Get the maximum allowed recursion depth. The depth is shared per process.
+
+    The maximum recursion depth is determined in the following order:
+    1. Manually set via set_max_recursion_depth()
+    2. XGRAMMAR_MAX_RECURSION_DEPTH environment variable (if set and is a valid integer <= 1000000)
+    3. Default value of 1000000
+
+    Returns
+    -------
+    max_recursion_depth : int
+        The maximum allowed recursion depth.
+    """
+    return _core.config.get_max_recursion_depth()
+
+
+def set_max_recursion_depth(max_recursion_depth: int) -> None:
+    """Set the maximum allowed recursion depth. The depth is shared per process. This method is
+    thread-safe.
+
+    Parameters
+    ----------
+    max_recursion_depth : int
+        The maximum allowed recursion depth.
+    """
+    _core.config.set_max_recursion_depth(max_recursion_depth)
+
+
+@contextmanager
+def max_recursion_depth(temp_depth: int):
+    """A context manager for temporarily setting recursion depth.
+
+    Example
+    -------
+    >>> with recursion_depth(1000):
+    ...     # recursion depth is 1000 here
+    ...     pass
+    ... # recursion depth is restored to original value
+    """
+    prev_depth = get_max_recursion_depth()
+    set_max_recursion_depth(temp_depth)
+    try:
+        yield
+    finally:
+        set_max_recursion_depth(prev_depth)

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -234,6 +234,11 @@ class GrammarMatcher(XGRObject):
         -------
         accepted : bool
             Whether the token is accepted.
+
+        Throws
+        ------
+        RuntimeError
+            If the recursion depth is exceeded.
         """
         return self._handle.accept_token(token_id, debug_print)
 
@@ -255,6 +260,11 @@ class GrammarMatcher(XGRObject):
         -------
         accepted : bool
             Whether the string is accepted.
+
+        Throws
+        ------
+        RuntimeError
+            If the recursion depth is exceeded.
         """
         return self._handle.accept_string(input_str, debug_print)
 
@@ -283,6 +293,11 @@ class GrammarMatcher(XGRObject):
         need_apply : bool
             Whether the bitmask need to be applied (not all-true). An optimization: if False,
             this means the bitmask is already all-true, so no need to apply it.
+
+        Throws
+        ------
+        RuntimeError
+            If the recursion depth is exceeded.
         """
         if bitmask.device.type != "cpu":
             raise ValueError("bitmask should be on CPU.")
@@ -303,6 +318,11 @@ class GrammarMatcher(XGRObject):
         -------
         jump_forward_string : str
             The jump-forward string.
+
+        Throws
+        ------
+        RuntimeError
+            If the recursion depth is exceeded.
         """
         return self._handle.find_jump_forward_string()
 

--- a/tests/python/test_recursion_depth.py
+++ b/tests/python/test_recursion_depth.py
@@ -1,0 +1,54 @@
+import sys
+
+import pytest
+
+import xgrammar as xgr
+from xgrammar.testing import _get_matcher_from_grammar
+
+
+def test_set_get_recursion_depth():
+    """Test getting default recursion depth"""
+    default_depth = xgr.get_max_recursion_depth()
+    assert default_depth == 10000
+
+    xgr.set_max_recursion_depth(1000)
+    new_depth = xgr.get_max_recursion_depth()
+    assert new_depth == 1000
+    xgr.set_max_recursion_depth(default_depth)
+
+
+def test_recursion_depth_context():
+    """Test recursion depth context manager"""
+    assert xgr.get_max_recursion_depth() == 10000
+    with xgr.max_recursion_depth(1000):
+        depth = xgr.get_max_recursion_depth()
+        assert depth == 1000
+    assert xgr.get_max_recursion_depth() == 10000
+
+
+def test_error_set_recursion_depth():
+    """Test setting recursion depth to an invalid value"""
+    with pytest.raises(RuntimeError):
+        xgr.set_max_recursion_depth(-1)
+
+    with pytest.raises(RuntimeError):
+        xgr.set_max_recursion_depth(100000000)
+
+
+def test_recursion_exceed():
+    with xgr.max_recursion_depth(1000):
+        grammar_ebnf = r"""
+    root ::= "\"" basic_string "\""
+    basic_string ::= "" | [^"\\\r\n] basic_string | "\\" escape basic_string
+    escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
+    """
+        input_str = '"' + " " * 10000 + '"'
+
+        matcher = _get_matcher_from_grammar(grammar_ebnf)
+
+        with pytest.raises(RuntimeError):
+            matcher.accept_string(input_str)
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)


### PR DESCRIPTION
This PR provides a new set of methods to control the max recursion depth:
- set_max_recursion_depth
- get_max_recursion_depth
- max_recursion_depth, a decorator

This avoids the segfault problem of xgrammar. Instead, an RuntimeError will be thrown.