### PR TITLE
[Refactor] RuleExpr -> GrammarExpr

### DIFF
--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -221,7 +221,7 @@ class EarleyParser {
    * it will be discarded.
    */
  protected:
-  using RuleExpr = Grammar::Impl::RuleExpr;
+  using GrammarExpr = Grammar::Impl::GrammarExpr;
 
   /*! \brief The grammar to be parsed. */
   Grammar grammar_;
@@ -280,7 +280,7 @@ class EarleyParser {
    * of the grammar is used to check if the grammar is completed,
    * so it should be added into the next states.
    */
-  void Complete(const ParserState& state, const RuleExpr& rule_expr);
+  void Complete(const ParserState& state, const GrammarExpr& grammar_expr);
 
   /*!
    * \brief The prediction operation of the Earley parser.
@@ -288,7 +288,7 @@ class EarleyParser {
    * then return true, otherwise return false.
    * \return Second: If the state is completable, then return true, otherwise return false.
    */
-  std::pair<bool, bool> Predict(const ParserState& state, const RuleExpr& rule_expr);
+  std::pair<bool, bool> Predict(const ParserState& state, const GrammarExpr& grammar_expr);
 
   /*!
    * \brief Handle the unexpanded rule, used for pushing initial state.
@@ -303,12 +303,12 @@ class EarleyParser {
    * The type of the state is kTagDispatch or kSequence. Moreover, the
    * element of the sequence should be a rule reference; the node in
    * the kTagDispatch should be an end node.
-   * \param rule_expr The rule expression to be expanded.
-   * \param sub_rule_expr The sub rule expression to be expanded, especially
+   * \param grammar_expr The grammar expression to be expanded.
+   * \param sub_grammar_expr The sub grammar expression to be expanded, especially
    * when the rule is a kSequence, and the sub rule is a kRuleRef.
    */
   void ExpandNextRuleRefElement(
-      const ParserState& state, const RuleExpr& rule_expr, const RuleExpr* sub_rule_expr
+      const ParserState& state, const GrammarExpr& grammar_expr, const GrammarExpr* sub_grammar_expr
   );
 
   /*!
@@ -319,7 +319,7 @@ class EarleyParser {
    * \return The next state, Invalid state if the character is not accepted.
    */
   void AdvanceCharacterClass(
-      const ParserState& state, const uint8_t ch, const RuleExpr& sub_sequence
+      const ParserState& state, const uint8_t ch, const GrammarExpr& sub_sequence
   );
 
   /*!
@@ -329,7 +329,9 @@ class EarleyParser {
    * \param sub_sequence The sub sequence to be checked.
    * \return The next state, Invalid state if the character is not accepted.
    */
-  void AdvanceByteString(const ParserState& state, const uint8_t ch, const RuleExpr& sub_sequence);
+  void AdvanceByteString(
+      const ParserState& state, const uint8_t ch, const GrammarExpr& sub_sequence
+  );
 
   /*!
    * \brief Advance the parser to the next state, with the sub sequence is kCharacterClassStar.
@@ -339,7 +341,7 @@ class EarleyParser {
    * \return The next state, Invalid state if the character is not accepted.
    */
   void AdvanceCharacterClassStar(
-      const ParserState& state, const uint8_t ch, const RuleExpr& sub_sequence
+      const ParserState& state, const uint8_t ch, const GrammarExpr& sub_sequence
   );
 
   /*!
@@ -349,7 +351,9 @@ class EarleyParser {
    * \param cur_sequence The sequence of the current state.
    * \return The next state, Invalid state if the character is not accepted.
    */
-  void AdvanceTagDispatch(const ParserState& state, const uint8_t ch, const RuleExpr& cur_sequence);
+  void AdvanceTagDispatch(
+      const ParserState& state, const uint8_t ch, const GrammarExpr& cur_sequence
+  );
 
   /*!
    * \brief Enqueue the state into the queue.

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -22,8 +22,8 @@ namespace xgrammar {
 class GrammarBuilder {
  public:
   using Rule = Grammar::Impl::Rule;
-  using RuleExprType = Grammar::Impl::RuleExprType;
-  using RuleExpr = Grammar::Impl::RuleExpr;
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  using GrammarExpr = Grammar::Impl::GrammarExpr;
 
   /*! \brief Default constructor. Creates a new grammar object. */
   GrammarBuilder() : grammar_(std::make_shared<Grammar::Impl>()) {}
@@ -64,36 +64,40 @@ class GrammarBuilder {
     return Grammar(grammar_);
   }
 
-  /****************** RuleExpr handling ******************/
+  /****************** GrammarExpr handling ******************/
 
-  /*! \brief Add a rule_expr and return the rule_expr id. */
-  int32_t AddRuleExpr(const RuleExpr& rule_expr) {
-    grammar_->rule_expr_indptr_.push_back(grammar_->rule_expr_data_.size());
-    grammar_->rule_expr_data_.push_back(static_cast<int32_t>(rule_expr.type));
-    grammar_->rule_expr_data_.push_back(rule_expr.data_len);
-    grammar_->rule_expr_data_.insert(
-        grammar_->rule_expr_data_.end(), rule_expr.data, rule_expr.data + rule_expr.data_len
+  /*! \brief Add a grammar_expr and return the grammar_expr id. */
+  int32_t AddGrammarExpr(const GrammarExpr& grammar_expr) {
+    grammar_->grammar_expr_indptr_.push_back(grammar_->grammar_expr_data_.size());
+    grammar_->grammar_expr_data_.push_back(static_cast<int32_t>(grammar_expr.type));
+    grammar_->grammar_expr_data_.push_back(grammar_expr.data_len);
+    grammar_->grammar_expr_data_.insert(
+        grammar_->grammar_expr_data_.end(),
+        grammar_expr.data,
+        grammar_expr.data + grammar_expr.data_len
     );
-    return static_cast<int32_t>(grammar_->rule_expr_indptr_.size()) - 1;
+    return static_cast<int32_t>(grammar_->grammar_expr_indptr_.size()) - 1;
   }
 
   /*!
-   * \brief Add a RuleExpr for string stored in bytes.
+   * \brief Add a GrammarExpr for string stored in bytes.
    * \param bytes A vector of int32_t, each representing a byte (0~255) in the string.
    * The string is stored in int32 vector to match the storage format of the grammar.
    */
   int32_t AddByteString(const std::vector<int32_t>& bytes) {
-    return AddRuleExpr({RuleExprType::kByteString, bytes.data(), static_cast<int32_t>(bytes.size())}
+    return AddGrammarExpr(
+        {GrammarExprType::kByteString, bytes.data(), static_cast<int32_t>(bytes.size())}
     );
   }
 
   /*!
-   * \brief Add a RuleExpr for string stored in bytes.
+   * \brief Add a GrammarExpr for string stored in bytes.
    * \param str The string to be added.
    */
   int32_t AddByteString(const std::string& str) {
     std::vector<int32_t> bytes(str.begin(), str.end());
-    return AddRuleExpr({RuleExprType::kByteString, bytes.data(), static_cast<int32_t>(bytes.size())}
+    return AddGrammarExpr(
+        {GrammarExprType::kByteString, bytes.data(), static_cast<int32_t>(bytes.size())}
     );
   }
 
@@ -107,7 +111,7 @@ class GrammarBuilder {
   };
 
   /*!
-   * \brief Add a RuleExpr for a character class.
+   * \brief Add a GrammarExpr for a character class.
    * \param elements A vector of CharacterClassElement, each containing a lower and a upper bound.
    * \param is_negative Whether the character class is negated.
    */
@@ -121,13 +125,13 @@ class GrammarBuilder {
       data.push_back(range.lower);
       data.push_back(range.upper);
     }
-    return AddRuleExpr(
-        {RuleExprType::kCharacterClass, data.data(), static_cast<int32_t>(data.size())}
+    return AddGrammarExpr(
+        {GrammarExprType::kCharacterClass, data.data(), static_cast<int32_t>(data.size())}
     );
   }
 
   /*!
-   * \brief Add a RuleExpr for a star quantifier of a character class.
+   * \brief Add a GrammarExpr for a star quantifier of a character class.
    * \param elements A vector of CharacterClassElement, each containing a lower and a upper bound.
    * \param is_negative Whether the character class is negated.
    */
@@ -141,37 +145,39 @@ class GrammarBuilder {
       data.push_back(range.lower);
       data.push_back(range.upper);
     }
-    return AddRuleExpr(
-        {RuleExprType::kCharacterClassStar, data.data(), static_cast<int32_t>(data.size())}
+    return AddGrammarExpr(
+        {GrammarExprType::kCharacterClassStar, data.data(), static_cast<int32_t>(data.size())}
     );
   }
 
-  /*! \brief Add a RuleExpr for empty string.*/
-  int32_t AddEmptyStr() { return AddRuleExpr({RuleExprType::kEmptyStr, nullptr, 0}); }
+  /*! \brief Add a GrammarExpr for empty string.*/
+  int32_t AddEmptyStr() { return AddGrammarExpr({GrammarExprType::kEmptyStr, nullptr, 0}); }
 
-  /*! \brief Add a RuleExpr for rule reference.*/
+  /*! \brief Add a GrammarExpr for rule reference.*/
   int32_t AddRuleRef(int32_t rule_id) {
     std::vector<int32_t> data;
     data.push_back(rule_id);
-    return AddRuleExpr({RuleExprType::kRuleRef, data.data(), static_cast<int32_t>(data.size())});
-  }
-
-  /*! \brief Add a RuleExpr for RuleExpr sequence.*/
-  int32_t AddSequence(const std::vector<int32_t>& elements) {
-    return AddRuleExpr(
-        {RuleExprType::kSequence, elements.data(), static_cast<int32_t>(elements.size())}
+    return AddGrammarExpr(
+        {GrammarExprType::kRuleRef, data.data(), static_cast<int32_t>(data.size())}
     );
   }
 
-  /*! \brief Add a RuleExpr for RuleExpr choices.*/
+  /*! \brief Add a GrammarExpr for GrammarExpr sequence.*/
+  int32_t AddSequence(const std::vector<int32_t>& elements) {
+    return AddGrammarExpr(
+        {GrammarExprType::kSequence, elements.data(), static_cast<int32_t>(elements.size())}
+    );
+  }
+
+  /*! \brief Add a GrammarExpr for GrammarExpr choices.*/
   int32_t AddChoices(const std::vector<int32_t>& choices) {
-    return AddRuleExpr(
-        {RuleExprType::kChoices, choices.data(), static_cast<int32_t>(choices.size())}
+    return AddGrammarExpr(
+        {GrammarExprType::kChoices, choices.data(), static_cast<int32_t>(choices.size())}
     );
   }
 
   /*!
-   * \brief Add a RuleExpr for tag dispatch.
+   * \brief Add a GrammarExpr for tag dispatch.
    * \param tag_dispatch_list A list of pairs of tag_expr_id and rule_id.
    */
   int32_t AddTagDispatch(const std::vector<std::pair<int32_t, int32_t>>& tag_dispatch_list) {
@@ -181,13 +187,16 @@ class GrammarBuilder {
       data.push_back(tag_expr_id);
       data.push_back(rule_id);
     }
-    return AddRuleExpr({RuleExprType::kTagDispatch, data.data(), static_cast<int32_t>(data.size())}
+    return AddGrammarExpr(
+        {GrammarExprType::kTagDispatch, data.data(), static_cast<int32_t>(data.size())}
     );
   }
 
-  int32_t NumRuleExprs() const { return grammar_->NumRuleExprs(); }
-  /*! \brief Get the rule_expr with the given id. */
-  RuleExpr GetRuleExpr(int32_t rule_expr_id) { return grammar_->GetRuleExpr(rule_expr_id); }
+  int32_t NumGrammarExprs() const { return grammar_->NumGrammarExprs(); }
+  /*! \brief Get the grammar_expr with the given id. */
+  GrammarExpr GetGrammarExpr(int32_t grammar_expr_id) {
+    return grammar_->GetGrammarExpr(grammar_expr_id);
+  }
 
   /****************** Rule handling ******************/
 
@@ -244,7 +253,7 @@ class GrammarBuilder {
 
   /*!
    * \brief Add a lookahead assertion to a rule referred by the given rule_id. The lookahead
-   * assertion should be a sequence RuleExpr id. An id of -1 means no lookahead assertion.
+   * assertion should be a sequence GrammarExpr id. An id of -1 means no lookahead assertion.
    */
   void UpdateLookaheadAssertion(int32_t rule_id, int32_t lookahead_assertion_id) {
     XGRAMMAR_CHECK(rule_id < static_cast<int32_t>(grammar_->rules_.size()))
@@ -254,7 +263,7 @@ class GrammarBuilder {
 
   /*!
    * \brief Add a lookahead assertion to a rule referred by the given name. The lookahead
-   * assertion should be a sequence RuleExpr id. An id of -1 means no lookahead assertion.
+   * assertion should be a sequence GrammarExpr id. An id of -1 means no lookahead assertion.
    */
   void UpdateLookaheadAssertion(std::string rule_name, int32_t lookahead_assertion_id) {
     int32_t rule_id = GetRuleId(rule_name);

--- a/cpp/grammar_data_structure.h
+++ b/cpp/grammar_data_structure.h
@@ -28,20 +28,20 @@ namespace xgrammar {
  * \details
  * ### Rules
  * The BNF grammar AST consists of a set of rules. Each rule contains a name and a definition, and
- * corresponds to a production in the grammar. The definition of a rule is a RuleExpr. Each rule
+ * corresponds to a production in the grammar. The definition of a rule is a GrammarExpr. Each rule
  * has a rule_id for reference.
  *
- * ### RuleExprs
- * RuleExpr is the definition of a rule or part of the definition of a rule. It can contain
- * elements, empty string, reference to other RuleExprs, or reference to other rules. Each RuleExpr
- * corresponds to an rule_expr_id for reference.
+ * ### GrammarExprs
+ * GrammarExpr is the definition of a rule or part of the definition of a rule. It can contain
+ * elements, empty string, reference to other GrammarExprs, or reference to other rules. Each
+ * GrammarExpr corresponds to an grammar_expr_id for reference.
  *
  * For example, in the following rule: rule ::= ("a" "b") | "c"
- * ("a" "b"), "c", ("a" "b") | "c" are all RuleExprs.
+ * ("a" "b"), "c", ("a" "b") | "c" are all GrammarExprs.
  *
- * #### Types of RuleExprs
- * Every RuleExpr is represented by a type as well as a variable-length array containing its data.
- * RuleExpr has several types:
+ * #### Types of GrammarExprs
+ * Every GrammarExpr is represented by a type as well as a variable-length array containing its
+ * data. GrammarExpr has several types:
  * - Byte string: a string of bytes (0~255). Supports UTF-8 strings.
  * - Character class: a range of characters (each character is a unicode codepoint), e.g. [a-z],
  *   [ac-z]. Can be negated: [^a-z], [^ac-z]. Now only ascii chars is allowed in [], but this
@@ -49,21 +49,23 @@ namespace xgrammar {
  * - Character class star: a star quantifier of a character class. e.g. [a-z]*, [^a-z]*.
  * - EmptyStr: an empty string, i.e. ""
  * - Rule reference: a reference to another rule
- * - Sequence: a sequence of rule_exprs, e.g. ("a" "b"). These rule_exprs are concatenated together.
- * - Choices: a choice of rule_exprs, e.g. ("a" "b") | "c". Each rule_expr can be matched.
+ * - Sequence: a sequence of grammar_exprs, e.g. ("a" "b"). These grammar_exprs are concatenated
+ * together.
+ * - Choices: a choice of grammar_exprs, e.g. ("a" "b") | "c". Each grammar_expr can be matched.
  *
- * #### Storage of RuleExprs
- * Each type of RuleExpr has a different data format. For the format of each type of RuleExpr, see
- * docs in Grammar::Impl::RuleExprType.
+ * #### Storage of GrammarExprs
+ * Each type of GrammarExpr has a different data format. For the format of each type of GrammarExpr,
+ * see docs in Grammar::Impl::GrammarExprType.
  *
- * We store all RuleExprs in csr_matrix style. That is, they are stored consecutively in one vector
- * (data vector) and the starting position of each RuleExpr is recorded in the indptr vector.
+ * We store all GrammarExprs in csr_matrix style. That is, they are stored consecutively in one
+ * vector (data vector) and the starting position of each GrammarExpr is recorded in the indptr
+ * vector.
  *
- * \remark The character class star RuleExpr is for the special support for elements like [a-z]*
+ * \remark The character class star GrammarExpr is for the special support for elements like [a-z]*
  * in the grammar. We add it to make the matching more efficient, as we can avoid recursion into
  * rules when matching a sequence of characters. It should be used like:
  * rule1 ::= ((element1 element2 rule2 ...) | ...)
- * rule2 ::= character_class_star_rule_expr(id_of_a_character_class_rule_expr)
+ * rule2 ::= character_class_star_grammar_expr(id_of_a_character_class_grammar_expr)
  */
 class Grammar::Impl {
  public:
@@ -71,10 +73,10 @@ class Grammar::Impl {
   struct Rule {
     /*! \brief The name of the rule. */
     std::string name;
-    /*! \brief The RuleExpr id of the body of the rule. */
+    /*! \brief The GrammarExpr id of the body of the rule. */
     int32_t body_expr_id;
     /*! \brief The id of the associated lookahead assertion expr. For now it must be a id of a
-     * sequence RuleExpr. -1 if not exists. */
+     * sequence GrammarExpr. -1 if not exists. */
     int32_t lookahead_assertion_id = -1;
   };
 
@@ -95,8 +97,8 @@ class Grammar::Impl {
     return rules_[root_rule_id_];
   }
 
-  /*! \brief The type of the rule expr. */
-  enum class RuleExprType : int32_t {
+  /*! \brief The type of the grammar expr. */
+  enum class GrammarExprType : int32_t {
     // data format: [byte0, byte1, ...]
     kByteString,
     // data format: [is_negative, lower0, upper0, lower1, upper1, ...]
@@ -106,20 +108,20 @@ class Grammar::Impl {
     kEmptyStr,
     // data format: [rule_id]
     kRuleRef,
-    // data format: [rule_expr_id0, rule_expr_id1, ...]
+    // data format: [grammar_expr_id0, grammar_expr_id1, ...]
     kSequence,
-    // data format: [rule_expr_id0, rule_expr_id1, ...]
+    // data format: [grammar_expr_id0, grammar_expr_id1, ...]
     kChoices,
     // data format: [tag_expr0, rule_id0, tag_expr1, rule_id1, ...]
     // tag_expr should be a byte string, and rule_id should be a rule id
     kTagDispatch,
   };
 
-  /*! \brief The object representing a rule expr. */
-  struct RuleExpr {
-    /*! \brief The type of the rule expr. */
-    RuleExprType type;
-    /*! \brief The data of the RuleExpr. A variable-length array. */
+  /*! \brief The object representing a grammar expr. */
+  struct GrammarExpr {
+    /*! \brief The type of the grammar expr. */
+    GrammarExprType type;
+    /*! \brief The data of the GrammarExpr. A variable-length array. */
     const int32_t* data;
     /*! \brief The length of the data array. */
     int32_t data_len;
@@ -135,47 +137,47 @@ class Grammar::Impl {
     const int32_t* end() const { return data + data_len; }
   };
 
-  /*! \brief Get the number of rule_exprs. */
-  int32_t NumRuleExprs() const { return rule_expr_indptr_.size(); }
-  /*! \brief Get the rule_expr with the given id. */
-  RuleExpr GetRuleExpr(int32_t rule_expr_id) const {
+  /*! \brief Get the number of grammar_exprs. */
+  int32_t NumGrammarExprs() const { return grammar_expr_indptr_.size(); }
+  /*! \brief Get the grammar_expr with the given id. */
+  GrammarExpr GetGrammarExpr(int32_t grammar_expr_id) const {
     XGRAMMAR_DCHECK(
-        rule_expr_id >= 0 && rule_expr_id < static_cast<int32_t>(rule_expr_indptr_.size())
-    ) << "rule_expr_id "
-      << rule_expr_id << " is out of bound";
-    int start_index = rule_expr_indptr_[rule_expr_id];
-    auto start_ptr = rule_expr_data_.data() + start_index;
-    auto type = static_cast<RuleExprType>(start_ptr[0]);
+        grammar_expr_id >= 0 && grammar_expr_id < static_cast<int32_t>(grammar_expr_indptr_.size())
+    ) << "grammar_expr_id "
+      << grammar_expr_id << " is out of bound";
+    int start_index = grammar_expr_indptr_[grammar_expr_id];
+    auto start_ptr = grammar_expr_data_.data() + start_index;
+    auto type = static_cast<GrammarExprType>(start_ptr[0]);
     auto data_ptr = start_ptr + 2;
     auto data_len = start_ptr[1];
     return {type, data_ptr, data_len};
   }
 
-  /******************* RuleExpr Getters *******************/
+  /******************* GrammarExpr Getters *******************/
 
-  /*! \brief Get the string of the byte string rule expr. */
-  std::string GetByteString(const RuleExpr& rule_expr) const {
+  /*! \brief Get the string of the byte string grammar expr. */
+  std::string GetByteString(const GrammarExpr& grammar_expr) const {
     std::string str;
-    str.reserve(rule_expr.size());
-    for (int i = 0; i < rule_expr.size(); ++i) {
-      str.push_back(static_cast<char>(static_cast<uint8_t>(rule_expr[i])));
+    str.reserve(grammar_expr.size());
+    for (int i = 0; i < grammar_expr.size(); ++i) {
+      str.push_back(static_cast<char>(static_cast<uint8_t>(grammar_expr[i])));
     }
     return str;
   }
 
-  /*! \brief Get the string of the byte string rule expr. */
-  std::string GetByteString(int32_t rule_expr_id) const {
-    return GetByteString(GetRuleExpr(rule_expr_id));
+  /*! \brief Get the string of the byte string grammar expr. */
+  std::string GetByteString(int32_t grammar_expr_id) const {
+    return GetByteString(GetGrammarExpr(grammar_expr_id));
   }
 
  private:
   /*! \brief The rules of the grammar. rule_id corresponds the index of this vector. */
   std::vector<Rule> rules_;
-  /*! \brief The data of all rule_exprs. */
-  std::vector<int32_t> rule_expr_data_;
-  /*! \brief The start index of every rule_expr in rule_expr_data_. rule_expr_id is the index
-   * to the elements in this vector. */
-  std::vector<int32_t> rule_expr_indptr_;
+  /*! \brief The data of all grammar_exprs. */
+  std::vector<int32_t> grammar_expr_data_;
+  /*! \brief The start index of every grammar_expr in grammar_expr_data_. grammar_expr_id is the
+   * index to the elements in this vector. */
+  std::vector<int32_t> grammar_expr_indptr_;
   /*! \brief The id of the root rule. */
   int32_t root_rule_id_ = -1;
 
@@ -211,10 +213,10 @@ XGRAMMAR_MEMBER_TABLE(
     Grammar::Impl,
     "rules_",
     &Grammar::Impl::rules_,
-    "rule_expr_data_",
-    &Grammar::Impl::rule_expr_data_,
-    "rule_expr_indptr_",
-    &Grammar::Impl::rule_expr_indptr_,
+    "grammar_expr_data_",
+    &Grammar::Impl::grammar_expr_data_,
+    "grammar_expr_indptr_",
+    &Grammar::Impl::grammar_expr_indptr_,
     "root_rule_id_",
     &Grammar::Impl::root_rule_id_,
     "root_tag_dispatch_fsm",

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -32,9 +32,9 @@ class SingleElementExprEliminator : public GrammarMutator {
   using GrammarMutator::GrammarMutator;
 
  private:
-  int32_t VisitSequence(const RuleExpr& rule_expr) final {
+  int32_t VisitSequence(const GrammarExpr& grammar_expr) final {
     std::vector<int32_t> sequence_ids;
-    for (int32_t i : rule_expr) {
+    for (int32_t i : grammar_expr) {
       sequence_ids.push_back(VisitExpr(i));
     }
     if (sequence_ids.size() == 1) {
@@ -43,9 +43,9 @@ class SingleElementExprEliminator : public GrammarMutator {
     return builder_.AddSequence(sequence_ids);
   }
 
-  int32_t VisitChoices(const RuleExpr& rule_expr) final {
+  int32_t VisitChoices(const GrammarExpr& grammar_expr) final {
     std::vector<int32_t> choice_ids;
-    for (int32_t i : rule_expr) {
+    for (int32_t i : grammar_expr) {
       choice_ids.push_back(VisitExpr(i));
     }
     if (choice_ids.size() == 1) {
@@ -54,9 +54,9 @@ class SingleElementExprEliminator : public GrammarMutator {
     return builder_.AddChoices(choice_ids);
   }
 
-  int32_t VisitCharacterClass(const RuleExpr& rule_expr) final {
-    if (rule_expr.data_len == 3 && rule_expr[0] == 0 && rule_expr[1] == rule_expr[2]) {
-      std::string str = PrintAsUTF8(rule_expr[1]);
+  int32_t VisitCharacterClass(const GrammarExpr& grammar_expr) final {
+    if (grammar_expr.data_len == 3 && grammar_expr[0] == 0 && grammar_expr[1] == grammar_expr[2]) {
+      std::string str = PrintAsUTF8(grammar_expr[1]);
       std::vector<int32_t> bytes;
       bytes.reserve(str.size());
       for (char c : str) {
@@ -64,7 +64,7 @@ class SingleElementExprEliminator : public GrammarMutator {
       }
       return builder_.AddByteString(bytes);
     }
-    return builder_.AddRuleExpr(rule_expr);
+    return builder_.AddGrammarExpr(grammar_expr);
   }
 };
 
@@ -101,9 +101,9 @@ class StructureNormalizerSub : public GrammarMutator {
     }
     for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
       auto rule = base_grammar_->GetRule(i);
-      auto rule_expr = base_grammar_->GetRuleExpr(rule.body_expr_id);
+      auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
       cur_rule_name_ = rule.name;
-      auto new_body_expr_id = VisitRuleBody(rule_expr);
+      auto new_body_expr_id = VisitRuleBody(grammar_expr);
       builder_.UpdateRuleBody(i, new_body_expr_id);
       builder_.UpdateLookaheadAssertion(i, VisitLookaheadAssertion(rule.lookahead_assertion_id));
     }
@@ -115,74 +115,74 @@ class StructureNormalizerSub : public GrammarMutator {
     if (lookahead_assertion_id == -1) {
       return -1;
     }
-    auto assertion_expr = base_grammar_->GetRuleExpr(lookahead_assertion_id);
+    auto assertion_expr = base_grammar_->GetGrammarExpr(lookahead_assertion_id);
     switch (assertion_expr.type) {
-      case RuleExprType::kSequence:
+      case GrammarExprType::kSequence:
         return builder_.AddSequence(VisitSequence_(assertion_expr));
-      case RuleExprType::kChoices:
+      case GrammarExprType::kChoices:
         XGRAMMAR_LOG(FATAL) << "Choices in lookahead assertion are not supported yet";
-      case RuleExprType::kEmptyStr:
+      case GrammarExprType::kEmptyStr:
         XGRAMMAR_LOG(FATAL) << "Empty string should not be in lookahead assertion";
-      case RuleExprType::kTagDispatch:
+      case GrammarExprType::kTagDispatch:
         XGRAMMAR_LOG(FATAL) << "TagDispatch should not be in lookahead assertion";
-      case RuleExprType::kByteString:
-      case RuleExprType::kCharacterClass:
-      case RuleExprType::kCharacterClassStar:
-      case RuleExprType::kRuleRef:
-        return builder_.AddSequence({builder_.AddRuleExpr(assertion_expr)});
+      case GrammarExprType::kByteString:
+      case GrammarExprType::kCharacterClass:
+      case GrammarExprType::kCharacterClassStar:
+      case GrammarExprType::kRuleRef:
+        return builder_.AddSequence({builder_.AddGrammarExpr(assertion_expr)});
       default:
         XGRAMMAR_LOG(FATAL) << "Unexpected lookahead assertion type: "
                             << static_cast<int>(assertion_expr.type);
     }
   }
 
-  /*! \brief Visit a RuleExpr as a rule body. */
-  int32_t VisitRuleBody(const RuleExpr& rule_expr) {
-    switch (rule_expr.type) {
-      case RuleExprType::kSequence:
-        return builder_.AddChoices({builder_.AddSequence(VisitSequence_(rule_expr))});
-      case RuleExprType::kChoices:
-        return builder_.AddChoices(VisitChoices_(rule_expr));
-      case RuleExprType::kEmptyStr:
+  /*! \brief Visit a GrammarExpr as a rule body. */
+  int32_t VisitRuleBody(const GrammarExpr& grammar_expr) {
+    switch (grammar_expr.type) {
+      case GrammarExprType::kSequence:
+        return builder_.AddChoices({builder_.AddSequence(VisitSequence_(grammar_expr))});
+      case GrammarExprType::kChoices:
+        return builder_.AddChoices(VisitChoices_(grammar_expr));
+      case GrammarExprType::kEmptyStr:
         return builder_.AddChoices({builder_.AddEmptyStr()});
-      case RuleExprType::kByteString:
-      case RuleExprType::kCharacterClass:
-      case RuleExprType::kCharacterClassStar:
-      case RuleExprType::kRuleRef:
-        return builder_.AddChoices({builder_.AddSequence({builder_.AddRuleExpr(rule_expr)})});
-      case RuleExprType::kTagDispatch:
-        return VisitTagDispatch(rule_expr);
+      case GrammarExprType::kByteString:
+      case GrammarExprType::kCharacterClass:
+      case GrammarExprType::kCharacterClassStar:
+      case GrammarExprType::kRuleRef:
+        return builder_.AddChoices({builder_.AddSequence({builder_.AddGrammarExpr(grammar_expr)})});
+      case GrammarExprType::kTagDispatch:
+        return VisitTagDispatch(grammar_expr);
       default:
-        XGRAMMAR_LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(rule_expr.type);
+        XGRAMMAR_LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(grammar_expr.type);
     }
   }
 
   /*!
-   * \brief Visit a RuleExpr containing choices.
-   * \returns A list of new choice RuleExpr ids.
+   * \brief Visit a GrammarExpr containing choices.
+   * \returns A list of new choice GrammarExpr ids.
    */
-  std::vector<int32_t> VisitChoices_(const RuleExpr& rule_expr) {
+  std::vector<int32_t> VisitChoices_(const GrammarExpr& grammar_expr) {
     std::vector<int32_t> new_choice_ids;
     bool found_empty = false;
-    for (auto i : rule_expr) {
-      auto choice_expr = base_grammar_->GetRuleExpr(i);
+    for (auto i : grammar_expr) {
+      auto choice_expr = base_grammar_->GetGrammarExpr(i);
       switch (choice_expr.type) {
-        case RuleExprType::kSequence:
+        case GrammarExprType::kSequence:
           VisitSequenceInChoices(choice_expr, &new_choice_ids, &found_empty);
           break;
-        case RuleExprType::kChoices:
+        case GrammarExprType::kChoices:
           VisitChoicesInChoices(choice_expr, &new_choice_ids, &found_empty);
           break;
-        case RuleExprType::kEmptyStr:
+        case GrammarExprType::kEmptyStr:
           found_empty = true;
           break;
-        case RuleExprType::kByteString:
-        case RuleExprType::kCharacterClass:
-        case RuleExprType::kCharacterClassStar:
-        case RuleExprType::kRuleRef:
+        case GrammarExprType::kByteString:
+        case GrammarExprType::kCharacterClass:
+        case GrammarExprType::kCharacterClassStar:
+        case GrammarExprType::kRuleRef:
           VisitElementInChoices(choice_expr, &new_choice_ids);
           break;
-        case RuleExprType::kTagDispatch: {
+        case GrammarExprType::kTagDispatch: {
           auto tag_dispatch_expr_id = VisitTagDispatch(choice_expr);
           auto new_rule_id = builder_.AddRuleWithHint(cur_rule_name_, tag_dispatch_expr_id);
           auto new_sequence_id = builder_.AddSequence({builder_.AddRuleRef(new_rule_id)});
@@ -200,11 +200,11 @@ class StructureNormalizerSub : public GrammarMutator {
     return new_choice_ids;
   }
 
-  /*! \brief Visit a sequence RuleExpr that is one of a list of choices. */
+  /*! \brief Visit a sequence GrammarExpr that is one of a list of choices. */
   void VisitSequenceInChoices(
-      const RuleExpr& rule_expr, std::vector<int32_t>* new_choice_ids, bool* found_empty
+      const GrammarExpr& grammar_expr, std::vector<int32_t>* new_choice_ids, bool* found_empty
   ) {
-    auto sub_sequence_ids = VisitSequence_(rule_expr);
+    auto sub_sequence_ids = VisitSequence_(grammar_expr);
     if (sub_sequence_ids.size() == 0) {
       *found_empty = true;
     } else {
@@ -212,12 +212,13 @@ class StructureNormalizerSub : public GrammarMutator {
     }
   }
 
-  /*! \brief Visit a choice RuleExpr that is one of a list of choices. */
+  /*! \brief Visit a choice GrammarExpr that is one of a list of choices. */
   void VisitChoicesInChoices(
-      const RuleExpr& rule_expr, std::vector<int32_t>* new_choice_ids, bool* found_empty
+      const GrammarExpr& grammar_expr, std::vector<int32_t>* new_choice_ids, bool* found_empty
   ) {
-    auto sub_choice_ids = VisitChoices_(rule_expr);
-    bool contains_empty = builder_.GetRuleExpr(sub_choice_ids[0]).type == RuleExprType::kEmptyStr;
+    auto sub_choice_ids = VisitChoices_(grammar_expr);
+    bool contains_empty =
+        builder_.GetGrammarExpr(sub_choice_ids[0]).type == GrammarExprType::kEmptyStr;
     if (contains_empty) {
       *found_empty = true;
       new_choice_ids->insert(
@@ -228,36 +229,38 @@ class StructureNormalizerSub : public GrammarMutator {
     }
   }
 
-  /*! \brief Visit an atom element RuleExpr that is one of a list of choices. */
-  void VisitElementInChoices(const RuleExpr& rule_expr, std::vector<int32_t>* new_choice_ids) {
-    auto sub_expr_id = builder_.AddRuleExpr(rule_expr);
+  /*! \brief Visit an atom element GrammarExpr that is one of a list of choices. */
+  void VisitElementInChoices(
+      const GrammarExpr& grammar_expr, std::vector<int32_t>* new_choice_ids
+  ) {
+    auto sub_expr_id = builder_.AddGrammarExpr(grammar_expr);
     new_choice_ids->push_back(builder_.AddSequence({sub_expr_id}));
   }
 
   /*!
-   * \brief Visit a RuleExpr containing a sequence.
-   * \returns A list of new sequence RuleExpr ids.
+   * \brief Visit a GrammarExpr containing a sequence.
+   * \returns A list of new sequence GrammarExpr ids.
    */
-  std::vector<int32_t> VisitSequence_(const RuleExpr& rule_expr) {
+  std::vector<int32_t> VisitSequence_(const GrammarExpr& grammar_expr) {
     std::vector<int32_t> new_sequence_ids;
-    for (auto i : rule_expr) {
-      auto element_expr = base_grammar_->GetRuleExpr(i);
+    for (auto i : grammar_expr) {
+      auto element_expr = base_grammar_->GetGrammarExpr(i);
       switch (element_expr.type) {
-        case RuleExprType::kSequence:
+        case GrammarExprType::kSequence:
           VisitSequenceInSequence(element_expr, &new_sequence_ids);
           break;
-        case RuleExprType::kChoices:
+        case GrammarExprType::kChoices:
           VisitChoiceInSequence(element_expr, &new_sequence_ids);
           break;
-        case RuleExprType::kEmptyStr:
+        case GrammarExprType::kEmptyStr:
           break;
-        case RuleExprType::kByteString:
-        case RuleExprType::kCharacterClass:
-        case RuleExprType::kCharacterClassStar:
-        case RuleExprType::kRuleRef:
+        case GrammarExprType::kByteString:
+        case GrammarExprType::kCharacterClass:
+        case GrammarExprType::kCharacterClassStar:
+        case GrammarExprType::kRuleRef:
           VisitElementInSequence(element_expr, &new_sequence_ids);
           break;
-        case RuleExprType::kTagDispatch: {
+        case GrammarExprType::kTagDispatch: {
           auto tag_dispatch_expr_id = VisitTagDispatch(element_expr);
           auto new_rule_id = builder_.AddRuleWithHint(cur_rule_name_, tag_dispatch_expr_id);
           new_sequence_ids.push_back(builder_.AddRuleRef(new_rule_id));
@@ -271,20 +274,24 @@ class StructureNormalizerSub : public GrammarMutator {
     return new_sequence_ids;
   }
 
-  /*! \brief Visit a sequence RuleExpr that is one element in another sequence. */
-  void VisitSequenceInSequence(const RuleExpr& rule_expr, std::vector<int32_t>* new_sequence_ids) {
-    auto sub_sequence_ids = VisitSequence_(rule_expr);
+  /*! \brief Visit a sequence GrammarExpr that is one element in another sequence. */
+  void VisitSequenceInSequence(
+      const GrammarExpr& grammar_expr, std::vector<int32_t>* new_sequence_ids
+  ) {
+    auto sub_sequence_ids = VisitSequence_(grammar_expr);
     new_sequence_ids->insert(
         new_sequence_ids->end(), sub_sequence_ids.begin(), sub_sequence_ids.end()
     );
   }
 
-  /*! \brief Visit a choice RuleExpr that is one element in a sequence. */
-  void VisitChoiceInSequence(const RuleExpr& rule_expr, std::vector<int32_t>* new_sequence_ids) {
-    auto sub_choice_ids = VisitChoices_(rule_expr);
+  /*! \brief Visit a choice GrammarExpr that is one element in a sequence. */
+  void VisitChoiceInSequence(
+      const GrammarExpr& grammar_expr, std::vector<int32_t>* new_sequence_ids
+  ) {
+    auto sub_choice_ids = VisitChoices_(grammar_expr);
     if (sub_choice_ids.size() == 1) {
-      auto choice_element_expr = builder_.GetRuleExpr(sub_choice_ids[0]);
-      if (choice_element_expr.type != RuleExprType::kEmptyStr) {
+      auto choice_element_expr = builder_.GetGrammarExpr(sub_choice_ids[0]);
+      if (choice_element_expr.type != GrammarExprType::kEmptyStr) {
         new_sequence_ids->insert(
             new_sequence_ids->end(), choice_element_expr.begin(), choice_element_expr.end()
         );
@@ -296,9 +303,11 @@ class StructureNormalizerSub : public GrammarMutator {
     }
   }
 
-  /*! \brief Visit an atom element RuleExpr that is in a sequence. */
-  void VisitElementInSequence(const RuleExpr& rule_expr, std::vector<int32_t>* new_sequence_ids) {
-    new_sequence_ids->push_back(builder_.AddRuleExpr(rule_expr));
+  /*! \brief Visit an atom element GrammarExpr that is in a sequence. */
+  void VisitElementInSequence(
+      const GrammarExpr& grammar_expr, std::vector<int32_t>* new_sequence_ids
+  ) {
+    new_sequence_ids->push_back(builder_.AddGrammarExpr(grammar_expr));
   }
 };
 
@@ -319,15 +328,15 @@ class ByteStringFuserImpl : public GrammarMutator {
 
  private:
   /*!
-   * \brief Visit a RuleExpr containing a sequence.
-   * \returns A list of new sequence RuleExpr ids.
+   * \brief Visit a GrammarExpr containing a sequence.
+   * \returns A list of new sequence GrammarExpr ids.
    */
-  int32_t VisitSequence(const RuleExpr& rule_expr) final {
+  int32_t VisitSequence(const GrammarExpr& grammar_expr) final {
     std::vector<int32_t> new_sequence_ids;
     std::vector<int32_t> cur_byte_string;
-    for (auto i : rule_expr) {
-      auto element_expr = base_grammar_->GetRuleExpr(i);
-      if (element_expr.type == RuleExprType::kByteString) {
+    for (auto i : grammar_expr) {
+      auto element_expr = base_grammar_->GetGrammarExpr(i);
+      if (element_expr.type == GrammarExprType::kByteString) {
         cur_byte_string.insert(cur_byte_string.end(), element_expr.begin(), element_expr.end());
         continue;
       } else {
@@ -335,7 +344,7 @@ class ByteStringFuserImpl : public GrammarMutator {
           new_sequence_ids.push_back(builder_.AddByteString(cur_byte_string));
           cur_byte_string.clear();
         }
-        new_sequence_ids.push_back(builder_.AddRuleExpr(element_expr));
+        new_sequence_ids.push_back(builder_.AddGrammarExpr(element_expr));
       }
     }
     if (!cur_byte_string.empty()) {
@@ -358,17 +367,17 @@ class RuleInlinerImpl : public GrammarMutator {
   using GrammarMutator::GrammarMutator;
 
  private:
-  int32_t VisitChoices(const RuleExpr& rule_expr) final {
+  int32_t VisitChoices(const GrammarExpr& grammar_expr) final {
     std::vector<int32_t> new_choice_ids;
-    for (int i : rule_expr) {
-      auto choice_expr = base_grammar_->GetRuleExpr(i);
-      if (choice_expr.type == RuleExprType::kEmptyStr) {
+    for (int i : grammar_expr) {
+      auto choice_expr = base_grammar_->GetGrammarExpr(i);
+      if (choice_expr.type == GrammarExprType::kEmptyStr) {
         new_choice_ids.push_back(VisitExpr(i));
         continue;
       }
-      XGRAMMAR_ICHECK(choice_expr.type == RuleExprType::kSequence);
-      auto first_element = base_grammar_->GetRuleExpr(choice_expr[0]);
-      if (first_element.type != RuleExprType::kRuleRef) {
+      XGRAMMAR_ICHECK(choice_expr.type == GrammarExprType::kSequence);
+      auto first_element = base_grammar_->GetGrammarExpr(choice_expr[0]);
+      if (first_element.type != GrammarExprType::kRuleRef) {
         new_choice_ids.push_back(VisitExpr(choice_expr));
         continue;
       }
@@ -388,11 +397,11 @@ class RuleInlinerImpl : public GrammarMutator {
       }
 
       auto ref_rule = base_grammar_->GetRule(rule_ref_id);
-      auto ref_rule_expr = base_grammar_->GetRuleExpr(ref_rule.body_expr_id);
+      auto ref_grammar_expr = base_grammar_->GetGrammarExpr(ref_rule.body_expr_id);
 
-      for (auto ref_choice_id : ref_rule_expr) {
-        auto ref_choice_expr = base_grammar_->GetRuleExpr(ref_choice_id);
-        XGRAMMAR_ICHECK(ref_choice_expr.type == RuleExprType::kSequence);
+      for (auto ref_choice_id : ref_grammar_expr) {
+        auto ref_choice_expr = base_grammar_->GetGrammarExpr(ref_choice_id);
+        XGRAMMAR_ICHECK(ref_choice_expr.type == GrammarExprType::kSequence);
         std::vector<int32_t> choice_to_add;
         for (auto ref_element_id : ref_choice_expr) {
           choice_to_add.push_back(VisitExpr(ref_element_id));
@@ -409,22 +418,22 @@ class RuleInlinerImpl : public GrammarMutator {
    */
   bool CheckIfRuleCanBeInlined(int32_t rule_id) {
     auto rule = base_grammar_->GetRule(rule_id);
-    auto rule_expr = base_grammar_->GetRuleExpr(rule.body_expr_id);
-    if (rule_expr.type != RuleExprType::kChoices) {
+    auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
+    if (grammar_expr.type != GrammarExprType::kChoices) {
       return false;
     }
-    if (rule_expr.size() == 0) {
+    if (grammar_expr.size() == 0) {
       return false;
     }
-    for (auto choice_id : rule_expr) {
-      auto choice_expr = base_grammar_->GetRuleExpr(choice_id);
-      if (choice_expr.type == RuleExprType::kEmptyStr) {
+    for (auto choice_id : grammar_expr) {
+      auto choice_expr = base_grammar_->GetGrammarExpr(choice_id);
+      if (choice_expr.type == GrammarExprType::kEmptyStr) {
         return false;
       }
-      XGRAMMAR_ICHECK(choice_expr.type == RuleExprType::kSequence);
+      XGRAMMAR_ICHECK(choice_expr.type == GrammarExprType::kSequence);
       for (auto element_id : choice_expr) {
-        auto element_expr = base_grammar_->GetRuleExpr(element_id);
-        if (element_expr.type == RuleExprType::kRuleRef) {
+        auto element_expr = base_grammar_->GetGrammarExpr(element_id);
+        if (element_expr.type == GrammarExprType::kRuleRef) {
           return false;
         }
       }
@@ -465,13 +474,13 @@ class UsedRulesAnalyzer : public GrammarVisitor<std::vector<int32_t>> {
     return std::vector<int32_t>(visited.begin(), visited.end());
   }
 
-  void VisitTagDispatch(const RuleExpr& rule_expr) {
-    for (int i = 0; i < rule_expr.size(); i += 2) {
-      visit_queue_.push(rule_expr[i + 1]);
+  void VisitTagDispatch(const GrammarExpr& grammar_expr) {
+    for (int i = 0; i < grammar_expr.size(); i += 2) {
+      visit_queue_.push(grammar_expr[i + 1]);
     }
   }
 
-  void VisitRuleRef(const RuleExpr& rule_expr) { visit_queue_.push(rule_expr[0]); }
+  void VisitRuleRef(const GrammarExpr& grammar_expr) { visit_queue_.push(grammar_expr[0]); }
 
  private:
   std::queue<int32_t> visit_queue_;
@@ -501,19 +510,19 @@ class DeadCodeEliminatorImpl : public GrammarMutator {
     return builder_.Get(rule_id_map_[grammar->GetRootRuleId()]);
   }
 
-  int32_t VisitTagDispatch(const RuleExpr& rule_expr) final {
+  int32_t VisitTagDispatch(const GrammarExpr& grammar_expr) final {
     std::vector<std::pair<int32_t, int32_t>> tag_dispatch_list;
-    for (int i = 0; i < rule_expr.size(); i += 2) {
-      XGRAMMAR_DCHECK(rule_id_map_.count(rule_expr[i + 1]) > 0);
-      auto new_rule_id = rule_id_map_[rule_expr[i + 1]];
-      tag_dispatch_list.push_back({VisitExpr(rule_expr[i]), new_rule_id});
+    for (int i = 0; i < grammar_expr.size(); i += 2) {
+      XGRAMMAR_DCHECK(rule_id_map_.count(grammar_expr[i + 1]) > 0);
+      auto new_rule_id = rule_id_map_[grammar_expr[i + 1]];
+      tag_dispatch_list.push_back({VisitExpr(grammar_expr[i]), new_rule_id});
     }
     return builder_.AddTagDispatch(tag_dispatch_list);
   }
 
-  int32_t VisitRuleRef(const RuleExpr& rule_expr) final {
-    XGRAMMAR_DCHECK(rule_id_map_.count(rule_expr[0]) > 0);
-    auto new_rule_id = rule_id_map_[rule_expr[0]];
+  int32_t VisitRuleRef(const GrammarExpr& grammar_expr) final {
+    XGRAMMAR_DCHECK(rule_id_map_.count(grammar_expr[0]) > 0);
+    auto new_rule_id = rule_id_map_[grammar_expr[0]];
     return builder_.AddRuleRef(new_rule_id);
   }
 
@@ -528,8 +537,8 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
   Grammar Apply(const Grammar& grammar) final {
     InitWithCopy(grammar);
     auto root_rule = grammar->GetRootRule();
-    auto root_rule_expr = base_grammar_->GetRuleExpr(root_rule.body_expr_id);
-    if (root_rule_expr.type == RuleExprType::kTagDispatch) {
+    auto root_grammar_expr = base_grammar_->GetGrammarExpr(root_rule.body_expr_id);
+    if (root_grammar_expr.type == GrammarExprType::kTagDispatch) {
       return grammar;
     }
     for (int i = 0; i < static_cast<int>(grammar->NumRules()); ++i) {
@@ -550,30 +559,30 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
     bool found = false;
     for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
       auto rule = base_grammar_->GetRule(i);
-      auto rule_expr = base_grammar_->GetRuleExpr(rule.body_expr_id);
-      if (rule_expr.type == RuleExprType::kTagDispatch) {
-        for (int j = 1; j < rule_expr.size(); j += 2) {
-          if (rule_expr[j] == rule_id) {
+      auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
+      if (grammar_expr.type == GrammarExprType::kTagDispatch) {
+        for (int j = 1; j < grammar_expr.size(); j += 2) {
+          if (grammar_expr[j] == rule_id) {
             return -1;
           }
         }
         continue;
       }
-      XGRAMMAR_DCHECK(rule_expr.type == RuleExprType::kChoices);
-      for (auto sequence_id : rule_expr) {
-        auto sequence_expr = base_grammar_->GetRuleExpr(sequence_id);
-        if (sequence_expr.type != RuleExprType::kSequence) {
+      XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kChoices);
+      for (auto sequence_id : grammar_expr) {
+        auto sequence_expr = base_grammar_->GetGrammarExpr(sequence_id);
+        if (sequence_expr.type != GrammarExprType::kSequence) {
           continue;
         }
-        auto last_element = base_grammar_->GetRuleExpr(sequence_expr.end()[-1]);
-        if (last_element.type == RuleExprType::kRuleRef && last_element[0] == rule_id &&
+        auto last_element = base_grammar_->GetGrammarExpr(sequence_expr.end()[-1]);
+        if (last_element.type == GrammarExprType::kRuleRef && last_element[0] == rule_id &&
             i != rule_id) {
           return -1;
         }
 
         for (int j = 0; j < sequence_expr.size() - 1; ++j) {
-          auto element_expr = base_grammar_->GetRuleExpr(sequence_expr[j]);
-          if (element_expr.type != RuleExprType::kRuleRef || element_expr[0] != rule_id) {
+          auto element_expr = base_grammar_->GetGrammarExpr(sequence_expr[j]);
+          if (element_expr.type != GrammarExprType::kRuleRef || element_expr[0] != rule_id) {
             continue;
           }
           if (found) {
@@ -664,8 +673,8 @@ class SubGrammarCombiner : public GrammarMutator {
     return new_rule_ids_names[grammar->GetRootRuleId()].first;
   }
 
-  int32_t VisitRuleRef(const RuleExpr& rule_expr) final {
-    return builder_.AddRuleRef(new_rule_ids_names[rule_expr[0]].first);
+  int32_t VisitRuleRef(const GrammarExpr& grammar_expr) final {
+    return builder_.AddRuleRef(new_rule_ids_names[grammar_expr[0]].first);
   }
 
   std::vector<std::pair<int32_t, std::string>> new_rule_ids_names;
@@ -753,9 +762,9 @@ class RuleRefGraphFinder : public GrammarVisitor<std::vector<std::vector<int32_t
     rule_visit_graph_ = std::vector<std::vector<int32_t>>(base_grammar_->NumRules());
     for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
       auto rule = base_grammar_->GetRule(i);
-      auto rule_expr = base_grammar_->GetRuleExpr(rule.body_expr_id);
+      auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
       cur_rule_id_ = i;
-      VisitExpr(rule_expr);
+      VisitExpr(grammar_expr);
     }
     for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
       std::sort(rule_visit_graph_[i].begin(), rule_visit_graph_[i].end());
@@ -766,13 +775,13 @@ class RuleRefGraphFinder : public GrammarVisitor<std::vector<std::vector<int32_t
   }
 
  private:
-  void VisitRuleRef(const RuleExpr& rule_expr) {
-    rule_visit_graph_[rule_expr[0]].push_back(cur_rule_id_);
+  void VisitRuleRef(const GrammarExpr& grammar_expr) {
+    rule_visit_graph_[grammar_expr[0]].push_back(cur_rule_id_);
   }
 
-  void VisitTagDispatch(const RuleExpr& rule_expr) {
-    for (int i = 1; i < rule_expr.size(); i += 2) {
-      rule_visit_graph_[rule_expr[i]].push_back(cur_rule_id_);
+  void VisitTagDispatch(const GrammarExpr& grammar_expr) {
+    for (int i = 1; i < grammar_expr.size(); i += 2) {
+      rule_visit_graph_[grammar_expr[i]].push_back(cur_rule_id_);
     }
   }
 
@@ -808,22 +817,22 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
   void FindExplicitEmptyRules(std::unordered_set<int32_t>* empty_rule_id_set) {
     for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
       auto rule = base_grammar_->GetRule(i);
-      auto rule_expr = base_grammar_->GetRuleExpr(rule.body_expr_id);
-      if (rule_expr.type == RuleExprType::kTagDispatch) {
+      auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
+      if (grammar_expr.type == GrammarExprType::kTagDispatch) {
         empty_rule_id_set->insert(i);
         continue;
       }
 
-      XGRAMMAR_DCHECK(rule_expr.type == RuleExprType::kChoices);
-      if (base_grammar_->GetRuleExpr(rule_expr[0]).type == RuleExprType::kEmptyStr) {
+      XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kChoices);
+      if (base_grammar_->GetGrammarExpr(grammar_expr[0]).type == GrammarExprType::kEmptyStr) {
         empty_rule_id_set->insert(i);
         continue;
       }
 
-      for (auto seq_id : rule_expr) {
-        auto seq_expr = base_grammar_->GetRuleExpr(seq_id);
+      for (auto seq_id : grammar_expr) {
+        auto seq_expr = base_grammar_->GetGrammarExpr(seq_id);
         if (std::all_of(seq_expr.begin(), seq_expr.end(), [&](int32_t i) {
-              return base_grammar_->GetRuleExpr(i).type == RuleExprType::kCharacterClassStar;
+              return base_grammar_->GetGrammarExpr(i).type == GrammarExprType::kCharacterClassStar;
             })) {
           empty_rule_id_set->insert(i);
           break;
@@ -833,18 +842,18 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
   }
 
   bool SeqExprIsEpsilon(
-      const RuleExpr& seq_expr, const std::unordered_set<int32_t>& empty_rule_id_set
+      const GrammarExpr& seq_expr, const std::unordered_set<int32_t>& empty_rule_id_set
   ) {
-    if (seq_expr.type == RuleExprType::kEmptyStr) {
+    if (seq_expr.type == GrammarExprType::kEmptyStr) {
       return true;
     }
-    XGRAMMAR_DCHECK(seq_expr.type == RuleExprType::kSequence);
+    XGRAMMAR_DCHECK(seq_expr.type == GrammarExprType::kSequence);
 
     return std::all_of(seq_expr.begin(), seq_expr.end(), [&](int32_t i) {
-      auto element_expr = base_grammar_->GetRuleExpr(i);
-      return (element_expr.type == RuleExprType::kRuleRef &&
+      auto element_expr = base_grammar_->GetGrammarExpr(i);
+      return (element_expr.type == GrammarExprType::kRuleRef &&
               empty_rule_id_set.count(element_expr[0])) ||
-             element_expr.type == RuleExprType::kCharacterClassStar;
+             element_expr.type == GrammarExprType::kCharacterClassStar;
     });
   }
 
@@ -866,13 +875,13 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
           continue;
         }
         auto rule = base_grammar_->GetRule(referer_rule_id);
-        auto rule_expr = base_grammar_->GetRuleExpr(rule.body_expr_id);
+        auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
 
-        XGRAMMAR_DCHECK(rule_expr.type != RuleExprType::kTagDispatch)
+        XGRAMMAR_DCHECK(grammar_expr.type != GrammarExprType::kTagDispatch)
             << "TagDispatch rules should already exist in empty_rule_id_set";
 
-        bool is_epsilon = std::any_of(rule_expr.begin(), rule_expr.end(), [&](int32_t i) {
-          auto seq_expr = base_grammar_->GetRuleExpr(i);
+        bool is_epsilon = std::any_of(grammar_expr.begin(), grammar_expr.end(), [&](int32_t i) {
+          auto seq_expr = base_grammar_->GetGrammarExpr(i);
           return SeqExprIsEpsilon(seq_expr, *empty_rule_id_set);
         });
 

--- a/cpp/grammar_serializer.cc
+++ b/cpp/grammar_serializer.cc
@@ -12,9 +12,9 @@
 namespace xgrammar {
 
 std::string GrammarPrinter::PrintRule(const Rule& rule) {
-  std::string res = rule.name + " ::= " + PrintRuleExpr(rule.body_expr_id);
+  std::string res = rule.name + " ::= " + PrintGrammarExpr(rule.body_expr_id);
   if (rule.lookahead_assertion_id != -1) {
-    res += " (=" + PrintRuleExpr(rule.lookahead_assertion_id) + ")";
+    res += " (=" + PrintGrammarExpr(rule.lookahead_assertion_id) + ")";
   }
   return res;
 }
@@ -23,80 +23,80 @@ std::string GrammarPrinter::PrintRule(int32_t rule_id) {
   return PrintRule(grammar_->GetRule(rule_id));
 }
 
-std::string GrammarPrinter::PrintRuleExpr(const RuleExpr& rule_expr) {
+std::string GrammarPrinter::PrintGrammarExpr(const GrammarExpr& grammar_expr) {
   std::string result;
-  switch (rule_expr.type) {
-    case RuleExprType::kByteString:
-      return PrintByteString(rule_expr);
-    case RuleExprType::kCharacterClass:
-      return PrintCharacterClass(rule_expr);
-    case RuleExprType::kCharacterClassStar:
-      return PrintCharacterClassStar(rule_expr);
-    case RuleExprType::kEmptyStr:
-      return PrintEmptyStr(rule_expr);
-    case RuleExprType::kRuleRef:
-      return PrintRuleRef(rule_expr);
-    case RuleExprType::kSequence:
-      return PrintSequence(rule_expr);
-    case RuleExprType::kChoices:
-      return PrintChoices(rule_expr);
-    case RuleExprType::kTagDispatch:
-      return PrintTagDispatch(rule_expr);
+  switch (grammar_expr.type) {
+    case GrammarExprType::kByteString:
+      return PrintByteString(grammar_expr);
+    case GrammarExprType::kCharacterClass:
+      return PrintCharacterClass(grammar_expr);
+    case GrammarExprType::kCharacterClassStar:
+      return PrintCharacterClassStar(grammar_expr);
+    case GrammarExprType::kEmptyStr:
+      return PrintEmptyStr(grammar_expr);
+    case GrammarExprType::kRuleRef:
+      return PrintRuleRef(grammar_expr);
+    case GrammarExprType::kSequence:
+      return PrintSequence(grammar_expr);
+    case GrammarExprType::kChoices:
+      return PrintChoices(grammar_expr);
+    case GrammarExprType::kTagDispatch:
+      return PrintTagDispatch(grammar_expr);
     default:
-      XGRAMMAR_LOG(FATAL) << "Unexpected RuleExpr type: " << static_cast<int>(rule_expr.type);
+      XGRAMMAR_LOG(FATAL) << "Unexpected GrammarExpr type: " << static_cast<int>(grammar_expr.type);
   }
 }
 
-std::string GrammarPrinter::PrintRuleExpr(int32_t rule_expr_id) {
-  return PrintRuleExpr(grammar_->GetRuleExpr(rule_expr_id));
+std::string GrammarPrinter::PrintGrammarExpr(int32_t grammar_expr_id) {
+  return PrintGrammarExpr(grammar_->GetGrammarExpr(grammar_expr_id));
 }
 
-std::string GrammarPrinter::PrintByteString(const RuleExpr& rule_expr) {
+std::string GrammarPrinter::PrintByteString(const GrammarExpr& grammar_expr) {
   std::string internal_str;
-  internal_str.reserve(rule_expr.data_len);
-  for (int i = 0; i < rule_expr.data_len; ++i) {
-    internal_str += static_cast<char>(rule_expr[i]);
+  internal_str.reserve(grammar_expr.data_len);
+  for (int i = 0; i < grammar_expr.data_len; ++i) {
+    internal_str += static_cast<char>(grammar_expr[i]);
   }
   return "\"" + PrintAsEscapedUTF8(internal_str) + "\"";
 }
 
-std::string GrammarPrinter::PrintCharacterClass(const RuleExpr& rule_expr) {
+std::string GrammarPrinter::PrintCharacterClass(const GrammarExpr& grammar_expr) {
   static const std::unordered_map<TCodepoint, std::string> kCustomEscapeMap = {
       {'-', "\\-"}, {']', "\\]"}
   };
   std::string result = "[";
-  bool is_negative = static_cast<bool>(rule_expr[0]);
+  bool is_negative = static_cast<bool>(grammar_expr[0]);
   if (is_negative) {
     result += "^";
   }
-  for (auto i = 1; i < rule_expr.data_len; i += 2) {
-    result += PrintAsEscapedUTF8(rule_expr[i], kCustomEscapeMap);
-    if (rule_expr[i] == rule_expr[i + 1]) {
+  for (auto i = 1; i < grammar_expr.data_len; i += 2) {
+    result += PrintAsEscapedUTF8(grammar_expr[i], kCustomEscapeMap);
+    if (grammar_expr[i] == grammar_expr[i + 1]) {
       continue;
     }
     result += "-";
-    result += PrintAsEscapedUTF8(rule_expr[i + 1], kCustomEscapeMap);
+    result += PrintAsEscapedUTF8(grammar_expr[i + 1], kCustomEscapeMap);
   }
   result += "]";
   return result;
 }
 
-std::string GrammarPrinter::PrintCharacterClassStar(const RuleExpr& rule_expr) {
-  return PrintCharacterClass(rule_expr) + "*";
+std::string GrammarPrinter::PrintCharacterClassStar(const GrammarExpr& grammar_expr) {
+  return PrintCharacterClass(grammar_expr) + "*";
 }
 
-std::string GrammarPrinter::PrintEmptyStr(const RuleExpr& rule_expr) { return "\"\""; }
+std::string GrammarPrinter::PrintEmptyStr(const GrammarExpr& grammar_expr) { return "\"\""; }
 
-std::string GrammarPrinter::PrintRuleRef(const RuleExpr& rule_expr) {
-  return grammar_->GetRule(rule_expr[0]).name;
+std::string GrammarPrinter::PrintRuleRef(const GrammarExpr& grammar_expr) {
+  return grammar_->GetRule(grammar_expr[0]).name;
 }
 
-std::string GrammarPrinter::PrintSequence(const RuleExpr& rule_expr) {
+std::string GrammarPrinter::PrintSequence(const GrammarExpr& grammar_expr) {
   std::string result;
   result += "(";
-  for (int i = 0; i < rule_expr.data_len; ++i) {
-    result += PrintRuleExpr(rule_expr[i]);
-    if (i + 1 != rule_expr.data_len) {
+  for (int i = 0; i < grammar_expr.data_len; ++i) {
+    result += PrintGrammarExpr(grammar_expr[i]);
+    if (i + 1 != grammar_expr.data_len) {
       result += " ";
     }
   }
@@ -104,13 +104,13 @@ std::string GrammarPrinter::PrintSequence(const RuleExpr& rule_expr) {
   return result;
 }
 
-std::string GrammarPrinter::PrintChoices(const RuleExpr& rule_expr) {
+std::string GrammarPrinter::PrintChoices(const GrammarExpr& grammar_expr) {
   std::string result;
 
   result += "(";
-  for (int i = 0; i < rule_expr.data_len; ++i) {
-    result += PrintRuleExpr(rule_expr[i]);
-    if (i + 1 != rule_expr.data_len) {
+  for (int i = 0; i < grammar_expr.data_len; ++i) {
+    result += PrintGrammarExpr(grammar_expr[i]);
+    if (i + 1 != grammar_expr.data_len) {
       result += " | ";
     }
   }
@@ -118,12 +118,12 @@ std::string GrammarPrinter::PrintChoices(const RuleExpr& rule_expr) {
   return result;
 }
 
-std::string GrammarPrinter::PrintTagDispatch(const RuleExpr& rule_expr) {
+std::string GrammarPrinter::PrintTagDispatch(const GrammarExpr& grammar_expr) {
   std::string result = "TagDispatch(";
-  for (int i = 0; i < rule_expr.data_len; i += 2) {
-    result +=
-        "(" + PrintRuleExpr(rule_expr[i]) + ", " + grammar_->GetRule(rule_expr[i + 1]).name + ")";
-    if (i + 2 != rule_expr.data_len) {
+  for (int i = 0; i < grammar_expr.data_len; i += 2) {
+    result += "(" + PrintGrammarExpr(grammar_expr[i]) + ", " +
+              grammar_->GetRule(grammar_expr[i + 1]).name + ")";
+    if (i + 2 != grammar_expr.data_len) {
       result += ", ";
     }
   }

--- a/cpp/grammar_serializer.h
+++ b/cpp/grammar_serializer.h
@@ -21,8 +21,8 @@ namespace xgrammar {
 class GrammarPrinter {
  private:
   using Rule = Grammar::Impl::Rule;
-  using RuleExprType = Grammar::Impl::RuleExprType;
-  using RuleExpr = Grammar::Impl::RuleExpr;
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  using GrammarExpr = Grammar::Impl::GrammarExpr;
 
  public:
   /*!
@@ -38,28 +38,28 @@ class GrammarPrinter {
   std::string PrintRule(const Rule& rule);
   /*! \brief Print a rule corresponding to the given id. */
   std::string PrintRule(int32_t rule_id);
-  /*! \brief Print a RuleExpr. */
-  std::string PrintRuleExpr(const RuleExpr& rule_expr);
-  /*! \brief Print a RuleExpr corresponding to the given id. */
-  std::string PrintRuleExpr(int32_t rule_expr_id);
+  /*! \brief Print a GrammarExpr. */
+  std::string PrintGrammarExpr(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr corresponding to the given id. */
+  std::string PrintGrammarExpr(int32_t grammar_expr_id);
 
  private:
-  /*! \brief Print a RuleExpr for byte string. */
-  std::string PrintByteString(const RuleExpr& rule_expr);
-  /*! \brief Print a RuleExpr for character class. */
-  std::string PrintCharacterClass(const RuleExpr& rule_expr);
-  /*! \brief Print a RuleExpr for a star quantifier of a character class. */
-  std::string PrintCharacterClassStar(const RuleExpr& rule_expr);
-  /*! \brief Print a RuleExpr for empty string. */
-  std::string PrintEmptyStr(const RuleExpr& rule_expr);
-  /*! \brief Print a RuleExpr for rule reference. */
-  std::string PrintRuleRef(const RuleExpr& rule_expr);
-  /*! \brief Print a RuleExpr for rule_expr sequence. */
-  std::string PrintSequence(const RuleExpr& rule_expr);
-  /*! \brief Print a RuleExpr for rule_expr choices. */
-  std::string PrintChoices(const RuleExpr& rule_expr);
-  /*! \brief Print a RuleExpr for tag dispatch. */
-  std::string PrintTagDispatch(const RuleExpr& rule_expr);
+  /*! \brief Print a GrammarExpr for byte string. */
+  std::string PrintByteString(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for character class. */
+  std::string PrintCharacterClass(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for a star quantifier of a character class. */
+  std::string PrintCharacterClassStar(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for empty string. */
+  std::string PrintEmptyStr(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for rule reference. */
+  std::string PrintRuleRef(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for grammar_expr sequence. */
+  std::string PrintSequence(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for grammar_expr choices. */
+  std::string PrintChoices(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for tag dispatch. */
+  std::string PrintTagDispatch(const GrammarExpr& grammar_expr);
 
   Grammar grammar_;
 };

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -33,20 +33,20 @@ struct StructuralTagItem {
  * \details
  * ### Rules
  * The BNF grammar AST consists of a set of rules. Each rule contains a name and a definition, and
- * corresponds to a production in the grammar. The definition of a rule is a RuleExpr. Each rule
+ * corresponds to a production in the grammar. The definition of a rule is a GrammarExpr. Each rule
  * has a rule_id for reference.
  *
- * ### RuleExprs
- * RuleExpr is the definition of a rule or part of the definition of a rule. It can contain
- * elements, empty string, reference to other RuleExprs, or reference to other rules. Each RuleExpr
- * corresponds to an rule_expr_id for reference.
+ * ### GrammarExprs
+ * GrammarExpr is the definition of a rule or part of the definition of a rule. It can contain
+ * elements, empty string, reference to other GrammarExprs, or reference to other rules. Each
+ * GrammarExpr corresponds to an grammar_expr_id for reference.
  *
  * For example, in the following rule: rule ::= ("a" "b") | "c"
- * ("a" "b"), "c", ("a" "b") | "c" are all RuleExprs.
+ * ("a" "b"), "c", ("a" "b") | "c" are all GrammarExprs.
  *
- * #### Types of RuleExprs
- * Every RuleExpr is represented by a type as well as a variable-length array containing its data.
- * RuleExpr has several types:
+ * #### Types of GrammarExprs
+ * Every GrammarExpr is represented by a type as well as a variable-length array containing its
+ * data. GrammarExpr has several types:
  * - Byte string: a string of bytes (0~255). Supports UTF-8 strings.
  * - Character class: a range of characters (each character is a unicode codepoint), e.g. [a-z],
  *   [ac-z]. Can be negated: [^a-z], [^ac-z]. Now only ascii chars is allowed in [], but this
@@ -54,21 +54,23 @@ struct StructuralTagItem {
  * - Character class star: a star quantifier of a character class. e.g. [a-z]*, [^a-z]*.
  * - EmptyStr: an empty string, i.e. ""
  * - Rule reference: a reference to another rule
- * - Sequence: a sequence of rule_exprs, e.g. ("a" "b"). These rule_exprs are concatenated together.
- * - Choices: a choice of rule_exprs, e.g. ("a" "b") | "c". Each rule_expr can be matched.
+ * - Sequence: a sequence of grammar_exprs, e.g. ("a" "b"). These grammar_exprs are concatenated
+ * together.
+ * - Choices: a choice of grammar_exprs, e.g. ("a" "b") | "c". Each grammar_expr can be matched.
  *
- * #### Storage of RuleExprs
- * Each type of RuleExpr has a different data format. For the format of each type of RuleExpr, see
- * docs in Grammar::Impl::RuleExprType.
+ * #### Storage of GrammarExprs
+ * Each type of GrammarExpr has a different data format. For the format of each type of GrammarExpr,
+ * see docs in Grammar::Impl::GrammarExprType.
  *
- * We store all RuleExprs in csr_matrix style. That is, they are stored consecutively in one vector
- * (data vector) and the starting position of each RuleExpr is recorded in the indptr vector.
+ * We store all GrammarExprs in csr_matrix style. That is, they are stored consecutively in one
+ * vector (data vector) and the starting position of each GrammarExpr is recorded in the indptr
+ * vector.
  *
- * \remark The character class star RuleExpr is for the special support for elements like [a-z]*
+ * \remark The character class star GrammarExpr is for the special support for elements like [a-z]*
  * in the grammar. We add it to make the matching more efficient, as we can avoid recursion into
  * rules when matching a sequence of characters. It should be used like:
  * rule1 ::= ((element1 element2 rule2 ...) | ...)
- * rule2 ::= character_class_star_rule_expr(id_of_a_character_class_rule_expr)
+ * rule2 ::= character_class_star_grammar_expr(id_of_a_character_class_grammar_expr)
  */
 class Grammar {
  public:


### PR DESCRIPTION
This PR renames ruleexpr to grammarexpr in C++ impl to better reflect its functionality.

Signed-off-by: Ubospica <ubospica@gmail.com>