### PR TITLE
Fix apply_bitmask logit for both CPU and triton versions when shape and stride doesn't match

### DIFF
--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -301,8 +301,10 @@ NB_MODULE(xgrammar_bindings, m) {
       &Kernels_ApplyTokenBitmaskInplaceCPU,
       nb::arg("logits_ptr"),
       nb::arg("logits_shape"),
+      nb::arg("logits_strides"),
       nb::arg("bitmask_ptr"),
       nb::arg("bitmask_shape"),
+      nb::arg("bitmask_strides"),
       nb::arg("vocab_size"),
       nb::arg("indices").none(),
       nb::call_guard<nb::gil_scoped_release>()

--- a/cpp/nanobind/python_methods.cc
+++ b/cpp/nanobind/python_methods.cc
@@ -82,13 +82,17 @@ std::pair<bool, int> Testing_IsSingleTokenBitmask(
 void Kernels_ApplyTokenBitmaskInplaceCPU(
     intptr_t logits_ptr,
     std::pair<int64_t, int64_t> logits_shape,
+    std::pair<int64_t, int64_t> logits_strides,
     intptr_t bitmask_ptr,
     std::pair<int64_t, int64_t> bitmask_shape,
+    std::pair<int64_t, int64_t> bitmask_strides,
     int vocab_size,
     std::optional<std::vector<int>> indices
 ) {
   std::array<int64_t, 2> logits_shape_arr = {logits_shape.first, logits_shape.second};
+  std::array<int64_t, 2> logits_strides_arr = {logits_strides.first, logits_strides.second};
   std::array<int64_t, 2> bitmask_shape_arr = {bitmask_shape.first, bitmask_shape.second};
+  std::array<int64_t, 2> bitmask_strides_arr = {bitmask_strides.first, bitmask_strides.second};
 
   DLTensor logits_dltensor{
       reinterpret_cast<void*>(logits_ptr),
@@ -96,7 +100,7 @@ void Kernels_ApplyTokenBitmaskInplaceCPU(
       2,
       DLDataType{kDLFloat, 32, 1},
       logits_shape_arr.data(),
-      nullptr,
+      logits_strides_arr.data(),
       0
   };
 
@@ -106,7 +110,7 @@ void Kernels_ApplyTokenBitmaskInplaceCPU(
       2,
       GetBitmaskDLType(),
       bitmask_shape_arr.data(),
-      nullptr,
+      bitmask_strides_arr.data(),
       0
   };
 

--- a/cpp/nanobind/python_methods.h
+++ b/cpp/nanobind/python_methods.h
@@ -39,8 +39,10 @@ std::pair<bool, int> Testing_IsSingleTokenBitmask(
 void Kernels_ApplyTokenBitmaskInplaceCPU(
     intptr_t logits_ptr,
     std::pair<int64_t, int64_t> logits_shape,
+    std::pair<int64_t, int64_t> logits_strides,
     intptr_t bitmask_ptr,
     std::pair<int64_t, int64_t> bitmask_shape,
+    std::pair<int64_t, int64_t> bitmask_strides,
     int vocab_size,
     std::optional<std::vector<int>> indices
 );

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cpu.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cpu.py
@@ -28,11 +28,28 @@ def apply_token_bitmask_inplace_cpu(
         raise ValueError("bitmask should be 1D or 2D, but got {}D".format(bitmask.dim()))
 
     logits_shape = (1, logits.shape[0]) if logits.dim() == 1 else (logits.shape[0], logits.shape[1])
+    logits_stride = logits.stride()
+    logits_stride = (
+        (logits_stride[0], 1) if logits.dim() == 1 else (logits_stride[0], logits_stride[1])
+    )
+
     bitmask_shape = (
         (1, bitmask.shape[0]) if bitmask.dim() == 1 else (bitmask.shape[0], bitmask.shape[1])
     )
+    bitmask_stride = bitmask.stride()
+    bitmask_stride = (
+        (bitmask_stride[0], 1) if bitmask.dim() == 1 else (bitmask_stride[0], bitmask_stride[1])
+    )
+
     vocab_size = min(logits.shape[-1], bitmask.shape[-1] * 32) if vocab_size is None else vocab_size
 
     _core.kernels.apply_token_bitmask_inplace_cpu(
-        logits.data_ptr(), logits_shape, bitmask.data_ptr(), bitmask_shape, vocab_size, indices
+        logits.data_ptr(),
+        logits_shape,
+        logits_stride,
+        bitmask.data_ptr(),
+        bitmask_shape,
+        bitmask_stride,
+        vocab_size,
+        indices,
     )

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu
@@ -168,6 +168,13 @@ void ApplyTokenBitmaskInplaceDispatchToPackedT(
     int32_t bitmask_stride,
     int32_t num_rows
 ) {
+  printf(
+      "===Jialin ApplyTokenBitmaskInplaceDispatchToPackedT vocab_size:%d logits_stride:%d "
+      "bitmask_stride:%d\n",
+      vocab_size,
+      logits_stride,
+      bitmask_stride
+  );
   if (logits_stride % (sizeof(float4) / sizeof(T)) == 0) {
     ApplyTokenBitmaskInplaceDispatchToBitsPerThread<T, float4>(
         logits, bitmask, indices, vocab_size, logits_stride, bitmask_stride, num_rows
@@ -234,6 +241,7 @@ void ApplyTokenBitmaskInplace(
 
   switch (logits.scalar_type()) {
     case torch::kFloat32: {
+      printf("===Jialin A!!!\n");
       ApplyTokenBitmaskInplaceDispatchToPackedT(
           logits.data_ptr<float>(),
           bitmask.data_ptr<int32_t>(),
@@ -246,6 +254,7 @@ void ApplyTokenBitmaskInplace(
       break;
     }
     case torch::kFloat16: {
+      printf("===Jialin B!!!\n");
       ApplyTokenBitmaskInplaceDispatchToPackedT(
           reinterpret_cast<__half*>(logits.data_ptr<torch::Half>()),
           bitmask.data_ptr<int32_t>(),
@@ -258,6 +267,7 @@ void ApplyTokenBitmaskInplace(
       break;
     }
     case torch::kBFloat16: {
+      printf("===Jialin C!!!\n");
       ApplyTokenBitmaskInplaceDispatchToPackedT(
           reinterpret_cast<__nv_bfloat16*>(logits.data_ptr<torch::BFloat16>()),
           bitmask.data_ptr<int32_t>(),

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cuda.cu
@@ -168,13 +168,6 @@ void ApplyTokenBitmaskInplaceDispatchToPackedT(
     int32_t bitmask_stride,
     int32_t num_rows
 ) {
-  printf(
-      "===Jialin ApplyTokenBitmaskInplaceDispatchToPackedT vocab_size:%d logits_stride:%d "
-      "bitmask_stride:%d\n",
-      vocab_size,
-      logits_stride,
-      bitmask_stride
-  );
   if (logits_stride % (sizeof(float4) / sizeof(T)) == 0) {
     ApplyTokenBitmaskInplaceDispatchToBitsPerThread<T, float4>(
         logits, bitmask, indices, vocab_size, logits_stride, bitmask_stride, num_rows
@@ -241,7 +234,6 @@ void ApplyTokenBitmaskInplace(
 
   switch (logits.scalar_type()) {
     case torch::kFloat32: {
-      printf("===Jialin A!!!\n");
       ApplyTokenBitmaskInplaceDispatchToPackedT(
           logits.data_ptr<float>(),
           bitmask.data_ptr<int32_t>(),
@@ -254,7 +246,6 @@ void ApplyTokenBitmaskInplace(
       break;
     }
     case torch::kFloat16: {
-      printf("===Jialin B!!!\n");
       ApplyTokenBitmaskInplaceDispatchToPackedT(
           reinterpret_cast<__half*>(logits.data_ptr<torch::Half>()),
           bitmask.data_ptr<int32_t>(),
@@ -267,7 +258,6 @@ void ApplyTokenBitmaskInplace(
       break;
     }
     case torch::kBFloat16: {
-      printf("===Jialin C!!!\n");
       ApplyTokenBitmaskInplaceDispatchToPackedT(
           reinterpret_cast<__nv_bfloat16*>(logits.data_ptr<torch::BFloat16>()),
           bitmask.data_ptr<int32_t>(),

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
@@ -83,6 +83,7 @@ def apply_token_bitmask_inplace_triton(
     vocab_size: Optional[int] = None,
     indices: Optional[List[int]] = None,
 ):
+    print("===Jialin apply_token_bitmask_inplace_triton")
     NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
     BLOCK_SIZE = 4096
 
@@ -109,8 +110,8 @@ def apply_token_bitmask_inplace_triton(
         indices,
         num_rows,
         vocab_size,
-        logits.shape[-1],
-        bitmask.shape[-1],
+        logits.stride[0],
+        bitmask.stride[0],
         NUM_SMS,
         BLOCK_SIZE,
         num_warps=BLOCK_SIZE // 32 // (16 // logits.element_size()),

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
@@ -83,7 +83,6 @@ def apply_token_bitmask_inplace_triton(
     vocab_size: Optional[int] = None,
     indices: Optional[List[int]] = None,
 ):
-    print("===Jialin apply_token_bitmask_inplace_triton")
     NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
     BLOCK_SIZE = 4096
 
@@ -110,8 +109,8 @@ def apply_token_bitmask_inplace_triton(
         indices,
         num_rows,
         vocab_size,
-        logits.stride[0],
-        bitmask.stride[0],
+        logits.stride()[0],
+        bitmask.stride()[0],
         NUM_SMS,
         BLOCK_SIZE,
         num_warps=BLOCK_SIZE // 32 // (16 // logits.element_size()),

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -2,10 +2,11 @@
 token.
 """
 
+import logging
 import math
 import warnings
 from typing import List, Optional, Tuple, Union
-import logging
+
 import torch
 from numpy.typing import ArrayLike
 
@@ -134,8 +135,6 @@ def apply_token_bitmask_inplace(
             "logits and bitmask should be on the same device. "
             + f"But got logits.device: {logits.device}, bitmask.device: {bitmask.device}"
         )
-
-    logging.info(f"===Jialin {logits.device.type=}")
 
     # dispatch to different implementations based on the device
     if logits.device.type == "cpu":

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -5,7 +5,7 @@ token.
 import math
 import warnings
 from typing import List, Optional, Tuple, Union
-
+import logging
 import torch
 from numpy.typing import ArrayLike
 
@@ -134,6 +134,8 @@ def apply_token_bitmask_inplace(
             "logits and bitmask should be on the same device. "
             + f"But got logits.device: {logits.device}, bitmask.device: {bitmask.device}"
         )
+
+    logging.info(f"===Jialin {logits.device.type=}")
 
     # dispatch to different implementations based on the device
     if logits.device.type == "cpu":

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -349,9 +349,6 @@ def test_apply_token_bitmask_inplace_indices(
     if impl in ["cuda", "triton", "torch_compile"]:
         logits_gpu = logits.to("cuda")
         bitmask_gpu = bitmask.to("cuda")
-        print(
-            f"===Jialin {logits_gpu.shape=} {logits_gpu.stride()=} {bitmask_gpu.shape=} {bitmask_gpu.stride()=}"
-        )
         kernel(logits_gpu, bitmask_gpu, indices=indices)
         torch.testing.assert_close(logits_gpu, logits_expected.to("cuda"))
     else:

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -78,32 +78,40 @@ def test_apply_token_bitmask_inplace(device: str):
 
 @pytest.mark.parametrize("device", ("cpu", "cuda"))
 def test_apply_token_bitmask_inplace_shape_stride_mismatch(device: str):
-    print("===Jialin test_apply_token_bitmask_inplace_shape_stride_mismatch step A")
     if device == "cuda" and not _is_cuda_available:
         pytest.skip(reason="CUDA is not installed")
 
     col = 100
     compacted_col = (col + 31) // 32
     neginf = float("-inf")
-    # Mask even positions (0-indexed) in the first row, and 
+    # Mask even positions (0-indexed) in the first row, and
     # mask odd positions in the second row.
-    bool_mask = torch.tensor([[i % 2 == 0 for i in range(col)], [i % 2 == 1 for i in range(col)]], dtype=torch.bool, device=device)
+    bool_mask = torch.tensor(
+        [[i % 2 == 0 for i in range(col)], [i % 2 == 1 for i in range(col)]],
+        dtype=torch.bool,
+        device=device,
+    )
     # In int32 binary representation,
     # 0x55555555 = 1431655765
     # 0xAAAAAAAA = -1431655766
-    bitmask = torch.tensor([[1431655765] * compacted_col, [-1431655766] * compacted_col], dtype=torch.int32, device=device)
+    bitmask = torch.tensor(
+        [[1431655765] * compacted_col, [-1431655766] * compacted_col],
+        dtype=torch.int32,
+        device=device,
+    )
     master_logits = torch.tensor(
-        [[i + 0.1 for i in range(col + 1)], [i + 0.2 for i in range(col + 1)]], dtype=torch.float32, device=device
+        [[i + 0.1 for i in range(col + 1)], [i + 0.2 for i in range(col + 1)]],
+        dtype=torch.float32,
+        device=device,
     )
     logits = master_logits[:, :col]
-    
+
     # Ensure the test environment setup is accurate (i.e. shape[-1] != stride[0])
     assert logits.size() == (2, col)
     assert logits.stride() == (col + 1, 1)
 
     expected = torch.where(bool_mask, logits, neginf)
 
-    print("===Jialin test_apply_token_bitmask_inplace_shape_stride_mismatch step B")
     xgr.apply_token_bitmask_inplace(logits, bitmask)
     torch.testing.assert_close(logits, expected)
 
@@ -341,6 +349,9 @@ def test_apply_token_bitmask_inplace_indices(
     if impl in ["cuda", "triton", "torch_compile"]:
         logits_gpu = logits.to("cuda")
         bitmask_gpu = bitmask.to("cuda")
+        print(
+            f"===Jialin {logits_gpu.shape=} {logits_gpu.stride()=} {bitmask_gpu.shape=} {bitmask_gpu.stride()=}"
+        )
         kernel(logits_gpu, bitmask_gpu, indices=indices)
         torch.testing.assert_close(logits_gpu, logits_expected.to("cuda"))
     else:

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -76,6 +76,38 @@ def test_apply_token_bitmask_inplace(device: str):
     torch.testing.assert_close(logits, expected)
 
 
+@pytest.mark.parametrize("device", ("cpu", "cuda"))
+def test_apply_token_bitmask_inplace_shape_stride_mismatch(device: str):
+    print("===Jialin test_apply_token_bitmask_inplace_shape_stride_mismatch step A")
+    if device == "cuda" and not _is_cuda_available:
+        pytest.skip(reason="CUDA is not installed")
+
+    col = 100
+    compacted_col = (col + 31) // 32
+    neginf = float("-inf")
+    # Mask even positions (0-indexed) in the first row, and 
+    # mask odd positions in the second row.
+    bool_mask = torch.tensor([[i % 2 == 0 for i in range(col)], [i % 2 == 1 for i in range(col)]], dtype=torch.bool, device=device)
+    # In int32 binary representation,
+    # 0x55555555 = 1431655765
+    # 0xAAAAAAAA = -1431655766
+    bitmask = torch.tensor([[1431655765] * compacted_col, [-1431655766] * compacted_col], dtype=torch.int32, device=device)
+    master_logits = torch.tensor(
+        [[i + 0.1 for i in range(col + 1)], [i + 0.2 for i in range(col + 1)]], dtype=torch.float32, device=device
+    )
+    logits = master_logits[:, :col]
+    
+    # Ensure the test environment setup is accurate (i.e. shape[-1] != stride[0])
+    assert logits.size() == (2, col)
+    assert logits.stride() == (col + 1, 1)
+
+    expected = torch.where(bool_mask, logits, neginf)
+
+    print("===Jialin test_apply_token_bitmask_inplace_shape_stride_mismatch step B")
+    xgr.apply_token_bitmask_inplace(logits, bitmask)
+    torch.testing.assert_close(logits, expected)
+
+
 def get_apply_token_bitmask_kernel(impl: str) -> Callable:
     if impl == "cpu":
         from xgrammar.kernels.apply_token_bitmask_inplace_cpu import apply_token_bitmask_inplace_cpu


### PR DESCRIPTION
# Motivation
In vLLM, in order to address [Issue #19493](https://github.com/vllm-project/vllm/issues/19493), [PR #19565](https://github.com/vllm-project/vllm/pull/19565) served as a workaround to mitigate the issue by switching to use torch.compile version instead of triton version.

# Root cause
With some investigation, we found that the error would happen when logits.stride()[0] != logits.shape[-1].

# Changes
- Add a unit test to reproduce the errors
- Fix CPU and Triton-version apply_grammar_bitmask for this scenario

# Tests
We've verified
- New unit tests would failed on trunk
- New unit tests passed with the change (and no new failure, however, there're a lot of failing tests in trunk, 47 failed in tests/python/test_token_bitmask_operations.py)

# Followup
We will follow up with a benchmark comparison to see if we should bring back triton-version or use the new cuda version on vLLM side.