### PR TITLE
[Fix] Fix dependency on macos-13.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "ninja",
   "numpy",
   "typing-extensions>=4.9.0",
+  "safetensors==0.5.*",
 ]
 
 [project.urls]
@@ -34,11 +35,9 @@ test = [
   "huggingface-hub[cli]",
   "protobuf",
   "pytest",
+  "transformers>=4.46.0",
   "sentencepiece",
   "tiktoken",
-  # transformers==4.50.0 has error on MacOS.
-  # https://github.com/huggingface/transformers/issues/36906
-  "transformers<4.50.0; platform_system == 'Darwin'",
 ]
 
 [build-system]
@@ -78,6 +77,7 @@ sdist.include = [
   "/cpp/**/*.h",
   "/include/**/*",
   "/python/xgrammar/**/*.py",
+  "/python/xgrammar/py.typed",
 
   # Third party files
   "/3rdparty/**/*",


### PR DESCRIPTION
This PR constrains the version of `safetensors` on macos-13. This addresses the compatibility between `safetensors` and `torch`.

ref:[https://github.com/ggml-org/llama.cpp/pull/15134](https://github.com/ggml-org/llama.cpp/pull/15134).
ref:[https://github.com/nvidia-holoscan/holohub/issues/1061](https://github.com/nvidia-holoscan/holohub/issues/1061).