### PR TITLE
[Refactor] Remove logics about max_rollback_tokens

### DIFF
--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -75,7 +75,7 @@ class GrammarMatcher {
       const CompiledGrammar& compiled_grammar,
       std::optional<std::vector<int>> override_stop_tokens = std::nullopt,
       bool terminate_without_stop_token = false,
-      int max_rollback_tokens = 0
+      int max_rollback_tokens = -1
   );
 
   /*!

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -193,8 +193,9 @@ class GrammarMatcher(XGRObject):
             Whether to terminate the matcher without accepting a stop token.
 
         max_rollback_tokens : int, default: -1
-            Deprecated because the earley parser significantly reduces the number of states, so not
-            needed anymore.
+            Deprecated. You don't need to set it and it's always unlimited (-1).
+            The new Earley parser significantly reduces the number of states, so we can allow
+            unlimited rollback.
 
             The maximum number of rollback tokens allowed. The rollback operation is useful for
             jump-forward decoding and speculative decoding.
@@ -204,7 +205,8 @@ class GrammarMatcher(XGRObject):
 
         if not max_rollback_tokens == -1:
             warnings.warn(
-                "max_rollback_tokens is deprecated because the earley parser significantly reduces the number of states, so not needed anymore.",
+                "max_rollback_tokens is deprecated. You don't need to set it and it's always "
+                "unlimited (-1).",
                 DeprecationWarning,
             )
 
@@ -292,8 +294,9 @@ class GrammarMatcher(XGRObject):
 
         Parameters
         ----------
-        bitmask : torch.Tensor
-            The bitmask for the next token prediction.
+        bitmask : ArrayLike
+            The bitmask for the next token prediction. It supports torch.Tensor and other
+            array-like objects, as long as they support the DLPack protocol.
 
         index : int, default: 0
             The batch id of the bitmask.
@@ -364,14 +367,16 @@ class GrammarMatcher(XGRObject):
 
     @property
     def max_rollback_tokens(self) -> int:
-        """Get the maximum number of rollback tokens allowed.
+        """Depracated. Now max_rollback_tokens is always unlimited (-1).
+
+        Get the maximum number of rollback tokens allowed.
 
         Returns
         -------
         max_rollback_tokens : int
             The maximum number of rollback tokens.
         """
-        return self._handle.max_rollback_tokens
+        return -1
 
     @property
     def stop_token_ids(self) -> List[int]:

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -189,7 +189,7 @@ def test_rollback():
         json_grammar, tokenizer_info, max_rollback_tokens=5
     )
 
-    assert matcher.max_rollback_tokens == 5
+    assert matcher.max_rollback_tokens == -1
 
     input_ids_splitted = [input_ids[i : i + 2] for i in range(0, len(input_ids), 2)]
 


### PR DESCRIPTION
The new earley parser significantly reduces the states that is needed to maintain, so max_rollback_tokens is not needed. This PR removes the logic about max_rollback_tokens, but keep the interface not changed.

Signed-off-by: Ubospica <ubospica@gmail.com>