### PR TITLE
[Fix] Fix the failure to build the website.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ intersphinx_mapping = {
     "torch": ("https://pytorch.org/docs/stable", None),
 }
 
-autodoc_mock_imports = ["torch"]
+autodoc_mock_imports = ["torch", "safetensors"]
 autodoc_default_options = {
     "members": True,
     "undoc-members": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,6 @@ intersphinx_mapping = {
     "torch": ("https://pytorch.org/docs/stable", None),
 }
 
-autodoc_mock_imports = ["torch", "safetensors"]
 autodoc_default_options = {
     "members": True,
     "undoc-members": True,


### PR DESCRIPTION
This PR fixes the problem some pages of the website are totally blank. This is caused by `torch` is in `autodoc_mock_imports`, and `safetensors` needs to check `torch.version` in its file. This PR fixes the problem by removing the `autodoc_mock_imports`.