### PR TITLE
[Fix] Fix regex converter when the property's pattern is empty.

### DIFF
--- a/cpp/regex_converter.cc
+++ b/cpp/regex_converter.cc
@@ -23,10 +23,12 @@ namespace xgrammar {
 class RegexConverter {
  public:
   explicit RegexConverter(const std::string& regex) : regex_(regex) {
-    regex_codepoints_ = ParseUTF8(regex_.c_str(), false);
-    if (regex_codepoints_[0] == kInvalidUTF8) {
-      XGRAMMAR_LOG(FATAL) << "The regex is not a valid UTF-8 string.";
-      XGRAMMAR_UNREACHABLE();
+    if (!regex.empty()) {
+      regex_codepoints_ = ParseUTF8(regex_.c_str(), false);
+      if (regex_codepoints_[0] == kInvalidUTF8) {
+        XGRAMMAR_LOG(FATAL) << "The regex is not a valid UTF-8 string.";
+        XGRAMMAR_UNREACHABLE();
+      }
     }
     regex_codepoints_.push_back(0);  // Add a null terminator
   }

--- a/tests/python/test_grammar_matcher_json_schema.py
+++ b/tests/python/test_grammar_matcher_json_schema.py
@@ -538,5 +538,21 @@ def test_regression_accept_invalid_token():
         matcher.fill_next_token_bitmask(token_bitmask, i)
 
 
+def test_regression_empty_property_key_regex():
+    schema = {
+        "type": "object",
+        "properties": {
+            "_links": {
+                "type": "object",
+                "patternProperties": {
+                    "": {"type": "object", "properties": {"href": {"type": "string"}}}
+                },
+            }
+        },
+    }
+    _ = xgr.Grammar.from_json_schema(schema)
+    assert _ is not None
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_regex_converter.py
+++ b/tests/python/test_regex_converter.py
@@ -469,13 +469,16 @@ def test_mask_generation(tokenizer_path: str, regex: str, instance: str):
     assert matcher.is_terminated()
 
 
-def test_empty():
-    regex = ""
-    grammar_str = _regex_to_ebnf(regex)
-    expected_grammar = 'root ::= ""\n'
-    assert grammar_str == expected_grammar
-    assert _is_grammar_accept_string(grammar_str, "")
-    assert not _is_grammar_accept_string(grammar_str, "a")
+empty_regex = ["", "^$", "(())", "()", "^", "$", "()|()"]
+
+
+@pytest.mark.parametrize("regex", empty_regex)
+def test_empty(regex: str):
+    grammar = xgr.Grammar.from_regex(regex)
+    expected_grammar = 'root ::= ("")\n'
+    assert str(grammar) == expected_grammar
+    assert _is_grammar_accept_string(grammar, "")
+    assert not _is_grammar_accept_string(grammar, "a")
 
 
 if __name__ == "__main__":

--- a/tests/python/test_regex_converter.py
+++ b/tests/python/test_regex_converter.py
@@ -469,5 +469,14 @@ def test_mask_generation(tokenizer_path: str, regex: str, instance: str):
     assert matcher.is_terminated()
 
 
+def test_empty():
+    regex = ""
+    grammar_str = _regex_to_ebnf(regex)
+    expected_grammar = 'root ::= ""\n'
+    assert grammar_str == expected_grammar
+    assert _is_grammar_accept_string(grammar_str, "")
+    assert not _is_grammar_accept_string(grammar_str, "a")
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
Currently, when we enconter such schema:
```
{
  "type": "object",
  "properties": {
    "_links": {
      "type": "object",
      "patternProperties": {
        "": {
          "type": "object",
          "properties": {
            "href": {
              "type": "string"
            }
          }
        }
      }
    }
  }
}
```
This will lead to a segmentation fault. It is caused by the lack of handling with the empty regex when `RegexConverter` is constructed. This PR fixed it.


Signed-off-by: Yuchuan <blemiade_qinchuan@sjtu.edu.cn>
