### PR TITLE
[Fix]Fix the grammar_compiler.

### DIFF
--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -288,7 +288,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
         if (fill_reject_indices) {
           tmp_rejected_indices_.push_back(i);
           fill_reject_indices =
-              tmp_rejected_indices_.size() < AdaptiveTokenMask::USE_BITSET_THRESHOLD;
+              tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
+                  ? false
+                  : fill_reject_indices;
         } else {
           i = last_rejected_range - 1;
         }
@@ -387,7 +389,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
           tmp_rejected_indices_.push_back(i);
           last_rejected_range = subtree_nodes_range[i];
           fill_reject_indices =
-              tmp_rejected_indices_.size() < AdaptiveTokenMask::USE_BITSET_THRESHOLD;
+              tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
+                  ? false
+                  : fill_reject_indices;
         }
       }
     }
@@ -396,7 +400,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       for (int i = interval.second; i < next_interval.first; ++i) {
         tmp_rejected_indices_.push_back(i);
       }
-      fill_reject_indices = tmp_rejected_indices_.size() < AdaptiveTokenMask::USE_BITSET_THRESHOLD;
+      fill_reject_indices = tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
+                                ? false
+                                : fill_reject_indices;
     }
   }
 


### PR DESCRIPTION
This PR fixes a minor bug in Grammar Compiler, which is reported by #382. The bug is led by a small optimization, which is used to reduce the time to fill the `tmp_rejected_indices`. In the implementation, jf `tmp_rejected_indices == false`, then it shouldn't be set to `true` again, since some infomation will miss. Regretfully,  when `tmp_rejected_indices` is initialized with `false`, and the `tmp_rejected_indices` is set to `true` until the end of the function, then the incorrect `tmp_rejected_indices` will be passed.


Signed-off-by: Yuchuan <blemiade_qinchuan@sjtu.edu.cn>