### PR TITLE
[Minor] Modify the built-in grammar to make it more accurate.

### DIFF
--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -86,7 +86,7 @@ value_non_str ::= (
     "true" |
     "false" |
     "null"
-) (= [ \n\t,}\]])
+) (= [ \n\t]* member_suffix_suffix)
 members_and_embrace ::= ("\"" characters_and_colon [ \n\t]* members_suffix | "}") (= [ \n\t,}\]])
 members_suffix ::= (
     value_non_str [ \n\t]* member_suffix_suffix |


### PR DESCRIPTION
In the built-in JSON grammar, the rule `value_non_str` should have a exact lookahead, while the current lookahead assertion is not exact. According to #401, in this case, a few tokens may be incorrectly accepted by the grammar. This PR fixed it.


Signed-off-by: Yuchuan <blemiade_qinchuan@sjtu.edu.cn>