### PR TITLE
[Feature] Support compiling the grammar JIT.

### DIFF
--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1060,12 +1060,7 @@ GrammarCompiler::GrammarCompiler(
 )
     : pimpl_(std::make_shared<Impl>(
           tokenizer_info, max_threads, cache_enabled, max_memory_bytes, is_jit
-      )) {
-  if (max_memory_bytes < -1) {
-    XGRAMMAR_LOG(FATAL) << "Invalid max_memory_bytes: " << max_memory_bytes << ". "
-                        << "It should be -1 (unlimited) or a non-negative integer.";
-  }
-}
+      )) {}
 
 CompiledGrammar GrammarCompiler::CompileJSONSchema(
     const std::string& schema,

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -656,7 +656,7 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
       latest_states_with_masks;
 
   auto add_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
-    auto grammar_matcher = GrammarMatcherForTokenMaskCache(grammar_, state, false);
+    auto grammar_matcher = GrammarMatcherForTokenMaskCache(grammar_, state, {}, false);
     auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask(
         tokenizer_info_.GetVocabSize(),
         tokenizer_info_.GetSortedDecodedVocab(),

--- a/cpp/grammar_matcher_for_cache.h
+++ b/cpp/grammar_matcher_for_cache.h
@@ -1,0 +1,101 @@
+/*!
+ *  Copyright (c) 2025 by Contributors
+ * \file xgrammar/grammar_matcher_for_cache.h
+ * \brief The header for the grammar matcher for the cache.
+ */
+
+#ifndef XGRAMMAR_GRAMMAR_MATCHER_FOR_CACHE_H_
+#define XGRAMMAR_GRAMMAR_MATCHER_FOR_CACHE_H_
+
+#include <bitset>
+
+#include "compiled_grammar_impl.h"
+#include "earley_parser.h"
+
+namespace xgrammar {
+/*! \brief The concrete implementation of GrammarMatcherNode. */
+class GrammarMatcherForTokenMaskCache : public EarleyParser {
+ public:
+  GrammarMatcherForTokenMaskCache(
+      const Grammar& grammar,
+      const ParserState& init_state,
+      const std::unordered_map<int32_t, DynamicBitset>&
+          tag_dispatch_rule_id_to_second_slicing_bitset,
+      const bool& need_expand = true
+  )
+      : EarleyParser(grammar, init_state),
+        init_rule_id(init_state.rule_id),
+        initial_state(init_state),
+        tag_dispatch_rule_id_to_second_slicing_bitset(tag_dispatch_rule_id_to_second_slicing_bitset
+        ) {}
+  /*!
+   * \brief Get the adaptive token mask for the given ParserState.
+   * \param is_root_rule Whether to consider the parent rule. If false, there will be
+   * no uncertain tokens. Useful for the root rule.
+   */
+  AdaptiveTokenMask GetAdaptiveTokenMask(
+      size_t vocab_size,
+      const std::vector<std::pair<int32_t, std::string>>& sorted_decoded_vocab,
+      const std::vector<int32_t>& subtree_nodes_range,
+      bool is_root_rule
+  );
+
+  /*!
+   * \brief Get the token mask for the given ParserState.
+   * \param sorted_decoded_vocab The sorted decoded vocabulary.
+   * \param first_char_mask The first character mask.
+   * \param is_root_rule Whether to consider the parent rule. If false, there will be
+   * no uncertain tokens. Useful for the root rule.
+   * \returns True if the rejected indices are filled as usual, False otherwise.
+   * It's used to determine which construction function will be used.
+   */
+  bool GetTokenMaskWithFirstCharacterCheck(
+      const std::vector<std::pair<int32_t, std::string>>& sorted_decoded_vocab,
+      const std::bitset<256>& first_char_mask,
+      const std::vector<int>& subtree_nodes_range,
+      bool is_root_rule
+  );
+
+ private:
+  /*! \brief Check if a token can pass the lookahead assertion. */
+  std::pair</*acceptable*/ bool, /*can reach end*/ bool> IsTokenPassLookaheadAssertion(
+      const std::string& token, const std::vector<bool>& can_reach_end_stack
+  );
+
+  /*!
+   * \brief Check if speculative calculation will be applied.
+   * \return first: whether speculative calculation is applicable.
+   * \return second: part of the first character mask,
+   * which can be used in speculative calculation.
+   */
+  std::pair<bool, std::bitset<256>> GetSpeculativeCalculation(
+      const std::vector<std::pair<int32_t, std::string>>& sorted_decoded_vocab
+  );
+
+  // The id of the initial rule.
+  int32_t init_rule_id;
+
+  // The initial state of the parser.
+  ParserState initial_state;
+
+  /*!
+   \brief This is a mapping from TagDispatch rule id to the bitset used for second slicing.
+   \note If a rule is a TagDispatch rule, then there will be an AC automaton for its triggers.
+    Which means that it can accept a lot of tokens. However, it will be slow to check a lot of
+    tokens. The DynamicBitset here is used to do a second slicing: if a token's substr(1, n - 1)
+    can be accepted by the start state of the AC automaton, then it will be True in the bitset.
+    When we check a token, we first check if its first character can transit to the start state.
+    If yes, then we check if it is in the bitset. If yes, then we accept it directly.
+  */
+  const std::unordered_map<int32_t, DynamicBitset>& tag_dispatch_rule_id_to_second_slicing_bitset;
+
+  // Temporary data for GetAdaptiveTokenMask.
+  std::vector<int32_t> tmp_accepted_indices_;
+  std::vector<int32_t> tmp_rejected_indices_;
+  std::vector<int32_t> tmp_uncertain_indices_;
+  std::vector<bool> tmp_can_reach_end_stack_;
+  std::vector<bool> tmp_can_reach_end_prefix_or_stack_;
+};
+}  // namespace xgrammar
+
+#endif  // XGRAMMAR_GRAMMAR_MATCHER_FOR_CACHE_H_

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -217,7 +217,7 @@ NB_MODULE(xgrammar_bindings, m) {
       .def_static("deserialize_json", &CompiledGrammar_DeserializeJSON);
 
   auto pyGrammarCompiler = nb::class_<GrammarCompiler>(m, "GrammarCompiler");
-  pyGrammarCompiler.def(nb::init<const TokenizerInfo&, int, bool, int64_t>())
+  pyGrammarCompiler.def(nb::init<const TokenizerInfo&, int, bool, int64_t, bool>())
       .def(
           "compile_json_schema",
           &GrammarCompiler::CompileJSONSchema,

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -63,6 +63,7 @@ class GrammarCompiler {
    * \param max_threads The maximum number of threads to use for compiling grammars.
    * \param cache_enabled Whether to enable the cache.
    * \param max_memory_bytes The maximum memory usage in bytes.
+   * \param is_jit Whether to enable Just-In-Time (JIT) compilation.
    */
   GrammarCompiler(
       const TokenizerInfo& tokenizer_info,

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -68,7 +68,8 @@ class GrammarCompiler {
       const TokenizerInfo& tokenizer_info,
       int max_threads = 8,
       bool cache_enabled = true,
-      int64_t max_memory_bytes = -1  // unlimited
+      int64_t max_memory_bytes = -1,  // unlimited
+      bool is_jit = false
   );
 
   /*! \brief Get the compiled grammar for a JSON schema string. */

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -132,6 +132,13 @@ class GrammarCompiler(XGRObject):
 
         is_jit : bool, default: False
             Whether to enable Just-In-Time (JIT) compilation.
+
+            When enabled, token masks are computed on-demand during matching
+            rather than being fully precomputed at compile time. This usually
+            makes the initial compilation step faster, at the cost of some
+            additional work the first time a particular token mask is needed
+            during matching. It can also reduce overall memory usage, since
+            token masks that are never used do not need to be stored.
         """
         if not isinstance(tokenizer_info, TokenizerInfo):
             raise ValueError(

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -129,6 +129,9 @@ class GrammarCompiler(XGRObject):
         cache_limit_bytes : int, default: -1
             The maximum memory usage for the cache in the specified unit.
             Note that the actual memory usage may slightly exceed this value.
+
+        is_jit : bool, default: False
+            Whether to enable Just-In-Time (JIT) compilation.
         """
         if not isinstance(tokenizer_info, TokenizerInfo):
             raise ValueError(

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -111,6 +111,7 @@ class GrammarCompiler(XGRObject):
         max_threads: int = 8,
         cache_enabled: bool = True,
         cache_limit_bytes: int = -1,
+        is_jit: bool = False,
     ):
         """Construct the compiler.
 
@@ -137,7 +138,7 @@ class GrammarCompiler(XGRObject):
 
         self._init_handle(
             _core.GrammarCompiler(
-                tokenizer_info._handle, max_threads, cache_enabled, cache_limit_bytes
+                tokenizer_info._handle, max_threads, cache_enabled, cache_limit_bytes, is_jit
             )
         )
 

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -111,7 +111,9 @@ def _ebnf_to_grammar_no_normalization(ebnf_string: str, root_rule_name: str = "r
     )
 
 
-def _get_matcher_from_grammar(grammar: Union[Grammar, str], **kwargs) -> GrammarMatcher:
+def _get_matcher_from_grammar(
+    grammar: Union[Grammar, str], is_jit: bool = False, **kwargs
+) -> GrammarMatcher:
     """Create a GrammarMatcher from a grammar. The tokenizer info will be set to an empty
     TokenizerInfo. The result matcher can only accept strings, and cannot accept tokens.
 
@@ -127,7 +129,7 @@ def _get_matcher_from_grammar(grammar: Union[Grammar, str], **kwargs) -> Grammar
         The created grammar matcher.
     """
     tokenizer_info = TokenizerInfo([])
-    grammar_compiler = GrammarCompiler(tokenizer_info, cache_enabled=False)
+    grammar_compiler = GrammarCompiler(tokenizer_info, cache_enabled=False, is_jit=is_jit)
     compiled_grammar = grammar_compiler.compile_grammar(grammar)
     return GrammarMatcher(compiled_grammar, terminate_without_stop_token=True, **kwargs)
 
@@ -299,7 +301,10 @@ def bitmask_to_bool_mask(bit_mask: torch.Tensor, vocab_size: Optional[int] = Non
 
 
 def _get_matcher_from_grammar_and_tokenizer_info(
-    grammar: Union[Grammar, str], tokenizer_info: Optional[TokenizerInfo] = None, **kwargs
+    grammar: Union[Grammar, str],
+    tokenizer_info: Optional[TokenizerInfo] = None,
+    is_jit: bool = False,
+    **kwargs,
 ) -> GrammarMatcher:
     """Create a GrammarMatcher from a grammar and tokenizer info.
 
@@ -321,7 +326,7 @@ def _get_matcher_from_grammar_and_tokenizer_info(
     """
     if tokenizer_info is None:
         tokenizer_info = TokenizerInfo([])
-    grammar_compiler = GrammarCompiler(tokenizer_info, cache_enabled=False)
+    grammar_compiler = GrammarCompiler(tokenizer_info, cache_enabled=False, is_jit=is_jit)
     compiled_grammar = grammar_compiler.compile_grammar(grammar)
     return GrammarMatcher(compiled_grammar, **kwargs)
 

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -329,5 +329,16 @@ def test_grammar_compiler_cache_limited():
     assert grammar_compiler.get_cache_size_bytes() == 0
 
 
+@pytest.mark.hf_token_required
+def test_grammar_compiler_jit():
+    grammar = xgr.Grammar.builtin_json_grammar()
+    tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-chat-hf")
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo.from_huggingface(tokenizer), is_jit=True)
+    time_start = time.monotonic_ns()
+    _ = compiler.compile_grammar(grammar)
+    time_end = time.monotonic_ns()
+    print(f"JIT compilation time: {(time_end - time_start) / 1e6} ms")
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_grammar_matcher_json.py
+++ b/tests/python/test_grammar_matcher_json.py
@@ -323,5 +323,64 @@ def test_fill_next_token_bitmask(
     assert len(rejected_token_ids) == expected_rejected_sizes[-1]
 
 
+@pytest.mark.hf_token_required
+@pytest.mark.parametrize(
+    "tokenizer_path, input_str, expected_rejected_sizes",
+    tokenizer_path__input_str__expected_rejected_sizes,
+)
+def test_fill_next_token_bitmask_with_jit(
+    tokenizer_path: str, input_str: str, expected_rejected_sizes: List[int]
+):
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_fast=True, trust_remote_code=True)
+    tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
+    compiler = xgr.GrammarCompiler(tokenizer_info, is_jit=True)
+
+    time_start = time.monotonic_ns()
+    matcher = xgr.GrammarMatcher(compiler.compile_builtin_json_grammar())
+    time_end = time.monotonic_ns()
+    print(f"Time to init GrammarMatcher: {(time_end - time_start) / 1e3} us")
+
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    logits_gpu = torch.zeros(1, tokenizer_info.vocab_size, dtype=torch.float32, device=device)
+
+    input_bytes = input_str.encode("utf-8")
+
+    for i, c in enumerate(input_bytes):
+        # 1. fill_next_token_bitmask
+        time_start = time.monotonic_ns()
+        assert matcher.fill_next_token_bitmask(token_bitmask)
+        time_end = time.monotonic_ns()
+        print(f"Time to fill_next_token_bitmask: {(time_end - time_start) / 1e3} us")
+
+        # 2. Correctness verification
+        rejected_token_ids = _get_masked_tokens_from_bitmask(
+            token_bitmask, tokenizer_info.vocab_size
+        )
+        assert len(rejected_token_ids) == expected_rejected_sizes[i]
+
+        # 3. apply_token_bitmask_inplace
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        time_start = time.monotonic_ns()
+        xgr.apply_token_bitmask_inplace(logits_gpu, token_bitmask.to(device))
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        time_end = time.monotonic_ns()
+        print(f"Time to apply_token_bitmask_inplace: {(time_end - time_start) / 1e3} us")
+
+        # 4. accept_string
+        print("Accepting char:", bytes([c]))
+        time_start = time.monotonic_ns()
+        assert matcher.accept_string(bytes([c]))
+        time_end = time.monotonic_ns()
+        print(f"Time to accept_token: {(time_end - time_start) / 1e3} us")
+
+    # 5. Final correctness verification
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected_token_ids = _get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size)
+    assert len(rejected_token_ids) == expected_rejected_sizes[-1]
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
This PR enables the xgrammar to compile the grammar just in time. To determine whether a grammar should be compiled just in time, you can use the code as follows:
```
grammar = xgr.Grammar.builtin_json_grammar() 
tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-chat-hf")
compiler = xgr.GrammarCompiler(xgr.TokenizerInfo.from_huggingface(tokenizer), is_jit=True)
compiled_grammar = compiler.compile_grammar(grammar)
... # the same codes with the pre-computed compiled_grammar.
```

Signed-off-by: Yuchuan <blemiade_qinchuan@sjtu.edu.cn>