### PR TITLE
[Fix] Fix the print function of AdaptiveTokenMask.

### DIFF
--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -84,7 +84,7 @@ std::string AdaptiveTokenMask::Print(const TokenizerInfo& tokenizer_info) const 
       if (uncertain_indices_set.count(i)) {
         continue;
       }
-      if (accepted_bitset[i]) {
+      if (accepted_bitset[sorted_decoded_vocab[i].first]) {
         accepted_indices.push_back(i);
       } else {
         rejected_indices.push_back(i);


### PR DESCRIPTION
This PR fixes the print function of adaptivetokenmask when its type is `kDynamicBitset`. This is helpful for development.

Signed-off-by: Yuchuan <blemiade_qinchuan@sjtu.edu.cn>