### PR TITLE
Convert Result to use unique_ptrs

### DIFF
--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -682,7 +682,7 @@ Result<FSMWithStartEnd> FSMWithStartEnd::Intersect(
     const FSMWithStartEnd& lhs, const FSMWithStartEnd& rhs, const int& num_of_states_limited
 ) {
   if (!lhs.IsLeaf() || !rhs.IsLeaf()) {
-    return Result<FSMWithStartEnd>::Err(std::make_shared<Error>("Intersect only support leaf fsm!")
+    return Result<FSMWithStartEnd>::Err(std::make_unique<Error>("Intersect only support leaf fsm!")
     );
   }
   auto lhs_dfa = lhs.ToDFA();
@@ -733,7 +733,7 @@ Result<FSMWithStartEnd> FSMWithStartEnd::Intersect(
   while (!queue.empty()) {
     if (int(state_map.size()) > num_of_states_limited) {
       return Result<FSMWithStartEnd>::Err(
-          std::make_shared<Error>("Intersection have too many states!")
+          std::make_unique<Error>("Intersection have too many states!")
       );
     }
     auto state = queue.front();

--- a/cpp/support/utils.h
+++ b/cpp/support/utils.h
@@ -83,7 +83,7 @@ class Result {
   static Result Ok(T value) { return Result(std::move(value), nullptr); }
 
   /*! \brief Construct an error Result */
-  static Result Err(std::shared_ptr<Error> error) { return Result(std::nullopt, std::move(error)); }
+  static Result Err(std::unique_ptr<Error> error) { return Result(std::nullopt, std::move(error)); }
 
   /*! \brief Check if Result contains success value */
   bool IsOk() const { return value_.has_value(); }
@@ -110,16 +110,7 @@ class Result {
   }
 
   /*! \brief Get the error value as a pointer, or terminate if this is not an error */
-  std::shared_ptr<Error> UnwrapErr() const& {
-    if (!IsErr()) {
-      XGRAMMAR_LOG(FATAL) << "Called UnwrapErr() on an Ok value";
-      XGRAMMAR_UNREACHABLE();
-    }
-    return error_;
-  }
-
-  /*! \brief Get the error value as a pointer, or terminate if this is not an error */
-  std::shared_ptr<Error> UnwrapErr() && {
+  std::unique_ptr<Error> UnwrapErr() && {
     if (!IsErr()) {
       XGRAMMAR_LOG(FATAL) << "Called UnwrapErr() on an Ok value";
       XGRAMMAR_UNREACHABLE();
@@ -149,11 +140,11 @@ class Result {
   }
 
  private:
-  Result(std::optional<T> value, std::shared_ptr<Error> error)
+  Result(std::optional<T> value, std::unique_ptr<Error> error)
       : value_(std::move(value)), error_(std::move(error)) {}
 
   std::optional<T> value_;
-  std::shared_ptr<Error> error_;
+  std::unique_ptr<Error> error_;
 };
 
 }  // namespace xgrammar


### PR DESCRIPTION
There seems to be no advantage of shared_ptr here - convert to unique_ptr to reduce overhead slightly.

This also removes the `const&` overload of `UnwrapErr`, since we can no longer copy the pointer, but in all use cases we can convert to using the `&&` overload instead.