### PR TITLE
[Minor] Replace all Result<...>::Ok with ResultOk

### DIFF
--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -872,7 +872,7 @@ Result<FSMWithStartEnd> FSMWithStartEnd::Intersect(
     const FSMWithStartEnd& lhs, const FSMWithStartEnd& rhs, int num_of_states_limited
 ) {
   if (!lhs.IsLeaf() || !rhs.IsLeaf()) {
-    return Result<FSMWithStartEnd>::Err("Intersect only support leaf fsm!");
+    return ResultErr("Intersect only support leaf fsm!");
   }
   auto lhs_dfa = lhs.ToDFA();
   auto rhs_dfa = rhs.ToDFA();
@@ -921,7 +921,7 @@ Result<FSMWithStartEnd> FSMWithStartEnd::Intersect(
   state_map[{lhs_dfa.GetStart(), rhs_dfa.GetStart()}] = 0;
   while (!queue.empty()) {
     if (int(state_map.size()) > num_of_states_limited) {
-      return Result<FSMWithStartEnd>::Err("Intersection have too many states!");
+      return ResultErr("Intersection have too many states!");
     }
     auto state = queue.front();
     queue.pop();
@@ -994,7 +994,7 @@ Result<FSMWithStartEnd> FSMWithStartEnd::Intersect(
       result.AddEndState(state_map[state]);
     }
   }
-  return Result<FSMWithStartEnd>::Ok(std::move(result));
+  return ResultOk(std::move(result));
 }
 
 bool FSMWithStartEnd::IsDFA() {

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -21,6 +22,7 @@
 
 #include "support/compact_2d_array.h"
 #include "support/reflection/reflection.h"
+#include "support/utils.h"
 
 namespace xgrammar {
 

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1995,7 +1995,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
 
   if (schema.count("prefixItems")) {
     if (!schema.at("prefixItems").is<picojson::array>()) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "prefixItems must be an array"
       );
     }
@@ -2003,12 +2003,12 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
     for (const auto& item : prefix_item_schemas) {
       if (item.is<bool>()) {
         if (!item.get<bool>()) {
-          return Result<ArraySpec, SchemaError>::Err(
+          return ResultErr<SchemaError>(
               SchemaErrorType::kUnsatisfiableSchema, "prefixItems contains false"
           );
         }
       } else if (!item.is<picojson::object>()) {
-        return Result<ArraySpec, SchemaError>::Err(
+        return ResultErr<SchemaError>(
             SchemaErrorType::kInvalidSchema, "prefixItems must be an array of objects or booleans"
         );
       }
@@ -2018,7 +2018,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
   if (schema.count("items")) {
     auto items_value = schema.at("items");
     if (!items_value.is<bool>() && !items_value.is<picojson::object>()) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "items must be a boolean or an object"
       );
     }
@@ -2031,7 +2031,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
   } else if (schema.count("unevaluatedItems")) {
     auto unevaluated_items_value = schema.at("unevaluatedItems");
     if (!unevaluated_items_value.is<bool>() && !unevaluated_items_value.is<picojson::object>()) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "unevaluatedItems must be a boolean or an object"
       );
     }
@@ -2050,16 +2050,14 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
 
   if (schema.count("minItems")) {
     if (!schema.at("minItems").is<int64_t>()) {
-      return Result<ArraySpec, SchemaError>::Err(
-          SchemaErrorType::kInvalidSchema, "minItems must be an integer"
-      );
+      return ResultErr<SchemaError>(SchemaErrorType::kInvalidSchema, "minItems must be an integer");
     }
     min_items = std::max(static_cast<int64_t>(0), schema.at("minItems").get<int64_t>());
   }
 
   if (schema.count("minContains")) {
     if (!schema.at("minContains").is<int64_t>()) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "minContains must be an integer"
       );
     }
@@ -2068,7 +2066,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
 
   if (schema.count("maxItems")) {
     if (!schema.at("maxItems").is<int64_t>() || schema.at("maxItems").get<int64_t>() < 0) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "maxItems must be a non-negative integer"
       );
     }
@@ -2077,7 +2075,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
 
   // Check if the schema is unsatisfiable
   if (max_items != -1 && min_items > max_items) {
-    return Result<ArraySpec, SchemaError>::Err(
+    return ResultErr<SchemaError>(
         SchemaErrorType::kUnsatisfiableSchema,
         "minItems is greater than maxItems: " + std::to_string(min_items) + " > " +
             std::to_string(max_items)
@@ -2085,7 +2083,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
   }
 
   if (max_items != -1 && max_items < static_cast<int64_t>(prefix_item_schemas.size())) {
-    return Result<ArraySpec, SchemaError>::Err(
+    return ResultErr<SchemaError>(
         SchemaErrorType::kUnsatisfiableSchema,
         "maxItems is less than the number of prefixItems: " + std::to_string(max_items) + " < " +
             std::to_string(prefix_item_schemas.size())
@@ -2095,7 +2093,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
   if (!allow_additional_items) {
     // [len, len] must be in [min, max]
     if (static_cast<int64_t>(prefix_item_schemas.size()) < min_items) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kUnsatisfiableSchema,
           "minItems is greater than the number of prefixItems, but additional items are not "
           "allowed: " +
@@ -2103,7 +2101,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
       );
     }
     if (max_items != -1 && static_cast<int64_t>(prefix_item_schemas.size()) > max_items) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kUnsatisfiableSchema,
           "maxItems is less than the number of prefixItems, but additional items are not "
           "allowed: " +

--- a/cpp/support/compact_2d_array.h
+++ b/cpp/support/compact_2d_array.h
@@ -12,8 +12,8 @@
 #include <vector>
 
 #include "logging.h"
+#include "memory_size.h"
 #include "reflection/reflection.h"
-#include "utils.h"
 
 namespace xgrammar {
 

--- a/cpp/support/utils.h
+++ b/cpp/support/utils.h
@@ -58,23 +58,6 @@ class TypedError : public std::runtime_error {
   T type_;
 };
 
-namespace detail {
-
-/*!
- * \brief Check if the parameter pack has exactly one type X. The generic version is false.
- */
-template <typename X, typename... Args>
-constexpr bool is_exactly_one_type = false;
-
-/*!
- * \brief Partial specialization of is_exactly_one_type that returns true if the parameter pack
- * has exactly one type Arg when it is exactly one X.
- */
-template <typename X, typename Arg>
-constexpr bool is_exactly_one_type<X, Arg> = std::is_same_v<std::decay_t<Arg>, X>;
-
-}  // namespace detail
-
 template <typename T, bool IsOk>
 struct PartialResult {
   template <typename... Args>
@@ -82,12 +65,12 @@ struct PartialResult {
   T value;
 };
 
-template <typename E = std::runtime_error, typename..., typename... Args>
+template <typename E = std::runtime_error, typename... Args>
 inline PartialResult<E, false> ResultErr(Args&&... args) {
   return PartialResult<E, false>{std::forward<Args>(args)...};
 }
 
-template <typename T, typename..., typename... Args>
+template <typename T, typename... Args>
 inline PartialResult<T, true> ResultOk(Args&&... args) {
   return PartialResult<T, true>{std::forward<Args>(args)...};
 }

--- a/cpp/support/utils.h
+++ b/cpp/support/utils.h
@@ -9,18 +9,13 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <iterator>
-#include <memory>
-#include <optional>
 #include <stdexcept>
 #include <tuple>
 #include <type_traits>
-#include <unordered_set>
 #include <utility>
 #include <variant>
 
 #include "logging.h"
-#include "memory_size.h"
 
 namespace xgrammar {
 
@@ -80,6 +75,28 @@ constexpr bool is_exactly_one_type<X, Arg> = std::is_same_v<std::decay_t<Arg>, X
 
 }  // namespace detail
 
+template <typename T, bool IsOk>
+struct PartialResult {
+  template <typename... Args>
+  PartialResult(Args&&... args) : value(std::forward<Args>(args)...) {}
+  T value;
+};
+
+template <typename E = std::runtime_error, typename..., typename... Args>
+inline PartialResult<E, false> ResultErr(Args&&... args) {
+  return PartialResult<E, false>{std::forward<Args>(args)...};
+}
+
+template <typename T, typename..., typename... Args>
+inline PartialResult<T, true> ResultOk(Args&&... args) {
+  return PartialResult<T, true>{std::forward<Args>(args)...};
+}
+
+template <typename T>
+inline PartialResult<T&&, true> ResultOk(T&& value) {
+  return PartialResult<T&&, true>{std::forward<T>(value)};
+}
+
 /*!
  * \brief An always-move Result type similar to Rust's Result, representing either success (Ok) or
  * failure (Err). It always uses move semantics for the success and error values.
@@ -122,31 +139,21 @@ class Result {
   static_assert(!std::is_same_v<T, E>, "T and E cannot be the same type");
 
  public:
+  /*! \brief Default constructor is deleted to avoid accidental use */
+  Result() = delete;
+
+  /*! \brief Construct from Result::Err */
+  template <typename V, typename = std::enable_if_t<std::is_same_v<std::decay_t<V>, E>>>
+  Result(PartialResult<V, false>&& partial_result)
+      : data_(std::in_place_type<E>, std::forward<V>(partial_result.value)) {}
+
+  /*! \brief Construct from Result::Ok */
+  template <typename U, typename = std::enable_if_t<std::is_same_v<std::decay_t<U>, T>>>
+  Result(PartialResult<U, true>&& partial_result)
+      : data_(std::in_place_type<T>, std::forward<U>(partial_result.value)) {}
+
   /*! \brief Construct a success Result by moving T */
   static Result Ok(T&& value) { return Result(std::in_place_type<T>, std::move(value)); }
-
-  /*!
-   * \brief Construct a success Result by invoking T's constructor.
-   * \note This method cannot accept T as the only argument, therefore avoiding user passing const
-   * T& and invoke the copy constructor.
-   */
-  template <typename... Args, typename = std::enable_if_t<!detail::is_exactly_one_type<T, Args...>>>
-  static Result Ok(Args&&... args) {
-    return Result(std::in_place_type<T>, std::forward<Args>(args)...);
-  }
-
-  /*! \brief Construct an error Result by moving E */
-  static Result Err(E&& value) { return Result(std::in_place_type<E>, std::move(value)); }
-
-  /*!
-   * \brief Construct an error Result by invoking E's constructor.
-   * \note This method cannot accept E as the only argument, therefore avoiding user passing const
-   * E& and invoke the copy constructor.
-   */
-  template <typename... Args, typename = std::enable_if_t<!detail::is_exactly_one_type<E, Args...>>>
-  static Result Err(Args&&... args) {
-    return Result(std::in_place_type<E>, std::forward<Args>(args)...);
-  }
 
   /*! \brief Check if Result contains success value */
   bool IsOk() const { return std::holds_alternative<T>(data_); }
@@ -186,18 +193,18 @@ class Result {
   template <typename F, typename U = std::decay_t<std::invoke_result_t<F, T>>>
   Result<U, E> Map(F&& f) && {
     if (IsOk()) {
-      return Result<U, E>::Ok(f(std::get<T>(std::move(data_))));
+      return ResultOk(f(std::get<T>(std::move(data_))));
     }
-    return Result<U, E>::Err(std::get<E>(std::move(data_)));
+    return ResultErr(std::get<E>(std::move(data_)));
   }
 
   /*! \brief Map error value to new type using provided function */
   template <typename F, typename V = std::decay_t<std::invoke_result_t<F, E>>>
   Result<T, V> MapErr(F&& f) && {
     if (IsErr()) {
-      return Result<T, V>::Err(f(std::get<E>(std::move(data_))));
+      return ResultErr(f(std::get<E>(std::move(data_))));
     }
-    return Result<T, V>::Ok(std::get<T>(std::move(data_)));
+    return ResultOk(std::get<T>(std::move(data_)));
   }
 
   /*!
@@ -207,9 +214,9 @@ class Result {
   template <typename U, typename V>
   static Result<T, E> Convert(Result<U, V>&& result) {
     if (result.IsOk()) {
-      return Result<T, E>::Ok(std::move(result).Unwrap());
+      return ResultOk(std::move(result).Unwrap());
     }
-    return Result<T, E>::Err(std::move(result).UnwrapErr());
+    return ResultErr(std::move(result).UnwrapErr());
   }
 
   /*! \brief Get a std::variant<T, E> from the result. */


### PR DESCRIPTION
When returning with OK, we don't need to actually specify the type in most cases. So we implement a wrapper class `PartialResult` to enable users to write code like: `ResultOK` and `ResultErr`. Still, we have fallback to specify the result type or the error type, and the code will look like `ResultOK<T>` and `ResultErr<E>`