### PR TITLE
[Fix]fix behaviors and boundary check in earley parser.

### DIFF
--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -91,19 +91,12 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
 ) {
   // Check if it's the tag dispatch.
   if (state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value()) {
-    if (state.rule_start_pos == ParserState::kNoPrevInputPos) {
-      tmp_accept_stop_token_ = true;
-    }
     // Try to expand the fsm.
     ExpandNextRuleRefElement(state, grammar_expr, nullptr);
-    return std::make_pair(
-        true, grammar_->per_rule_fsms[state.rule_id].value().IsEndState(state.element_id)
-    );
+    const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
+    return std::make_pair(fsm.IsScanableState(state.element_id), fsm.IsEndState(state.element_id));
   }
-  XGRAMMAR_DCHECK(
-      grammar_expr.type == GrammarExprType::kSequence ||
-      grammar_expr.type == GrammarExprType::kEmptyStr
-  );
+  XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kSequence);
   if (state.element_id == grammar_expr.size()) {
     // The rule is completed.
     return std::make_pair(false, true);
@@ -185,6 +178,7 @@ bool EarleyParser::Advance(const uint8_t ch) {
   while (!tmp_process_state_queue_.empty()) {
     const auto state = tmp_process_state_queue_.front();
     tmp_process_state_queue_.pop();
+    // XGRAMMAR_LOG(INFO) << "Process state: " << state.ToString();
     GrammarExpr grammar_expr = grammar_->GetGrammarExpr(state.sequence_id);
     auto [scanable, completable] = Predict(state, grammar_expr);
     if (completable) {
@@ -315,11 +309,13 @@ void EarleyParser::ExpandNextRuleRefElement(
   std::vector<int32_t> ref_rule_ids;
   // Path A. The rule has a corresponding FSM.
   if (state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value()) {
-    // If the rule is a tag dispatch rule, we need to add the tag dispatch FSM.
     const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
     for (const auto& edge : current_fsm->GetEdges(state.element_id)) {
       if (edge.IsRuleRef()) {
         ref_rule_ids.push_back(edge.GetRefRuleId());
+      } else if (edge.IsEpsilon()) {
+        Enqueue(ParserState{state.rule_id, state.sequence_id, edge.target, state.rule_start_pos, 0}
+        );
       }
     }
   } else {
@@ -330,7 +326,8 @@ void EarleyParser::ExpandNextRuleRefElement(
   for (const auto& ref_rule_id : ref_rule_ids) {
     {  // Add the reference rule to map.
       if ((state.element_id != grammar_expr.size() - 1) ||
-          state.rule_start_pos == ParserState::kNoPrevInputPos) {
+          state.rule_start_pos == ParserState::kNoPrevInputPos ||
+          grammar_->per_rule_fsms[state.rule_id].has_value()) {
         // It's not the right recursion, or it's the root rule.
         auto& states_map = rule_id_to_completeable_states_.back();
         states_map.insert({ref_rule_id, state});
@@ -344,14 +341,31 @@ void EarleyParser::ExpandNextRuleRefElement(
                    return StateEqualForParsing()(s.second, state_);
                  }) != range.second;
         };
+
+        bool no_fsm_parent = true;
         for (auto parent_state_iter = parent_states_map.lower_bound(state.rule_id);
              parent_state_iter != parent_states_map.end() &&
              parent_state_iter->first == state.rule_id;
              parent_state_iter++) {
           const auto& parent_state = parent_state_iter->second;
-          if (!in_vec(parent_state)) {
-            states_map.insert({ref_rule_id, parent_state});
+          if (grammar_->per_rule_fsms[parent_state.rule_id].has_value()) {
+            no_fsm_parent = false;
+            break;
           }
+        }
+        if (no_fsm_parent) {
+          for (auto parent_state_iter = parent_states_map.lower_bound(state.rule_id);
+               parent_state_iter != parent_states_map.end() &&
+               parent_state_iter->first == state.rule_id;
+               parent_state_iter++) {
+            const auto& parent_state = parent_state_iter->second;
+            if (!in_vec(parent_state)) {
+              states_map.insert({ref_rule_id, parent_state});
+            }
+          }
+        } else {
+          auto& states_map = rule_id_to_completeable_states_.back();
+          states_map.insert({ref_rule_id, state});
         }
       }
 
@@ -371,7 +385,6 @@ void EarleyParser::ExpandNextRuleRefElement(
                 });
               }
             }
-            tmp_accept_stop_token_ = true;
             continue;
           }
           XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kSequence);

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -178,7 +178,6 @@ bool EarleyParser::Advance(const uint8_t ch) {
   while (!tmp_process_state_queue_.empty()) {
     const auto state = tmp_process_state_queue_.front();
     tmp_process_state_queue_.pop();
-    // XGRAMMAR_LOG(INFO) << "Process state: " << state.ToString();
     GrammarExpr grammar_expr = grammar_->GetGrammarExpr(state.sequence_id);
     auto [scanable, completable] = Predict(state, grammar_expr);
     if (completable) {

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -418,9 +418,21 @@ void EarleyParser::ExpandNextRuleRefElement(
         for (const auto& sequence_id : ref_grammar_expr) {
           const auto& sequence = grammar_->GetGrammarExpr(sequence_id);
           if (sequence.type == GrammarExprType::kEmptyStr) {
-            Enqueue(ParserState{
-                state.rule_id, state.sequence_id, state.element_id + 1, state.rule_start_pos, 0
-            });
+            if (grammar_->per_rule_fsms[state.rule_id].has_value()) {
+              const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
+              const auto& current_edges = current_fsm->GetEdges(state.element_id);
+              for (const auto& edge : current_edges) {
+                if (edge.IsRuleRef() && edge.GetRefRuleId() == ref_rule_id) {
+                  Enqueue(ParserState{
+                      state.rule_id, state.sequence_id, edge.target, state.rule_start_pos, 0
+                  });
+                }
+              }
+            } else {
+              Enqueue(ParserState{
+                  state.rule_id, state.sequence_id, state.element_id + 1, state.rule_start_pos, 0
+              });
+            }
             continue;
           }
           // Assert: the state can't be repeated. Since the rule_start_pos is the current

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -100,7 +100,10 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
         true, grammar_->per_rule_fsms[state.rule_id].value().IsEndState(state.element_id)
     );
   }
-  XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kSequence);
+  XGRAMMAR_DCHECK(
+      grammar_expr.type == GrammarExprType::kSequence ||
+      grammar_expr.type == GrammarExprType::kEmptyStr
+  );
   if (state.element_id == grammar_expr.size()) {
     // The rule is completed.
     return std::make_pair(false, true);
@@ -384,7 +387,10 @@ void EarleyParser::ExpandNextRuleRefElement(
       const auto& ref_rule = grammar_->GetRule(ref_rule_id);
       const auto& ref_grammar_expr_id = ref_rule.body_expr_id;
       const auto& ref_grammar_expr = grammar_->GetGrammarExpr(ref_grammar_expr_id);
-      XGRAMMAR_DCHECK(ref_grammar_expr.type == GrammarExprType::kChoices);
+      XGRAMMAR_DCHECK(
+          ref_grammar_expr.type == GrammarExprType::kChoices ||
+          grammar_->per_rule_fsms[ref_rule_id].has_value()
+      );
       for (const auto& sequence_id : ref_grammar_expr) {
         const auto& sequence = grammar_->GetGrammarExpr(sequence_id);
         if (sequence.type == GrammarExprType::kEmptyStr) {

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -96,7 +96,10 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
     const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
     return std::make_pair(fsm.IsScanableState(state.element_id), fsm.IsEndState(state.element_id));
   }
-  XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kSequence);
+  XGRAMMAR_DCHECK(
+      grammar_expr.type == GrammarExprType::kSequence ||
+      grammar_expr.type == GrammarExprType::kEmptyStr
+  );
   if (state.element_id == grammar_expr.size()) {
     // The rule is completed.
     return std::make_pair(false, true);

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -510,6 +510,20 @@ class FSMWithStartEndBase {
     start_ = state;
   }
 
+  /*! \brief Checks if a given state is a scanable state.
+   * \param state The state to check.
+   * \return True if the state is scanable, false otherwise.
+   */
+  bool IsScanableState(int state) const {
+    XGRAMMAR_DCHECK(state < NumStates());
+    for (const auto& edge : fsm_.GetEdges(state)) {
+      if (edge.IsCharRange()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /*!
    * \brief Adds an end/accepting state to the FSM.
    * \param state The state to add as an end state.

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -548,7 +548,10 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
           cur_sequence.type == GrammarExprType::kChoices ||
           cur_sequence.type == GrammarExprType::kEmptyStr)
     );
-    XGRAMMAR_DCHECK(cur_sequence.type == GrammarExprType::kSequence);
+    XGRAMMAR_DCHECK(
+        cur_sequence.type == GrammarExprType::kSequence ||
+        grammar_->per_rule_fsms[state.rule_id].has_value()
+    );
     auto adaptive_token_mask_it = adaptive_token_mask_cache.find(state);
     XGRAMMAR_CHECK(adaptive_token_mask_it != adaptive_token_mask_cache.end()) << state;
     const auto& adaptive_token_mask = adaptive_token_mask_it->second;


### PR DESCRIPTION
Like #369, this PR fixes wrong boundary check in earley parser. Moreover, it supports fsms in a more general way.
This PR also fixed some latent issues:
- Support epsilon edges in fsms.
- Disable right recursion optimization on fsms.
- Fix the boundary check. 
- Fix the parser when a fsm is referred by other rules.