### PR TITLE
Add tiktoken and sentencepiece to test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,15 +29,14 @@ GitHub = "https://github.com/mlc-ai/xgrammar"
 
 [project.optional-dependencies]
 test = [
-  "pytest",
-  "protobuf",
   "huggingface-hub[cli]",
+  "protobuf",
+  "pytest",
   "sentencepiece",
   "tiktoken",
   # transformers==4.50.0 has error on MacOS.
   # https://github.com/huggingface/transformers/issues/36906
   "transformers<4.50.0; platform_system == 'Darwin'",
-  "tiktoken",
 ]
 
 [tool.scikit-build.metadata.version]


### PR DESCRIPTION
Not sure why it worked in presubmit but not on main, but there were some test failures due to tiktoken being missing. Readd that to the test dependencies.