### PR TITLE
[Feature] Provide more Python APIs to build grammars.

### DIFF
--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -158,14 +158,6 @@ Grammar Grammar::BuiltinJSONGrammar() {
   return grammar;
 }
 
-Grammar Grammar::Union(const std::vector<Grammar>& grammars) {
-  return GrammarUnionFunctor::Apply(grammars);
-}
-
-Grammar Grammar::Concat(const std::vector<Grammar>& grammars) {
-  return GrammarConcatFunctor::Apply(grammars);
-}
-
 std::ostream& operator<<(std::ostream& os, const Grammar& grammar) {
   os << grammar.ToString();
   return os;

--- a/cpp/grammar_constructor.cc
+++ b/cpp/grammar_constructor.cc
@@ -1,0 +1,348 @@
+/*!
+ *  Copyright (c) 2025 by Contributors
+ * \file xgrammar/grammar_constructor.cc
+ * \brief The implementation for building the BNF AST.
+ */
+#include "grammar_constructor.h"
+
+#include <xgrammar/grammar.h>
+
+#include <cstdint>
+#include <string>
+
+#include "grammar_functor.h"
+#include "support/utils.h"
+
+namespace xgrammar {
+
+/*!
+ * \brief Implementation of grammar union operation.
+ *
+ * Creates a new grammar that accepts strings from any of the input grammars.
+ * The resulting grammar has a new root rule that chooses between the root rules
+ * of all input grammars.
+ */
+class GrammarUnionFunctorImpl : public GrammarMutator {
+ public:
+  GrammarUnionFunctorImpl() = default;
+
+  Grammar Apply(const std::vector<Grammar>& grammars) {
+    InitGrammar();
+    InitBuilder();
+    auto root_rule_id = builder_->AddEmptyRule("root");
+
+    std::vector<int32_t> new_root_choices;
+    new_root_choices.reserve(grammars.size());
+
+    for (const auto& grammar : grammars) {
+      auto new_root_id_for_grammar = SubGrammarAdder().Apply(builder_, grammar);
+      auto new_rule_ref = builder_->AddRuleRef(new_root_id_for_grammar);
+      auto new_rule_ref_seq = builder_->AddSequence({new_rule_ref});
+      new_root_choices.push_back(new_rule_ref_seq);
+    }
+
+    builder_->UpdateRuleBody(root_rule_id, builder_->AddChoices(new_root_choices));
+    return builder_->Get(root_rule_id);
+  }
+
+  // Avoid hiding the original Apply(const Grammar&)
+  Grammar Apply(const Grammar& grammar) final {
+    XGRAMMAR_LOG(FATAL) << "Should not be called";
+    XGRAMMAR_UNREACHABLE();
+  }
+};
+
+/*!
+ * \brief Implementation of grammar concatenation operation.
+ *
+ * Creates a new grammar that accepts strings that are concatenations of strings
+ * from the input grammars in order. The resulting grammar has a new root rule
+ * that concatenates the root rules of all input grammars.
+ */
+class GrammarConcatFunctorImpl : public GrammarMutator {
+ public:
+  GrammarConcatFunctorImpl() = default;
+
+  Grammar Apply(const std::vector<Grammar>& grammars) {
+    InitGrammar();
+    InitBuilder();
+    auto root_rule_id = builder_->AddEmptyRule("root");
+
+    std::vector<int32_t> new_root_sequence;
+    new_root_sequence.reserve(grammars.size());
+
+    for (const auto& grammar : grammars) {
+      auto new_root_id_for_grammar = SubGrammarAdder().Apply(builder_, grammar);
+      auto new_rule_ref = builder_->AddRuleRef(new_root_id_for_grammar);
+      new_root_sequence.push_back(new_rule_ref);
+    }
+
+    auto new_root_seq = builder_->AddSequence(new_root_sequence);
+    builder_->UpdateRuleBody(root_rule_id, builder_->AddChoices({new_root_seq}));
+
+    return builder_->Get(root_rule_id);
+  }
+
+  // Avoid hiding the original Apply(const Grammar&)
+  Grammar Apply(const Grammar& grammar) final {
+    XGRAMMAR_LOG(FATAL) << "Should not be called";
+    XGRAMMAR_UNREACHABLE();
+  }
+};
+
+class StructuralTagGrammarCreatorImpl : public GrammarMutator {
+ public:
+  Grammar Apply(
+      const std::vector<std::string>& triggers,
+      const std::vector<std::vector<std::pair<StructuralTagItem, Grammar>>>& tag_groups
+  ) {
+    XGRAMMAR_CHECK(triggers.size() == tag_groups.size())
+        << "Number of triggers must match number of tag groups";
+
+    InitGrammar();
+    InitBuilder();
+
+    auto root_rule_id = builder_->AddEmptyRule("root");
+
+    Grammar::Impl::TagDispatch tag_dispatch{
+        /* tag_rule_pairs = */ {},
+        /* stop_eos = */ true,
+        /* stop_str = */ {},
+        /* loop_after_dispatch = */ true,
+    };
+    tag_dispatch.tag_rule_pairs.reserve(triggers.size());
+
+    // Create rules for each trigger group
+    for (size_t i = 0; i < triggers.size(); i++) {
+      // Skip empty trigger groups
+      if (tag_groups[i].empty()) {
+        continue;
+      }
+
+      auto rule_name = "trigger_rule_" + std::to_string(i);
+      auto rule_id = builder_->AddEmptyRule(rule_name);
+
+      // Create choices for each tag in this trigger group
+      std::vector<int32_t> choices;
+      choices.reserve(tag_groups[i].size());
+      for (const auto& [tag, schema_grammar] : tag_groups[i]) {
+        // Create sequence: start_suffix + schema + end
+        std::vector<int32_t> seq_elements;
+        seq_elements.reserve(3);
+
+        // Add begin suffix (everything after trigger)
+        XGRAMMAR_DCHECK(tag.begin.size() >= triggers[i].size())
+            << "Tag begin must be at least as long as trigger";
+        if (tag.begin.size() > triggers[i].size()) {
+          seq_elements.push_back(builder_->AddByteString(tag.begin.substr(triggers[i].size())));
+        }
+
+        // Create and visit schema grammar for this tag
+        auto schema_rule_id = SubGrammarAdder().Apply(builder_, schema_grammar);
+        seq_elements.push_back(builder_->AddRuleRef(schema_rule_id));
+
+        // Add end string
+        if (!tag.end.empty()) {
+          seq_elements.push_back(builder_->AddByteString(tag.end));
+        }
+
+        choices.push_back(builder_->AddSequence(seq_elements));
+      }
+
+      builder_->UpdateRuleBody(rule_id, builder_->AddChoices(choices));
+      tag_dispatch.tag_rule_pairs.emplace_back(triggers[i], rule_id);
+    }
+
+    // Create root TagDispatch rule
+    auto tag_dispatch_id = builder_->AddTagDispatch(tag_dispatch);
+    builder_->UpdateRuleBody(root_rule_id, tag_dispatch_id);
+    return builder_->Get(root_rule_id);
+  }
+
+  // Avoid hiding the original Apply(const Grammar&)
+  Grammar Apply(const Grammar& grammar) final {
+    XGRAMMAR_LOG(FATAL) << "Should not be called";
+    XGRAMMAR_UNREACHABLE();
+  }
+};
+
+class TagDispatchGrammarCreatorImpl : public GrammarMutator {
+ public:
+  Grammar Apply(
+      const std::vector<std::string>& triggers,
+      const std::vector<Grammar>& tags,
+      bool stop_eos,
+      bool loop_after_dispatch,
+      std::vector<std::string> stop_strs
+  ) {
+    InitGrammar();
+    InitBuilder();
+
+    auto root_rule_id = builder_->AddEmptyRule("root");
+
+    Grammar::Impl::TagDispatch tag_dispatch{
+        /* tag_rule_pairs = */ {},
+        /* stop_eos = */ stop_eos,
+        /* stop_str = */ stop_strs,
+        /* loop_after_dispatch = */ loop_after_dispatch,
+    };
+    tag_dispatch.tag_rule_pairs.reserve(triggers.size());
+
+    // Create rules for each trigger group
+    for (size_t i = 0; i < triggers.size(); i++) {
+      auto rule_name = "trigger_rule_" + std::to_string(i);
+      auto rule_id = builder_->AddEmptyRule(rule_name);
+
+      // Create choices for each tag in this trigger group
+      std::vector<int32_t> choices;
+      std::vector<int32_t> seq_elements;
+      seq_elements.reserve(1);
+
+      // Create and visit schema grammar for this tag
+      auto new_rule_id = SubGrammarAdder().Apply(builder_, tags[i]);
+      seq_elements.push_back(builder_->AddRuleRef(new_rule_id));
+
+      choices.push_back(builder_->AddSequence(seq_elements));
+
+      builder_->UpdateRuleBody(rule_id, builder_->AddChoices(choices));
+      tag_dispatch.tag_rule_pairs.emplace_back(triggers[i], rule_id);
+    }
+
+    auto tag_dispatch_id = builder_->AddTagDispatch(tag_dispatch);
+    builder_->UpdateRuleBody(root_rule_id, tag_dispatch_id);
+
+    return builder_->Get(root_rule_id);
+  }
+
+  // Avoid hiding the original Apply(const Grammar&)
+  Grammar Apply(const Grammar& grammar) final {
+    XGRAMMAR_LOG(FATAL) << "Should not be called";
+    XGRAMMAR_UNREACHABLE();
+  }
+};
+
+class StarGrammarCreatorImpl : public GrammarMutator {
+ public:
+  Grammar Apply(const Grammar& grammar) {
+    // Initialize the grammar and builder.
+    InitGrammar();
+    InitBuilder();
+
+    // Add a new empty rule for the root.
+    auto root_rule_id = builder_->AddEmptyRule("root");
+
+    // Add the original grammar as a subgrammar.
+    auto original_root_rule_id = SubGrammarAdder().Apply(builder_, grammar);
+
+    // Get a rule reference for root_original.
+    auto original_root_rule_ref = builder_->AddRuleRef(original_root_rule_id);
+
+    // Get a rule reference for the new root rule.
+    auto root_rule_ref = builder_->AddRuleRef(root_rule_id);
+
+    // We get root_original root.
+    auto new_root_seq = builder_->AddSequence({original_root_rule_ref, root_rule_ref});
+
+    // root ::= "" | root_original root
+    auto new_root_choice = builder_->AddChoices({builder_->AddEmptyStr(), new_root_seq});
+    builder_->UpdateRuleBody(root_rule_id, new_root_choice);
+    return builder_->Get(root_rule_id);
+  }
+};
+
+/**************************************** Grammar Functions ***************************************/
+
+Grammar Grammar::Empty() { return Grammar::FromEBNF("root ::= \"\""); }
+
+Grammar Grammar::String(const std::string& str) {
+  static const std::unordered_map<char, std::string> kCodepointToEscape = {
+      {'\'', "\\\'"},
+      {'\"', "\\\""},
+      {'\?', "\\?"},
+      {'\\', "\\\\"},
+      {'\a', "\\a"},
+      {'\b', "\\b"},
+      {'\f', "\\f"},
+      {'\n', "\\n"},
+      {'\r', "\\r"},
+      {'\t', "\\t"},
+      {'\v', "\\v"},
+      {'\0', "\\0"},
+      {'\x1B', "\\e"}
+  };
+  std::string ebnf_string = "root ::= \"";
+  for (auto ch : str) {
+    if (kCodepointToEscape.find(ch) != kCodepointToEscape.end()) {
+      ebnf_string += kCodepointToEscape.at(ch);
+    } else {
+      ebnf_string += ch;
+    }
+  }
+  ebnf_string += "\"";
+  return Grammar::FromEBNF(ebnf_string);
+}
+
+Grammar Grammar::CharacterClass(const std::string& str) { return Grammar::FromRegex(str); }
+
+Grammar Grammar::TagDispatch(
+    const std::vector<std::string>& triggers,
+    const std::vector<Grammar>& tags,
+    bool stop_eos,
+    bool loop_after_dispatch,
+    const std::vector<std::string>& stop_strs
+) {
+  return TagDispatchGrammarCreator::Apply(triggers, tags, stop_eos, loop_after_dispatch, stop_strs);
+}
+
+Grammar Grammar::Union(const std::vector<Grammar>& grammars) {
+  return GrammarUnionFunctor::Apply(grammars);
+}
+
+Grammar Grammar::Concat(const std::vector<Grammar>& grammars) {
+  return GrammarConcatFunctor::Apply(grammars);
+}
+
+Grammar Grammar::Star(const Grammar& grammar) { return StarGrammarCreator::Apply(grammar); }
+
+Grammar Grammar::Plus(const Grammar& grammar) {
+  return Grammar::Concat({grammar, Grammar::Star(grammar)});
+}
+
+Grammar Grammar::Optional(const Grammar& grammar) {
+  return Grammar::Union({grammar, Grammar::Empty()});
+}
+
+/*************************** Forward grammar Constructors to their impl ***************************/
+
+Grammar GrammarUnionFunctor::Apply(const std::vector<Grammar>& grammars) {
+  return GrammarUnionFunctorImpl().Apply(grammars);
+}
+
+Grammar GrammarConcatFunctor::Apply(const std::vector<Grammar>& grammars) {
+  return GrammarConcatFunctorImpl().Apply(grammars);
+}
+
+Grammar StructuralTagGrammarCreator::Apply(
+    const std::vector<std::string>& triggers,
+    const std::vector<std::vector<std::pair<StructuralTagItem, Grammar>>>& tag_groups
+) {
+  return StructuralTagGrammarCreatorImpl().Apply(triggers, tag_groups);
+}
+
+Grammar TagDispatchGrammarCreator::Apply(
+    const std::vector<std::string>& triggers,
+    const std::vector<Grammar>& tags,
+    bool stop_eos,
+    bool loop_after_dispatch,
+    const std::vector<std::string>& stop_strs
+) {
+  return TagDispatchGrammarCreatorImpl().Apply(
+      triggers, tags, stop_eos, loop_after_dispatch, stop_strs
+  );
+}
+
+Grammar StarGrammarCreator::Apply(const Grammar& grammar) {
+  return StarGrammarCreatorImpl().Apply(grammar);
+}
+
+}  // namespace xgrammar

--- a/cpp/grammar_constructor.h
+++ b/cpp/grammar_constructor.h
@@ -1,0 +1,62 @@
+/*!
+ *  Copyright (c) 2025 by Contributors
+ * \file xgrammar/grammar_constructor.h
+ * \brief The header for the building the BNF AST.
+ */
+#ifndef XGRAMMAR_GRAMMAR_CONSTRUCTOR_H_
+#define XGRAMMAR_GRAMMAR_CONSTRUCTOR_H_
+#include <xgrammar/xgrammar.h>
+
+namespace xgrammar {
+/*!
+ * \brief Find the union of multiple grammars as a new grammar.
+ */
+class GrammarUnionFunctor {
+ public:
+  static Grammar Apply(const std::vector<Grammar>& grammars);
+};
+
+/*!
+ * \brief Find the concatenation of multiple grammars as a new grammar.
+ */
+class GrammarConcatFunctor {
+ public:
+  static Grammar Apply(const std::vector<Grammar>& grammars);
+};
+
+/*!
+ * \brief Create a grammar that recognizes structural tags based on their triggers. See
+ * StructuralTagToGrammar() for more details.
+ *
+ * \param triggers The trigger strings that identify each tag group
+ * \param tag_groups The tags and their schema grammars, grouped by trigger. tag_groups[i][j] is the
+ * j-th tag that matches triggers[i], and its corresponding schema grammar.
+ * \return A grammar that matches all the tagged patterns.
+ */
+class StructuralTagGrammarCreator {
+ public:
+  static Grammar Apply(
+      const std::vector<std::string>& triggers,
+      const std::vector<std::vector<std::pair<StructuralTagItem, Grammar>>>& tag_groups
+  );
+};
+
+class TagDispatchGrammarCreator {
+ public:
+  static Grammar Apply(
+      const std::vector<std::string>& triggers,
+      const std::vector<Grammar>& tags,
+      bool stop_eos = true,
+      bool loop_after_dispatch = true,
+      const std::vector<std::string>& stop_strs = {}
+  );
+};
+
+class StarGrammarCreator {
+ public:
+  static Grammar Apply(const Grammar& grammar);
+};
+
+}  // namespace xgrammar
+
+#endif

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -765,6 +765,14 @@ class SubGrammarAdderImpl : public GrammarMutator {
     );
   }
 
+  int32_t VisitTagDispatch(const GrammarExpr& grammar_expr) final {
+    Grammar::Impl::TagDispatch tag_dispatch = base_grammar_->GetTagDispatch(grammar_expr);
+    for (auto& [tag, grammar_rule_id] : tag_dispatch.tag_rule_pairs) {
+      grammar_rule_id = new_rule_ids_names[grammar_rule_id].first;
+    }
+    return builder_->AddTagDispatch(tag_dispatch);
+  }
+
   std::vector<std::pair<int32_t, std::string>> new_rule_ids_names;
 };
 
@@ -1624,14 +1632,6 @@ class RepetitionNormalizerImpl {
 
 Grammar GrammarNormalizer::Apply(const Grammar& grammar) {
   return GrammarNormalizerImpl().Apply(grammar);
-}
-
-Grammar GrammarUnionFunctor::Apply(const std::vector<Grammar>& grammars) {
-  return GrammarUnionFunctorImpl().Apply(grammars);
-}
-
-Grammar GrammarConcatFunctor::Apply(const std::vector<Grammar>& grammars) {
-  return GrammarConcatFunctorImpl().Apply(grammars);
 }
 
 std::vector<int32_t> AllowEmptyRuleAnalyzer::Apply(const Grammar& grammar) {

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -258,22 +258,6 @@ class GrammarNormalizer {
 };
 
 /*!
- * \brief Find the union of multiple grammars as a new grammar.
- */
-class GrammarUnionFunctor {
- public:
-  static Grammar Apply(const std::vector<Grammar>& grammars);
-};
-
-/*!
- * \brief Find the concatenation of multiple grammars as a new grammar.
- */
-class GrammarConcatFunctor {
- public:
-  static Grammar Apply(const std::vector<Grammar>& grammars);
-};
-
-/*!
  * \brief Analyze the grammar to find the rules that are allowed to be empty.
  */
 class AllowEmptyRuleAnalyzer {

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -157,6 +157,24 @@ NB_MODULE(xgrammar_bindings, m) {
       .def_static("builtin_json_grammar", &Grammar::BuiltinJSONGrammar)
       .def_static("union", &Grammar::Union, nb::call_guard<nb::gil_scoped_release>())
       .def_static("concat", &Grammar::Concat, nb::call_guard<nb::gil_scoped_release>())
+      .def_static("string", &Grammar::String, nb::call_guard<nb::gil_scoped_release>())
+      .def_static("star", &Grammar::Star, nb::call_guard<nb::gil_scoped_release>())
+      .def_static("plus", &Grammar::Plus, nb::call_guard<nb::gil_scoped_release>())
+      .def_static("optional", &Grammar::Optional, nb::call_guard<nb::gil_scoped_release>())
+      .def_static("empty", &Grammar::Empty)
+      .def_static(
+          "character_class", &Grammar::CharacterClass, nb::call_guard<nb::gil_scoped_release>()
+      )
+      .def_static(
+          "tag_dispatch",
+          &Grammar::TagDispatch,
+          nb::arg("tags"),
+          nb::arg("grammars"),
+          nb::arg("stop_eos") = true,
+          nb::arg("loop_after_dispatch") = true,
+          nb::arg("stop_strs"),
+          nb::call_guard<nb::gil_scoped_release>()
+      )
       .def("serialize_json", &Grammar::SerializeJSON)
       .def_static("deserialize_json", &Grammar_DeserializeJSON);
 

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -10,7 +10,6 @@
 #include <xgrammar/object.h>
 
 #include <optional>
-#include <stdexcept>
 #include <string>
 #include <variant>
 #include <vector>
@@ -157,6 +156,69 @@ class Grammar {
    * \returns The concatenation of the grammars.
    */
   static Grammar Concat(const std::vector<Grammar>& grammars);
+
+  /*!
+   * \brief Create an empty grammar that matches an empty string.
+   * \return An empty grammar.
+   */
+  static Grammar Empty();
+
+  /*!
+   * \brief Create a character class grammar that matches a set of characters.
+   * \param str The string representing the character class, Which should be in the format of
+   * [a-z], [^a-z], [0-9], etc.
+   * \return A grammar that matches the character class.
+   */
+  static Grammar CharacterClass(const std::string& str);
+
+  /*!
+   * \brief Create a grammar that matches a tag dispatch. A tag dispatch is a grammar that matches
+   * a set of tags, each with a trigger and a schema.
+   * \param tags The tags corresponding to the grammars.
+   * \param grammars The grammar to match.
+   * \param stop_eos Whether to end the tag dispatch when matching any characters before a tag is
+   * dispatched.
+   * \param loop_after_dispatch Whether to loop back to the start of the tag dispatch after
+   * dispatching a tag. If true, the tag dispatch will continue to match tags after dispatching one.
+   * \param stop_strs The strings to stop the tag dispatch. If this is not empty, the tag dispatch
+   * will stop when it matches one of the strings in stop_strs.
+   * \return A grammar that matches the tag dispatch.
+   */
+  static Grammar TagDispatch(
+      const std::vector<std::string>& tags,
+      const std::vector<Grammar>& grammars,
+      bool stop_eos,
+      bool loop_after_dispatch,
+      const std::vector<std::string>& stop_strs
+  );
+
+  /*!
+   * \brief Create a grammar that matches a string.
+   * \param str The string to match.
+   * \return A grammar that matches the string.
+   */
+  static Grammar String(const std::string& str);
+
+  /*!
+   * \brief Create a grammar that matches zero or more occurrences of the given grammar.
+   * \param grammar The grammar to match.
+   * \return A grammar that matches zero or more occurrences of the given grammar.
+   */
+  static Grammar Star(const Grammar& grammar);
+
+  /*!
+   * \brief Create a grammar that matches one or more occurrences of the given grammar.
+   * \param grammar The grammar to match.
+   * \return A grammar that matches one or more occurrences of the given grammar.
+   */
+  static Grammar Plus(const Grammar& grammar);
+
+  /*!
+   * \brief Create a grammar that matches zero or one occurrences of the given grammar.
+   * \param grammar The grammar to match.
+   * \return A grammar that matches zero or one occurrences of the given grammar.
+   */
+  static Grammar Optional(const Grammar& grammar);
 
   /*!
    * \brief Print a BNF grammar.

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -355,6 +355,143 @@ class Grammar(XGRObject):
         grammar_handles = [grammar._handle for grammar in grammars]
         return Grammar._create_from_handle(_core.Grammar.union(grammar_handles))
 
+    @staticmethod
+    def empty() -> "Grammar":
+        """Create an empty grammar that matches nothing.
+
+        Returns
+        -------
+        grammar : Grammar
+            The empty grammar.
+        """
+        return Grammar._create_from_handle(_core.Grammar.empty())
+
+    @staticmethod
+    def string(string: str) -> "Grammar":
+        """Create a grammar that matches a specific string.
+
+        Parameters
+        ----------
+        string : str
+            The string to match.
+
+        Returns
+        -------
+        grammar : Grammar
+            The grammar that matches the specific string.
+        """
+        return Grammar._create_from_handle(_core.Grammar.string(string))
+
+    @staticmethod
+    def character_class(string: str) -> "Grammar":
+        """Create a grammar that matches a character class.
+
+        Parameters
+        ----------
+        string : str
+            The string representing the character class, which should be in the format of
+            [a-z], [^a-z], [0-9], etc.
+        Returns
+        -------
+        grammar : Grammar
+            The grammar that matches the character class.
+        """
+        if len(string) < 2 or not (string.startswith("[") and string.endswith("]")):
+            raise ValueError(
+                "The character class string should be in the format of [a-z], [^a-z], etc."
+            )
+        return Grammar._create_from_handle(_core.Grammar.character_class(string))
+
+    @staticmethod
+    def star(grammar: "Grammar") -> "Grammar":
+        """Create a grammar that matches zero or more occurrences of the given grammar.
+
+        Parameters
+        ----------
+        grammar : Grammar
+            The grammar to match zero or more occurrences of.
+
+        Returns
+        -------
+        grammar : Grammar
+            The grammar that matches zero or more occurrences of the given grammar.
+        """
+        return Grammar._create_from_handle(_core.Grammar.star(grammar._handle))
+
+    @staticmethod
+    def plus(grammar: "Grammar") -> "Grammar":
+        """Create a grammar that matches one or more occurrences of the given grammar.
+
+        Parameters
+        ----------
+        grammar : Grammar
+            The grammar to match one or more occurrences of.
+
+        Returns
+        -------
+        grammar : Grammar
+            The grammar that matches one or more occurrences of the given grammar.
+        """
+        return Grammar._create_from_handle(_core.Grammar.plus(grammar._handle))
+
+    def optional(grammar: "Grammar") -> "Grammar":
+        """Create a grammar that matches zero or one occurrence of the given grammar.
+
+        Parameters
+        ----------
+        grammar : Grammar
+            The grammar to match zero or one occurrence of.
+
+        Returns
+        -------
+        grammar : Grammar
+            The grammar that matches zero or one occurrence of the given grammar.
+        """
+        return Grammar._create_from_handle(_core.Grammar.optional(grammar._handle))
+
+    @staticmethod
+    def tag_dispatch(
+        tags: List[str],
+        grammars: "Grammar",
+        stop_eos: bool = True,
+        stop_str: List[str] = [],
+        loop_after_dispatch: bool = True,
+    ) -> "Grammar":
+        """Create a grammar that dispatches to different grammars based on the triggers.
+        The grammar will match the triggers, and then dispatch to the corresponding grammar
+        based on the tags.
+
+        Parameters
+        ----------
+        triggers : List[str]
+            The list of triggers. The grammar will match the triggers, and then dispatch to the
+            corresponding grammar based on the tags.
+        tags : List[Grammar]
+            The list of grammars to dispatch to. The grammar will match the triggers, and then
+            dispatch to the corresponding grammar based on the tags.
+        stop_eos : bool, default: True
+            Whether to stop the grammar when not dispatching to any grammar.
+            If True, the grammar will be able to stop when not dispatching to any grammar.
+        stop_str : List[str], default: []
+            The list of strings that will stop the grammar when matched. If the grammar matches
+            any of the strings in the list, it will stop the grammar.
+        loop_after_dispatch : bool, default: True
+            Whether to loop after dispatching to the grammar. If True, the grammar will loop
+            after dispatching to the grammar, allowing the grammar to match the triggers again.
+
+        Returns
+        -------
+        grammar : Grammar
+            The grammar that dispatches to different grammars based on the triggers.
+        """
+
+        grammar_handles = [grammar._handle for grammar in grammars]
+        return Grammar._create_from_handle(
+            _core.Grammar.tag_dispatch(
+                tags, grammar_handles, stop_eos, loop_after_dispatch, stop_str
+            )
+        )
+
     def serialize_json(self) -> str:
         """Serialize the grammar to a JSON string.
 

--- a/tests/python/test_grammar_constructor.py
+++ b/tests/python/test_grammar_constructor.py
@@ -1,0 +1,335 @@
+import sys
+
+import pytest
+
+import xgrammar as xgr
+from xgrammar.testing import _is_grammar_accept_string
+
+
+def test_grammar_constructor_empty():
+    expected_grammar = 'root ::= ("")\n'
+    empty_grammar = xgr.Grammar.empty()
+    assert empty_grammar is not None
+    empty_grammar_str = str(empty_grammar)
+    assert empty_grammar_str == expected_grammar
+
+
+input_test_string_expected_grammar_test_grammar_constructor_string = (
+    ("our beautiful Earth", "our beautiful Earth", 'root ::= (("our beautiful Earth"))\n'),
+    ("wqepqw\n", "wqepqw\n", 'root ::= (("wqepqw\\n"))\n'),
+    ("世界", "世界", 'root ::= (("\\u4e16\\u754c"))\n'),
+    ("ぉ", "ぉ", 'root ::= (("\\u3049"))\n'),
+    (
+        "123werlkここぉ1q12",
+        "123werlkここぉ1q12",
+        'root ::= (("123werlk\\u3053\\u3053\\u30491q12"))\n',
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "input, test_string, expected_grammar",
+    input_test_string_expected_grammar_test_grammar_constructor_string,
+)
+def test_grammar_constructor_string(input: str, test_string: str, expected_grammar: str):
+    grammar = xgr.Grammar.string(input)
+    assert grammar is not None
+    grammar_str = str(grammar)
+    assert _is_grammar_accept_string(grammar, test_string)
+    assert grammar_str == expected_grammar
+
+
+def test_grammar_union():
+    grammar1 = xgr.Grammar.from_ebnf(
+        """root ::= r1 | r2
+r1 ::= "true" | ""
+r2 ::= "false" | ""
+"""
+    )
+
+    grammar2 = xgr.Grammar.from_ebnf(
+        """root ::= "abc" | r1
+r1 ::= "true" | r1
+"""
+    )
+
+    grammar3 = xgr.Grammar.from_ebnf(
+        """root ::= r1 | r2 | r3
+r1 ::= "true" | r3
+r2 ::= "false" | r3
+r3 ::= "abc" | ""
+"""
+    )
+
+    expected = """root ::= ((root_1) | (root_2) | (root_3))
+root_1 ::= ((r1) | (r2))
+r1 ::= ("" | ("true"))
+r2 ::= ("" | ("false"))
+root_2 ::= (("abc") | (r1_1))
+r1_1 ::= (("true") | (r1_1))
+root_3 ::= ((r1_2) | (r2_1) | (r3))
+r1_2 ::= (("true") | (r3))
+r2_1 ::= (("false") | (r3))
+r3 ::= ("" | ("abc"))
+"""
+
+    union_grammar = xgr.Grammar.union(grammar1, grammar2, grammar3)
+    assert str(union_grammar) == expected
+
+
+def test_grammar_concat():
+    grammar1 = xgr.Grammar.from_ebnf(
+        """root ::= r1 | r2
+r1 ::= "true" | ""
+r2 ::= "false" | ""
+"""
+    )
+
+    grammar2 = xgr.Grammar.from_ebnf(
+        """root ::= "abc" | r1
+r1 ::= "true" | r1
+"""
+    )
+
+    grammar3 = xgr.Grammar.from_ebnf(
+        """root ::= r1 | r2 | r3
+r1 ::= "true" | r3
+r2 ::= "false" | r3
+r3 ::= "abc" | ""
+"""
+    )
+
+    expected = """root ::= ((root_1 root_2 root_3))
+root_1 ::= ((r1) | (r2))
+r1 ::= ("" | ("true"))
+r2 ::= ("" | ("false"))
+root_2 ::= (("abc") | (r1_1))
+r1_1 ::= (("true") | (r1_1))
+root_3 ::= ((r1_2) | (r2_1) | (r3))
+r1_2 ::= (("true") | (r3))
+r2_1 ::= (("false") | (r3))
+r3 ::= ("" | ("abc"))
+"""
+
+    concat_grammar = xgr.Grammar.concat(grammar1, grammar2, grammar3)
+    assert str(concat_grammar) == expected
+
+
+input_expected_accepted_test_grammar_constructor_character_class = (
+    ("a", True),
+    ("b", True),
+    ("c", True),
+    ("-", True),
+    ("1", False),
+    (" ", False),
+    ("A", True),
+)
+
+
+@pytest.mark.parametrize(
+    "input, expected_accept", input_expected_accepted_test_grammar_constructor_character_class
+)
+def test_grammar_character_constructor_class(input: str, expected_accept: bool):
+    expected_grammar = "root ::= (([\\-a-zA-Z]))\n"
+    grammar_str = "[-a-zA-Z]"
+    grammar = xgr.Grammar.character_class(grammar_str)
+    assert grammar is not None
+    assert str(grammar) == expected_grammar
+    assert _is_grammar_accept_string(grammar, input) == expected_accept
+
+
+input_expected_accepted_test_grammar_constructor_character_class_negated = (
+    ("a", False),
+    ("b", False),
+    ("c", False),
+    ("-", False),
+    ("1", True),
+    (" ", True),
+    ("A", False),
+    ("好", True),
+)
+
+
+@pytest.mark.parametrize(
+    "input, expected_accept",
+    input_expected_accepted_test_grammar_constructor_character_class_negated,
+)
+def test_grammar_constructor_character_class_negated(input: str, expected_accept: bool):
+    expected_grammar = "root ::= (([^\\-a-zA-Z]))\n"
+    grammar_str = "[^-a-zA-Z]"
+    grammar = xgr.Grammar.character_class(grammar_str)
+    assert grammar is not None
+    assert str(grammar) == expected_grammar
+    assert _is_grammar_accept_string(grammar, input) == expected_accept
+
+
+input_expected_accepted_test_grammar_constructor_tag_dispatch = (
+    ("eeeee", True),
+    ("tag114", True),
+    ("tag1", False),
+    ("tag2123", False),
+    ("tag11tag20.3", True),
+    ("tag20.", False),
+    ("tag11111tag20.2", True),
+)
+
+
+@pytest.mark.parametrize(
+    "input, expected_accept", input_expected_accepted_test_grammar_constructor_tag_dispatch
+)
+def test_grammar_constructor_tag_dispatch(input: str, expected_accept: bool):
+    expected_grammar = """root ::= TagDispatch(
+  ("tag1", trigger_rule_0),
+  ("tag2", trigger_rule_1),
+  stop_eos=true,
+  stop_str=(),
+  loop_after_dispatch=true
+)
+trigger_rule_0 ::= ((root_1))
+root_1 ::= (("[a-z]+") | (rule2))
+rule2 ::= ((rule2_1))
+rule2_1 ::= (([0-9] rule2_1) | ([0-9]))
+trigger_rule_1 ::= ((root_2))
+root_2 ::= (("0." rule2_2))
+rule2_2 ::= ((rule2_1_1))
+rule2_1_1 ::= (([0-9] rule2_1_1) | ([0-9]))
+"""
+
+    grammar_1_str = """
+        root ::= rule1 | rule2
+        rule1 ::= \"[a-z]+\"
+        rule2 ::= [0-9]+
+    """
+
+    grammar_2_str = """
+        root ::= rule1 rule2
+        rule1 ::= "0."
+        rule2 ::= [0-9]+
+    """
+
+    tag1 = "tag1"
+    tag2 = "tag2"
+
+    grammar_1 = xgr.Grammar.from_ebnf(grammar_1_str)
+    grammar_2 = xgr.Grammar.from_ebnf(grammar_2_str)
+
+    grammar_list = [grammar_1, grammar_2]
+    tag_list = [tag1, tag2]
+    grammar = xgr.Grammar.tag_dispatch(tags=tag_list, grammars=grammar_list)
+    assert grammar is not None
+    assert str(grammar) == expected_grammar
+    assert _is_grammar_accept_string(grammar, input) == expected_accept
+
+
+def test_grammar_constructor_plus():
+    grammar1 = xgr.Grammar.string("0.")
+    grammar2 = xgr.Grammar.plus(xgr.Grammar.character_class("[0-9]"))
+    grammar = xgr.Grammar.concat(grammar1, grammar2)
+    expected_grammar = """root ::= ((root_1 root_2))
+root_1 ::= (("0."))
+root_2 ::= ((root_1_1 root_2_1))
+root_1_1 ::= (([0-9]))
+root_2_1 ::= ("" | (root_1_1_1 root_2_1))
+root_1_1_1 ::= (([0-9]))
+"""
+
+    assert str(grammar) == expected_grammar
+    assert _is_grammar_accept_string(grammar, "0.1234567890")
+    assert not _is_grammar_accept_string(grammar, "0.123456789a")
+    assert not _is_grammar_accept_string(grammar, "0.")
+    assert _is_grammar_accept_string(grammar, "0.0")
+
+
+def test_grammar_constructor_star():
+    grammar1 = xgr.Grammar.string('"')
+    grammar2 = xgr.Grammar.star(xgr.Grammar.character_class("[a-z]"))
+    grammar = xgr.Grammar.concat(grammar1, grammar2, grammar1)
+    expected_grammar = """root ::= ((root_1 root_2 root_3))
+root_1 ::= (("\\\""))
+root_2 ::= ("" | (root_1_1 root_2))
+root_1_1 ::= (([a-z]))
+root_3 ::= (("\\\""))
+"""
+
+    assert str(grammar) == expected_grammar
+    assert _is_grammar_accept_string(grammar, '"azazaz"')
+    assert _is_grammar_accept_string(grammar, '""')
+    assert not _is_grammar_accept_string(grammar, "azazaz")
+    assert not _is_grammar_accept_string(grammar, '"azazaz')
+    assert not _is_grammar_accept_string(grammar, '"a--"a')
+
+
+def test_grammar_constructor_optional():
+    grammar1 = xgr.Grammar.union(xgr.Grammar.string("-"), xgr.Grammar.string("+"))
+    grammar2 = xgr.Grammar.plus(xgr.Grammar.character_class("[0-9]"))
+    grammar1_optional = xgr.Grammar.optional(grammar1)
+    grammar = xgr.Grammar.concat(grammar1_optional, grammar2)
+    expected_grammar = """root ::= ((root_1 root_4))
+root_1 ::= ((root_1_1) | (root_3))
+root_1_1 ::= ((root_1_1_1) | (root_2))
+root_1_1_1 ::= (("-"))
+root_2 ::= (("+"))
+root_3 ::= ("")
+root_4 ::= ((root_1_2 root_2_1))
+root_1_2 ::= (([0-9]))
+root_2_1 ::= ("" | (root_1_1_2 root_2_1))
+root_1_1_2 ::= (([0-9]))
+"""
+
+    assert str(grammar) == expected_grammar
+    assert _is_grammar_accept_string(grammar, "123")
+    assert _is_grammar_accept_string(grammar, "-123")
+    assert _is_grammar_accept_string(grammar, "+123")
+    assert not _is_grammar_accept_string(grammar, "++123")
+    assert not _is_grammar_accept_string(grammar, "123-")
+    assert not _is_grammar_accept_string(grammar, "+-123")
+
+
+def test_grammar_constructor_tag_dispatch_with_concatenation():
+    grammar_1_str = """
+root ::= rule1 | rule2
+rule1 ::= \"[a-z]+\"
+rule2 ::= [0-9]+
+"""
+    grammar1 = xgr.Grammar.from_ebnf(grammar_1_str)
+    tag = "tag1"
+    grammar = xgr.Grammar.tag_dispatch(
+        tags=[tag], grammars=[grammar1], stop_eos=False, stop_str=["end"], loop_after_dispatch=False
+    )
+    test_grammar = xgr.Grammar.concat(grammar, xgr.Grammar.string("between"), grammar)
+    assert test_grammar is not None
+    assert _is_grammar_accept_string(test_grammar, "tag1123endbetween123end")
+    assert _is_grammar_accept_string(test_grammar, "endbetweenend")
+    assert _is_grammar_accept_string(test_grammar, "endbetweentag123end")
+    assert not _is_grammar_accept_string(test_grammar, "tag1endbetween123end")
+    assert not _is_grammar_accept_string(test_grammar, "endend")
+    assert not _is_grammar_accept_string(test_grammar, "tag1abcendbetween123endextra")
+
+
+def test_grammar_constructor_tag_dispatch_with_union():
+    grammar_1_str = """
+root ::= [a-z]+
+"""
+    grammar1 = xgr.Grammar.from_ebnf(grammar_1_str)
+
+    tagdispatch_a = xgr.Grammar.tag_dispatch(
+        tags=["tag1"],
+        grammars=[grammar1],
+        stop_eos=False,
+        stop_str=["end"],
+        loop_after_dispatch=False,
+    )
+
+    grammar = xgr.Grammar.union(tagdispatch_a, xgr.Grammar.string("Interesting"))
+
+    assert grammar is not None
+    assert _is_grammar_accept_string(grammar, "tag1abcend")
+    assert _is_grammar_accept_string(grammar, "Interesting")
+    assert _is_grammar_accept_string(grammar, "tag1abcendextraend")
+    assert _is_grammar_accept_string(grammar, "Interesting")
+    assert not _is_grammar_accept_string(grammar, "tag1abcI")
+    assert not _is_grammar_accept_string(grammar, "Interestingextra")
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)


### PR DESCRIPTION
At present, we have several methods to build grammars: from an EBNF grammar, from a json schema, or from a regex e.t.c. This PR offers more functions to build grammar. Typically, here are:
- `empty()`, return an empty grammar.
- `string(str)`, return a grammar which match the specific string.
- `character_class(bool, List[char])`, return a grammar which matches(or rejects) a chracterclass.
- `star(grammar)`, return a grammar matches grammar*.
- `plus(grammar)`, return a grammar matches grammar+.
- `optional(grammar)`, return a grammar matches grammar?.

For example, if we want to create a grammar to match a signed integer, we can use:
```
import xgrammar as xgr
grammar1 = xgr.Grammar.union(xgr.Grammar.string("-"), xgr.Grammar.string("+"))
grammar2 = xgr.Grammar.character_class("[1-9]")
grammar3 = xgr.Grammar.star(xgr.Grammar.character_class("[0-9]"))
grammar1_optional = xgr.Grammar.optional(grammar1)
grammar = xgr.Grammar.concat(grammar1_optional, grammar2, grammar3)
```
Then, we can use `grammar` to match integers.


Signed-off-by: Yuchuan <blemiade_qinchuan@sjtu.edu.cn>