### PR TITLE
[Feature] Add a new expression to represent repetition to speed up.

### DIFF
--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -43,22 +43,19 @@ struct ParserState {
   constexpr ParserState() = default;
 
   constexpr ParserState(
-      int32_t rule_id,
-      int32_t sequence_id,
-      int32_t element_id,
-      int32_t rule_start_pos,
-      int32_t sub_element_id
+      const int32_t& rule_id,
+      const int32_t& sequence_id,
+      const int32_t& element_id,
+      const int32_t& rule_start_pos,
+      const int32_t& sub_element_id,
+      const int32_t& repeat_count = 0
   )
       : rule_id(rule_id),
         sequence_id(sequence_id),
         element_id(element_id),
         rule_start_pos(rule_start_pos),
-        sub_element_id(sub_element_id) {}
-
-  constexpr ParserState(const ParserState&) = default;
-  constexpr ParserState(ParserState&&) = default;
-  ParserState& operator=(const ParserState&) = default;
-  ParserState& operator=(ParserState&&) = default;
+        sub_element_id(sub_element_id),
+        repeat_count(repeat_count) {}
 
   /*!
    * \brief A sequence_id value of kUnexpandedRuleStartSequenceId means a rule hasn't been
@@ -92,6 +89,9 @@ struct ParserState {
   /*! \brief The id of the sub element in the current selement of the sequence. */
   int32_t sub_element_id = 0;
 
+  /*! \brief The number of times the element is repeated. It will be used in kRepeat.*/
+  int32_t repeat_count = 0;
+
   /*! \brief The element is invalid when sequence_id is -1. */
   bool IsInvalid() const { return sequence_id == -1; }
 
@@ -107,13 +107,15 @@ struct ParserState {
     if (sequence_id != other.sequence_id) return sequence_id < other.sequence_id;
     if (element_id != other.element_id) return element_id < other.element_id;
     if (rule_start_pos != other.rule_start_pos) return rule_start_pos < other.rule_start_pos;
-    return sub_element_id < other.sub_element_id;
+    if (sub_element_id != other.sub_element_id) return sub_element_id < other.sub_element_id;
+    return repeat_count < other.repeat_count;
   }
 
   friend std::ostream& operator<<(std::ostream& os, const ParserState& state) {
     os << "ParserState(rule_id=" << state.rule_id << ", sequence_id=" << state.sequence_id
        << ", element_id=" << state.element_id << ", rule_start_pos=" << state.rule_start_pos
-       << ", sub_element_id=" << state.sub_element_id << ")";
+       << ", sub_element_id=" << state.sub_element_id << ", repeat_count=" << state.repeat_count
+       << ")";
     return os;
   }
 
@@ -132,7 +134,8 @@ XGRAMMAR_MEMBER_ARRAY(
     &ParserState::sequence_id,
     &ParserState::element_id,
     &ParserState::rule_start_pos,
-    &ParserState::sub_element_id
+    &ParserState::sub_element_id,
+    &ParserState::repeat_count
 );
 
 /*!
@@ -170,7 +173,8 @@ class StateHashForParsing {
         state.sequence_id,
         state.element_id,
         state.rule_start_pos,
-        state.sub_element_id
+        state.sub_element_id,
+        state.repeat_count
     );
   }
 };

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -199,6 +199,12 @@ class GrammarBuilder {
     );
   }
 
+  int32_t AddRepeat(const int32_t ref_rule_id, int32_t min_repeat_count, int32_t max_repeat_count) {
+    std::vector<int32_t> data({ref_rule_id, min_repeat_count, max_repeat_count});
+    return AddGrammarExpr({GrammarExprType::kRepeat, data.data(), static_cast<int32_t>(data.size())}
+    );
+  }
+
   /*! \brief Get the number of grammar_exprs. */
   int32_t NumGrammarExprs() const { return grammar_->NumGrammarExprs(); }
 

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -131,6 +131,8 @@ class GrammarFunctor {
         return VisitRuleRef(grammar_expr);
       case GrammarExprType::kTagDispatch:
         return VisitTagDispatch(grammar_expr);
+      case GrammarExprType::kRepeat:
+        return VisitRepeat(grammar_expr);
       default:
         XGRAMMAR_LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(grammar_expr.type);
         XGRAMMAR_UNREACHABLE();
@@ -211,6 +213,9 @@ class GrammarFunctor {
 
   /*! \brief Visit a rule reference GrammarExpr. */
   virtual T VisitRuleRef(const GrammarExpr& grammar_expr) { return VisitElement(grammar_expr); }
+
+  /*! \brief Visit a repeat GrammarExpr. */
+  virtual T VisitRepeat(const GrammarExpr& grammar_expr) { return VisitElement(grammar_expr); }
 
   /*! \brief The grammar to visit or mutate. */
   Grammar base_grammar_{NullObj{}};
@@ -340,10 +345,14 @@ class GrammarFSMBuilder {
  public:
   static void Apply(Grammar* grammar);
 };
-
 class SubGrammarAdder {
  public:
   static int32_t Apply(GrammarBuilder* builder, const Grammar& sub_grammar);
+};
+
+class RepetitionNormalizer {
+ public:
+  static void Apply(Grammar* grammar);
 };
 
 }  // namespace xgrammar

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -118,6 +118,8 @@ class Grammar::Impl {
     // tag_expr should be a byte string, and rule_id should be a rule id.
     // loop_after_dispatch is a bool.
     kTagDispatch,
+    // data format: [grammar_expr_id, min_repeat_count, max_repeat_count]
+    kRepeat,
   };
 
   /*! \brief The object representing a grammar expr. */
@@ -138,6 +140,7 @@ class Grammar::Impl {
     }
     const int32_t* begin() const { return data; }
     const int32_t* end() const { return data + data_len; }
+    void SetData(int index, int value) { const_cast<int32_t*>(data)[index] = value; }
   };
 
   /*! \brief Get the number of grammar_exprs. */
@@ -247,6 +250,9 @@ class Grammar::Impl {
   /*! \brief The ids of the rules that are allowed to be empty. */
   std::vector<int32_t> allow_empty_rule_ids;
 
+  /*! \brief Store the lookahead which are exact, used to reduce uncertainty.*/
+  std::vector<int32_t> exact_lookahead;
+
   friend class GrammarBuilder;
   friend class GrammarCompiler;
 
@@ -276,7 +282,9 @@ XGRAMMAR_MEMBER_TABLE(
     "per_rule_fsms",
     &Grammar::Impl::per_rule_fsms,
     "allow_empty_rule_ids",
-    &Grammar::Impl::allow_empty_rule_ids
+    &Grammar::Impl::allow_empty_rule_ids,
+    "exact_lookahead",
+    &Grammar::Impl::exact_lookahead
 );
 
 }  // namespace xgrammar

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -366,18 +366,14 @@ bool GrammarMatcher::Impl::IsStopTokenAccepted() const { return stop_token_is_ac
 // TODO(yixin): Polish verbose logging
 bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   if (IsStopTokenAccepted()) {
-    if (debug_print) {
-      XGRAMMAR_LOG(WARNING) << "The matcher has terminated after accepting the stop token, but is "
-                            << "trying to accept new token with id " << token_id << ".";
-    }
+    XGRAMMAR_LOG(WARNING) << "The matcher has terminated after accepting the stop token, but is "
+                          << "trying to accept new token with id " << token_id << ".";
     return false;
   }
 
   if (token_id < 0 || token_id >= tokenizer_info_.GetVocabSize()) {
-    if (debug_print) {
-      XGRAMMAR_LOG(WARNING) << "The token id " << token_id << " is out of range [0, "
-                            << tokenizer_info_.GetVocabSize() << "). Rejecting the token.";
-    }
+    XGRAMMAR_LOG(WARNING) << "The token id " << token_id << " is out of range [0, "
+                          << tokenizer_info_.GetVocabSize() << "). Rejecting the token.";
     return false;
   }
 
@@ -404,11 +400,9 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   const auto& special_token_ids = tokenizer_info_.GetSpecialTokenIds();
   if (std::find(special_token_ids.begin(), special_token_ids.end(), token_id) !=
       special_token_ids.end()) {
-    if (debug_print) {
-      XGRAMMAR_LOG(WARNING) << "GrammarMatcher cannot accept special token id " << token_id << ": "
-                            << tokenizer_info_.GetDecodedVocab()[token_id]
-                            << ". Rejecting the token.";
-    }
+    XGRAMMAR_LOG(WARNING) << "GrammarMatcher cannot accept special token id " << token_id << ": "
+                          << tokenizer_info_.GetDecodedVocab()[token_id]
+                          << ". Rejecting the token.";
     return false;
   }
 

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -7,12 +7,16 @@
 
 #include <picojson.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <variant>
+#include <vector>
 
 #include "grammar_builder.h"
 #include "grammar_impl.h"
 #include "support/encoding.h"
 #include "support/logging.h"
+#include "xgrammar/grammar.h"
 
 namespace xgrammar {
 
@@ -757,57 +761,59 @@ int32_t EBNFParser::HandleQuestionQuantifier(int32_t grammar_expr_id) {
   return builder_.AddRuleRef(new_rule_id);
 }
 
-int32_t EBNFParser::HandleRepetitionRange(int32_t grammar_expr_id, int64_t lower, int64_t upper) {
-  // Construct expr expr ... expr (l times)
-  std::vector<int32_t> elements;
-  for (int64_t i = 0; i < lower; ++i) {
-    elements.push_back(grammar_expr_id);
-  }
-
-  // Case 1: {l}:
-  // expr expr ... expr (l times)
-  if (upper == lower) {
-    return builder_.AddSequence(elements);
-  }
-
-  // Case 2: {l,}:
-  // expr expr ... expr (l times) rest
-  // rest ::= "" | expr rest
+int32_t EBNFParser::HandleRepetitionRange(
+    const int32_t grammar_expr_id, int64_t lower, int64_t upper
+) {
   if (upper == -1) {
-    auto new_rule_name = builder_.GetNewRuleName(cur_rule_name_);
-    auto new_rule_id = builder_.AddEmptyRule(new_rule_name);
-    auto ref_to_new_rule = builder_.AddRuleRef(new_rule_id);
-    auto new_grammar_expr_id = builder_.AddChoices(
-        {builder_.AddEmptyStr(), builder_.AddSequence({grammar_expr_id, ref_to_new_rule})}
-    );
-    builder_.UpdateRuleBody(new_rule_id, new_grammar_expr_id);
+    // The repeation is unbounded, e.g. {2,}
+    upper = 0x7FFFFFFF;  // Use a large number to represent unbounded
+  }
+  const auto repeat_name = builder_.GetNewRuleName(cur_rule_name_) + "_xgrammar_repetition_context";
+  std::vector<int32_t> elements;
+  int splited_count = lower >= 4 ? 4 : lower;
+  int nullable_splited_count = 0;
+  if (splited_count != 4) {
+    nullable_splited_count =
+        (upper - lower) >= (4 - splited_count) ? 4 - splited_count : upper - lower;
+  }
+  // The repetition sentence.
+  if (upper != (splited_count + nullable_splited_count)) {
+    auto new_rule_name = builder_.GetNewRuleName(repeat_name);
+    auto new_grammar_expr_id = builder_.AddChoices({builder_.AddSequence({grammar_expr_id})});
+    auto new_rule_id = builder_.AddRule(new_rule_name, new_grammar_expr_id);
+    elements.push_back(builder_.AddRepeat(
+        new_rule_id, lower - splited_count, upper - splited_count - nullable_splited_count
+    ));
+  }
+  // The last split_count exprs.
+
+  // The nullable exprs.
+  for (int i = 0; i < nullable_splited_count; i++) {
+    auto new_rule_name = builder_.GetNewRuleName(repeat_name);
+    auto new_grammar_expr_id =
+        builder_.AddChoices({builder_.AddEmptyStr(), builder_.AddSequence({grammar_expr_id})});
+    auto new_rule_id = builder_.AddRule(new_rule_name, new_grammar_expr_id);
     elements.push_back(builder_.AddRuleRef(new_rule_id));
-    return builder_.AddSequence(elements);
   }
 
-  // Case 3: {l, r} (r - l >= 1)
-  // expr expr ... expr (l times) rest1
-  // rest1 ::= "" | expr rest2
-  // rest2 ::= "" | expr rest3
-  // ...
-  // rest(r - l) ::= "" | expr
-  std::vector<int32_t> rest_rule_ids;
-
-  for (int64_t i = 0; i < upper - lower; ++i) {
-    auto new_rule_name = builder_.GetNewRuleName(cur_rule_name_);
-    rest_rule_ids.push_back(builder_.AddEmptyRule(new_rule_name));
+  for (int i = 0; i < splited_count; i++) {
+    auto new_rule_name = builder_.GetNewRuleName(repeat_name);
+    auto new_grammar_expr_id = builder_.AddChoices({builder_.AddSequence({grammar_expr_id})});
+    auto new_rule_id = builder_.AddRule(new_rule_name, new_grammar_expr_id);
+    elements.push_back(builder_.AddRuleRef(new_rule_id));
   }
-  for (int64_t i = 0; i < upper - lower - 1; ++i) {
-    auto ref_to_next_rule = builder_.AddRuleRef(rest_rule_ids[i + 1]);
-    auto new_grammar_expr_id = builder_.AddChoices(
-        {builder_.AddEmptyStr(), builder_.AddSequence({grammar_expr_id, ref_to_next_rule})}
+
+  // Add the lookahead elements
+  std::vector<int32_t> lookahead_elements = elements;
+  if (elements.empty()) {
+    return builder_.AddEmptyStr();
+  }
+  for (size_t i = 0; i < elements.size() - 1; i++) {
+    lookahead_elements.erase(lookahead_elements.begin());
+    builder_.UpdateLookaheadAssertion(
+        builder_.GetGrammarExpr(elements[i])[0], builder_.AddSequence(lookahead_elements)
     );
-    builder_.UpdateRuleBody(rest_rule_ids[i], new_grammar_expr_id);
   }
-  auto last_grammar_expr_id = builder_.AddChoices({builder_.AddEmptyStr(), grammar_expr_id});
-  builder_.UpdateRuleBody(rest_rule_ids.back(), last_grammar_expr_id);
-
-  elements.push_back(builder_.AddRuleRef(rest_rule_ids[0]));
   return builder_.AddSequence(elements);
 }
 

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -7,7 +7,6 @@
 
 #include <picojson.h>
 
-#include <cstddef>
 #include <cstdint>
 #include <variant>
 #include <vector>
@@ -808,7 +807,7 @@ int32_t EBNFParser::HandleRepetitionRange(
   if (elements.empty()) {
     return builder_.AddEmptyStr();
   }
-  for (size_t i = 0; i < elements.size() - 1; i++) {
+  for (int64_t i = 0; i < static_cast<int64_t>(elements.size() - 1); i++) {
     lookahead_elements.erase(lookahead_elements.begin());
     builder_.UpdateLookaheadAssertion(
         builder_.GetGrammarExpr(elements[i])[0], builder_.AddSequence(lookahead_elements)

--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -42,6 +42,8 @@ std::string GrammarPrinter::PrintGrammarExpr(const GrammarExpr& grammar_expr) {
       return PrintChoices(grammar_expr);
     case GrammarExprType::kTagDispatch:
       return PrintTagDispatch(grammar_expr);
+    case GrammarExprType::kRepeat:
+      return PrintRepeat(grammar_expr);
     default:
       XGRAMMAR_LOG(FATAL) << "Unexpected GrammarExpr type: " << static_cast<int>(grammar_expr.type);
       XGRAMMAR_UNREACHABLE();
@@ -143,6 +145,17 @@ std::string GrammarPrinter::PrintTagDispatch(const GrammarExpr& grammar_expr) {
   result += "),\n";
   result += indent + "loop_after_dispatch=" + PrintBoolean(tag_dispatch.loop_after_dispatch) + "\n";
   result += ")";
+  return result;
+}
+
+std::string GrammarPrinter::PrintRepeat(const GrammarExpr& grammar_expr) {
+  int32_t lower_bound = grammar_expr[1];
+  int32_t upper_bound = grammar_expr[2];
+  std::string result = grammar_->GetRule(grammar_expr[0]).name + "{";
+  result += std::to_string(lower_bound);
+  result += ", ";
+  result += std::to_string(upper_bound);
+  result += "}";
   return result;
 }
 

--- a/cpp/grammar_printer.h
+++ b/cpp/grammar_printer.h
@@ -60,6 +60,8 @@ class GrammarPrinter {
   std::string PrintChoices(const GrammarExpr& grammar_expr);
   /*! \brief Print a GrammarExpr for tag dispatch. */
   std::string PrintTagDispatch(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for repeat. */
+  std::string PrintRepeat(const GrammarExpr& grammar_expr);
   /*! \brief Print a string. */
   std::string PrintString(const std::string& str);
   /*! \brief Print a boolean. */

--- a/tests/python/test_grammar_matcher_ebnf.py
+++ b/tests/python/test_grammar_matcher_ebnf.py
@@ -51,6 +51,28 @@ def test_repetition(input: str, accepted: bool):
     assert _is_grammar_accept_string(grammar, input) == accepted
 
 
+input_accepted_test_repetition_with_empty = (
+    ("aaa", True),
+    ("abcbc", True),
+    ("bcbcbcbcbc", True),
+    ("bcbcbcbcbcbcbcb", True),
+    ("aaaa", False),
+    ("", True),
+    ("a", True),
+    ("d", True),
+)
+
+
+@pytest.mark.parametrize("input, accepted", input_accepted_test_repetition_with_empty)
+def test_repetition_with_empty(input: str, accepted: bool):
+    grammar_str = """
+        root ::= rule {2, 3} "d"?
+        rule ::= ("a" | [bc] {4,}) | ""
+    """
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    assert _is_grammar_accept_string(grammar, input) == accepted
+
+
 def test_utf8():
     # Test utf8-encoded string with EBNF grammar
     ebnf_grammar_str = "root ::= [，]+"

--- a/tests/python/test_grammar_matcher_regex.py
+++ b/tests/python/test_grammar_matcher_regex.py
@@ -159,5 +159,19 @@ def test_fill_next_token_bitmask(regex: str, input_str: str):
     assert tokenizer.eos_token_id not in rejected_token_ids
 
 
+@pytest.mark.hf_token_required
+def test_regex_with_large_range_compilation():
+    regex_with_large_range = r"[a-z]{100,20000}"
+    tokenizer_path = "meta-llama/Meta-Llama-3-8B-Instruct"
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_fast=True, trust_remote_code=True)
+    tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
+    compiler = xgr.GrammarCompiler(tokenizer_info)
+
+    time_start = time.monotonic_ns()
+    _ = compiler.compile_regex(regex_with_large_range)
+    time_end = time.monotonic_ns()
+    print(f"Time to compile regex with large range: {(time_end - time_start) / 1e3} us")
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_grammar_parser.py
+++ b/tests/python/test_grammar_parser.py
@@ -146,7 +146,10 @@ def test_repetition_range_exact():
     """Test repetition range with exact count {n}."""
     before = """root ::= "a"{3}
 """
-    expected = """root ::= ((("a" "a" "a")))
+    expected = """root ::= (((root_1_xgrammar_repetition_context root_1_xgrammar_repetition_context_1 root_1_xgrammar_repetition_context_2)))
+root_1_xgrammar_repetition_context ::= (("a")) (=(root_1_xgrammar_repetition_context_1 root_1_xgrammar_repetition_context_2))
+root_1_xgrammar_repetition_context_1 ::= (("a")) (=(root_1_xgrammar_repetition_context_2))
+root_1_xgrammar_repetition_context_2 ::= (("a"))
 """
     grammar = _ebnf_to_grammar_no_normalization(before)
     after = str(grammar)
@@ -157,9 +160,11 @@ def test_repetition_range_min_max():
     """Test repetition range with min and max {n,m}."""
     before = """root ::= "a"{2,4}
 """
-    expected = """root ::= ((("a" "a" root_1)))
-root_1 ::= ("" | ("a" root_2))
-root_2 ::= ("" | "a")
+    expected = """root ::= (((root_1_xgrammar_repetition_context root_1_xgrammar_repetition_context_1 root_1_xgrammar_repetition_context_2 root_1_xgrammar_repetition_context_3)))
+root_1_xgrammar_repetition_context ::= ("" | ("a")) (=(root_1_xgrammar_repetition_context_1 root_1_xgrammar_repetition_context_2 root_1_xgrammar_repetition_context_3))
+root_1_xgrammar_repetition_context_1 ::= ("" | ("a")) (=(root_1_xgrammar_repetition_context_2 root_1_xgrammar_repetition_context_3))
+root_1_xgrammar_repetition_context_2 ::= (("a")) (=(root_1_xgrammar_repetition_context_3))
+root_1_xgrammar_repetition_context_3 ::= (("a"))
 """
     grammar = _ebnf_to_grammar_no_normalization(before)
     after = str(grammar)
@@ -170,8 +175,12 @@ def test_repetition_range_min_only():
     """Test repetition range with only min {n,}."""
     before = """root ::= "a"{2,}
 """
-    expected = """root ::= ((("a" "a" root_1)))
-root_1 ::= ("" | ("a" root_1))
+    expected = """root ::= (((root_1_xgrammar_repetition_context{0, 2147483643} root_1_xgrammar_repetition_context_1 root_1_xgrammar_repetition_context_2 root_1_xgrammar_repetition_context_3 root_1_xgrammar_repetition_context_4)))
+root_1_xgrammar_repetition_context ::= (("a")) (=(root_1_xgrammar_repetition_context_1 root_1_xgrammar_repetition_context_2 root_1_xgrammar_repetition_context_3 root_1_xgrammar_repetition_context_4))
+root_1_xgrammar_repetition_context_1 ::= ("" | ("a")) (=(root_1_xgrammar_repetition_context_2 root_1_xgrammar_repetition_context_3 root_1_xgrammar_repetition_context_4))
+root_1_xgrammar_repetition_context_2 ::= ("" | ("a")) (=(root_1_xgrammar_repetition_context_3 root_1_xgrammar_repetition_context_4))
+root_1_xgrammar_repetition_context_3 ::= (("a")) (=(root_1_xgrammar_repetition_context_4))
+root_1_xgrammar_repetition_context_4 ::= (("a"))
 """
     grammar = _ebnf_to_grammar_no_normalization(before)
     after = str(grammar)
@@ -266,11 +275,12 @@ rule1 ::= [a-z]{1,3} (=":")
 rule2 ::= [0-9]+ "." [0-9]*
 """
     expected = """root ::= (("start" root_1 "end"))
-rule1 ::= ((([a-z] rule1_1))) (=((":")))
+rule1 ::= (((rule1_1_xgrammar_repetition_context rule1_1_xgrammar_repetition_context_1 rule1_1_xgrammar_repetition_context_2))) (=((":")))
 rule2 ::= ((rule2_1 "." [0-9]*))
 root_1 ::= ((((rule1) | (rule2)) root_1) | ((rule1) | (rule2)))
-rule1_1 ::= ("" | ([a-z] rule1_2))
-rule1_2 ::= ("" | [a-z])
+rule1_1_xgrammar_repetition_context ::= ("" | ([a-z])) (=(rule1_1_xgrammar_repetition_context_1 rule1_1_xgrammar_repetition_context_2))
+rule1_1_xgrammar_repetition_context_1 ::= ("" | ([a-z])) (=(rule1_1_xgrammar_repetition_context_2))
+rule1_1_xgrammar_repetition_context_2 ::= (([a-z]))
 rule2_1 ::= (([0-9] rule2_1) | [0-9])
 """
     grammar = _ebnf_to_grammar_no_normalization(before)
@@ -344,26 +354,35 @@ g ::= "g" {0}
 """
 
     expected = """root ::= ((a b c d e f g))
-a ::= (("a" a_1))
-b ::= ((b_5 b_1))
-c ::= ((c_1))
-d ::= ((d_1))
-e ::= (("ee" e_1))
-f ::= (("fff"))
-g ::= (())
-a_1 ::= ("" | ("a"))
-b_1 ::= ("" | (b_1_1 b_2))
-b_2 ::= ("" | (b_2_1 b_3))
-b_3 ::= ("" | (b_3_1 b_4))
-b_4 ::= ("" | (a) | ("b"))
-c_1 ::= ("" | ("c" c_2))
-c_2 ::= ("" | ("c"))
-d_1 ::= ("" | ("d" d_1))
-e_1 ::= ("" | ("e" e_1))
-b_5 ::= ((a) | ("b"))
-b_1_1 ::= ((a) | ("b"))
-b_2_1 ::= ((a) | ("b"))
-b_3_1 ::= ((a) | ("b"))
+a ::= ((a_1_xgrammar_repetition_context a_1_xgrammar_repetition_context_1))
+b ::= ((b_1_xgrammar_repetition_context{0, 1} b_1_xgrammar_repetition_context_1 b_1_xgrammar_repetition_context_2 b_1_xgrammar_repetition_context_3 b_1_xgrammar_repetition_context_4))
+c ::= ((c_1_xgrammar_repetition_context c_1_xgrammar_repetition_context_1))
+d ::= ((d_1_xgrammar_repetition_context{0, 2147483643} d_1_xgrammar_repetition_context_1 d_1_xgrammar_repetition_context_2 d_1_xgrammar_repetition_context_3 d_1_xgrammar_repetition_context_4))
+e ::= ((e_1_xgrammar_repetition_context{0, 2147483643} e_1_xgrammar_repetition_context_1 e_1_xgrammar_repetition_context_2 e_1_xgrammar_repetition_context_3 e_1_xgrammar_repetition_context_4))
+f ::= ((f_1_xgrammar_repetition_context f_1_xgrammar_repetition_context_1 f_1_xgrammar_repetition_context_2))
+g ::= ("")
+a_1_xgrammar_repetition_context ::= ("" | ("a")) (=(a_1_xgrammar_repetition_context_1))
+a_1_xgrammar_repetition_context_1 ::= (("a"))
+b_1_xgrammar_repetition_context ::= ((a) | ("b")) (=(b_1_xgrammar_repetition_context_1 b_1_xgrammar_repetition_context_2 b_1_xgrammar_repetition_context_3 b_1_xgrammar_repetition_context_4))
+b_1_xgrammar_repetition_context_1 ::= ("" | (a) | ("b")) (=(b_1_xgrammar_repetition_context_2 b_1_xgrammar_repetition_context_3 b_1_xgrammar_repetition_context_4))
+b_1_xgrammar_repetition_context_2 ::= ("" | (a) | ("b")) (=(b_1_xgrammar_repetition_context_3 b_1_xgrammar_repetition_context_4))
+b_1_xgrammar_repetition_context_3 ::= ("" | (a) | ("b")) (=(b_1_xgrammar_repetition_context_4))
+b_1_xgrammar_repetition_context_4 ::= ((a) | ("b"))
+c_1_xgrammar_repetition_context ::= ("" | ("c")) (=(c_1_xgrammar_repetition_context_1))
+c_1_xgrammar_repetition_context_1 ::= ("" | ("c"))
+d_1_xgrammar_repetition_context ::= (("d")) (=(d_1_xgrammar_repetition_context_1 d_1_xgrammar_repetition_context_2 d_1_xgrammar_repetition_context_3 d_1_xgrammar_repetition_context_4))
+d_1_xgrammar_repetition_context_1 ::= ("" | ("d")) (=(d_1_xgrammar_repetition_context_2 d_1_xgrammar_repetition_context_3 d_1_xgrammar_repetition_context_4))
+d_1_xgrammar_repetition_context_2 ::= ("" | ("d")) (=(d_1_xgrammar_repetition_context_3 d_1_xgrammar_repetition_context_4))
+d_1_xgrammar_repetition_context_3 ::= ("" | ("d")) (=(d_1_xgrammar_repetition_context_4))
+d_1_xgrammar_repetition_context_4 ::= ("" | ("d"))
+e_1_xgrammar_repetition_context ::= (("e")) (=(e_1_xgrammar_repetition_context_1 e_1_xgrammar_repetition_context_2 e_1_xgrammar_repetition_context_3 e_1_xgrammar_repetition_context_4))
+e_1_xgrammar_repetition_context_1 ::= ("" | ("e")) (=(e_1_xgrammar_repetition_context_2 e_1_xgrammar_repetition_context_3 e_1_xgrammar_repetition_context_4))
+e_1_xgrammar_repetition_context_2 ::= ("" | ("e")) (=(e_1_xgrammar_repetition_context_3 e_1_xgrammar_repetition_context_4))
+e_1_xgrammar_repetition_context_3 ::= (("e")) (=(e_1_xgrammar_repetition_context_4))
+e_1_xgrammar_repetition_context_4 ::= (("e"))
+f_1_xgrammar_repetition_context ::= (("f")) (=(f_1_xgrammar_repetition_context_1 f_1_xgrammar_repetition_context_2))
+f_1_xgrammar_repetition_context_1 ::= (("f")) (=(f_1_xgrammar_repetition_context_2))
+f_1_xgrammar_repetition_context_2 ::= (("f"))
 """
 
     grammar = _ebnf_to_grammar_no_normalization(before)

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -60,8 +60,10 @@ def test_serialize_grammar():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
+        "exact_lookahead": [],
         "__VERSION__": "v4",
     }
+    print(json.loads(serialized))  # For debugging purposes
     assert json.loads(serialized) == expected_json
 
 
@@ -79,6 +81,7 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
+        "exact_lookahead": [],
         "__VERSION__": "v4",
     }
 
@@ -202,6 +205,7 @@ def test_serialize_compiled_grammar():
             "root_rule_id": 1,
             "allow_empty_rule_ids": [0],
             "complete_fsm": {"data_": [], "indptr_": [0]},
+            "exact_lookahead": [],
             "per_rule_fsms": [None, None],
         },
         "tokenizer_metadata": {


### PR DESCRIPTION
Currently, if we try to compile a grammar with a expression like `[a-z]{2, 20000}`, it will cost a lot of time to compile the grammar. In this PR, we add a new type of expression `kRepeat` in the parser, which can significantly improve the efficiency in such cases.