### PR TITLE
[Fix] Fix lookahead assertion analyzer.

### DIFF
--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -129,6 +129,11 @@ std::pair<bool, bool> GrammarMatcherForTokenMaskCache::IsTokenPassLookaheadAsser
     if (!can_reach_end_stack[i]) {
       continue;
     }
+    if (IsCompleted()) {
+      // If the lookahead assertion is already completed, we can accept the token.
+      PopLastStates(1);
+      return {true, true};
+    }
     int last_accept_pos = i - 1;
     for (int pos = i; pos < token_len; ++pos) {
       if (!Advance(token[pos])) {

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -608,8 +608,7 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
           continue;
         }
         auto last_element = base_grammar_->GetGrammarExpr(sequence_expr.end()[-1]);
-        if (last_element.type == GrammarExprType::kRuleRef && last_element[0] == rule_id &&
-            i != rule_id) {
+        if (last_element.type == GrammarExprType::kRuleRef && last_element[0] == rule_id) {
           return -1;
         }
 

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -73,7 +73,7 @@ basic_number_3 ::= ("" | ("." basic_number_2)) (=(basic_number_6))
 basic_number_4 ::= ("" | ([+\-])) (=(basic_number_5))
 basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
 basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-root_prop_1_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string_2 root_prop_1_1)) (=([ \n\t]* "]"))
+root_prop_1_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string_2 root_prop_1_1))
 basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*)) (=(basic_number_3 basic_number_6))
 """
 
@@ -97,7 +97,7 @@ def test_structural_tag():
     triggers = ["<function=f", "<function=g"]
 
     grammar = xgr.Grammar.from_structural_tag(tags, triggers)
-
+    print(grammar)
     assert str(grammar) == expected_grammar_test_structural_tag
 
     accepted_inputs = [

--- a/tests/python/test_grammar_parser.py
+++ b/tests/python/test_grammar_parser.py
@@ -486,7 +486,7 @@ rule5 ::= "" | "g" rule5 "h"
     expected = r"""root ::= (("a" rule1 "b" rule3 rule5 rule2))
 rule1 ::= (("b")) (=("b" rule3 rule5 rule2))
 rule2 ::= (("c"))
-rule3 ::= (("") | ("d" rule3)) (=(rule5 rule2))
+rule3 ::= (("") | ("d" rule3))
 rule4 ::= (("") | ("e" rule4 "f")) (=("f"))
 rule5 ::= (("") | ("g" rule5 "h"))
 """

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -238,7 +238,6 @@ def test_serialize_compiled_grammar():
 
     recovered_obj = json.loads(serialized)
     adaptive_token_mask_cache = recovered_obj.pop("adaptive_token_mask_cache", None)
-    print(recovered_obj)
     assert recovered_obj == expected_json
     AdaptiveTokenMaskCache.model_validate(adaptive_token_mask_cache)
 

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -49,11 +49,11 @@ def test_serialize_grammar():
     grammar = construct_grammar()
     serialized = grammar.serialize_json()
     expected_json = {
-        "rules": [["rule1", 4, 9], ["root_rule", 8, -1]],
-        "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 28, 31],
+        "rules": [["rule1", 4, -1], ["root_rule", 8, -1]],
+        "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 28],
         "grammar_expr_indptr": [
             # fmt: off
-            3,0,1,3,1,48,57,4,1,0,5,2,1,2,6,2,0,3,4,1,0,0,1,97,5,2,5,6,6,1,7,5,1,6
+            3,0,1,3,1,48,57,4,1,0,5,2,1,2,6,2,0,3,4,1,0,0,1,97,5,2,5,6,6,1,7
             # fmt: on
         ],
         "root_rule_id": 1,
@@ -195,11 +195,11 @@ def test_serialize_compiled_grammar():
 
     expected_json = {
         "grammar": {
-            "rules": [["rule1", 4, 6], ["root_rule", 10, -1]],
-            "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 27, 30, 34],
+            "rules": [["rule1", 4, -1], ["root_rule", 8, -1]],
+            "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 28],
             "grammar_expr_indptr": [
                 # fmt: off
-                3,0,1,3,1,48,57,4,1,0,5,2,1,2,6,2,0,3,0,1,97,5,1,5,4,1,0,0,1,97,5,2,7,8,6,1,9
+                3,0,1,3,1,48,57,4,1,0,5,2,1,2,6,2,0,3,4,1,0,0,1,97,5,2,5,6,6,1,7
                 # fmt: on
             ],
             "root_rule_id": 1,
@@ -238,6 +238,7 @@ def test_serialize_compiled_grammar():
 
     recovered_obj = json.loads(serialized)
     adaptive_token_mask_cache = recovered_obj.pop("adaptive_token_mask_cache", None)
+    print(recovered_obj)
     assert recovered_obj == expected_json
     AdaptiveTokenMaskCache.model_validate(adaptive_token_mask_cache)
 


### PR DESCRIPTION
This PR fixes the issue reported in #400. This is caused by improper lookahead, and the lack of handling empty lookahead assertion.


Signed-off-by: Yuchuan <blemiade_qinchuan@sjtu.edu.cn>