### PR TITLE
[Feature] Support more types of schemas in structural tags.

### DIFF
--- a/cpp/nanobind/python_methods.cc
+++ b/cpp/nanobind/python_methods.cc
@@ -122,14 +122,14 @@ std::vector<int32_t> GetAllowEmptyRuleIds(const CompiledGrammar& compiled_gramma
 }
 
 Grammar Grammar_FromStructuralTag(
-    const std::vector<std::tuple<std::string, std::string, std::string>>& tags,
+    const std::vector<std::tuple<std::string, std::string, std::string, std::string>>& tags,
     const std::vector<std::string>& triggers
 ) {
   std::vector<StructuralTagItem> tags_objects;
   tags_objects.reserve(tags.size());
   for (const auto& tag : tags) {
     tags_objects.emplace_back(
-        StructuralTagItem{std::get<0>(tag), std::get<1>(tag), std::get<2>(tag)}
+        StructuralTagItem{std::get<0>(tag), std::get<1>(tag), std::get<2>(tag), std::get<3>(tag)}
     );
   }
   return Grammar::FromStructuralTag(tags_objects, triggers);
@@ -137,14 +137,14 @@ Grammar Grammar_FromStructuralTag(
 
 CompiledGrammar GrammarCompiler_CompileStructuralTag(
     GrammarCompiler& compiler,
-    const std::vector<std::tuple<std::string, std::string, std::string>>& tags,
+    const std::vector<std::tuple<std::string, std::string, std::string, std::string>>& tags,
     const std::vector<std::string>& triggers
 ) {
   std::vector<StructuralTagItem> tags_objects;
   tags_objects.reserve(tags.size());
   for (const auto& tag : tags) {
     tags_objects.emplace_back(
-        StructuralTagItem{std::get<0>(tag), std::get<1>(tag), std::get<2>(tag)}
+        StructuralTagItem{std::get<0>(tag), std::get<1>(tag), std::get<2>(tag), std::get<3>(tag)}
     );
   }
   return compiler.CompileStructuralTag(tags_objects, triggers);

--- a/cpp/nanobind/python_methods.h
+++ b/cpp/nanobind/python_methods.h
@@ -50,13 +50,13 @@ void Kernels_ApplyTokenBitmaskInplaceCPU(
 std::vector<int32_t> GetAllowEmptyRuleIds(const CompiledGrammar& compiled_grammar);
 
 Grammar Grammar_FromStructuralTag(
-    const std::vector<std::tuple<std::string, std::string, std::string>>& tags,
+    const std::vector<std::tuple<std::string, std::string, std::string, std::string>>& tags,
     const std::vector<std::string>& triggers
 );
 
 CompiledGrammar GrammarCompiler_CompileStructuralTag(
     GrammarCompiler& compiler,
-    const std::vector<std::tuple<std::string, std::string, std::string>>& tags,
+    const std::vector<std::tuple<std::string, std::string, std::string, std::string>>& tags,
     const std::vector<std::string>& triggers
 );
 

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -33,8 +33,16 @@ Grammar StructuralTagToGrammar(
   std::vector<Grammar> schema_grammars;
   schema_grammars.reserve(tags.size());
   for (const auto& tag : tags) {
-    auto schema_grammar = Grammar::FromJSONSchema(tag.schema, true);
-    schema_grammars.push_back(schema_grammar);
+    XGRAMMAR_LOG(INFO) << tag.type;
+    if (tag.type == "jsonschema") {
+      schema_grammars.push_back(Grammar::FromJSONSchema(tag.schema, true));
+    } else if (tag.type == "regex") {
+      schema_grammars.push_back(Grammar::FromRegex(tag.schema));
+    } else if (tag.type == "ebnf") {
+      schema_grammars.push_back(Grammar::FromEBNF(tag.schema));
+    } else {
+      XGRAMMAR_LOG(FATAL) << "Unexpected tag type: " << tag.type;
+    }
   }
 
   std::vector<std::vector<std::pair<StructuralTagItem, Grammar>>> tag_groups(triggers.size());

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -23,9 +23,10 @@ struct StructuralTagItem {
   std::string begin;
   std::string schema;
   std::string end;
+  std::string type;
 
   bool operator==(const StructuralTagItem& other) const {
-    return begin == other.begin && schema == other.schema && end == other.end;
+    return begin == other.begin && schema == other.schema && end == other.end && type == other.type;
   }
 };
 

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -223,7 +223,10 @@ class GrammarCompiler(XGRObject):
         compiled_grammar : CompiledGrammar
             The compiled grammar.
         """
-        tags_tuple = [(tag.begin, _convert_schema_to_str(tag.schema_), tag.end) for tag in tags]
+        tags_tuple = [
+            (tag.begin, _convert_schema_to_str(tag.schema_), tag.end, tag.schema_type)
+            for tag in tags
+        ]
         return CompiledGrammar._create_from_handle(
             self._handle.compile_structural_tag(tags_tuple, triggers)
         )

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -17,6 +17,10 @@ class StructuralTagItem(BaseModel):
     """The schema."""
     end: str
     """The end tag."""
+    schema_type: str = "jsonschema"
+    """The type of the schema. json schema, ebnf grammar, or regex.
+       Valid values: "jsonschema", "ebnf", "regex".
+    """
 
 
 def _convert_schema_to_str(schema: Union[str, Type[BaseModel], Dict[str, Any]]) -> str:
@@ -265,7 +269,10 @@ class Grammar(XGRObject):
         >>> triggers = ["<function="]
         >>> grammar = Grammar.from_structural_tag(tags, triggers)
         """
-        tags_tuple = [(tag.begin, _convert_schema_to_str(tag.schema_), tag.end) for tag in tags]
+        tags_tuple = [
+            (tag.begin, _convert_schema_to_str(tag.schema_), tag.end, tag.schema_type)
+            for tag in tags
+        ]
         return Grammar._create_from_handle(_core.Grammar.from_structural_tag(tags_tuple, triggers))
 
     @staticmethod


### PR DESCRIPTION
As the request of #393 ,  `StructuralTagItem` only allows jsonschemas as its constraint at present. This PR provides more types of schemas of `StructualTagItem`. In general, there are 3 types provided by the PR: `jsonschema`(default), `ebnf`, `regex`. When constructing a `StructuralTagItem`, assign its `schema_type` to determine the type of the schema, like this:
```
class Schema(BaseModel):
    arg3: float
    arg4: List[str]

tags = [
    xgr.StructuralTagItem(
        begin="<function=f>", schema="[0-9]{6,10}", end="</function>", schema_type="regex"
    ),
    xgr.StructuralTagItem(
        begin="<function=g>",
        schema="root ::= [a-z]{1,100}",
        end="</function>",
        schema_type="ebnf",
    ),
    xgr.StructuralTagItem(
        begin="<function=f>", schema=json.dumps(Schema.model_json_schema()), end="</function>"
    ),
]
```


Signed-off-by: Yuchuan <blemiade_qinchuan@sjtu.edu.cn>