### PR TITLE
Fix: fix wrong DEBUG boundary check

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2416,7 +2416,6 @@ std::string JSONSchemaConverter::GetPartialRuleForProperties(
     if (allow_additional) {
       key_matched_min.back() = std::max(1, key_matched_min.back());
     } else {
-      XGRAMMAR_DCHECK(key_matched_min.back() <= max_properties);
       key_matched_min.back() = std::max(min_properties, key_matched_min.back());
     }
     for (int i = properties_size - 2; i >= 0; --i) {

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2282,7 +2282,7 @@ std::string JSONSchemaConverter::GetOtherPropertyPattern(
 std::string JSONSchemaConverter::GetPropertyWithNumberConstrains(
     const std::string& pattern, int min_properties, int max_properties, int already_repeated_times
 ) {
-  XGRAMMAR_DCHECK(max_properties >= already_repeated_times);
+  XGRAMMAR_DCHECK(max_properties >= already_repeated_times || max_properties == -1);
   if (max_properties == already_repeated_times) {
     return "\"\"";
   }


### PR DESCRIPTION
When compiled with `CMAKE_BUILD_TYPE Debug`, we found that some of the tests crashed.

Try this in main branch and it will lead to some crashs:

```
pytest -k test_empty_
```

I would suggest turning on `XGRAMMAR_DCHECK` in ci to detect more bugs like this.

One more suggestion. I don't think magic numbers like `-1` is good enough. Maybe we can rewrite with `std::optional<int>` for better readability in future.