### PR TITLE
[Refac] Refactor part of the simplification functions of fsms.

### DIFF
--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -1101,7 +1101,10 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon() const {
   return result.RebuildWithMapping(new_to_old, cnt);
 }
 
-FSMWithStartEnd FSMWithStartEnd::MergeEquivalentSuccessors() const {
+FSMWithStartEnd FSMWithStartEnd::MergeEquivalentSuccessors(int max_node_size) const {
+  if (NumStates() > max_node_size) {
+    return *this;
+  }
   bool changed = true;
   FSMWithStartEnd result = Copy();
   UnionFindSet<int> union_find_set;

--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -1018,8 +1018,11 @@ bool FSMWithStartEnd::IsDFA() {
   return true;
 }
 
-FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon() const {
+FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
   if (is_dfa_) {
+    return *this;
+  }
+  if (NumStates() > max_num_states) {
     return *this;
   }
   UnionFindSet<int> union_find_set;

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -743,7 +743,7 @@ class FSMWithStartEnd : public FSMWithStartEndBase<FSM> {
    * 2) they are not pointed to by other edges, then we can merge them.
    * \example n0 --(c)--> n1, n0 --(c)--> n2, then we can merge n1 and n2.
    */
-  FSMWithStartEnd MergeEquivalentSuccessors(int max_result_num_states = 2e4) const;
+  FSMWithStartEnd MergeEquivalentSuccessors(int max_result_num_states = 2e6) const;
 
   /*!
    * \brief Transform the FSM to a DFA.

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -743,7 +743,7 @@ class FSMWithStartEnd : public FSMWithStartEndBase<FSM> {
    * 2) they are not pointed to by other edges, then we can merge them.
    * \example n0 --(c)--> n1, n0 --(c)--> n2, then we can merge n1 and n2.
    */
-  FSMWithStartEnd MergeEquivalentSuccessors(int max_result_num_states = 2e6) const;
+  FSMWithStartEnd MergeEquivalentSuccessors(int max_result_num_states = 1e5) const;
 
   /*!
    * \brief Transform the FSM to a DFA.

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -735,7 +735,7 @@ class FSMWithStartEnd : public FSMWithStartEndBase<FSM> {
    * \details If a --\epsilon--> b, and either 1) b doesn't have any other inward edges, or
    * 2) a doesn't have any other outward edges, we can merge a and b.
    */
-  FSMWithStartEnd SimplifyEpsilon() const;
+  FSMWithStartEnd SimplifyEpsilon(int max_num_states = 1e8) const;
 
   /*!
    * \brief Merge equivalent states in the FSM.
@@ -743,7 +743,7 @@ class FSMWithStartEnd : public FSMWithStartEndBase<FSM> {
    * 2) they are not pointed to by other edges, then we can merge them.
    * \example n0 --(c)--> n1, n0 --(c)--> n2, then we can merge n1 and n2.
    */
-  FSMWithStartEnd MergeEquivalentSuccessors(int max_result_num_states = 1e5) const;
+  FSMWithStartEnd MergeEquivalentSuccessors(int max_num_states = 1e5) const;
 
   /*!
    * \brief Transform the FSM to a DFA.

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -743,21 +743,21 @@ class FSMWithStartEnd : public FSMWithStartEndBase<FSM> {
    * 2) they are not pointed to by other edges, then we can merge them.
    * \example n0 --(c)--> n1, n0 --(c)--> n2, then we can merge n1 and n2.
    */
-  FSMWithStartEnd MergeEquivalentSuccessors() const;
+  FSMWithStartEnd MergeEquivalentSuccessors(int max_result_num_states = 2e4) const;
 
   /*!
    * \brief Transform the FSM to a DFA.
    * \param max_result_num_states The maximum number of states in the DFA.
    * \return The DFA.
    */
-  Result<FSMWithStartEnd> ToDFA(int max_result_num_states = 1e6) const;
+  Result<FSMWithStartEnd> ToDFA(int max_result_num_states = 1e4) const;
 
   /*!
    * \brief Minimize the DFA.
    * \param max_result_num_states The maximum number of states in the DFA.
    * \return The minimized DFA.
    */
-  Result<FSMWithStartEnd> MinimizeDFA(int max_result_num_states = 1e6) const;
+  Result<FSMWithStartEnd> MinimizeDFA(int max_result_num_states = 1e4) const;
 };
 
 /*!

--- a/cpp/support/union_find_set.h
+++ b/cpp/support/union_find_set.h
@@ -76,6 +76,8 @@ class UnionFindSet {
     element_to_parent_and_size_[root_a].second += element_to_parent_and_size_[root_b].second;
   }
 
+  int Count(const T& element) const { return element_to_parent_and_size_.count(element); }
+
   std::vector<std::vector<T>> GetAllSets() {
     std::vector<std::vector<T>> result;
     std::unordered_map<T, size_t> root_to_set;

--- a/tests/cpp/test_fsm.cc
+++ b/tests/cpp/test_fsm.cc
@@ -248,6 +248,7 @@ TEST(XGrammarFSMTest, FunctionTest) {
   fsm_wse = fsm_wse.MergeEquivalentSuccessors();
   EXPECT_TRUE(fsm_wse.AcceptString(test_str));
   test_str = "abcd";
+  XGRAMMAR_LOG(INFO) << fsm_wse;
   EXPECT_FALSE(fsm_wse.AcceptString(test_str));
   EXPECT_EQ(fsm_wse.GetFsm().NumStates(), 4);
   std::cout << "--------- Function Test8 -----------" << std::endl;

--- a/tests/cpp/test_fsm.cc
+++ b/tests/cpp/test_fsm.cc
@@ -248,7 +248,6 @@ TEST(XGrammarFSMTest, FunctionTest) {
   fsm_wse = fsm_wse.MergeEquivalentSuccessors();
   EXPECT_TRUE(fsm_wse.AcceptString(test_str));
   test_str = "abcd";
-  XGRAMMAR_LOG(INFO) << fsm_wse;
   EXPECT_FALSE(fsm_wse.AcceptString(test_str));
   EXPECT_EQ(fsm_wse.GetFsm().NumStates(), 4);
   std::cout << "--------- Function Test8 -----------" << std::endl;


### PR DESCRIPTION
This PR refactors part of the fsm functions. In general, this PR:
- Refactor the `MergeEquivalentSuccessors` to speed up.
- Set proper limitations of number of states for the fsm functions.


Signed-off-by: Yuchuan <blemiade_qinchuan@sjtu.edu.cn>