### PR TITLE
Support Structural Tag

### DIFF
--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -152,7 +152,10 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
       return std::make_pair(true, false);  // The element is scanable, but not completable.
     }
     default: {
-      return std::make_pair(false, false);
+      // TODO: check with linzhang
+      XGRAMMAR_LOG(FATAL) << "The element type is not supported! The type is: "
+                          << int(element_expr.type);
+      XGRAMMAR_UNREACHABLE();
     }
   }
 }
@@ -178,6 +181,7 @@ void EarleyParser::Scan(const ParserState& state, const uint8_t ch) {
       default: {
         XGRAMMAR_LOG(FATAL) << "The element type is not supported! The type is: "
                             << int(element_expr.type);
+        XGRAMMAR_UNREACHABLE();
       }
     }
   } else {
@@ -269,19 +273,9 @@ void EarleyParser::PushStateAndExpand(const ParserState& state) {
   tmp_states_visited_in_queue_.Clear();
   tmp_accept_stop_token_ = false;
   tmp_states_to_be_added_.clear();
-  if (state.IsInvalid()) {
-    ExpandAndEnqueueUnexpandedState(ParserState{
-        grammar_->GetRootRuleId(),
-        ParserState::kUnexpandedRuleStartSequenceId,
-        0,
-        ParserState::kNoPrevInputPos,
-        0
-    });
-  } else {
-    // If the rule can't be expanded, we need to add it to the queue.
-    if (!ExpandAndEnqueueUnexpandedState(state)) {
-      Enqueue(state);
-    }
+  // If the rule can't be expanded, we need to add it to the queue.
+  if (!ExpandAndEnqueueUnexpandedState(state)) {
+    Enqueue(state);
   }
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
   while (!tmp_process_state_queue_.empty()) {

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -152,7 +152,6 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
       return std::make_pair(true, false);  // The element is scanable, but not completable.
     }
     default: {
-      // TODO: check with linzhang
       XGRAMMAR_LOG(FATAL) << "The element type is not supported! The type is: "
                           << int(element_expr.type);
       XGRAMMAR_UNREACHABLE();

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -111,10 +111,7 @@ struct ParserState {
   }
 
   friend std::ostream& operator<<(std::ostream& os, const ParserState& state) {
-    os << "ParserState(rule_id=" << state.rule_id << ", sequence_id=" << state.sequence_id
-       << ", element_id=" << state.element_id << ", rule_start_pos=" << state.rule_start_pos
-       << ", sub_element_id=" << state.sub_element_id << ", repeat_count=" << state.repeat_count
-       << ")";
+    os << state.ToString();
     return os;
   }
 
@@ -456,10 +453,12 @@ class EarleyParser {
 
   std::string PrintStates() const {
     std::string result;
-    result += "There are " + std::to_string(scanable_state_history_.size()) + " scanable states:\n";
+    result += "There are " + std::to_string(scanable_state_history_.size()) +
+              " steps in history. Last step: [\n";
     for (const auto& state : scanable_state_history_[scanable_state_history_.size() - 1]) {
-      result += state.ToString() + "\n";
+      result += state.ToString() + ", \n";
     }
+    result += "]";
     return result;
   }
 };

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -125,21 +125,9 @@ XGRAMMAR_MEMBER_ARRAY(FSMEdge, &FSMEdge::min, &FSMEdge::max, &FSMEdge::target);
 
 }  // namespace xgrammar
 
-namespace std {
-
-/*!
- * \brief Hash function for FSMEdge.
- */
-template <>
-struct hash<xgrammar::FSMEdge> {
-  size_t operator()(const xgrammar::FSMEdge& edge) const {
-    return std::hash<std::tuple<int16_t, int16_t, int32_t>>()(
-        std::make_tuple(edge.min, edge.max, edge.target)
-    );
-  }
-};
-
-}  // namespace std
+XGRAMMAR_HASH_BY_MEMBERS(
+    xgrammar::FSMEdge, &xgrammar::FSMEdge::min, &xgrammar::FSMEdge::max, &xgrammar::FSMEdge::target
+);
 
 namespace xgrammar {
 

--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -65,11 +65,10 @@ Grammar Grammar::FromRegex(const std::string& regex, bool print_converted_ebnf) 
   return FromEBNF(ebnf_string);
 }
 
-Grammar Grammar::FromStructuralTag(
-    const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
+std::variant<Grammar, StructuralTagError> Grammar::FromStructuralTag(
+    const std::string& structural_tag_json
 ) {
-  Grammar grammar = StructuralTagToGrammar(tags, triggers);
-  return grammar;
+  return StructuralTagToGrammar(structural_tag_json).ToVariant();
 }
 
 // Optimized json grammar for the speed of the grammar matcher

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -202,7 +202,7 @@ class GrammarBuilder {
     );
   }
 
-  int32_t AddRepeat(const int32_t ref_rule_id, int32_t min_repeat_count, int32_t max_repeat_count) {
+  int32_t AddRepeat(int32_t ref_rule_id, int32_t min_repeat_count, int32_t max_repeat_count) {
     std::vector<int32_t> data({ref_rule_id, min_repeat_count, max_repeat_count});
     return AddGrammarExpr({GrammarExprType::kRepeat, data.data(), static_cast<int32_t>(data.size())}
     );
@@ -248,6 +248,10 @@ class GrammarBuilder {
    * \sa GrammarBuilder::UpdateRuleBody
    */
   int32_t AddEmptyRule(const std::string& name) { return AddRule({name, -1}); }
+
+  int32_t AddEmptyRuleWithHint(const std::string& name_hint) {
+    return AddRule({GetNewRuleName(name_hint), -1});
+  }
 
   /*!
    * \brief Update the rule body of the given rule, specified by rule id. Can be used to set the

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -995,82 +995,6 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
   }
 };
 
-class StructuralTagGrammarCreatorImpl : public GrammarMutator {
- public:
-  Grammar Apply(
-      const std::vector<std::string>& triggers,
-      const std::vector<std::vector<std::pair<StructuralTagItem, Grammar>>>& tag_groups
-  ) {
-    XGRAMMAR_CHECK(triggers.size() == tag_groups.size())
-        << "Number of triggers must match number of tag groups";
-
-    InitGrammar();
-    InitBuilder();
-
-    auto root_rule_id = builder_->AddEmptyRule("root");
-
-    Grammar::Impl::TagDispatch tag_dispatch{
-        /* tag_rule_pairs = */ {},
-        /* stop_eos = */ true,
-        /* stop_str = */ {},
-        /* loop_after_dispatch = */ true,
-    };
-    tag_dispatch.tag_rule_pairs.reserve(triggers.size());
-
-    // Create rules for each trigger group
-    for (size_t i = 0; i < triggers.size(); i++) {
-      // Skip empty trigger groups
-      if (tag_groups[i].empty()) {
-        continue;
-      }
-
-      auto rule_name = "trigger_rule_" + std::to_string(i);
-      auto rule_id = builder_->AddEmptyRule(rule_name);
-
-      // Create choices for each tag in this trigger group
-      std::vector<int32_t> choices;
-      choices.reserve(tag_groups[i].size());
-      for (const auto& [tag, schema_grammar] : tag_groups[i]) {
-        // Create sequence: start_suffix + schema + end
-        std::vector<int32_t> seq_elements;
-        seq_elements.reserve(3);
-
-        // Add begin suffix (everything after trigger)
-        XGRAMMAR_DCHECK(tag.begin.size() >= triggers[i].size())
-            << "Tag begin must be at least as long as trigger";
-        if (tag.begin.size() > triggers[i].size()) {
-          seq_elements.push_back(builder_->AddByteString(tag.begin.substr(triggers[i].size())));
-        }
-
-        // Create and visit schema grammar for this tag
-        auto schema_rule_id = SubGrammarAdderImpl().ApplyWithBuilder(builder_, schema_grammar);
-        seq_elements.push_back(builder_->AddRuleRef(schema_rule_id));
-
-        // Add end string
-        if (!tag.end.empty()) {
-          seq_elements.push_back(builder_->AddByteString(tag.end));
-        }
-
-        choices.push_back(builder_->AddSequence(seq_elements));
-      }
-
-      builder_->UpdateRuleBody(rule_id, builder_->AddChoices(choices));
-      tag_dispatch.tag_rule_pairs.emplace_back(triggers[i], rule_id);
-    }
-
-    // Create root TagDispatch rule
-    auto tag_dispatch_id = builder_->AddTagDispatch(tag_dispatch);
-    builder_->UpdateRuleBody(root_rule_id, tag_dispatch_id);
-    return builder_->Get(root_rule_id);
-  }
-
-  // Avoid hiding the original Apply(const Grammar&)
-  Grammar Apply(const Grammar& grammar) final {
-    XGRAMMAR_LOG(FATAL) << "Should not be called";
-    XGRAMMAR_UNREACHABLE();
-  }
-};
-
 class GrammarFSMBuilderImpl {
  public:
   const static uint32_t kMax1ByteUnicode = 0x7F;
@@ -1712,13 +1636,6 @@ Grammar GrammarConcatFunctor::Apply(const std::vector<Grammar>& grammars) {
 
 std::vector<int32_t> AllowEmptyRuleAnalyzer::Apply(const Grammar& grammar) {
   return AllowEmptyRuleAnalyzerImpl().Apply(grammar);
-}
-
-Grammar StructuralTagGrammarCreator::Apply(
-    const std::vector<std::string>& triggers,
-    const std::vector<std::vector<std::pair<StructuralTagItem, Grammar>>>& tag_groups
-) {
-  return StructuralTagGrammarCreatorImpl().Apply(triggers, tag_groups);
 }
 
 Grammar RuleInliner::Apply(const Grammar& grammar) { return RuleInlinerImpl().Apply(grammar); }

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -282,23 +282,6 @@ class AllowEmptyRuleAnalyzer {
 };
 
 /*!
- * \brief Create a grammar that recognizes structural tags based on their triggers. See
- * StructuralTagToGrammar() for more details.
- *
- * \param triggers The trigger strings that identify each tag group
- * \param tag_groups The tags and their schema grammars, grouped by trigger. tag_groups[i][j] is the
- * j-th tag that matches triggers[i], and its corresponding schema grammar.
- * \return A grammar that matches all the tagged patterns.
- */
-class StructuralTagGrammarCreator {
- public:
-  static Grammar Apply(
-      const std::vector<std::string>& triggers,
-      const std::vector<std::vector<std::pair<StructuralTagItem, Grammar>>>& tag_groups
-  );
-};
-
-/*!
  * \brief Normalize the structure of the grammar. It will ensure each rule is a choices of
  * sequences of elements, or a tag dispatch. The expanded context will be a sequence of elements.
  */

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -228,8 +228,8 @@ class JSONSchemaConverter {
       std::optional<int> indent,
       std::optional<std::pair<std::string, std::string>> separators,
       bool strict_mode,
-      std::optional<int> max_whitespace_cnt = std::nullopt,
-      JSONFormat json_format = JSONFormat::kJSON
+      std::optional<int> max_whitespace_cnt,
+      JSONFormat json_format
   );
 
   /*! \brief The root method. Convert the JSON schema to EBNF grammar string. */

--- a/cpp/nanobind/python_methods.cc
+++ b/cpp/nanobind/python_methods.cc
@@ -15,6 +15,7 @@
 
 #include "../grammar_impl.h"
 #include "../support/logging.h"
+#include "../support/utils.h"
 #include "xgrammar/exception.h"
 
 namespace xgrammar {
@@ -121,45 +122,18 @@ std::vector<int32_t> GetAllowEmptyRuleIds(const CompiledGrammar& compiled_gramma
   return compiled_grammar.GetGrammar()->allow_empty_rule_ids;
 }
 
-Grammar Grammar_FromStructuralTag(
-    const std::vector<std::tuple<std::string, std::string, std::string>>& tags,
-    const std::vector<std::string>& triggers
-) {
-  std::vector<StructuralTagItem> tags_objects;
-  tags_objects.reserve(tags.size());
-  for (const auto& tag : tags) {
-    tags_objects.emplace_back(
-        StructuralTagItem{std::get<0>(tag), std::get<1>(tag), std::get<2>(tag)}
-    );
+Grammar Grammar_FromStructuralTag(const std::string& structural_tag_json) {
+  auto result = Grammar::FromStructuralTag(structural_tag_json);
+  if (std::holds_alternative<StructuralTagError>(result)) {
+    ThrowVariantError(std::get<StructuralTagError>(result));
   }
-  return Grammar::FromStructuralTag(tags_objects, triggers);
-}
-
-CompiledGrammar GrammarCompiler_CompileStructuralTag(
-    GrammarCompiler& compiler,
-    const std::vector<std::tuple<std::string, std::string, std::string>>& tags,
-    const std::vector<std::string>& triggers
-) {
-  std::vector<StructuralTagItem> tags_objects;
-  tags_objects.reserve(tags.size());
-  for (const auto& tag : tags) {
-    tags_objects.emplace_back(
-        StructuralTagItem{std::get<0>(tag), std::get<1>(tag), std::get<2>(tag)}
-    );
-  }
-  return compiler.CompileStructuralTag(tags_objects, triggers);
-}
-
-[[noreturn]]
-static void ThrowSerializationError(const SerializationError& error) {
-  std::visit([](const auto& e) { throw e; }, error);
-  XGRAMMAR_UNREACHABLE();
+  return std::get<Grammar>(result);
 }
 
 Grammar Grammar_DeserializeJSON(const std::string& json_string) {
   auto result = Grammar::DeserializeJSON(json_string);
   if (std::holds_alternative<SerializationError>(result)) {
-    ThrowSerializationError(std::get<SerializationError>(result));
+    ThrowVariantError(std::get<SerializationError>(result));
   }
   return std::get<Grammar>(result);
 }
@@ -167,7 +141,7 @@ Grammar Grammar_DeserializeJSON(const std::string& json_string) {
 TokenizerInfo TokenizerInfo_DeserializeJSON(const std::string& json_string) {
   auto result = TokenizerInfo::DeserializeJSON(json_string);
   if (std::holds_alternative<SerializationError>(result)) {
-    ThrowSerializationError(std::get<SerializationError>(result));
+    ThrowVariantError(std::get<SerializationError>(result));
   }
   return std::get<TokenizerInfo>(result);
 }
@@ -177,7 +151,7 @@ CompiledGrammar CompiledGrammar_DeserializeJSON(
 ) {
   auto result = CompiledGrammar::DeserializeJSON(json_string, tokenizer);
   if (std::holds_alternative<SerializationError>(result)) {
-    ThrowSerializationError(std::get<SerializationError>(result));
+    ThrowVariantError(std::get<SerializationError>(result));
   }
   return std::get<CompiledGrammar>(result);
 }

--- a/cpp/nanobind/python_methods.h
+++ b/cpp/nanobind/python_methods.h
@@ -49,16 +49,7 @@ void Kernels_ApplyTokenBitmaskInplaceCPU(
 
 std::vector<int32_t> GetAllowEmptyRuleIds(const CompiledGrammar& compiled_grammar);
 
-Grammar Grammar_FromStructuralTag(
-    const std::vector<std::tuple<std::string, std::string, std::string>>& tags,
-    const std::vector<std::string>& triggers
-);
-
-CompiledGrammar GrammarCompiler_CompileStructuralTag(
-    GrammarCompiler& compiler,
-    const std::vector<std::tuple<std::string, std::string, std::string>>& tags,
-    const std::vector<std::string>& triggers
-);
+Grammar Grammar_FromStructuralTag(const std::string& structural_tag_json);
 
 Grammar Grammar_DeserializeJSON(const std::string& json_string);
 

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -162,13 +162,14 @@ Result<Format, ISTError> StructuralTagParser::ParseFormat(const picojson::value&
 Result<ConstStringFormat, ISTError> StructuralTagParser::ParseConstStringFormat(
     const picojson::object& obj
 ) {
-  // text is required.
-  auto text_it = obj.find("text");
-  if (text_it == obj.end() || !text_it->second.is<std::string>() ||
-      text_it->second.get<std::string>().empty()) {
-    return ResultErr<ISTError>("ConstString format must have a text field with a non-empty string");
+  // value is required.
+  auto value_it = obj.find("value");
+  if (value_it == obj.end() || !value_it->second.is<std::string>() ||
+      value_it->second.get<std::string>().empty()) {
+    return ResultErr<ISTError>("ConstString format must have a value field with a non-empty string"
+    );
   }
-  return ResultOk<ConstStringFormat>(text_it->second.get<std::string>());
+  return ResultOk<ConstStringFormat>(value_it->second.get<std::string>());
 }
 
 Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
@@ -656,7 +657,7 @@ Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format)
 }
 
 Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const ConstStringFormat& format) {
-  auto expr = grammar_builder_.AddByteString(format.text);
+  auto expr = grammar_builder_.AddByteString(format.value);
   auto sequence_expr = grammar_builder_.AddSequence({expr});
   auto choices_expr = grammar_builder_.AddChoices({sequence_expr});
   return ResultOk(grammar_builder_.AddRuleWithHint("const_string", choices_expr));

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -4,66 +4,989 @@
  */
 #include "structural_tag.h"
 
+#include <picojson.h>
+#include <xgrammar/exception.h>
+
 #include <algorithm>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 
 #include "grammar_functor.h"
+#include "grammar_impl.h"
 #include "support/logging.h"
+#include "support/recursion_guard.h"
+#include "support/utils.h"
 
 namespace xgrammar {
 
-Grammar StructuralTagToGrammar(
-    const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
+// Short alias for the error type.
+using ISTError = InvalidStructuralTagError;
+
+/************** StructuralTag Parser **************/
+
+class StructuralTagParser {
+ public:
+  static Result<StructuralTag, StructuralTagError> FromJSON(const std::string& json);
+
+ private:
+  Result<StructuralTag, ISTError> ParseStructuralTag(const picojson::value& value);
+
+  /*!
+   * \brief Parse a Format object from a JSON value.
+   * \param value The JSON value to parse.
+   * \return A Format object if the JSON is valid, otherwise an error message in std::runtime_error.
+   * \note The "type" field is checked in this function, and not checked in the Parse*Format
+   * functions.
+   */
+  Result<Format, ISTError> ParseFormat(const picojson::value& value);
+  Result<ConstStringFormat, ISTError> ParseConstStringFormat(const picojson::object& value);
+  Result<JSONSchemaFormat, ISTError> ParseJSONSchemaFormat(const picojson::object& value);
+  Result<AnyTextFormat, ISTError> ParseAnyTextFormat(const picojson::object& value);
+  Result<SequenceFormat, ISTError> ParseSequenceFormat(const picojson::object& value);
+  Result<OrFormat, ISTError> ParseOrFormat(const picojson::object& value);
+  /*! \brief ParseTagFormat with extra check for object and the type field. */
+  Result<TagFormat, ISTError> ParseTagFormat(const picojson::value& value);
+  Result<TagFormat, ISTError> ParseTagFormat(const picojson::object& value);
+  Result<TriggeredTagsFormat, ISTError> ParseTriggeredTagsFormat(const picojson::object& value);
+  Result<TagsWithSeparatorFormat, ISTError> ParseTagsWithSeparatorFormat(
+      const picojson::object& value
+  );
+
+  int parse_format_recursion_depth_ = 0;
+};
+
+Result<StructuralTag, StructuralTagError> StructuralTagParser::FromJSON(const std::string& json) {
+  picojson::value value;
+  std::string err = picojson::parse(value, json);
+  if (!err.empty()) {
+    return ResultErr<InvalidJSONError>("Failed to parse JSON: " + err);
+  }
+  return Result<StructuralTag, StructuralTagError>::Convert(
+      StructuralTagParser().ParseStructuralTag(value)
+  );
+}
+
+Result<StructuralTag, ISTError> StructuralTagParser::ParseStructuralTag(const picojson::value& value
 ) {
-  // Step 1: handle triggers. Triggers should not be mutually inclusive
-  std::vector<std::string> sorted_triggers(triggers.begin(), triggers.end());
-  std::sort(sorted_triggers.begin(), sorted_triggers.end());
-  for (int i = 0; i < static_cast<int>(sorted_triggers.size()) - 1; ++i) {
-    XGRAMMAR_CHECK(
-        sorted_triggers[i + 1].size() < sorted_triggers[i].size() ||
-        std::string_view(sorted_triggers[i + 1]).substr(0, sorted_triggers[i].size()) !=
-            sorted_triggers[i]
-    ) << "Triggers should not be mutually inclusive, but "
-      << sorted_triggers[i] << " is a prefix of " << sorted_triggers[i + 1];
+  if (!value.is<picojson::object>()) {
+    return ResultErr<ISTError>("Structural tag must be an object");
+  }
+  const auto& obj = value.get<picojson::object>();
+  // The type field is optional but must be "structural_tag" if present.
+  if (obj.find("type") != obj.end()) {
+    if (!obj["type"].is<std::string>() || obj["type"].get<std::string>() != "structural_tag") {
+      return ResultErr<ISTError>("Structural tag's type must be a string \"structural_tag\"");
+    }
+  }
+  // The format field is required.
+  if (obj.find("format") == obj.end()) {
+    return ResultErr<ISTError>("Structural tag must have a format field");
+  }
+  auto format = ParseFormat(obj["format"]);
+  if (format.IsErr()) {
+    return ResultErr<ISTError>(std::move(format).UnwrapErr());
+  }
+  return ResultOk<StructuralTag>(std::move(format).Unwrap());
+}
+
+Result<Format, ISTError> StructuralTagParser::ParseFormat(const picojson::value& value) {
+  RecursionGuard guard(&parse_format_recursion_depth_);
+  if (!value.is<picojson::object>()) {
+    return ResultErr<ISTError>("Format must be an object");
+  }
+  const auto& obj = value.get<picojson::object>();
+  // If type is present, use it to determine the format.
+  if (obj.find("type") != obj.end()) {
+    if (!obj["type"].is<std::string>()) {
+      return ResultErr<ISTError>("Format's type must be a string");
+    }
+    auto type = obj["type"].get<std::string>();
+    if (type == "const_string") {
+      return Result<Format, ISTError>::Convert(ParseConstStringFormat(obj));
+    } else if (type == "json_schema") {
+      return Result<Format, ISTError>::Convert(ParseJSONSchemaFormat(obj));
+    } else if (type == "any_text") {
+      return Result<Format, ISTError>::Convert(ParseAnyTextFormat(obj));
+    } else if (type == "sequence") {
+      return Result<Format, ISTError>::Convert(ParseSequenceFormat(obj));
+    } else if (type == "or") {
+      return Result<Format, ISTError>::Convert(ParseOrFormat(obj));
+    } else if (type == "tag") {
+      return Result<Format, ISTError>::Convert(ParseTagFormat(obj));
+    } else if (type == "triggered_tags") {
+      return Result<Format, ISTError>::Convert(ParseTriggeredTagsFormat(obj));
+    } else if (type == "tags_with_separator") {
+      return Result<Format, ISTError>::Convert(ParseTagsWithSeparatorFormat(obj));
+    } else {
+      return ResultErr<ISTError>("Format type not recognized: " + type);
+    }
   }
 
-  // Step 2: For each tag, find the trigger that is a prefix of the tag.begin
-  // Convert the schema to grammar at the same time
-  std::vector<Grammar> schema_grammars;
-  schema_grammars.reserve(tags.size());
-  for (const auto& tag : tags) {
-    auto schema_grammar = Grammar::FromJSONSchema(tag.schema, true);
-    schema_grammars.push_back(schema_grammar);
+  // If type is not present, try every format type one by one. Tag is prioritized.
+  auto tag_format = ParseTagFormat(obj);
+  if (!tag_format.IsErr()) {
+    return ResultOk<Format>(std::move(tag_format).Unwrap());
+  }
+  auto const_string_format = ParseConstStringFormat(obj);
+  if (!const_string_format.IsErr()) {
+    return ResultOk<Format>(std::move(const_string_format).Unwrap());
+  }
+  auto json_schema_format = ParseJSONSchemaFormat(obj);
+  if (!json_schema_format.IsErr()) {
+    return ResultOk<Format>(std::move(json_schema_format).Unwrap());
+  }
+  auto any_text_format = ParseAnyTextFormat(obj);
+  if (!any_text_format.IsErr()) {
+    return ResultOk<Format>(std::move(any_text_format).Unwrap());
+  }
+  auto sequence_format = ParseSequenceFormat(obj);
+  if (!sequence_format.IsErr()) {
+    return ResultOk<Format>(std::move(sequence_format).Unwrap());
+  }
+  auto or_format = ParseOrFormat(obj);
+  if (!or_format.IsErr()) {
+    return ResultOk<Format>(std::move(or_format).Unwrap());
+  }
+  auto triggered_tags_format = ParseTriggeredTagsFormat(obj);
+  if (!triggered_tags_format.IsErr()) {
+    return ResultOk<Format>(std::move(triggered_tags_format).Unwrap());
+  }
+  auto tags_with_separator_format = ParseTagsWithSeparatorFormat(obj);
+  if (!tags_with_separator_format.IsErr()) {
+    return ResultOk<Format>(std::move(tags_with_separator_format).Unwrap());
+  }
+  return ResultErr<ISTError>("Invalid format: " + value.serialize(false));
+}
+
+Result<ConstStringFormat, ISTError> StructuralTagParser::ParseConstStringFormat(
+    const picojson::object& obj
+) {
+  // text is required.
+  auto text_it = obj.find("text");
+  if (text_it == obj.end() || !text_it->second.is<std::string>() ||
+      text_it->second.get<std::string>().empty()) {
+    return ResultErr<ISTError>("ConstString format must have a text field with a non-empty string");
+  }
+  return ResultOk<ConstStringFormat>(text_it->second.get<std::string>());
+}
+
+Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
+    const picojson::object& obj
+) {
+  // json_schema is required.
+  auto json_schema_it = obj.find("json_schema");
+  if (json_schema_it == obj.end() ||
+      !(json_schema_it->second.is<picojson::object>() || json_schema_it->second.is<bool>())) {
+    return ResultErr<ISTError>(
+        "JSON schema format must have a json_schema field with a object or boolean value"
+    );
+  }
+  // here introduces a serialization/deserialization overhead; try to avoid it in the future.
+  return ResultOk<JSONSchemaFormat>(json_schema_it->second.serialize(false));
+}
+
+Result<AnyTextFormat, ISTError> StructuralTagParser::ParseAnyTextFormat(const picojson::object& obj
+) {
+  // obj should not have any fields other than "type"
+  if (obj.size() > 1 || (obj.size() == 1 && obj.begin()->first != "type")) {
+    return ResultErr<ISTError>("Any text format should not have any fields other than type");
+  }
+  return ResultOk<AnyTextFormat>();
+}
+
+Result<SequenceFormat, ISTError> StructuralTagParser::ParseSequenceFormat(
+    const picojson::object& obj
+) {
+  // elements is required.
+  auto elements_it = obj.find("elements");
+  if (elements_it == obj.end() || !elements_it->second.is<picojson::array>()) {
+    return ResultErr<ISTError>("Sequence format must have an elements field with an array");
+  }
+  const auto& elements_array = elements_it->second.get<picojson::array>();
+  std::vector<Format> elements;
+  elements.reserve(elements_array.size());
+  for (const auto& element : elements_array) {
+    auto format = ParseFormat(element);
+    if (format.IsErr()) {
+      return ResultErr<ISTError>(std::move(format).UnwrapErr());
+    }
+    elements.push_back(std::move(format).Unwrap());
+  }
+  if (elements.size() == 0) {
+    return ResultErr<ISTError>("Sequence format must have at least one element");
+  }
+  return ResultOk<SequenceFormat>(std::move(elements));
+}
+
+Result<OrFormat, ISTError> StructuralTagParser::ParseOrFormat(const picojson::object& obj) {
+  // elements is required.
+  auto elements_it = obj.find("elements");
+  if (elements_it == obj.end() || !elements_it->second.is<picojson::array>()) {
+    return ResultErr<ISTError>("Or format must have an elements field with an array");
+  }
+  const auto& elements_array = elements_it->second.get<picojson::array>();
+  std::vector<Format> elements;
+  elements.reserve(elements_array.size());
+  for (const auto& element : elements_array) {
+    auto format = ParseFormat(element);
+    if (format.IsErr()) {
+      return ResultErr<ISTError>(std::move(format).UnwrapErr());
+    }
+    elements.push_back(std::move(format).Unwrap());
+  }
+  if (elements.size() == 0) {
+    return ResultErr<ISTError>("Or format must have at least one element");
+  }
+  return ResultOk<OrFormat>(std::move(elements));
+}
+
+Result<TagFormat, ISTError> StructuralTagParser::ParseTagFormat(const picojson::value& value) {
+  if (!value.is<picojson::object>()) {
+    return ResultErr<ISTError>("Tag format must be an object");
+  }
+  const auto& obj = value.get<picojson::object>();
+  if (obj.find("type") != obj.end() &&
+      (!obj["type"].is<std::string>() || obj["type"].get<std::string>() != "tag")) {
+    return ResultErr<ISTError>("Tag format's type must be a string \"tag\"");
+  }
+  return ParseTagFormat(obj);
+}
+
+Result<TagFormat, ISTError> StructuralTagParser::ParseTagFormat(const picojson::object& obj) {
+  // begin is required.
+  auto begin_it = obj.find("begin");
+  if (begin_it == obj.end() || !begin_it->second.is<std::string>()) {
+    return ResultErr<ISTError>("Tag format's begin field must be a string");
+  }
+  // content is required.
+  auto content_it = obj.find("content");
+  if (content_it == obj.end()) {
+    return ResultErr<ISTError>("Tag format must have a content field");
+  }
+  auto content = ParseFormat(content_it->second);
+  if (content.IsErr()) {
+    return ResultErr<ISTError>(std::move(content).UnwrapErr());
+  }
+  // end is required.
+  auto end_it = obj.find("end");
+  if (end_it == obj.end() || !end_it->second.is<std::string>()) {
+    return ResultErr<ISTError>("Tag format's end field must be a string");
+  }
+  return ResultOk<TagFormat>(
+      begin_it->second.get<std::string>(),
+      std::make_shared<Format>(std::move(content).Unwrap()),
+      end_it->second.get<std::string>()
+  );
+}
+
+Result<TriggeredTagsFormat, ISTError> StructuralTagParser::ParseTriggeredTagsFormat(
+    const picojson::object& obj
+) {
+  // triggers is required.
+  auto triggers_it = obj.find("triggers");
+  if (triggers_it == obj.end() || !triggers_it->second.is<picojson::array>()) {
+    return ResultErr<ISTError>("Triggered tags format must have a triggers field with an array");
+  }
+  const auto& triggers_array = triggers_it->second.get<picojson::array>();
+  std::vector<std::string> triggers;
+  triggers.reserve(triggers_array.size());
+  for (const auto& trigger : triggers_array) {
+    if (!trigger.is<std::string>() || trigger.get<std::string>().empty()) {
+      return ResultErr<ISTError>("Triggered tags format's triggers must be non-empty strings");
+    }
+    triggers.push_back(trigger.get<std::string>());
+  }
+  if (triggers.size() == 0) {
+    return ResultErr<ISTError>("Triggered tags format's triggers must be non-empty");
+  }
+  // tags is required.
+  auto tags_it = obj.find("tags");
+  if (tags_it == obj.end() || !tags_it->second.is<picojson::array>()) {
+    return ResultErr<ISTError>("Triggered tags format must have a tags field with an array");
+  }
+  const auto& tags_array = tags_it->second.get<picojson::array>();
+  std::vector<TagFormat> tags;
+  tags.reserve(tags_array.size());
+  for (const auto& tag : tags_array) {
+    auto tag_format = ParseTagFormat(tag);
+    if (tag_format.IsErr()) {
+      return ResultErr<ISTError>(std::move(tag_format).UnwrapErr());
+    }
+    tags.push_back(std::move(tag_format).Unwrap());
+  }
+  if (tags.size() == 0) {
+    return ResultErr<ISTError>("Triggered tags format's tags must be non-empty");
+  }
+  // at_least_one is optional.
+  bool at_least_one = false;
+  auto at_least_one_it = obj.find("at_least_one");
+  if (at_least_one_it != obj.end()) {
+    if (!at_least_one_it->second.is<bool>()) {
+      return ResultErr<ISTError>("at_least_one must be a boolean");
+    }
+    at_least_one = at_least_one_it->second.get<bool>();
+  }
+  // stop_after_first is optional.
+  bool stop_after_first = false;
+  auto stop_after_first_it = obj.find("stop_after_first");
+  if (stop_after_first_it != obj.end()) {
+    if (!stop_after_first_it->second.is<bool>()) {
+      return ResultErr<ISTError>("stop_after_first must be a boolean");
+    }
+    stop_after_first = stop_after_first_it->second.get<bool>();
+  }
+  return ResultOk<TriggeredTagsFormat>(
+      std::move(triggers), std::move(tags), at_least_one, stop_after_first
+  );
+}
+
+Result<TagsWithSeparatorFormat, ISTError> StructuralTagParser::ParseTagsWithSeparatorFormat(
+    const picojson::object& obj
+) {
+  // tags is required.
+  auto tags_it = obj.find("tags");
+  if (tags_it == obj.end() || !tags_it->second.is<picojson::array>()) {
+    return ResultErr<ISTError>("Tags with separator format must have a tags field with an array");
+  }
+  const auto& tags_array = tags_it->second.get<picojson::array>();
+  std::vector<TagFormat> tags;
+  tags.reserve(tags_array.size());
+  for (const auto& tag : tags_array) {
+    auto tag_format = ParseTagFormat(tag);
+    if (tag_format.IsErr()) {
+      return ResultErr<ISTError>(std::move(tag_format).UnwrapErr());
+    }
+    tags.push_back(std::move(tag_format).Unwrap());
+  }
+  if (tags.size() == 0) {
+    return ResultErr<ISTError>("Tags with separator format's tags must be non-empty");
+  }
+  // separator is required.
+  auto separator_it = obj.find("separator");
+  if (separator_it == obj.end() || !separator_it->second.is<std::string>() ||
+      separator_it->second.get<std::string>().empty()) {
+    return ResultErr<ISTError>(
+        "Tags with separator format's separator field must be a non-empty string"
+    );
+  }
+  // at_least_one is optional.
+  bool at_least_one = false;
+  auto at_least_one_it = obj.find("at_least_one");
+  if (at_least_one_it != obj.end()) {
+    if (!at_least_one_it->second.is<bool>()) {
+      return ResultErr<ISTError>("at_least_one must be a boolean");
+    }
+    at_least_one = at_least_one_it->second.get<bool>();
+  }
+  // stop_after_first is optional.
+  bool stop_after_first = false;
+  auto stop_after_first_it = obj.find("stop_after_first");
+  if (stop_after_first_it != obj.end()) {
+    if (!stop_after_first_it->second.is<bool>()) {
+      return ResultErr<ISTError>("stop_after_first must be a boolean");
+    }
+    stop_after_first = stop_after_first_it->second.get<bool>();
+  }
+  return ResultOk<TagsWithSeparatorFormat>(
+      std::move(tags), separator_it->second.get<std::string>(), at_least_one, stop_after_first
+  );
+}
+
+/************** StructuralTag Analyzer **************/
+
+/*!
+ * \brief Analyze a StructuralTag and extract useful information for conversion to Grammar.
+ */
+class StructuralTagAnalyzer {
+ public:
+  static std::optional<ISTError> Analyze(StructuralTag* structural_tag);
+
+ private:
+  /*! \brief A variant that can hold the pointer of any Format types. */
+  using FormatPtrVariant = std::variant<
+      ConstStringFormat*,
+      JSONSchemaFormat*,
+      AnyTextFormat*,
+      SequenceFormat*,
+      OrFormat*,
+      TagFormat*,
+      TriggeredTagsFormat*,
+      TagsWithSeparatorFormat*>;
+
+  // Call this if we have a pointer to a Format.
+  std::optional<ISTError> Visit(Format* format);
+  // Call this if we have a pointer to a variant of Format.
+  std::optional<ISTError> Visit(FormatPtrVariant format);
+
+  // The following is dispatched from Visit. Don't call them directly because they don't handle
+  // stack logics.
+  std::optional<ISTError> VisitSub(ConstStringFormat* format);
+  std::optional<ISTError> VisitSub(JSONSchemaFormat* format);
+  std::optional<ISTError> VisitSub(AnyTextFormat* format);
+  std::optional<ISTError> VisitSub(SequenceFormat* format);
+  std::optional<ISTError> VisitSub(OrFormat* format);
+  std::optional<ISTError> VisitSub(TagFormat* format);
+  std::optional<ISTError> VisitSub(TriggeredTagsFormat* format);
+  std::optional<ISTError> VisitSub(TagsWithSeparatorFormat* format);
+
+  std::optional<std::string> DetectEndString();
+  bool IsUnlimited(const Format& format);
+
+  int visit_format_recursion_depth_ = 0;
+  std::vector<FormatPtrVariant> stack_;
+};
+
+std::optional<ISTError> StructuralTagAnalyzer::Analyze(StructuralTag* structural_tag) {
+  return StructuralTagAnalyzer().Visit(&structural_tag->format);
+}
+
+std::optional<std::string> StructuralTagAnalyzer::DetectEndString() {
+  for (int i = static_cast<int>(stack_.size()) - 1; i >= 0; --i) {
+    auto& format = stack_[i];
+
+    if (std::holds_alternative<TagFormat*>(format)) {
+      auto* tag = std::get<TagFormat*>(format);
+      return tag->end;
+    }
+  }
+  return std::nullopt;
+}
+
+bool StructuralTagAnalyzer::IsUnlimited(const Format& format) {
+  return std::visit(
+      [&](auto&& arg) -> bool {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, AnyTextFormat>) {
+          return true;
+        } else if constexpr (std::is_same_v<T, TriggeredTagsFormat>) {
+          return true;
+        } else if constexpr (std::is_same_v<T, TagsWithSeparatorFormat>) {
+          return true;
+        } else if constexpr (std::is_same_v<T, SequenceFormat>) {
+          return arg.is_unlimited_;
+        } else if constexpr (std::is_same_v<T, OrFormat>) {
+          return arg.is_unlimited_;
+        } else {
+          return false;
+        }
+      },
+      format
+  );
+}
+
+std::optional<ISTError> StructuralTagAnalyzer::Visit(Format* format) {
+  FormatPtrVariant format_ptr_variant =
+      std::visit([&](auto&& arg) -> FormatPtrVariant { return &arg; }, *format);
+  return Visit(format_ptr_variant);
+}
+
+std::optional<ISTError> StructuralTagAnalyzer::Visit(FormatPtrVariant format) {
+  RecursionGuard guard(&visit_format_recursion_depth_);
+
+  // Push format to stack
+  stack_.push_back(format);
+
+  // Dispatch to the corresponding visit function
+  auto result =
+      std::visit([&](auto&& arg) -> std::optional<ISTError> { return VisitSub(arg); }, format);
+
+  // Pop format from stack
+  stack_.pop_back();
+
+  return result;
+}
+
+std::optional<ISTError> StructuralTagAnalyzer::VisitSub(ConstStringFormat* format) {
+  return std::nullopt;
+}
+
+std::optional<ISTError> StructuralTagAnalyzer::VisitSub(JSONSchemaFormat* format) {
+  return std::nullopt;
+}
+
+std::optional<ISTError> StructuralTagAnalyzer::VisitSub(AnyTextFormat* format) {
+  format->detected_end_str_ = DetectEndString();
+  return std::nullopt;
+}
+
+std::optional<ISTError> StructuralTagAnalyzer::VisitSub(SequenceFormat* format) {
+  for (size_t i = 0; i < format->elements.size() - 1; ++i) {
+    auto& element = format->elements[i];
+    auto err = Visit(&element);
+    if (err.has_value()) {
+      return err;
+    }
+    if (IsUnlimited(element)) {
+      return ISTError(
+          "Only the last element in a sequence can be unlimited, but the " + std::to_string(i) +
+          "th element of sequence format is unlimited"
+      );
+    }
   }
 
-  std::vector<std::vector<std::pair<StructuralTagItem, Grammar>>> tag_groups(triggers.size());
-  for (int it_tag = 0; it_tag < static_cast<int>(tags.size()); ++it_tag) {
-    const auto& tag = tags[it_tag];
-    bool found = false;
-    for (int it_trigger = 0; it_trigger < static_cast<int>(sorted_triggers.size()); ++it_trigger) {
-      const auto& trigger = sorted_triggers[it_trigger];
-      if (trigger.size() <= tag.begin.size() &&
-          std::string_view(tag.begin).substr(0, trigger.size()) == trigger) {
-        tag_groups[it_trigger].push_back(std::make_pair(tag, schema_grammars[it_tag]));
-        found = true;
-        break;
+  auto& element = format->elements.back();
+  auto err = Visit(&element);
+  if (err.has_value()) {
+    return err;
+  }
+  format->is_unlimited_ = IsUnlimited(element);
+  return std::nullopt;
+}
+
+std::optional<ISTError> StructuralTagAnalyzer::VisitSub(OrFormat* format) {
+  bool is_any_unlimited = false;
+  bool is_all_unlimited = true;
+  for (auto& element : format->elements) {
+    auto err = Visit(&element);
+    if (err.has_value()) {
+      return err;
+    }
+    auto is_unlimited = IsUnlimited(element);
+    is_any_unlimited |= is_unlimited;
+    is_all_unlimited &= is_unlimited;
+  }
+
+  if (is_any_unlimited && !is_all_unlimited) {
+    return ISTError(
+        "Now we only support all elements in an or format to be unlimited or all limited, but the "
+        "or format has both unlimited and limited elements"
+    );
+  }
+
+  format->is_unlimited_ = is_any_unlimited;
+  return std::nullopt;
+}
+
+std::optional<ISTError> StructuralTagAnalyzer::VisitSub(TagFormat* format) {
+  auto err = Visit(format->content.get());
+  if (err.has_value()) {
+    return err;
+  }
+  auto is_content_unlimited = IsUnlimited(*(format->content));
+  if (is_content_unlimited) {
+    if (format->end.empty()) {
+      return ISTError("When the content is unlimited, the end of the tag format cannot be empty");
+    }
+    // Clear the end string because it is moved to the detected_end_str_ field.
+    format->end.clear();
+  }
+  return std::nullopt;
+}
+
+std::optional<ISTError> StructuralTagAnalyzer::VisitSub(TriggeredTagsFormat* format) {
+  for (auto& tag : format->tags) {
+    auto err = Visit(&tag);
+    if (err.has_value()) {
+      return err;
+    }
+  }
+  format->detected_end_str_ = DetectEndString();
+  return std::nullopt;
+}
+
+std::optional<ISTError> StructuralTagAnalyzer::VisitSub(TagsWithSeparatorFormat* format) {
+  for (auto& tag : format->tags) {
+    auto err = Visit(&tag);
+    if (err.has_value()) {
+      return err;
+    }
+  }
+  format->detected_end_str_ = DetectEndString();
+  return std::nullopt;
+}
+
+/************** StructuralTag to Grammar Converter **************/
+
+class StructuralTagGrammarConverter {
+ public:
+  static Result<Grammar, ISTError> Convert(const StructuralTag& structural_tag);
+
+ private:
+  /*!
+   * \brief Visit a Format and return the rule id of the added rule.
+   * \param format The Format to visit.
+   * \return The rule id of the added rule. If the visit fails, the error is returned.
+   */
+  Result<int, ISTError> Visit(const Format& format);
+  Result<int, ISTError> VisitSub(const ConstStringFormat& format);
+  Result<int, ISTError> VisitSub(const JSONSchemaFormat& format);
+  Result<int, ISTError> VisitSub(const AnyTextFormat& format);
+  Result<int, ISTError> VisitSub(const SequenceFormat& format);
+  Result<int, ISTError> VisitSub(const OrFormat& format);
+  Result<int, ISTError> VisitSub(const TagFormat& format);
+  Result<int, ISTError> VisitSub(const TriggeredTagsFormat& format);
+  Result<int, ISTError> VisitSub(const TagsWithSeparatorFormat& format);
+  Grammar AddRootRuleAndGetGrammar(int ref_rule_id);
+
+  bool IsPrefix(const std::string& prefix, const std::string& full_str);
+
+  GrammarBuilder grammar_builder_;
+};
+
+bool StructuralTagGrammarConverter::IsPrefix(
+    const std::string& prefix, const std::string& full_str
+) {
+  return prefix.size() <= full_str.size() &&
+         std::string_view(full_str).substr(0, prefix.size()) == prefix;
+}
+
+Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(const StructuralTag& structural_tag
+) {
+  auto converter = StructuralTagGrammarConverter();
+  auto result = converter.Visit(structural_tag.format);
+  if (result.IsErr()) {
+    return ResultErr(std::move(result).UnwrapErr());
+  }
+  // Add a root rule
+  auto root_rule_id = std::move(result).Unwrap();
+  return ResultOk(converter.AddRootRuleAndGetGrammar(root_rule_id));
+}
+
+Grammar StructuralTagGrammarConverter::AddRootRuleAndGetGrammar(int ref_rule_id) {
+  auto expr = grammar_builder_.AddRuleRef(ref_rule_id);
+  auto sequence_expr = grammar_builder_.AddSequence({expr});
+  auto choices_expr = grammar_builder_.AddChoices({sequence_expr});
+  auto root_rule_id = grammar_builder_.AddRuleWithHint("root", choices_expr);
+  return grammar_builder_.Get(root_rule_id);
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format) {
+  return std::visit([&](auto&& arg) -> Result<int, ISTError> { return VisitSub(arg); }, format);
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const ConstStringFormat& format) {
+  auto expr = grammar_builder_.AddByteString(format.text);
+  auto sequence_expr = grammar_builder_.AddSequence({expr});
+  auto choices_expr = grammar_builder_.AddChoices({sequence_expr});
+  return ResultOk(grammar_builder_.AddRuleWithHint("const_string", choices_expr));
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFormat& format) {
+  auto sub_grammar = Grammar::FromJSONSchema(format.json_schema);
+  auto added_root_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
+  return ResultOk(added_root_rule_id);
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const AnyTextFormat& format) {
+  if (format.detected_end_str_.has_value()) {
+    XGRAMMAR_DCHECK(!format.detected_end_str_.value().empty())
+        << "The detected end string cannot be empty";
+    auto tag_dispatch_expr = grammar_builder_.AddTagDispatch(
+        Grammar::Impl::TagDispatch{{}, false, {format.detected_end_str_.value()}, false}
+    );
+    return ResultOk(grammar_builder_.AddRuleWithHint("any_text", tag_dispatch_expr));
+  } else {
+    auto any_text_expr = grammar_builder_.AddCharacterClassStar({{0, 0x10FFFF}}, false);
+    auto sequence_expr = grammar_builder_.AddSequence({any_text_expr});
+    auto choices_expr = grammar_builder_.AddChoices({sequence_expr});
+    return ResultOk(grammar_builder_.AddRuleWithHint("any_text", choices_expr));
+  }
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const SequenceFormat& format) {
+  std::vector<int> rule_ref_ids;
+  rule_ref_ids.reserve(format.elements.size());
+  for (const auto& element : format.elements) {
+    auto result = Visit(element);
+    if (result.IsErr()) {
+      return result;
+    }
+    int sub_rule_id = std::move(result).Unwrap();
+    rule_ref_ids.push_back(grammar_builder_.AddRuleRef(sub_rule_id));
+  }
+  auto expr = grammar_builder_.AddChoices({grammar_builder_.AddSequence(rule_ref_ids)});
+  return ResultOk(grammar_builder_.AddRuleWithHint("sequence", expr));
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const OrFormat& format) {
+  std::vector<int> sequence_ids;
+  sequence_ids.reserve(format.elements.size());
+  for (const auto& element : format.elements) {
+    auto result = Visit(element);
+    if (result.IsErr()) {
+      return result;
+    }
+    int sub_rule_id = std::move(result).Unwrap();
+    auto rule_ref_expr = grammar_builder_.AddRuleRef(sub_rule_id);
+    sequence_ids.push_back(grammar_builder_.AddSequence({rule_ref_expr}));
+  }
+  auto expr = grammar_builder_.AddChoices(sequence_ids);
+  return ResultOk(grammar_builder_.AddRuleWithHint("or", expr));
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TagFormat& format) {
+  auto result = Visit(*format.content);
+  if (result.IsErr()) {
+    return result;
+  }
+  auto sub_rule_id = std::move(result).Unwrap();
+  auto begin_expr = grammar_builder_.AddByteString(format.begin);
+  auto rule_ref_expr = grammar_builder_.AddRuleRef(sub_rule_id);
+  int32_t sequence_expr_id;
+  if (!format.end.empty()) {
+    auto end_expr = grammar_builder_.AddByteString(format.end);
+    sequence_expr_id = grammar_builder_.AddSequence({begin_expr, rule_ref_expr, end_expr});
+  } else {
+    sequence_expr_id = grammar_builder_.AddSequence({begin_expr, rule_ref_expr});
+  }
+  auto choices_expr = grammar_builder_.AddChoices({sequence_expr_id});
+  return ResultOk(grammar_builder_.AddRuleWithHint("tag", choices_expr));
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTagsFormat& format) {
+  // Step 1. Visit all tags and add to grammar
+  std::vector<std::vector<int>> trigger_to_tag_ids(format.triggers.size());
+  std::vector<int> tag_content_rule_ids;
+  tag_content_rule_ids.reserve(format.tags.size());
+
+  for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
+    const auto& tag = format.tags[it_tag];
+    // Find matched triggers
+    int matched_trigger_id = -1;
+    for (int it_trigger = 0; it_trigger < static_cast<int>(format.triggers.size()); ++it_trigger) {
+      const auto& trigger = format.triggers[it_trigger];
+      if (IsPrefix(trigger, tag.begin)) {
+        if (matched_trigger_id != -1) {
+          return ResultErr<ISTError>("One tag matches multiple triggers in a triggered tags format"
+          );
+        }
+        matched_trigger_id = it_trigger;
       }
     }
-    XGRAMMAR_CHECK(found) << "Tag " << tag.begin << " does not match any trigger";
+    if (matched_trigger_id == -1) {
+      return ResultErr<ISTError>("One tag does not match any trigger in a triggered tags format");
+    }
+    trigger_to_tag_ids[matched_trigger_id].push_back(it_tag);
+
+    // Add the tag content to grammar
+    auto result = Visit(*tag.content);
+    if (result.IsErr()) {
+      return result;
+    }
+    tag_content_rule_ids.push_back(std::move(result).Unwrap());
   }
 
-  // Step 3: Combine the tags to form a grammar
-  // root ::= TagDispatch((trigger1, rule1), (trigger2, rule2), ...)
-  // Suppose tag1 and tag2 matches trigger1, then
-  // rule1 ::= (tag1.begin[trigger1.size():] + ToEBNF(tag1.schema) + tag1.end) |
-  //            (tag2.begin[trigger1.size():] + ToEBNF(tag2.schema) + tag2.end) | ...
-  //
-  // Suppose tag3 matches trigger2, then
-  // rule2 ::= (tag3.begin[trigger2.size():] + ToEBNF(tag3.schema) + tag3.end)
-  //
-  // ...
-  return StructuralTagGrammarCreator::Apply(sorted_triggers, tag_groups);
+  // at_least_one is implemented as generating any one of the tags first, then do optional
+  // triggered tags generation. That means we don't generate any text before the first tag.
+
+  // Step 2. Special Case: at_least_one && stop_after_first.
+  // Then we will generate exactly one tag without text. We just do a selection between all tags.
+  if (format.at_least_one && format.stop_after_first) {
+    std::vector<int> choice_elements;
+    for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
+      const auto& tag = format.tags[it_tag];
+      auto begin_expr_id = grammar_builder_.AddByteString(tag.begin);
+      auto end_expr_id = grammar_builder_.AddByteString(tag.end);
+      auto rule_ref_expr_id = grammar_builder_.AddRuleRef(tag_content_rule_ids[it_tag]);
+      choice_elements.push_back(
+          grammar_builder_.AddSequence({begin_expr_id, rule_ref_expr_id, end_expr_id})
+      );
+    }
+    auto choice_expr_id = grammar_builder_.AddChoices(choice_elements);
+
+    // Handle the detected end string.
+    if (format.detected_end_str_.has_value()) {
+      auto sub_rule_id = grammar_builder_.AddRuleWithHint("triggered_tags_sub", choice_expr_id);
+      auto ref_sub_rule_expr_id = grammar_builder_.AddRuleRef(sub_rule_id);
+      auto end_str_expr_id = grammar_builder_.AddByteString(format.detected_end_str_.value());
+      auto sequence_expr_id = grammar_builder_.AddSequence({ref_sub_rule_expr_id, end_str_expr_id});
+      choice_expr_id = grammar_builder_.AddChoices({sequence_expr_id});
+    }
+
+    return ResultOk(grammar_builder_.AddRuleWithHint("triggered_tags", choice_expr_id));
+  }
+
+  // Step 3. Normal Case. We generate mixture of text and triggered tags.
+  // - When at_least_one is true, one tag is generated first, then we do triggered tags
+  // generation.
+  // - When stop_after_first is true, we set loop_after_dispatch of the tag dispatch to false.
+  // - When detected_end_str_ is not empty, we use that as the stop_str of the tag dispatch.
+  //   Otherwise, we set stop_eos to true to generate until EOS.
+
+  // Step 3.1 Get tag_rule_pairs.
+  std::vector<std::pair<std::string, int32_t>> tag_rule_pairs;
+  for (int it_trigger = 0; it_trigger < static_cast<int>(format.triggers.size()); ++it_trigger) {
+    const auto& trigger = format.triggers[it_trigger];
+    std::vector<int> choice_elements;
+    for (const auto& tag_id : trigger_to_tag_ids[it_trigger]) {
+      const auto& tag = format.tags[tag_id];
+      int begin_expr_id = grammar_builder_.AddByteString(tag.begin.substr(trigger.size()));
+      int end_expr_id = grammar_builder_.AddByteString(tag.end);
+      int rule_ref_expr_id = grammar_builder_.AddRuleRef(tag_content_rule_ids[tag_id]);
+      choice_elements.push_back(
+          grammar_builder_.AddSequence({begin_expr_id, rule_ref_expr_id, end_expr_id})
+      );
+    }
+    auto choice_expr_id = grammar_builder_.AddChoices(choice_elements);
+    auto sub_rule_id = grammar_builder_.AddRuleWithHint("triggered_tags_group", choice_expr_id);
+    tag_rule_pairs.push_back(std::make_pair(trigger, sub_rule_id));
+  }
+
+  // Step 3.2 Add TagDispatch.
+  int32_t rule_expr_id;
+  bool loop_after_dispatch = !format.stop_after_first;
+  if (format.detected_end_str_.has_value()) {
+    rule_expr_id = grammar_builder_.AddTagDispatch(Grammar::Impl::TagDispatch{
+        tag_rule_pairs, false, {format.detected_end_str_.value()}, loop_after_dispatch
+    });
+  } else {
+    rule_expr_id = grammar_builder_.AddTagDispatch(
+        Grammar::Impl::TagDispatch{tag_rule_pairs, true, {}, loop_after_dispatch}
+    );
+  }
+
+  // Step 3.3 Consider at_least_one
+  if (format.at_least_one) {
+    // Construct the first rule
+    std::vector<int> first_choice_elements;
+    for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
+      const auto& tag = format.tags[it_tag];
+      auto begin_expr_id = grammar_builder_.AddByteString(tag.begin);
+      auto end_expr_id = grammar_builder_.AddByteString(tag.end);
+      auto rule_ref_expr_id = grammar_builder_.AddRuleRef(tag_content_rule_ids[it_tag]);
+      first_choice_elements.push_back(
+          grammar_builder_.AddSequence({begin_expr_id, rule_ref_expr_id, end_expr_id})
+      );
+    }
+    auto first_choice_expr_id = grammar_builder_.AddChoices(first_choice_elements);
+    auto first_rule_id =
+        grammar_builder_.AddRuleWithHint("triggered_tags_first", first_choice_expr_id);
+
+    // Construct the full rule
+    auto tag_dispatch_rule_id =
+        grammar_builder_.AddRuleWithHint("triggered_tags_sub", rule_expr_id);
+    auto ref_first_rule_expr_id = grammar_builder_.AddRuleRef(first_rule_id);
+    auto ref_tag_dispatch_rule_expr_id = grammar_builder_.AddRuleRef(tag_dispatch_rule_id);
+    auto sequence_expr_id =
+        grammar_builder_.AddSequence({ref_first_rule_expr_id, ref_tag_dispatch_rule_expr_id});
+    rule_expr_id = grammar_builder_.AddChoices({sequence_expr_id});
+  }
+
+  auto rule_id = grammar_builder_.AddRuleWithHint("triggered_tags", rule_expr_id);
+  return ResultOk(rule_id);
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TagsWithSeparatorFormat& format
+) {
+  // The grammar:
+  // Step 1. tags_rule: call tags
+  //   tags_rule ::= tag1 | tag2 | ... | tagN
+  // Step 2. Special handling (stop_after_first is true):
+  //   if at_least_one is false:
+  //     root ::= tags_rule end_str | end_str
+  //   if at_least_one is true:
+  //     root ::= tags_rule end_str
+  // Step 3. Normal handling (stop_after_first is false):
+  //   if at_least_one is false:
+  //     root ::= tags_rule tags_rule_sub | end_str
+  //   if at_least_one is true:
+  //     root ::= tags_rule tags_rule_sub
+  //   tags_rule_sub ::= sep tags_rule tags_rule_sub | end_str
+
+  // Step 1. Construct a rule representing any tag
+  std::vector<int> choice_ids;
+  for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
+    auto tag_rule_id = Visit(format.tags[it_tag]);
+    if (tag_rule_id.IsErr()) {
+      return tag_rule_id;
+    }
+    auto tag_rule_ref_id = grammar_builder_.AddRuleRef(std::move(tag_rule_id).Unwrap());
+    auto sequence_expr_id = grammar_builder_.AddSequence({tag_rule_ref_id});
+    choice_ids.push_back(sequence_expr_id);
+  }
+  auto choice_expr_id = grammar_builder_.AddChoices(choice_ids);
+  auto all_tags_rule_id =
+      grammar_builder_.AddRuleWithHint("tags_with_separator_tags", choice_expr_id);
+
+  auto all_tags_rule_ref_id = grammar_builder_.AddRuleRef(all_tags_rule_id);
+
+  // Handle end str
+  int32_t end_str_expr_id = -1;
+  if (format.detected_end_str_.has_value()) {
+    end_str_expr_id = grammar_builder_.AddByteString(format.detected_end_str_.value());
+  }
+
+  // Step 2. Special case (stop_after_first is true):
+  if (format.stop_after_first ||
+      (end_str_expr_id != -1 && format.detected_end_str_.value() == format.separator)) {
+    int32_t rule_body_expr_id;
+    if (format.at_least_one) {
+      if (end_str_expr_id == -1) {
+        // root ::= tags_rule
+        rule_body_expr_id =
+            grammar_builder_.AddChoices({grammar_builder_.AddSequence({all_tags_rule_ref_id})});
+      } else {
+        // root ::= tags_rule end_str
+        rule_body_expr_id = grammar_builder_.AddChoices(
+            {grammar_builder_.AddSequence({all_tags_rule_ref_id, end_str_expr_id})}
+        );
+      }
+    } else {
+      if (end_str_expr_id == -1) {
+        // root ::= tags_rule | ""
+        rule_body_expr_id = grammar_builder_.AddChoices(
+            {grammar_builder_.AddSequence({all_tags_rule_ref_id}), grammar_builder_.AddEmptyStr()}
+        );
+      } else {
+        // root ::= tags_rule end_str | end_str
+        rule_body_expr_id = grammar_builder_.AddChoices(
+            {grammar_builder_.AddSequence({all_tags_rule_ref_id, end_str_expr_id}),
+             grammar_builder_.AddSequence({end_str_expr_id})}
+        );
+      }
+    }
+
+    auto rule_id = grammar_builder_.AddRuleWithHint("tags_with_separator", rule_body_expr_id);
+    return ResultOk(rule_id);
+  }
+
+  // Step 3. Normal handling (stop_after_first is false):
+  // Step 3.1 Construct sub rule
+  auto sub_rule_id = grammar_builder_.AddEmptyRuleWithHint("tags_with_separator_sub");
+  auto end_str_sequence_id = end_str_expr_id == -1
+                                 ? grammar_builder_.AddEmptyStr()
+                                 : grammar_builder_.AddSequence({end_str_expr_id});
+  auto sub_rule_body_id = grammar_builder_.AddChoices(
+      {grammar_builder_.AddSequence(
+           {grammar_builder_.AddByteString(format.separator),
+            all_tags_rule_ref_id,
+            grammar_builder_.AddRuleRef(sub_rule_id)}
+       ),
+       end_str_sequence_id}
+  );
+  grammar_builder_.UpdateRuleBody(sub_rule_id, sub_rule_body_id);
+
+  // Step 3.2 Construct root rule
+  std::vector<int> choices = {
+      grammar_builder_.AddSequence({all_tags_rule_ref_id, grammar_builder_.AddRuleRef(sub_rule_id)}
+      ),
+  };
+  if (!format.at_least_one) {
+    choices.push_back(end_str_sequence_id);
+  }
+  auto rule_body_expr_id = grammar_builder_.AddChoices(choices);
+  auto rule_id = grammar_builder_.AddRuleWithHint("tags_with_separator", rule_body_expr_id);
+  return ResultOk(rule_id);
+}
+
+/************** StructuralTag Conversion Public API **************/
+
+Result<Grammar, StructuralTagError> StructuralTagToGrammar(const std::string& structural_tag_json) {
+  auto structural_tag_result = StructuralTagParser::FromJSON(structural_tag_json);
+  if (structural_tag_result.IsErr()) {
+    return ResultErr(std::move(structural_tag_result).UnwrapErr());
+  }
+  auto structural_tag = std::move(structural_tag_result).Unwrap();
+  auto err = StructuralTagAnalyzer().Analyze(&structural_tag);
+  if (err.has_value()) {
+    return ResultErr(std::move(err).value());
+  }
+  auto result = StructuralTagGrammarConverter().Convert(structural_tag);
+  if (result.IsErr()) {
+    return ResultErr(std::move(result).UnwrapErr());
+  }
+  return ResultOk(std::move(result).Unwrap());
 }
 
 }  // namespace xgrammar

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -1,21 +1,174 @@
 /*!
  *  Copyright (c) 2024 by Contributors
- * \file xgrammar/structural_tag.h
- * \brief The header for the definition of the structural tag.
+ * \file xgrammar/structural_tag_impl.h
+ * \brief The implementation header for the structural tag.
  */
+
 #ifndef XGRAMMAR_STRUCTURAL_TAG_H_
 #define XGRAMMAR_STRUCTURAL_TAG_H_
 
-#include <xgrammar/xgrammar.h>
+#include <xgrammar/exception.h>
+#include <xgrammar/grammar.h>
 
+#include <memory>
+#include <optional>
+#include <stdexcept>
 #include <string>
+#include <variant>
 #include <vector>
+
+#include "support/utils.h"
 
 namespace xgrammar {
 
-Grammar StructuralTagToGrammar(
-    const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
-);
+/******************** Structural Tag Definition ********************/
+
+// TODO(yixin): Consider moving the definition to Public API.
+
+struct ConstStringFormat;
+struct JSONSchemaFormat;
+struct AnyTextFormat;
+struct SequenceFormat;
+struct OrFormat;
+struct TagFormat;
+struct TriggeredTagsFormat;
+struct TagsWithSeparatorFormat;
+
+using Format = std::variant<
+    ConstStringFormat,
+    JSONSchemaFormat,
+    AnyTextFormat,
+    SequenceFormat,
+    OrFormat,
+    TagFormat,
+    TriggeredTagsFormat,
+    TagsWithSeparatorFormat>;
+
+/******************** Basic Formats ********************/
+
+struct ConstStringFormat {
+  static constexpr const char* type = "const_string";
+  std::string text;
+  ConstStringFormat(std::string text) : text(std::move(text)) {}
+};
+
+struct JSONSchemaFormat {
+  static constexpr const char* type = "json_schema";
+  std::string json_schema;
+  JSONSchemaFormat(std::string json_schema) : json_schema(std::move(json_schema)) {}
+};
+
+struct AnyTextFormat {
+  static constexpr const char* type = "any_text";
+  AnyTextFormat() {}
+
+ private:
+  // Detected in StructuralTagAnalyzer
+  std::optional<std::string> detected_end_str_ = std::nullopt;
+  friend class StructuralTagAnalyzer;
+  friend class StructuralTagGrammarConverter;
+};
+
+/******************** Combinatorial Formats ********************/
+
+struct SequenceFormat {
+  static constexpr const char* type = "sequence";
+  std::vector<Format> elements;
+  SequenceFormat(std::vector<Format> elements) : elements(std::move(elements)) {}
+
+ private:
+  // Detected in StructuralTagAnalyzer
+  bool is_unlimited_ = false;
+  friend class StructuralTagAnalyzer;
+  friend class StructuralTagGrammarConverter;
+};
+
+struct OrFormat {
+  static constexpr const char* type = "or";
+  std::vector<Format> elements;
+  OrFormat(std::vector<Format> elements) : elements(std::move(elements)) {}
+
+ private:
+  // Detected in StructuralTagAnalyzer
+  bool is_unlimited_ = false;
+  friend class StructuralTagAnalyzer;
+  friend class StructuralTagGrammarConverter;
+};
+
+struct TagFormat {
+  static constexpr const char* type = "tag";
+  std::string begin;
+  std::shared_ptr<Format> content;
+  std::string end;
+
+  TagFormat(std::string begin, std::shared_ptr<Format> content, std::string end)
+      : begin(std::move(begin)), content(std::move(content)), end(std::move(end)) {}
+};
+
+struct TriggeredTagsFormat {
+  static constexpr const char* type = "triggered_tags";
+  std::vector<std::string> triggers;
+  std::vector<TagFormat> tags;
+  bool at_least_one = false;
+  bool stop_after_first = false;
+
+  TriggeredTagsFormat(
+      std::vector<std::string> triggers,
+      std::vector<TagFormat> tags,
+      bool at_least_one,
+      bool stop_after_first
+  )
+      : triggers(std::move(triggers)),
+        tags(std::move(tags)),
+        at_least_one(at_least_one),
+        stop_after_first(stop_after_first) {}
+
+ private:
+  // Detected in StructuralTagAnalyzer
+  std::optional<std::string> detected_end_str_ = std::nullopt;
+  friend class StructuralTagAnalyzer;
+  friend class StructuralTagGrammarConverter;
+};
+
+struct TagsWithSeparatorFormat {
+  static constexpr const char* type = "tags_with_separator";
+  std::vector<TagFormat> tags;
+  std::string separator;
+  bool at_least_one = false;
+  bool stop_after_first = false;
+
+  TagsWithSeparatorFormat(
+      std::vector<TagFormat> tags, std::string separator, bool at_least_one, bool stop_after_first
+  )
+      : tags(std::move(tags)),
+        separator(std::move(separator)),
+        at_least_one(at_least_one),
+        stop_after_first(stop_after_first) {}
+
+ private:
+  // Detected in StructuralTagAnalyzer
+  std::optional<std::string> detected_end_str_ = std::nullopt;
+  friend class StructuralTagAnalyzer;
+  friend class StructuralTagGrammarConverter;
+};
+
+/******************** Top Level ********************/
+
+struct StructuralTag {
+  static constexpr const char* type = "structural_tag";
+  Format format;
+
+  StructuralTag(Format format) : format(std::move(format)) {}
+};
+
+/******************** Conversion API ********************/
+
+/*!
+ * \brief Convert a structural tag JSON string to a grammar.
+ * \param structural_tag_json The JSON string of the structural tag.
+ * \return A grammar if the JSON is valid, otherwise an error message in std::string.
+ */
+Result<Grammar, StructuralTagError> StructuralTagToGrammar(const std::string& structural_tag_json);
 
 }  // namespace xgrammar
 

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -48,8 +48,8 @@ using Format = std::variant<
 
 struct ConstStringFormat {
   static constexpr const char* type = "const_string";
-  std::string text;
-  ConstStringFormat(std::string text) : text(std::move(text)) {}
+  std::string value;
+  ConstStringFormat(std::string value) : value(std::move(value)) {}
 };
 
 struct JSONSchemaFormat {

--- a/cpp/support/thread_safe_cache.h
+++ b/cpp/support/thread_safe_cache.h
@@ -269,10 +269,10 @@ class ThreadSafeLRUCache {
   };
 
  public:
-  inline static constexpr std::size_t UNLIMITED_SIZE = static_cast<std::size_t>(-1);
+  inline static constexpr std::size_t kUnlimitedSize = static_cast<std::size_t>(-1);
 
   explicit ThreadSafeLRUCache(
-      std::size_t max_size = UNLIMITED_SIZE,
+      std::size_t max_size = kUnlimitedSize,
       const Computer& computer = Computer{},
       const SizeEstimator& size_estimator = SizeEstimator{}
   )
@@ -289,7 +289,7 @@ class ThreadSafeLRUCache {
   void Clear() {
     // Remove all the ready entries.
     const auto lock_map = std::lock_guard{map_mutex_};
-    if (this->max_size_ == UNLIMITED_SIZE)
+    if (this->max_size_ == kUnlimitedSize)
       cache_.GetMap().clear();
     else
       cache_.LRUEvict(
@@ -308,7 +308,7 @@ class ThreadSafeLRUCache {
 
  private:
   std::shared_future<SizedValue> GetFuture(const Key& key) {
-    if (this->max_size_ == UNLIMITED_SIZE) return GetFutureUnlimited(key);
+    if (this->max_size_ == kUnlimitedSize) return GetFutureUnlimited(key);
     auto& map = cache_.GetMap();
 
     {

--- a/cpp/support/utils.h
+++ b/cpp/support/utils.h
@@ -17,46 +17,109 @@
 
 #include "logging.h"
 
+/****************** Hash Library ******************/
+
 namespace xgrammar {
 
 /*!
  * \brief Hash and combine value into seed.
  * \ref https://www.boost.org/doc/libs/1_84_0/boost/intrusive/detail/hash_combine.hpp
  */
-inline void HashCombineBinary(uint32_t& seed, uint32_t value) {
-  seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+inline void HashCombineBinary(size_t& seed, size_t value) {
+  seed ^= value + 0x9e3779b97f4a7c15ull + (seed << 6) + (seed >> 2);
 }
 
 /*!
- * \brief Find the hash sum of several uint32_t args.
+ * \brief Find the hash sum of several size_t args.
  */
 template <typename... Args>
-inline uint32_t HashCombine(Args... args) {
-  uint32_t seed = 0;
+inline size_t HashCombine(Args... args) {
+  size_t seed = 0;
   (..., HashCombineBinary(seed, args));
   return seed;
 }
 
-// Sometimes GCC fails to detect some branches will not return, such as when we use LOG(FATAL)
-// to raise an error. This macro manually mark them as unreachable to avoid warnings.
-#ifdef __GNUC__
-#define XGRAMMAR_UNREACHABLE() __builtin_unreachable()
-#else
-#define XGRAMMAR_UNREACHABLE()
-#endif
+/*!
+ * \brief Helper class to define the hash function for a struct by its members.
+ */
+template <class T, auto... Members>
+struct HashByMembers {
+  std::size_t operator()(T const& x) const noexcept {
+    return HashCombine(std::hash<std::decay_t<decltype(x.*Members)>>{}(x.*Members)...);
+  }
+};
+
+}  // namespace xgrammar
 
 /*!
- * \brief An error class that contains a type. The type can be an enum.
+ * \brief Define a hash function for a struct by its members in namespace std. Should be used
+ * outside of namespace xgrammar.
+ * \param Type The type of the struct.
+ * \param ... The member pointers of the struct.
+ * \example
+ * \code
+ * // In the global namespace
+ * XGRAMMAR_HASH_BY_MEMBERS(Type, &Type::member1, &Type::member2, &Type::member3);
+ * \endcode
+ */
+#define XGRAMMAR_HASH_BY_MEMBERS(Type, ...)                                 \
+  namespace std {                                                           \
+  template <>                                                               \
+  struct hash<Type> : public xgrammar::HashByMembers<Type, __VA_ARGS__> {}; \
+  }
+
+/*!
+ * \brief Empty specialization of XGRAMMAR_HASH_BY_MEMBERS.
+ */
+#define XGRAMMAR_HASH_BY_MEMBERS_EMPTY(Type)                   \
+  namespace std {                                              \
+  template <>                                                  \
+  struct hash<Type> : public xgrammar::HashByMembers<Type> {}; \
+  }
+
+namespace std {
+
+/*!
+ * \brief Define the hash function for std::pair.
+ */
+template <typename T, typename U>
+struct hash<std::pair<T, U>> {
+  size_t operator()(const std::pair<T, U>& pair) const noexcept {
+    return xgrammar::HashCombine(std::hash<T>{}(pair.first), std::hash<U>{}(pair.second));
+  }
+};
+
+/*!
+ * \brief Define the hash function for std::tuple.
+ */
+template <typename... Args>
+struct hash<std::tuple<Args...>> {
+  size_t operator()(const std::tuple<Args...>& tuple) const noexcept {
+    return std::apply(
+        [](const Args&... args) { return xgrammar::HashCombine(std::hash<Args>{}(args)...); }, tuple
+    );
+  }
+};
+
+/*!
+ * \brief Define the hash function for std::vector.
  */
 template <typename T>
-class TypedError : public std::runtime_error {
- public:
-  explicit TypedError(T type, const std::string& msg) : std::runtime_error(msg), type_(type) {}
-  const T& Type() const noexcept { return type_; }
-
- private:
-  T type_;
+struct hash<std::vector<T>> {
+  size_t operator()(const std::vector<T>& vec) const {
+    uint32_t seed = 0;
+    for (const auto& item : vec) {
+      xgrammar::HashCombineBinary(seed, std::hash<T>{}(item));
+    }
+    return seed;
+  }
 };
+
+}  // namespace std
+
+namespace xgrammar {
+
+/****************** Result Library ******************/
 
 /*!
  * \brief A partial result type that can be used to construct a Result. Holds a result value or an
@@ -71,19 +134,81 @@ struct PartialResult {
   T value;
 };
 
-template <typename E = std::runtime_error, typename... Args>
-inline PartialResult<E, false> ResultErr(Args&&... args) {
-  return PartialResult<E, false>{std::forward<Args>(args)...};
-}
-
+/*!
+ * \brief Construct a success result with the arguments to construct a T.
+ * \tparam T The type of the success value
+ * \tparam Args The types of the arguments to construct a T
+ * \param args The arguments to construct a T
+ * \return A PartialResult with the arguments to construct a T
+ * \example
+ * \code
+ * // Call the constructor of T with the arguments
+ * return ResultOk<T>(1, 2, 3);
+ * \endcode
+ */
 template <typename T, typename... Args>
 inline PartialResult<T, true> ResultOk(Args&&... args) {
   return PartialResult<T, true>{std::forward<Args>(args)...};
 }
 
+/*!
+ * \brief Construct a success result with a universal reference (both lvalue and rvalue)
+ * \tparam T The type of the success value
+ * \param value The universal reference to the success value
+ * \return A PartialResult with the universal reference to the success value
+ * \example
+ * \code
+ * T value = T(1, 2, 3);
+ * // Move the value to the PartialResult
+ * return ResultOk(std::move(value));
+ * \endcode
+ */
 template <typename T>
 inline PartialResult<T&&, true> ResultOk(T&& value) {
   return PartialResult<T&&, true>{std::forward<T>(value)};
+}
+
+/*!
+ * \brief Construct a error result with the arguments to construct a E.
+ * \tparam E The type of the error value. Default to std::runtime_error.
+ * \tparam Args The types of the arguments to construct a E
+ * \param args The arguments to construct a E
+ * \return A PartialResult with the arguments to construct a E
+ * \example
+ * \code
+ * // Construct a std::runtime_error with a error
+ * std::runtime_error error("Message");
+ * return ResultErr(std::move(error));
+ * \endcode
+ * \code
+ * // Construct a std::runtime_error with its argument
+ * return ResultErr("Error");
+ * \endcode
+ * \code
+ * // Construct an E error with its argument
+ * return ResultErr<E>("Error");
+ * \endcode
+ */
+template <typename E = std::runtime_error, typename... Args>
+inline PartialResult<E, false> ResultErr(Args&&... args) {
+  return PartialResult<E, false>{std::forward<Args>(args)...};
+}
+
+/*!
+ * \brief Construct a error result with a universal reference (both lvalue and rvalue)
+ * \tparam E The type of the error value
+ * \param err The universal reference to the error value
+ * \return A PartialResult with the universal reference to the error value
+ * \example
+ * \code
+ * E err = E("Error");
+ * // Move the err to the PartialResult
+ * return ResultErr(std::move(err));
+ * \endcode
+ */
+template <typename E>
+inline PartialResult<E&&, false> ResultErr(E&& err) {
+  return PartialResult<E&&, false>{std::forward<E>(err)};
 }
 
 /*!
@@ -131,15 +256,15 @@ class Result {
   /*! \brief Default constructor is deleted to avoid accidental use */
   Result() = delete;
 
-  /*! \brief Construct from Result::Err */
-  template <typename V, typename = std::enable_if_t<std::is_same_v<std::decay_t<V>, E>>>
-  Result(PartialResult<V, false>&& partial_result)
-      : data_(std::in_place_type<E>, std::forward<V>(partial_result.value)) {}
-
   /*! \brief Construct from Result::Ok */
-  template <typename U, typename = std::enable_if_t<std::is_same_v<std::decay_t<U>, T>>>
+  template <typename U, typename = std::enable_if_t<std::is_constructible_v<T, std::decay_t<U>>>>
   Result(PartialResult<U, true>&& partial_result)
       : data_(std::in_place_type<T>, std::forward<U>(partial_result.value)) {}
+
+  /*! \brief Construct from Result::Err */
+  template <typename V, typename = std::enable_if_t<std::is_constructible_v<E, std::decay_t<V>>>>
+  Result(PartialResult<V, false>&& partial_result)
+      : data_(std::in_place_type<E>, std::forward<V>(partial_result.value)) {}
 
   /*! \brief Check if Result contains success value */
   bool IsOk() const { return std::holds_alternative<T>(data_); }
@@ -189,9 +314,9 @@ class Result {
   template <typename U, typename V>
   static Result<T, E> Convert(Result<U, V>&& result) {
     if (result.IsOk()) {
-      return ResultOk(std::move(result).Unwrap());
+      return ResultOk<T>(std::move(result).Unwrap());
     }
-    return ResultErr(std::move(result).UnwrapErr());
+    return ResultErr<E>(std::move(result).UnwrapErr());
   }
 
   /*! \brief Get a std::variant<T, E> from the result. */
@@ -229,37 +354,87 @@ class Result {
   std::variant<T, E> data_;
 };
 
-}  // namespace xgrammar
+/****************** Misc ******************/
 
-namespace std {
+// Sometimes GCC fails to detect some branches will not return, such as when we use LOG(FATAL)
+// to raise an error. This macro manually mark them as unreachable to avoid warnings.
+#ifdef __GNUC__
+#define XGRAMMAR_UNREACHABLE() __builtin_unreachable()
+#else
+#define XGRAMMAR_UNREACHABLE()
+#endif
 
-template <typename T, typename U>
-struct hash<std::pair<T, U>> {
-  size_t operator()(const std::pair<T, U>& pair) const {
-    return xgrammar::HashCombine(std::hash<T>{}(pair.first), std::hash<U>{}(pair.second));
-  }
-};
-
-template <typename... Args>
-struct hash<std::tuple<Args...>> {
-  size_t operator()(const std::tuple<Args...>& tuple) const {
-    return std::apply(
-        [](const Args&... args) { return xgrammar::HashCombine(std::hash<Args>{}(args)...); }, tuple
-    );
-  }
-};
-
+/*!
+ * \brief An error class that contains a type. The type can be an enum.
+ */
 template <typename T>
-struct hash<std::vector<T>> {
-  size_t operator()(const std::vector<T>& vec) const {
-    uint32_t seed = 0;
-    for (const auto& item : vec) {
-      xgrammar::HashCombineBinary(seed, std::hash<T>{}(item));
-    }
-    return seed;
-  }
+class TypedError : public std::runtime_error {
+ public:
+  explicit TypedError(T type, const std::string& msg) : std::runtime_error(msg), type_(type) {}
+  const T& Type() const noexcept { return type_; }
+
+ private:
+  T type_;
 };
 
-}  // namespace std
+/**
+ * \brief Helper function to compare two objects by their members.
+ */
+template <class T, auto... Ms>
+constexpr bool EqualByMembers(const T& lhs, const T& rhs) noexcept {
+  return std::tie(lhs.*Ms...) == std::tie(rhs.*Ms...);
+}
+
+/**
+ * \brief Define == and != operator for a struct by its members.
+ * \param Type The type of the struct. Must be under namespace xgrammar.
+ * \param ... The member pointers of the struct.
+ * \example
+ * \code
+ * struct Type {
+ *   int member1;
+ *   std::string member2;
+ *   double member3;
+ *
+ *   XGRAMMAR_EQUAL_BY_MEMBERS(Type, &Type::member1, &Type::member2, &Type::member3);
+ * };
+ * \endcode
+ */
+#define XGRAMMAR_EQUAL_BY_MEMBERS(Type, ...)                          \
+  friend bool operator==(const Type& lhs, const Type& rhs) noexcept { \
+    return EqualByMembers<Type, __VA_ARGS__>(lhs, rhs);               \
+  }                                                                   \
+  friend bool operator!=(const Type& lhs, const Type& rhs) noexcept { return !(lhs == rhs); }
+
+/*!
+ * \brief Empty specialization of XGRAMMAR_EQUAL_BY_MEMBERS.
+ */
+#define XGRAMMAR_EQUAL_BY_MEMBERS_EMPTY(Type)                                        \
+  friend bool operator==(const Type& lhs, const Type& rhs) noexcept { return true; } \
+  friend bool operator!=(const Type& lhs, const Type& rhs) noexcept { return false; }
+
+/*!
+ * \brief Throw an error from a variant of multiple error types.
+ * \param error_variant The variant of multiple error types.
+ * \tparam Args The types of the error types. Each type should inherit from std::runtime_error.
+ */
+template <typename... Args>
+[[noreturn]] void ThrowVariantError(const std::variant<Args...>& error_variant) {
+  std::visit([](const auto& e) { throw e; }, error_variant);
+  XGRAMMAR_UNREACHABLE();
+}
+
+/*!
+ * \brief Get the message from a variant of multiple error types.
+ * \param error_variant The variant of multiple error types.
+ * \return The message from the error variant.
+ * \tparam Args The types of the error types. Each type should inherit from std::runtime_error.
+ */
+template <typename... Args>
+std::string GetMessageFromVariantError(const std::variant<Args...>& error_variant) {
+  return std::visit([](const auto& e) { return e.what(); }, error_variant);
+}
+
+}  // namespace xgrammar
 
 #endif  // XGRAMMAR_SUPPORT_UTILS_H_

--- a/docs/api/python/exception.rst
+++ b/docs/api/python/exception.rst
@@ -1,8 +1,9 @@
 Exception
 ==========================
 
-.. currentmodule:: xgrammar
+.. currentmodule:: xgrammar.exception
 
-.. autoclass:: xgrammar.DeserializeFormatError
-.. autoclass:: xgrammar.DeserializeVersionError
-.. autoclass:: xgrammar.InvalidJSONError
+.. autoclass:: DeserializeFormatError
+.. autoclass:: DeserializeVersionError
+.. autoclass:: InvalidJSONError
+.. autoclass:: InvalidStructuralTagError

--- a/docs/api/python/structural_tag.rst
+++ b/docs/api/python/structural_tag.rst
@@ -1,8 +1,58 @@
 Structural Tag
 ==========================
 
-.. currentmodule:: xgrammar
+.. currentmodule:: xgrammar.structural_tag
+
+Basic Formats
+-------------
+
+.. autoclass:: ConstStringFormat
+   :show-inheritance:
+   :exclude-members: model_config
+
+.. autoclass:: JSONSchemaFormat
+   :show-inheritance:
+   :exclude-members: model_config
+
+.. autoclass:: AnyTextFormat
+   :show-inheritance:
+   :exclude-members: model_config
+
+Combinatorial Formats
+---------------------
+
+.. autoclass:: SequenceFormat
+   :show-inheritance:
+   :exclude-members: model_config
+
+.. autoclass:: OrFormat
+   :show-inheritance:
+   :exclude-members: model_config
+
+.. autoclass:: TagFormat
+   :show-inheritance:
+   :exclude-members: model_config
+
+.. autoclass:: TriggeredTagsFormat
+   :show-inheritance:
+   :exclude-members: model_config
+
+.. autoclass:: TagsWithSeparatorFormat
+   :show-inheritance:
+   :exclude-members: model_config
+
+Format Union
+------------
+
+.. autodata:: Format
+
+Top Level Classes
+-----------------
 
 .. autoclass:: StructuralTagItem
+   :show-inheritance:
+   :exclude-members: model_config
+
+.. autoclass:: StructuralTag
    :show-inheritance:
    :exclude-members: model_config

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,8 @@ The mission of this project is to bring flexible zero-overhead structure generat
    tutorials/constrained_decoding
    tutorials/workflow_of_xgrammar
    tutorials/advanced_topics
+   tutorials/structural_tag
+   tutorials/advanced_structural_tag
    tutorials/engine_integration
    tutorials/json_generation
    tutorials/ebnf_guided_generation

--- a/docs/tutorials/advanced_structural_tag.md
+++ b/docs/tutorials/advanced_structural_tag.md
@@ -1,0 +1,51 @@
+# Advanced Topics of the Structural Tag
+
+## Deprecated API: `Grammar.from_structural_tag(tags, triggers)`
+
+**The deprecated API is still available for backward compatibility. However, it is recommended to use the new API instead.**
+
+Create a grammar from structural tags. The structural tag handles the dispatching of different grammars based on the tags and triggers: it initially allows any output, until a trigger is encountered, then dispatch to the corresponding tag; when the end tag is encountered, the grammar will allow any following output, until the next trigger is encountered.
+
+The tags parameter is used to specify the output pattern. It is especially useful for LLM function calling, where the pattern is:
+`<function=func_name>{"arg1": ..., "arg2": ...}</function>`.
+This pattern consists of three parts: a begin tag (`<function=func_name>`), a parameter list according to some schema (`{"arg1": ..., "arg2": ...}`), and an end tag (`</function>`). This pattern can be described in a StructuralTagItem with a begin tag, a schema, and an end tag. The structural tag is able to handle multiple such patterns by passing them into multiple tags.
+
+The triggers parameter is used to trigger the dispatching of different grammars. The trigger should be a prefix of a provided begin tag. When the trigger is encountered, the corresponding tag should be used to constrain the following output. There can be multiple tags matching the same trigger. Then if the trigger is encountered, the following output should match one of the tags. For example, in function calling, the triggers can be `["<function="]`. Then if `"<function="` is encountered, the following output must match one of the tags (e.g. `<function=get_weather>{"city": "Beijing"}</function>`).
+
+The correspondence of tags and triggers is automatically determined: all tags with the same trigger will be grouped together. User should make sure any trigger is not a prefix of another trigger: then the correspondence of tags and triggers will be ambiguous.
+
+To use this grammar in grammar-guided generation, the GrammarMatcher constructed from structural tag will generate a mask for each token. When the trigger is not encountered, the mask will likely be all-1 and not have to be used (fill_next_token_bitmask returns False, meaning no token is masked). When a trigger is encountered, the mask should be enforced (fill_next_token_bitmask will return True, meaning some token is masked) to the output logits.
+
+The benefit of this method is the token boundary between tags and triggers is automatically handled. The user does not need to worry about the token boundary.
+
+#### Parameters
+
+- **tags** (`List[StructuralTagItem]`): The structural tags.
+- **triggers** (`List[str]`): The triggers.
+
+#### Returns
+
+- **grammar** (`Grammar`): The constructed grammar.
+
+#### Example
+
+```python
+from pydantic import BaseModel
+from typing import List
+from xgrammar import Grammar, StructuralTagItem
+
+class Schema1(BaseModel):
+    arg1: str
+    arg2: int
+
+class Schema2(BaseModel):
+    arg3: float
+    arg4: List[str]
+
+tags = [
+    StructuralTagItem(begin="<function=f>", schema=Schema1, end="</function>"),
+    StructuralTagItem(begin="<function=g>", schema=Schema2, end="</function>"),
+]
+triggers = ["<function="]
+grammar = Grammar.from_structural_tag(tags, triggers)
+```

--- a/docs/tutorials/advanced_structural_tag.md
+++ b/docs/tutorials/advanced_structural_tag.md
@@ -18,16 +18,16 @@ To use this grammar in grammar-guided generation, the GrammarMatcher constructed
 
 The benefit of this method is the token boundary between tags and triggers is automatically handled. The user does not need to worry about the token boundary.
 
-#### Parameters
+### Parameters
 
 - **tags** (`List[StructuralTagItem]`): The structural tags.
 - **triggers** (`List[str]`): The triggers.
 
-#### Returns
+### Returns
 
 - **grammar** (`Grammar`): The constructed grammar.
 
-#### Example
+### Example
 
 ```python
 from pydantic import BaseModel

--- a/docs/tutorials/structural_tag.md
+++ b/docs/tutorials/structural_tag.md
@@ -1,0 +1,709 @@
+# Structural Tag Usage
+
+The structural tag API aims to provide a JSON-config-based way to precisely describe the output format of an LLM. It is more flexible and dynamic than the OpenAI API:
+
+* flexible: supports various structures, including function calling, reasoning (\<think\>...\</think\>), etc. More will be supported in the future.
+* dynamic: allows a mixture of free-form text and structures such as function calls, entering constrained generation when a pre-set trigger is met.
+
+## Usage
+
+The structural tag is a response format. It's compatible with the OpenAI API.
+
+```javascript
+{
+    ..., // other request parameters
+    "response_format": {
+        "type": "structural_tag",
+        "format": {
+            "type": "...",
+            ...
+        }
+    }
+}
+```
+
+The format field requires a format object. We provide several basic format objects, and they can be composed to allow for more complex formats. Each format object represent a "chunk" of text.
+
+## Format Types
+
+1. const\_string
+
+   The LLM output must exactly match the given string.
+
+   This is useful for like force reasoning, where the LLM output must start with "Let's think step by step".
+
+```javascript
+{
+    "type": "const_string",
+    "text": "..."
+}
+```
+
+2. JSON schema
+
+   The output should be a valid JSON object that matches the JSON schema.
+
+   This is similar to OpenAI's structured output API. It is a key component of the following elements.
+
+```javascript
+{
+    "type": "json_schema",
+    "json_schema": "..."
+}
+```
+
+3. sequence
+
+   Concatenate several elements into one. LLM's output must follow each element in order.
+
+```
+{
+    "type": "sequence",
+    "elements": [
+        ...
+    ]
+}
+```
+
+
+
+4. Or
+   The output should follow at least one of the elements.
+
+```
+{
+    "type": "or",
+    "elements": [
+        ...
+    ]
+}
+```
+
+5. tag
+
+   The tag represents a chunk of text starting and ending with certain strings. Say `<think>...</think>` or `<function>...</function>`. The content inside needs to follow a specific format
+
+```
+{
+    "type": "tag",
+    "begin": "...",
+    "content": {
+        ...
+    },
+    "end": "..."
+}
+```
+
+   The output should start with the "begin" value, then follow the format in "content", and end with the "end" value.
+
+
+
+6. wildcard tag
+
+   The wildcard tag is a special tag whose content allows any text except the end tag.
+
+```
+{
+    "type": "tag",
+    "begin": "...",
+    "content": {
+        "type": "any_text",
+    },
+    "end": "..."
+}
+```
+
+   The wildcard part should not contain an end tag. The end tag should not be empty.
+
+
+
+   The any\_text format cannot be used outside a tag.
+
+
+
+7. triggered\_tags
+
+   The output should be a mixture of text and tags. Each tag is selected from the tags provided in the tags field. E.g.
+
+```
+any_text tag0 any_text tag1 any_text tag2 any_text ...
+```
+
+(TODO: consider renaming to triggered\_tags)
+Config:
+
+```
+{
+    "type": "triggered_tags",
+    "triggers": ["<function="],
+    "tags": [
+        {
+            "begin": "...",
+            "content": {
+                ...
+            },
+            "end": "..."
+        },
+        {
+            "begin": "...",
+            "content": {
+                ...
+            },
+            "end": "..."
+        },
+    ],
+    "at_least_one": bool,
+    "stop_after_first": bool,
+}
+```
+
+The text and tags are separated by triggers. When a trigger is found in the output, the mode will be switched from text to tag.
+
+Each element in the tags field should be an object of the tag format.
+
+By setting the stop\_after\_first to true, this part will stop after the first tag is found.
+
+"at\_least\_one" and "stop\_after\_first" may not be implemented in the first version, but will be added in the future.
+
+8. tags\_with\_separator
+
+   The output should be an alternation of tags and string separators. Each tag is selected from the tags provided in the tags field. E.g.
+
+```
+tag0 separator tag1 separator tag2 separator ... tagx
+```
+
+   Note there is no separator before the first tag and after the last tag.
+
+
+
+   Config:
+
+```
+{
+    "type": "tags_with_separator",
+    "tags": [
+        {
+            "type": "tag", // optional
+            "begin": "..."
+            "content": {
+                ...
+            }
+            "end": "..."
+        },
+        {
+            "type": "tag", // optional
+            ...
+        }
+    ],
+    "separator": "...",
+    "at_least_one": bool,
+    "stop_after_first": bool
+}
+```
+
+   "at\_least\_one" and "stop\_after\_first" may not be implemented in the first version, but will be added in the future.
+
+There will be more formats in the future to provide more control over the output.
+
+## Examples
+
+### Example 1: Tool calling
+
+The structural tag can support most common tool calling formats.
+
+Llama JSON-based tool calling, Gemma:
+
+```
+{"name": "function_name", "parameters": params}
+```
+
+Config:
+
+```
+{
+    "type": "structural_tag",
+    "format": {
+        "type": "triggered_tags",
+        "triggers": ["{\"name\":"],
+        "tags": [
+            {
+                "begin": "{\"name\": \"func1\", \"parameters\": ",
+                "content": {"type": "json_schema", "json_schema": ...},
+                "end": "}"
+            },
+            {
+                "begin": "{\"name\": \"func2\", \"parameters\": ",
+                "content": {"type": "json_schema", "json_schema": ...},
+                "end": "}"
+            },
+        ],
+    },
+}
+```
+
+Llama user-defined custom tool calling:
+
+```
+<function=function_name>params</function>
+```
+
+Config:
+
+```
+{
+    "type": "structural_tag",
+    "format": {
+        "type": "triggered_tags",
+        "triggers": ["<function="],
+        "tags": [
+            {
+                "begin": "<function=func1>",
+                "content": {"type": "json_schema", "json_schema": ...},
+                "end": "</function>",
+            },
+            {
+                "begin": "<function=func2>",
+                "content": {"type": "json_schema", "json_schema": ...},
+                "end": "</function>",
+            },
+        ],
+    },
+}
+```
+
+Qwen 2.5/3, Hermes:
+
+```
+<tool_call>
+{"name": "get_current_temperature", "arguments": {"location": "San Francisco, CA, USA"}}
+</tool_call>
+```
+
+Config:
+
+```
+{
+    "type": "structural_tag",
+    "format": {
+        "type": "triggered_tags",
+        "triggers": ["<tool_call>"],
+        "tags": [
+            {
+                "begin": "<tool_call>\n{\"name\": \"func1\", \"arguments\": ",
+                "content": {"type": "json_schema", "json_schema": ...},
+                "end": "}\n</tool_call>",
+            },
+            {
+                "begin": "<tool_call>\n{\"name\": \"func2\", \"arguments\": ",
+                "content": {"type": "json_schema", "json_schema": ...},
+                "end": "}\n</tool_call>",
+            },
+        ],
+    },
+}
+```
+
+DeepSeek:
+
+There is a special tag `<｜tool▁calls▁begin｜> ... <｜tool▁calls▁end｜>` quotes the whole tool calling part.
+
+````
+<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>function_name_1
+```jsonc
+{params}
+```<｜tool▁call▁end｜>
+
+```jsonc
+{params}
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+````
+
+Config:
+
+````
+{
+    "type": "structural_tag",
+    "format": {
+        "type": "tag_and_text",
+        "triggers": ["<｜tool▁calls▁begin｜>"],
+        "tags": [
+            {
+                "begin": "<｜tool▁calls▁begin｜>",
+                "end": "<｜tool▁calls▁end｜>",
+                "content": {
+                    "type": "tags_with_separator",
+                    "separator": "\n",
+                    "tags": [
+                        {
+                            "begin": "<｜tool▁call▁begin｜>function<｜tool▁sep｜>function_name_1\n```jsonc\n",
+                            "content": {"type": "json_schema", "json_schema": ...},
+                            "end": "\n```<｜tool▁call▁end｜>",
+                        },
+                        {
+                            "begin": "<｜tool▁call▁begin｜>function<｜tool▁sep｜>function_name_2\n```jsonc\n",
+                            "content": {"type": "json_schema", "json_schema": ...},
+                            "end": "\n```<｜tool▁call▁end｜>",
+                        }
+                    ]
+                }
+            }
+        ],
+        "stop_after_first": true,
+
+    },
+}
+````
+
+Phi-4-mini:
+
+Similar to DeepSeek-V3, but the tool calling part is wrapped in `<|tool_call|>...<|/tool_call|>` and organized in a list.
+
+```
+<|tool_call|>[{"name": "function_name_1", "arguments": params}, {"name": "function_name_2", "arguments": params}]<|/tool_call|>
+```
+
+Config:
+
+```
+{
+    "type": "structural_tag",
+    "format": {
+        "type": "tag_and_text",
+        "triggers": ["<|tool_call|>"],
+        "tags": [
+            {
+                "begin": "<|tool_call|>[",
+                "end": "]<|/tool_call|>",
+                "content": {
+                    "type": "tags_with_separator",
+                    "separator": ", ",
+                    "tags": [
+                        {
+                            "begin": "{\"name\": \"function_name_1\", \"arguments\": ",
+                            "content": {"type": "json_schema", "json_schema": ...},
+                            "end": "}",
+                        },
+                        {
+                            "begin": "{\"name\": \"function_name_2\", \"arguments\": ",
+                            "content": {"type": "json_schema", "json_schema": ...},
+                            "end": "}",
+                        }
+                    ]
+                }
+            }
+        ],
+        "stop_after_first": true,
+    },
+}
+```
+
+### Example 2: Force think
+
+The output should start with a reasoning part (`<think>...</think>`), then can generate a mix of text and function calls.
+
+Format:
+
+```
+<think> any_text </think> any_text <function=func1> params </function> any_text
+```
+
+Config:
+
+```
+{
+    "type": "structural_tag",
+    "format": {
+        "type": "sequence",
+        "elements": [
+            {
+                "type": "tag",
+                "begin": "<think>",
+                "content": {"type": "any_text"},
+                "end": "</think>",
+            },
+            {
+                "type": "triggered_tags",
+                "triggers": ["<function="],
+                "tags": [
+                    {
+                        "begin": "<function=func1>",
+                        "content": {"type": "json_schema", "json_schema": ...},
+                        "end": "</function>",
+                    },
+                    {
+                        "begin": "<function=func2>",
+                        "content": {"type": "json_schema", "json_schema": ...},
+                        "end": "</function>",
+                    },
+                ],
+            },
+        ],
+    },
+}
+```
+
+### Example 3: Think & Force tool calling (Llama style)
+
+The output should start with a reasoning part (`<think>...</think>`), then need to generate exactly one tool call in the tool set.
+
+Format:
+
+```
+<think> any_text </think> <function=func1> params </function>
+```
+
+Config:
+
+```
+{
+    "type": "structural_tag",
+    "format": {
+        "type": "sequence",
+        "elements": [
+            {
+                "type": "tag",
+                "begin": "<think>",
+                "content": {"type": "any_text"},
+                "end": "</think>",
+            },
+            {
+                "type": "triggered_tags",
+                "triggers": ["<function="],
+                "tags": [
+                    {
+                        "begin": "<function=func1>",
+                        "content": {"type": "json_schema", "json_schema": ...},
+                        "end": "</function>",
+                    },
+                    {
+                        "begin": "<function=func2>",
+                        "content": {"type": "json_schema", "json_schema": ...},
+                        "end": "</function>",
+                    },
+                ],
+                "stop_after_first": true,
+                "at_least_one": true,
+            },
+        ],
+    },
+}
+```
+
+### Example 4: Think & force tool calling (DeepSeek style)
+
+The output should start with a reasoning part (`<think>...</think>`), then must generate a tool call following the DeepSeek style.
+
+Config:
+
+````
+{
+    "type": "structural_tag",
+    "format": {
+        "type": "sequence",
+        "elements": [
+            {
+                "type": "tag",
+                "begin": "<think>",
+                "content": {"type": "any_text"},
+                "end": "</think>",
+            },
+            {
+                "type": "tag_and_text",
+                "triggers": ["<｜tool▁calls▁begin｜>"],
+                "tags": [
+                    {
+                        "begin": "<｜tool▁calls▁begin｜>",
+                        "end": "<｜tool▁calls▁end｜>",
+                        "content": {
+                            "type": "tags_with_separator",
+                            "separator": "\n",
+                            "tags": [
+                                {
+                                    "begin": "<｜tool▁call▁begin｜>function<｜tool▁sep｜>function_name_1\n```jsonc\n",
+                                    "content": {"type": "json_schema", "json_schema": ...},
+                                    "end": "\n```<｜tool▁call▁end｜>",
+                                },
+                                {
+                                    "begin": "<｜tool▁call▁begin｜>function<｜tool▁sep｜>function_name_2\n```jsonc\n",
+                                    "content": {"type": "json_schema", "json_schema": ...},
+                                    "end": "\n```<｜tool▁call▁end｜>",
+                                }
+                            ],
+                            "at_least_one": true, // Note this line!
+                            "stop_after_first": true, // Note this line!
+                        }
+                    }
+                ],
+                "stop_after_first": true,
+            },
+        ],
+    },
+},
+````
+
+### Example 5: Force non-thinking mode
+
+Qwen-3 has a hybrid thinking mode that allows switching between thinking and non-thinking mode. Thinking mode is the same as above, while in non-thinking mode, the output would start with a empty thinking part `<think></think>`, and then can generate any text.
+
+We now specify the non-thinking mode.
+
+```
+{
+    "type": "structural_tag",
+    "format": {
+        "type": "sequence",
+        "elements": [
+            {
+                "type": "const_string",
+                "text": "<think></think>"
+            },
+            {
+                "type": "triggered_tags",
+                "triggers": ["<tool_call>"],
+                "tags": [
+                    {
+                        "begin": "<tool_call>\n{\"name\": \"func1\", \"arguments\": ",
+                        "content": {"type": "json_schema", "json_schema": ...},
+                        "end": "}\n</tool_call>",
+                    },
+                    {
+                        "begin": "<tool_call>\n{\"name\": \"func2\", \"arguments\": ",
+                        "content": {"type": "json_schema", "json_schema": ...},
+                        "end": "}\n</tool_call>",
+                    },
+                ],
+            },
+        ],
+    },
+}
+```
+
+## Compatibility with the OAI Function Calling API
+
+In addition to the OpenAI-compatible API usage described above, the structural tag also provides an equivalent Python API, which can be used to implement the OpenAI Function Calling API with strict format constraints.
+
+### Basic Function Calling
+
+The OpenAI API requires user to specify the tools in the request. Each tool contains a name, description, and parameters.
+
+```py
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get current temperature for a given location.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "City and country e.g. Bogotá, Colombia"
+                }
+            },
+            "required": [
+                "location"
+            ],
+            "additionalProperties": False
+        },
+        "strict": True
+    }
+}]
+
+completion = client.chat.completions.create(
+    model="gpt-4.1",
+    messages=[{"role": "user", "content": "What is the weather like in Paris today?"}],
+    tools=tools
+)
+```
+
+To use the structural tag, we need to
+
+1. Find the tool calling format of the current model (need to be defined in the LLM engine)
+2. Construct a structural tag as in *Example 1: Tool calling*
+3. Use XGrammar to do constraint decoding with the structural tag.
+4. Use the XGrammar structural tag parser to parse the string response into a structured object.
+5. Convert the parsed result to the OpenAI Function Calling API format.
+
+### Tool Choice
+
+`tool_choice` is a parameter in the OpenAI API. It can be
+
+* `auto`: Let the model decide which tool to use
+* `required`: Call at least one tool
+* `{"type": "function", "function": {"name": "function_name"}}`: The forced mode, call exactly one specific function
+
+The above basic section describes the support of the auto mode.
+
+The required mode can be implemented by
+
+```
+{
+    "type": "structural_tag",
+    "format": {
+        "type": "triggered_tags",
+        "triggers": ["<function="],
+        "tags": [
+            {
+                "begin": "<function=func1>",
+                "content": {"type": "json_schema", "json_schema": ...},
+                "end": "</function>",
+            },
+            {
+                "begin": "<function=func2>",
+                "content": {"type": "json_schema", "json_schema": ...},
+                "end": "</function>",
+            },
+        ],
+        "at_least_one": true,
+    },
+}
+```
+
+The forced mode can be implemented by
+
+```
+{
+    "type": "structural_tag",
+    "format": {
+        "type": "tag",
+        "begin": "<function=func1>",
+        "content": {"type": "json_schema", "json_schema": ...},
+        "end": "</function>",
+    },
+}
+```
+
+### Parallel Function Calling
+
+OAI's `parallel_tool_calls` parameter controls if the model can call multiple functions in one round.
+
+* If `true`, the model can call multiple functions in one round. (This is default)
+* If `false`, the model can call at most one function in one round.
+
+The above basic section describes the support of the true mode.
+
+The false mode can be implemented by
+
+```
+{
+    "type": "structural_tag",
+    "format": {
+        "type": "triggered_tags",
+        "triggers": ["<function="],
+        "tags": [
+            {
+                "begin": "<function=func1>",
+                "content": {"type": "json_schema", "json_schema": ...},
+                "end": "</function>",
+            },
+            {
+                "begin": "<function=func2>",
+                "content": {"type": "json_schema", "json_schema": ...},
+                "end": "</function>",
+            },
+        ],
+        "stop_after_first": true,
+    },
+}
+```

--- a/docs/xgrammar_features/serialization.md
+++ b/docs/xgrammar_features/serialization.md
@@ -11,7 +11,7 @@ Each serialized result have a `__VERSION__` field to indicate the serialization 
 internal data structure is changed in XGrammar, the serialization version will be updated. Use
 [`xgr.get_serialization_version`](xgrammar.get_serialization_version) to get the current serialization
 version. In deserialization, if the version in the JSON string does not match the current version,
-the deserialization will fail and raise a [`xgr.DeserializeVersionError`](xgrammar.DeserializeVersionError).
+the deserialization will fail and raise a [`xgr.exception.DeserializeVersionError`](xgrammar.exception. DeserializeVersionError).
 
 > **Note:**<br>
 > After upgrading XGrammar, the serialization format may change. If you have cached serialization
@@ -19,9 +19,9 @@ the deserialization will fail and raise a [`xgr.DeserializeVersionError`](xgramm
 
 Three error types are raised when deserialization fails:
 
-- [`xgr.InvalidJSONError`](xgrammar.InvalidJSONError): When the JSON string is invalid.
-- [`xgr.DeserializeFormatError`](xgrammar.DeserializeFormatError): When the JSON string does not follow the serialization format of the type.
-- [`xgr.DeserializeVersionError`](xgrammar.DeserializeVersionError): When the serialization version in the JSON string is not the same as the
+- [`xgr.exception.InvalidJSONError`](xgrammar.exception.InvalidJSONError): When the JSON string is invalid.
+- [`xgr.exception.DeserializeFormatError`](xgrammar.exception.DeserializeFormatError): When the JSON string does not follow the serialization format of the type.
+- [`xgr.exception.DeserializeVersionError`](xgrammar.exception.DeserializeVersionError): When the serialization version in the JSON string is not the same as the
   current version.
 
 ## [`xgr.Grammar`](xgrammar.Grammar)

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -68,7 +68,7 @@ class GrammarCompiler {
       const TokenizerInfo& tokenizer_info,
       int max_threads = 8,
       bool cache_enabled = true,
-      long long max_memory_bytes = -1  // unlimited
+      int64_t max_memory_bytes = -1  // unlimited
   );
 
   /*! \brief Get the compiled grammar for a JSON schema string. */
@@ -87,10 +87,13 @@ class GrammarCompiler {
   /*! \brief Get the compiled grammar for a grammar. */
   CompiledGrammar CompileGrammar(const Grammar& grammar);
 
-  /*! \brief Get the compiled grammar for a structural tag. */
-  CompiledGrammar CompileStructuralTag(
-      const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
+  /*! \brief Get the compiled grammar for a grammar. */
+  CompiledGrammar CompileGrammar(
+      const std::string& ebnf_str, const std::string& root_rule_name = "root"
   );
+
+  /*! \brief Get the compiled grammar for a structural tag. */
+  CompiledGrammar CompileStructuralTag(const std::string& structural_tag_json);
 
   /*! \brief Get the compiled grammar for a regex. */
   CompiledGrammar CompileRegex(const std::string& regex);
@@ -99,10 +102,10 @@ class GrammarCompiler {
   void ClearCache();
 
   /*! \brief Return the approximate memory usage of the compiler in bytes. */
-  long long GetCacheSizeBytes() const;
+  int64_t GetCacheSizeBytes() const;
 
   /*! \brief Return the approximate memory usage of the compiler in bytes. -1 means unlimited. */
-  long long CacheLimitBytes() const;
+  int64_t CacheLimitBytes() const;
 
   XGRAMMAR_DEFINE_PIMPL_METHODS(GrammarCompiler);
 };

--- a/include/xgrammar/exception.h
+++ b/include/xgrammar/exception.h
@@ -6,23 +6,62 @@
 
 namespace xgrammar {
 
+/************** Exception Definitions **************/
+
+/*!
+ * \brief Exception thrown when the version in the serialized data does not follow the current
+ * serialization version.
+ */
 struct DeserializeVersionError : std::runtime_error {
   DeserializeVersionError(const std::string& message)
       : std::runtime_error("Deserialize version error: " + message) {}
 };
 
+/*!
+ * \brief Exception thrown when the JSON is invalid.
+ */
 struct InvalidJSONError : std::runtime_error {
   InvalidJSONError(const std::string& message)
       : std::runtime_error("Invalid JSON error: " + message) {}
 };
 
+/*!
+ * \brief Exception thrown when the serialized data does not follow the expected format.
+ */
 struct DeserializeFormatError : std::runtime_error {
   DeserializeFormatError(const std::string& message)
       : std::runtime_error("Deserialize format error: " + message) {}
 };
 
+/*!
+ * \brief Exception thrown when the JSON schema is invalid or not satisfiable.
+ */
+struct InvalidJSONSchemaError : std::runtime_error {
+  InvalidJSONSchemaError(const std::string& message)
+      : std::runtime_error("Invalid JSON schema error: " + message) {}
+};
+
+/*!
+ * \brief Exception thrown when the structural tag is invalid.
+ */
+struct InvalidStructuralTagError : std::runtime_error {
+  InvalidStructuralTagError(const std::string& message)
+      : std::runtime_error("Invalid structural tag error: " + message) {}
+};
+
+/************** Union Exceptions **************/
+
+/*!
+ * \brief Represents a serialization error.
+ */
 using SerializationError =
     std::variant<DeserializeVersionError, InvalidJSONError, DeserializeFormatError>;
+
+/*!
+ * \brief Represents an error from the structural tag conversion.
+ */
+using StructuralTagError =
+    std::variant<InvalidJSONError, InvalidJSONSchemaError, InvalidStructuralTagError>;
 
 }  // namespace xgrammar
 

--- a/include/xgrammar/exception.h
+++ b/include/xgrammar/exception.h
@@ -14,7 +14,7 @@ namespace xgrammar {
  */
 struct DeserializeVersionError : std::runtime_error {
   DeserializeVersionError(const std::string& message)
-      : std::runtime_error("Deserialize version error: " + message) {}
+      : std::runtime_error(std::string("Deserialize version error: ") + message) {}
 };
 
 /*!
@@ -22,7 +22,7 @@ struct DeserializeVersionError : std::runtime_error {
  */
 struct InvalidJSONError : std::runtime_error {
   InvalidJSONError(const std::string& message)
-      : std::runtime_error("Invalid JSON error: " + message) {}
+      : std::runtime_error(std::string("Invalid JSON error: ") + message) {}
 };
 
 /*!
@@ -30,7 +30,7 @@ struct InvalidJSONError : std::runtime_error {
  */
 struct DeserializeFormatError : std::runtime_error {
   DeserializeFormatError(const std::string& message)
-      : std::runtime_error("Deserialize format error: " + message) {}
+      : std::runtime_error(std::string("Deserialize format error: ") + message) {}
 };
 
 /*!
@@ -38,7 +38,7 @@ struct DeserializeFormatError : std::runtime_error {
  */
 struct InvalidJSONSchemaError : std::runtime_error {
   InvalidJSONSchemaError(const std::string& message)
-      : std::runtime_error("Invalid JSON schema error: " + message) {}
+      : std::runtime_error(std::string("Invalid JSON schema error: ") + message) {}
 };
 
 /*!
@@ -46,7 +46,7 @@ struct InvalidJSONSchemaError : std::runtime_error {
  */
 struct InvalidStructuralTagError : std::runtime_error {
   InvalidStructuralTagError(const std::string& message)
-      : std::runtime_error("Invalid structural tag error: " + message) {}
+      : std::runtime_error(std::string("Invalid structural tag error: ") + message) {}
 };
 
 /************** Union Exceptions **************/

--- a/include/xgrammar/exception.h
+++ b/include/xgrammar/exception.h
@@ -2,6 +2,7 @@
 #define XGRAMMAR_EXCEPTION_H
 
 #include <stdexcept>
+#include <string>
 #include <variant>
 
 namespace xgrammar {

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -129,11 +129,11 @@ class Grammar {
   static Grammar FromRegex(const std::string& regex, bool print_converted_ebnf = false);
 
   /*!
-   * \brief Construct a grammar from a regular expression string.
-   * \param regex The regular expression string.
+   * \brief Construct a grammar from a structural tag string.
+   * \param structural_tag_json The structural tag string.
    */
-  static Grammar FromStructuralTag(
-      const std::vector<StructuralTagItem>& tags, const std::vector<std::string>& triggers
+  static std::variant<Grammar, StructuralTagError> FromStructuralTag(
+      const std::string& structural_tag_json
   );
 
   /*!

--- a/include/xgrammar/xgrammar.h
+++ b/include/xgrammar/xgrammar.h
@@ -9,6 +9,7 @@
 
 #include <xgrammar/compiler.h>
 #include <xgrammar/config.h>
+#include <xgrammar/exception.h>
 #include <xgrammar/grammar.h>
 #include <xgrammar/matcher.h>
 #include <xgrammar/tokenizer_info.h>

--- a/python/xgrammar/__init__.py
+++ b/python/xgrammar/__init__.py
@@ -7,7 +7,12 @@ from .config import (
     set_max_recursion_depth,
 )
 from .contrib import hf
-from .exception import DeserializeFormatError, DeserializeVersionError, InvalidJSONError
+from .exception import (
+    DeserializeFormatError,
+    DeserializeVersionError,
+    InvalidJSONError,
+    InvalidStructuralTagError,
+)
 from .grammar import Grammar, StructuralTagItem
 from .matcher import (
     GrammarMatcher,

--- a/python/xgrammar/__init__.py
+++ b/python/xgrammar/__init__.py
@@ -1,4 +1,4 @@
-from . import testing
+from . import exception, structural_tag, testing
 from .compiler import CompiledGrammar, GrammarCompiler
 from .config import (
     get_max_recursion_depth,

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -221,9 +221,7 @@ class GrammarCompiler(XGRObject):
     @overload
     def compile_structural_tag(
         self, structural_tag: Union[StructuralTag, str, Dict[str, Any]]
-    ) -> CompiledGrammar:
-        """Compile a grammar from a structural tag."""
-        ...
+    ) -> CompiledGrammar: ...
 
     @overload
     @deprecated(
@@ -232,27 +230,50 @@ class GrammarCompiler(XGRObject):
     )
     def compile_structural_tag(
         self, tags: List[StructuralTagItem], triggers: List[str]
-    ) -> CompiledGrammar:
-        """Compile a grammar from structural tags. See Grammar.from_structural_tag() for more
-        details.
+    ) -> CompiledGrammar: ...
+
+    def compile_structural_tag(self, *args, **kwargs) -> CompiledGrammar:
+        """Compile a grammar from a structural tag. See the Structural Tag Usage in XGrammar
+        documentation for its usage.
+
+        This method supports two calling patterns:
+
+        1. Single structural tag parameter:
+           compile_structural_tag(structural_tag)
+
+        2. Legacy pattern (deprecated):
+           compile_structural_tag(tags, triggers)
 
         Parameters
         ----------
+        structural_tag : Union[StructuralTag, str, Dict[str, Any]]
+            The structural tag either as a StructuralTag object, or a JSON string or a dictionary.
+
         tags : List[StructuralTagItem]
-            The structural tags.
+            (Deprecated) The structural tags. Use StructuralTag class instead.
 
         triggers : List[str]
-            The triggers.
+            (Deprecated) The triggers. Use StructuralTag class instead.
 
         Returns
         -------
         compiled_grammar : CompiledGrammar
-            The compiled grammar.
-        """
-        ...
+            The compiled grammar from the structural tag.
 
-    def compile_structural_tag(self, *args, **kwargs) -> CompiledGrammar:
-        """Compile a grammar from structural tag."""
+        Raises
+        ------
+        InvalidJSONError
+            When the structural tag is not a valid JSON string.
+        InvalidStructuralTagError
+            When the structural tag is not valid.
+        TypeError
+            When the arguments are invalid.
+
+        Notes
+        -----
+        The legacy pattern compile_structural_tag(tags, triggers) is deprecated. Use the
+        StructuralTag class to construct structural tags instead.
+        """
         structural_tag_str = _get_structural_tag_str_from_args(args, kwargs)
         return CompiledGrammar._create_from_handle(
             self._handle.compile_structural_tag(structural_tag_str)

--- a/python/xgrammar/exception.py
+++ b/python/xgrammar/exception.py
@@ -15,8 +15,12 @@ if TYPE_CHECKING or isinstance(_core, str):
     class InvalidJSONError(RuntimeError):
         """Raised when the JSON is invalid."""
 
+    class InvalidStructuralTagError(RuntimeError):
+        """Raised when the structural tag is invalid."""
+
 else:
     # real implementation here
-    DeserializeFormatError = _core.DeserializeFormatError
-    DeserializeVersionError = _core.DeserializeVersionError
-    InvalidJSONError = _core.InvalidJSONError
+    DeserializeFormatError = _core.exception.DeserializeFormatError
+    DeserializeVersionError = _core.exception.DeserializeVersionError
+    InvalidJSONError = _core.exception.InvalidJSONError
+    InvalidStructuralTagError = _core.exception.InvalidStructuralTagError

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -242,27 +242,9 @@ class Grammar(XGRObject):
 
     @overload
     @staticmethod
-    def from_structural_tag(structural_tag: Union[StructuralTag, str, Dict[str, Any]]) -> "Grammar":
-        """Create a grammar from a structural tag.
-
-        Parameters
-        ----------
-        structural_tag : Union[StructuralTag, str, Dict[str, Any]]
-            The structural tag either as a StructuralTag object, or a JSON string or a dictionary.
-
-        Returns
-        -------
-        grammar : Grammar
-            The constructed grammar.
-
-        Raises
-        ------
-        InvalidJSONError
-            When the structural tag is not a valid JSON string.
-        InvalidStructuralTagError
-            When the structural tag is not valid.
-        """
-        ...
+    def from_structural_tag(
+        structural_tag: Union[StructuralTag, str, Dict[str, Any]]
+    ) -> "Grammar": ...
 
     @overload
     @staticmethod
@@ -270,76 +252,58 @@ class Grammar(XGRObject):
         "from_structural_tag(tags, triggers) is deprecated. Construct structural tag with the "
         "StructuralTag class instead."
     )
-    def from_structural_tag(tags: List[StructuralTagItem], triggers: List[str]) -> "Grammar":
-        """Create a grammar from structural tags. The structural tag handles the dispatching
-        of different grammars based on the tags and triggers: it initially allows any output,
-        until a trigger is encountered, then dispatch to the corresponding tag; when the end tag
-        is encountered, the grammar will allow any following output, until the next trigger is
-        encountered.
+    def from_structural_tag(tags: List[StructuralTagItem], triggers: List[str]) -> "Grammar": ...
 
-        The tags parameter is used to specify the output pattern. It is especially useful for LLM
-        function calling, where the pattern is:
-        <function=func_name>{"arg1": ..., "arg2": ...}</function>.
-        This pattern consists of three parts: a begin tag (<function=func_name>), a parameter list
-        according to some schema ({"arg1": ..., "arg2": ...}), and an end tag (</function>). This
-        pattern can be described in a StructuralTagItem with a begin tag, a schema, and an end tag.
-        The structural tag is able to handle multiple such patterns by passing them into multiple
-        tags.
+    @staticmethod
+    def from_structural_tag(*args, **kwargs) -> "Grammar":
+        """Create a grammar from a structural tag. See the Structural Tag Usage in XGrammar
+        documentation for its usage.
 
-        The triggers parameter is used to trigger the dispatching of different grammars. The trigger
-        should be a prefix of a provided begin tag. When the trigger is encountered, the
-        corresponding tag should be used to constrain the following output. There can be multiple
-        tags matching the same trigger. Then if the trigger is encountered, the following output
-        should match one of the tags. For example, in function calling, the triggers can be
-        ["<function="]. Then if "<function=" is encountered, the following output must match one
-        of the tags (e.g. <function=get_weather>{"city": "Beijing"}</function>).
+        This method supports two calling patterns:
 
-        The corrrespondence of tags and triggers is automatically determined: all tags with the
-        same trigger will be grouped together. User should make sure any trigger is not a prefix
-        of another trigger: then the corrrespondence of tags and triggers will be ambiguous.
+        1. Single structural tag parameter:
+           from_structural_tag(structural_tag)
 
-        To use this grammar in grammar-guided generation, the GrammarMatcher constructed from
-        structural tag will generate a mask for each token. When the trigger is not encountered,
-        the mask will likely be all-1 and not have to be used (fill_next_token_bitmask returns
-        False, meaning no token is masked). When a trigger is encountered, the mask should be
-        enforced (fill_next_token_bitmask will return True, meaning some token is masked) to the
-        output logits.
-
-        The benefit of this method is the token boundary between tags and triggers is automatically
-        handled. The user does not need to worry about the token boundary.
+        2. Legacy pattern (deprecated):
+           from_structural_tag(tags, triggers)
 
         Parameters
         ----------
+        structural_tag : Union[StructuralTag, str, Dict[str, Any]]
+            The structural tag either as a StructuralTag object, or a JSON string or a dictionary.
+
         tags : List[StructuralTagItem]
-            The structural tags.
+            (Deprecated) The structural tags. Use StructuralTag class instead.
 
         triggers : List[str]
-            The triggers.
+            (Deprecated) The triggers. Use StructuralTag class instead.
 
         Returns
         -------
         grammar : Grammar
-            The constructed grammar.
+            The constructed grammar from the structural tag.
 
-        Examples
-        --------
-        >>> class Schema1(BaseModel):
-        ...     arg1: str
-        ...     arg2: int
-        >>> class Schema2(BaseModel):
-        ...     arg3: float
-        ...     arg4: List[str]
-        >>> tags = [
-        ...     StructuralTagItem(begin="<function=f>", schema=Schema1, end="</function>"),
-        ...     StructuralTagItem(begin="<function=g>", schema=Schema2, end="</function>"),
-        ... ]
-        >>> triggers = ["<function="]
-        >>> grammar = Grammar.from_structural_tag(tags, triggers)
+        Raises
+        ------
+        InvalidJSONError
+            When the structural tag is not a valid JSON string.
+        InvalidStructuralTagError
+            When the structural tag is not valid.
+        TypeError
+            When the arguments are invalid.
+
+        Notes
+        -----
+        The legacy pattern from_structural_tag(tags, triggers) is deprecated. Use the StructuralTag
+        class to construct structural tags instead.
+
+        For the deprecated pattern: The structural tag handles the dispatching of different grammars
+        based on the tags and triggers: it initially allows any output, until a trigger is
+        encountered, then dispatch to the corresponding tag; when the end tag is encountered, the
+        grammar will allow any following output, until the next trigger is encountered. See the
+        Advanced Topics of the Structural Tag in XGrammar documentation for its semantic.
+        Structural Tag in XGrammar documentation for its semantic.
         """
-        ...
-
-    @staticmethod
-    def from_structural_tag(*args, **kwargs) -> "Grammar":
         structural_tag_str = _get_structural_tag_str_from_args(args, kwargs)
         return Grammar._create_from_handle(_core.Grammar.from_structural_tag(structural_tag_str))
 

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -62,7 +62,7 @@ class OrFormat(BaseModel):
 
 
 class TagFormat(BaseModel):
-    """A format that matches a tag: `begin content end`."""
+    """A format that matches a tag: ``begin content end``."""
 
     type: Literal["tag"] = "tag"
     """The type of the format."""
@@ -218,7 +218,7 @@ class StructuralTagItem(BaseModel):
 class StructuralTag(BaseModel):
     """
     Describes a complete structural tag structure. It corresponds to
-    `"response_format": {"type": "structural_tag", "format": {...}}` in API.
+    ``"response_format": {"type": "structural_tag", "format": {...}}`` in API.
     """
 
     type: Literal["structural_tag"] = "structural_tag"

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -1,7 +1,14 @@
 """Defines all structural tag formats."""
 
 import json
-from typing import Annotated, Any, Dict, List, Literal, Type, Union
+from typing import Any, Dict, List, Literal, Type, Union
+
+try:
+    # Python 3.9+
+    from typing import Annotated
+except ImportError:
+    # Python 3.8
+    from typing_extensions import Annotated
 
 from pydantic import BaseModel, Field
 
@@ -77,31 +84,33 @@ class TriggeredTagsFormat(BaseModel):
 
     Examples
     --------
-    ```
-    structural_tag = TriggeredTagsFormat(
-        triggers=["<function="],
-        tags=[
-            TagFormat(
-                begin="<function=func1>",
-                content=JSONSchemaFormat(json_schema=...),
-                end="</function>",
-            ),
-            TagFormat(
-                begin="<function=func2>",
-                content=JSONSchemaFormat(json_schema=...),
-                end="</function>",
-            ),
-        ],
-        at_least_one=False,
-        stop_after_first=False,
-    )
-    ```
-    The above structural tag can accept the following outputs:
-    ```
-    <function=func1>{"name": "John", "age": 30}</function>
-    <function=func2>{"name": "Jane", "age": 25}</function>
-    any_text<function=func1>{"name": "John", "age": 30}</function>any_text1<function=func2>{"name": "Jane", "age": 25}</function>any_text2
-    ```
+
+    .. code-block:: python
+
+        structural_tag = TriggeredTagsFormat(
+            triggers=["<function="],
+            tags=[
+                TagFormat(
+                    begin="<function=func1>",
+                    content=JSONSchemaFormat(json_schema=...),
+                    end="</function>",
+                ),
+                TagFormat(
+                    begin="<function=func2>",
+                    content=JSONSchemaFormat(json_schema=...),
+                    end="</function>",
+                ),
+            ],
+            at_least_one=False,
+            stop_after_first=False,
+        )
+
+    The above structural tag can accept the following outputs::
+
+        <function=func1>{"name": "John", "age": 30}</function>
+        <function=func2>{"name": "Jane", "age": 25}</function>
+        any_text<function=func1>{"name": "John", "age": 30}</function>any_text1<function=func2>{"name": "Jane", "age": 25}</function>any_text2
+
     """
 
     type: Literal["triggered_tags"] = "triggered_tags"
@@ -122,23 +131,24 @@ class TagsWithSeparatorFormat(BaseModel):
 
     Examples
     --------
-    ```
-    structural_tag = TagsWithSeparatorFormat(
-        tags=[
-            TagFormat(begin="<function=func1>", content=JSONSchemaFormat(json_schema=...), end="</function>"),
-            TagFormat(begin="<function=func2>", content=JSONSchemaFormat(json_schema=...), end="</function>"),
-        ],
-        separator=",",
-        at_least_one=False,
-        stop_after_first=False,
-    )
-    ```
-    The above structural tag can accept an empty string, or the following outputs:
-    ```
-    <function=func1>{"name": "John", "age": 30}</function>
-    <function=func1>{"name": "John", "age": 30}</function>,<function=func2>{"name": "Jane", "age": 25}</function>
-    <function=func1>{"name": "John", "age": 30}</function>,<function=func2>{"name": "Jane", "age": 25}</function>,<function=func1>{"name": "John", "age": 30}</function>
-    ```
+
+    .. code-block:: python
+
+        structural_tag = TagsWithSeparatorFormat(
+            tags=[
+                TagFormat(begin="<function=func1>", content=JSONSchemaFormat(json_schema=...), end="</function>"),
+                TagFormat(begin="<function=func2>", content=JSONSchemaFormat(json_schema=...), end="</function>"),
+            ],
+            separator=",",
+            at_least_one=False,
+            stop_after_first=False,
+        )
+
+    The above structural tag can accept an empty string, or the following outputs::
+
+        <function=func1>{"name": "John", "age": 30}</function>
+        <function=func1>{"name": "John", "age": 30}</function>,<function=func2>{"name": "Jane", "age": 25}</function>
+        <function=func1>{"name": "John", "age": 30}</function>,<function=func2>{"name": "Jane", "age": 25}</function>,<function=func1>{"name": "John", "age": 30}</function>
     """
 
     type: Literal["tags_with_separator"] = "tags_with_separator"
@@ -257,3 +267,18 @@ class StructuralTag(BaseModel):
             return StructuralTag.model_validate(json_str)
         else:
             raise ValueError("Invalid JSON string or dictionary")
+
+
+__all__ = [
+    "ConstStringFormat",
+    "JSONSchemaFormat",
+    "AnyTextFormat",
+    "SequenceFormat",
+    "OrFormat",
+    "TagFormat",
+    "TriggeredTagsFormat",
+    "TagsWithSeparatorFormat",
+    "Format",
+    "StructuralTagItem",
+    "StructuralTag",
+]

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -1,0 +1,158 @@
+import json
+from typing import Annotated, Any, Dict, List, Literal, Type, Union
+
+from pydantic import BaseModel, Field
+
+# ---------- Basic Formats ----------
+
+
+class ConstStringFormat(BaseModel):
+    type: Literal["const_string"] = "const_string"
+    text: str
+
+
+class JSONSchemaFormat(BaseModel):
+    type: Literal["json_schema"] = "json_schema"
+    json_schema: Union[bool, Dict[str, Any]]
+
+
+class AnyTextFormat(BaseModel):
+    type: Literal["any_text"] = "any_text"
+
+
+# ---------- Combinatorial Formats ----------
+
+
+class SequenceFormat(BaseModel):
+    type: Literal["sequence"] = "sequence"
+    elements: List["Format"]
+
+
+class OrFormat(BaseModel):
+    type: Literal["or"] = "or"
+    elements: List["Format"]
+
+
+class TagFormat(BaseModel):
+    type: Literal["tag"] = "tag"
+    begin: str
+    content: "Format"
+    end: str
+
+
+class TriggeredTagsFormat(BaseModel):
+    type: Literal["triggered_tags"] = "triggered_tags"
+    triggers: List[str]
+    tags: List[TagFormat]
+    at_least_one: bool = False
+    stop_after_first: bool = False
+
+
+class TagsWithSeparatorFormat(BaseModel):
+    type: Literal["tags_with_separator"] = "tags_with_separator"
+    tags: List[TagFormat]
+    separator: str
+    at_least_one: bool = False
+    stop_after_first: bool = False
+
+
+# ---------- Discriminated Union ----------
+
+
+Format = Annotated[
+    Union[
+        AnyTextFormat,
+        ConstStringFormat,
+        JSONSchemaFormat,
+        OrFormat,
+        SequenceFormat,
+        TagFormat,
+        TriggeredTagsFormat,
+        TagsWithSeparatorFormat,
+    ],
+    Field(discriminator="type"),
+]
+
+
+# Solve forward references
+if hasattr(BaseModel, "model_rebuild"):
+    SequenceFormat.model_rebuild()
+    TagFormat.model_rebuild()
+    TriggeredTagsFormat.model_rebuild()
+    TagsWithSeparatorFormat.model_rebuild()
+elif hasattr(BaseModel, "update_forward_refs"):
+    # This is for backward compatibility with pydantic v1
+    SequenceFormat.update_forward_refs()
+    TagFormat.update_forward_refs()
+    TriggeredTagsFormat.update_forward_refs()
+    TagsWithSeparatorFormat.update_forward_refs()
+else:
+    raise RuntimeError("Unsupported pydantic version")
+
+
+# ---------- Top Level ----------
+
+
+class StructuralTagItem(BaseModel):
+    """Deprecated. Definition of a structural tag item.
+
+    See :meth:`xgrammar.Grammar.from_structural_tag` for more details.
+    """
+
+    begin: str
+    """The begin tag."""
+    schema_: Union[str, Type[BaseModel], Dict[str, Any]] = Field(alias="schema")
+    """The schema."""
+    end: str
+    """The end tag."""
+
+
+class StructuralTag(BaseModel):
+    """
+    Top level object, corresponding to `"response_format": {"type":"structural_tag", "format":{...}}` in API
+    """
+
+    type: Literal["structural_tag"] = "structural_tag"
+    format: Format
+
+    @staticmethod
+    def from_legacy_structural_tag(
+        tags: List[StructuralTagItem], triggers: List[str]
+    ) -> "StructuralTag":
+        """Convert a legacy structural tag item to a structural tag."""
+        return StructuralTag(
+            type="structural_tag",
+            format=TriggeredTagsFormat(
+                type="triggered_tags",
+                triggers=triggers,
+                tags=[
+                    TagFormat(
+                        begin=tag.begin,
+                        content=JSONSchemaFormat(
+                            json_schema=(
+                                json.loads(tag.schema_)
+                                if isinstance(tag.schema_, str)
+                                else (
+                                    tag.schema_.model_json_schema()
+                                    if isinstance(tag.schema_, type)
+                                    and issubclass(tag.schema_, BaseModel)
+                                    else tag.schema_
+                                )
+                            )
+                        ),
+                        end=tag.end,
+                    )
+                    for tag in tags
+                ],
+            ),
+        )
+
+    @staticmethod
+    def from_json(json_str: Union[str, Dict[str, Any]]) -> "StructuralTag":
+        """Convert a JSON string to a structural tag."""
+        if isinstance(json_str, str):
+            return StructuralTag.model_validate_json(json_str)
+        elif isinstance(json_str, dict):
+            return StructuralTag.model_validate(json_str)
+        else:
+            raise ValueError("Invalid JSON string or dictionary")

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -68,7 +68,7 @@ class TagFormat(BaseModel):
 
 
 class TriggeredTagsFormat(BaseModel):
-    """A format that matches a triggered tags. It can allow any output until a trigger is
+    """A format that matches triggered tags. It can allow any output until a trigger is
     encountered, then dispatch to the corresponding tag; when the end tag is encountered, the
     grammar will allow any following output, until the next trigger is encountered.
 

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -13,7 +13,7 @@ class ConstStringFormat(BaseModel):
 
     type: Literal["const_string"] = "const_string"
     """The type of the format."""
-    text: str
+    value: str
     """The constant string."""
 
 

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -37,36 +37,27 @@ def test_utf8():
         assert _is_grammar_accept_string(grammar, input_str, print_time=True)
 
 
-expected_grammar_test_structural_tag = r"""root ::= TagDispatch(
-  ("<function=f", trigger_rule_0),
-  ("<function=g", trigger_rule_1),
-  stop_eos=true,
-  stop_str=(),
-  loop_after_dispatch=true
-)
-trigger_rule_0 ::= (("1>" root_1 "</function>") | ("2>" root_2 "</function>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9])) (=(basic_string_sub))
+expected_grammar_test_structural_tag = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9])) (=(basic_string_sub))
 basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
 basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
 basic_string ::= (("\"" basic_string_sub)) (=(root_part_0 [ \n\t]* "}"))
 root_part_0 ::= (([ \n\t]* "," [ \n\t]* "\"arg2\"" [ \n\t]* ":" [ \n\t]* basic_integer)) (=([ \n\t]* "}"))
-root_1 ::= (("{" [ \n\t]* "\"arg1\"" [ \n\t]* ":" [ \n\t]* basic_string root_part_0 [ \n\t]* "}"))
+root ::= (("{" [ \n\t]* "\"arg1\"" [ \n\t]* ":" [ \n\t]* basic_string root_part_0 [ \n\t]* "}"))
 basic_integer_1 ::= ("" | ("-")) (=([1-9] [0-9]*))
 basic_escape_1 ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9])) (=(basic_string_sub_1))
 basic_string_sub_1 ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub_1) | ("\\" basic_escape_1 basic_string_sub_1)) (=([ \n\t]* [,}\]:]))
 basic_integer_2 ::= (("0") | (basic_integer_1_1 [1-9] [0-9]*))
 basic_string_1 ::= (("\"" basic_string_sub_1)) (=(root_part_0_1 [ \n\t]* "}"))
 root_part_0_1 ::= (([ \n\t]* "," [ \n\t]* "\"arg2\"" [ \n\t]* ":" [ \n\t]* basic_integer_2)) (=([ \n\t]* "}"))
-root_2 ::= (("{" [ \n\t]* "\"arg1\"" [ \n\t]* ":" [ \n\t]* basic_string_1 root_part_0_1 [ \n\t]* "}"))
+root_1 ::= (("{" [ \n\t]* "\"arg1\"" [ \n\t]* ":" [ \n\t]* basic_string_1 root_part_0_1 [ \n\t]* "}"))
 basic_integer_1_1 ::= ("" | ("-")) (=([1-9] [0-9]*))
-trigger_rule_1 ::= ((">" root_3 "</function>"))
 basic_escape_2 ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9])) (=(basic_string_sub_2))
 basic_string_sub_2 ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub_2) | ("\\" basic_escape_2 basic_string_sub_2)) (=([ \n\t]* [,}\]:]))
 basic_number ::= ((basic_number_7 basic_number_3 basic_number_6)) (=(root_part_0_2 [ \n\t]* "}"))
 basic_string_2 ::= (("\"" basic_string_sub_2))
 root_prop_1 ::= (("[" [ \n\t]* basic_string_2 root_prop_1_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 root_part_0_2 ::= (([ \n\t]* "," [ \n\t]* "\"arg4\"" [ \n\t]* ":" [ \n\t]* root_prop_1)) (=([ \n\t]* "}"))
-root_3 ::= (("{" [ \n\t]* "\"arg3\"" [ \n\t]* ":" [ \n\t]* basic_number root_part_0_2 [ \n\t]* "}"))
+root_2 ::= (("{" [ \n\t]* "\"arg3\"" [ \n\t]* ":" [ \n\t]* basic_number root_part_0_2 [ \n\t]* "}"))
 basic_number_1 ::= ("" | ("-")) (=([1-9] [0-9]*))
 basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
 basic_number_3 ::= ("" | ("." basic_number_2)) (=(basic_number_6))
@@ -75,6 +66,16 @@ basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
 basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
 root_prop_1_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string_2 root_prop_1_1)) (=([ \n\t]* "]"))
 basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*)) (=(basic_number_3 basic_number_6))
+triggered_tags_group ::= (("1>" root "</function>") | ("2>" root_1 "</function>"))
+triggered_tags_group_1 ::= ((">" root_2 "</function>"))
+triggered_tags ::= TagDispatch(
+  ("<function=f", triggered_tags_group),
+  ("<function=g", triggered_tags_group_1),
+  stop_eos=true,
+  stop_str=(),
+  loop_after_dispatch=true
+)
+root_3 ::= ((triggered_tags))
 """
 
 

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -71,7 +71,7 @@ def check_stag_with_instance(
 
 const_string_stag_grammar = [
     (
-        {"type": "const_string", "text": "Hello!"},
+        {"type": "const_string", "value": "Hello!"},
         r"""const_string ::= (("Hello!"))
 root ::= ((const_string))
 """,
@@ -133,7 +133,7 @@ sequence_stag_grammar = [
         {
             "type": "sequence",
             "elements": [
-                {"type": "const_string", "text": "Hello!"},
+                {"type": "const_string", "value": "Hello!"},
                 {"type": "json_schema", "json_schema": {"type": "number"}},
             ],
         },
@@ -177,7 +177,7 @@ or_stag_grammar = [
         {
             "type": "or",
             "elements": [
-                {"type": "const_string", "text": "Hello!"},
+                {"type": "const_string", "value": "Hello!"},
                 {"type": "json_schema", "json_schema": {"type": "number"}},
             ],
         },
@@ -317,8 +317,8 @@ def _get_triggered_tag_format(at_least_one: bool, stop_after_first: bool):
         "type": "triggered_tags",
         "triggers": ["A"],
         "tags": [
-            {"begin": "A1", "content": {"type": "const_string", "text": "L1"}, "end": "A"},
-            {"begin": "A2", "content": {"type": "const_string", "text": "L2"}, "end": "A"},
+            {"begin": "A1", "content": {"type": "const_string", "value": "L1"}, "end": "A"},
+            {"begin": "A2", "content": {"type": "const_string", "value": "L2"}, "end": "A"},
         ],
         "at_least_one": at_least_one,
         "stop_after_first": stop_after_first,
@@ -420,7 +420,7 @@ test_triggered_tags_corner_case_data = [
             "tags": [
                 {
                     "begin": "<start>",
-                    "content": {"type": "const_string", "text": "[TEXT]"},
+                    "content": {"type": "const_string", "value": "[TEXT]"},
                     "end": "<end>",
                 }
             ],
@@ -458,8 +458,8 @@ triggered_tag_format = {
     "type": "triggered_tags",
     "triggers": ["A"],
     "tags": [
-        {"begin": "A1", "content": {"type": "const_string", "text": "L1"}, "end": "A"},
-        {"begin": "A2", "content": {"type": "const_string", "text": "L2"}, "end": "A"},
+        {"begin": "A1", "content": {"type": "const_string", "value": "L1"}, "end": "A"},
+        {"begin": "A2", "content": {"type": "const_string", "value": "L2"}, "end": "A"},
     ],
 }
 
@@ -472,8 +472,8 @@ def _get_triggered_tag_with_outside_tag(at_least_one: bool, stop_after_first: bo
             "type": "triggered_tags",
             "triggers": ["A"],
             "tags": [
-                {"begin": "A1", "content": {"type": "const_string", "text": "L1"}, "end": "A"},
-                {"begin": "A2", "content": {"type": "const_string", "text": "L2"}, "end": "A"},
+                {"begin": "A1", "content": {"type": "const_string", "value": "L1"}, "end": "A"},
+                {"begin": "A2", "content": {"type": "const_string", "value": "L2"}, "end": "A"},
             ],
             "at_least_one": at_least_one,
             "stop_after_first": stop_after_first,
@@ -578,8 +578,8 @@ def _get_tags_with_separator_format(at_least_one: bool, stop_after_first: bool):
     return {
         "type": "tags_with_separator",
         "tags": [
-            {"begin": "A1", "content": {"type": "const_string", "text": "L1"}, "end": "A"},
-            {"begin": "A2", "content": {"type": "const_string", "text": "L2"}, "end": "A"},
+            {"begin": "A1", "content": {"type": "const_string", "value": "L1"}, "end": "A"},
+            {"begin": "A2", "content": {"type": "const_string", "value": "L2"}, "end": "A"},
         ],
         "separator": "AA",
         "at_least_one": at_least_one,
@@ -671,8 +671,8 @@ def _get_tags_with_separator_format_with_outside_tag(at_least_one: bool, stop_af
         "content": {
             "type": "tags_with_separator",
             "tags": [
-                {"begin": "A1", "content": {"type": "const_string", "text": "L1"}, "end": "A"},
-                {"begin": "A2", "content": {"type": "const_string", "text": "L2"}, "end": "A"},
+                {"begin": "A1", "content": {"type": "const_string", "value": "L1"}, "end": "A"},
+                {"begin": "A2", "content": {"type": "const_string", "value": "L2"}, "end": "A"},
             ],
             "separator": "AA",
             "at_least_one": at_least_one,
@@ -954,7 +954,7 @@ compound_stag_instance_is_accepted = [
         {
             "type": "sequence",
             "elements": [
-                {"type": "const_string", "text": "<think></think>"},
+                {"type": "const_string", "value": "<think></think>"},
                 {
                     "type": "triggered_tags",
                     "triggers": ["<tool_call>"],
@@ -1004,7 +1004,7 @@ end_string_detector_test_data = [
             "begin": "<start>",
             "content": {
                 "type": "sequence",
-                "elements": [{"type": "const_string", "text": "[TEXT]"}, {"type": "any_text"}],
+                "elements": [{"type": "const_string", "value": "[TEXT]"}, {"type": "any_text"}],
             },
             "end": "<end>",
         },
@@ -1044,7 +1044,7 @@ root ::= ((tag))
                     {
                         "type": "sequence",
                         "elements": [
-                            {"type": "const_string", "text": "[TEXT2]"},
+                            {"type": "const_string", "value": "[TEXT2]"},
                             {"type": "any_text"},
                         ],
                     },
@@ -1118,7 +1118,7 @@ root ::= ((tag_1))
                 },
                 {
                     "type": "sequence",
-                    "elements": [{"type": "const_string", "text": "[TEXT]"}, {"type": "any_text"}],
+                    "elements": [{"type": "const_string", "value": "[TEXT]"}, {"type": "any_text"}],
                 },
                 {
                     "type": "or",
@@ -1138,7 +1138,7 @@ root ::= ((tag_1))
                         {
                             "type": "sequence",
                             "elements": [
-                                {"type": "const_string", "text": "[TEXT2]"},
+                                {"type": "const_string", "value": "[TEXT2]"},
                                 {"type": "any_text"},
                             ],
                         },
@@ -1215,19 +1215,19 @@ def test_end_string_detector(
 json_format_error_test_data = [
     # JSON Parsing Errors
     (
-        '{"type": "structural_tag", "format": {"type": "const_string", "text": "hello"',
+        '{"type": "structural_tag", "format": {"type": "const_string", "value": "hello"',
         "Failed to parse JSON",
     ),
     ('"not_an_object"', "Structural tag must be an object"),
     (
-        '{"type": "wrong_type", "format": {"type": "const_string", "text": "hello"}}',
+        '{"type": "wrong_type", "format": {"type": "const_string", "value": "hello"}}',
         'Structural tag\'s type must be a string "structural_tag"',
     ),
     ('{"type": "structural_tag"}', "Structural tag must have a format field"),
     # Format Parsing Errors
     ('{"type": "structural_tag", "format": "not_an_object"}', "Format must be an object"),
     (
-        '{"type": "structural_tag", "format": {"type": 123, "text": "hello"}}',
+        '{"type": "structural_tag", "format": {"type": 123, "value": "hello"}}',
         "Format's type must be a string",
     ),
     (
@@ -1238,15 +1238,15 @@ json_format_error_test_data = [
     # ConstStringFormat Errors
     (
         '{"type": "structural_tag", "format": {"type": "const_string"}}',
-        "ConstString format must have a text field with a non-empty string",
+        "ConstString format must have a value field with a non-empty string",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "const_string", "text": 123}}',
-        "ConstString format must have a text field with a non-empty string",
+        '{"type": "structural_tag", "format": {"type": "const_string", "value": 123}}',
+        "ConstString format must have a value field with a non-empty string",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "const_string", "text": ""}}',
-        "ConstString format must have a text field with a non-empty string",
+        '{"type": "structural_tag", "format": {"type": "const_string", "value": ""}}',
+        "ConstString format must have a value field with a non-empty string",
     ),
     # JSONSchemaFormat Errors
     (
@@ -1290,11 +1290,11 @@ json_format_error_test_data = [
     ),
     # TagFormat Errors
     (
-        '{"type": "structural_tag", "format": {"type": "tag", "content": {"type": "const_string", "text": "hello"}, "end": "end"}}',
+        '{"type": "structural_tag", "format": {"type": "tag", "content": {"type": "const_string", "value": "hello"}, "end": "end"}}',
         "Tag format's begin field must be a string",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "tag", "begin": 123, "content": {"type": "const_string", "text": "hello"}, "end": "end"}}',
+        '{"type": "structural_tag", "format": {"type": "tag", "begin": 123, "content": {"type": "const_string", "value": "hello"}, "end": "end"}}',
         "Tag format's begin field must be a string",
     ),
     (
@@ -1302,32 +1302,32 @@ json_format_error_test_data = [
         "Tag format must have a content field",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "tag", "begin": "start", "content": {"type": "const_string", "text": "hello"}}}',
+        '{"type": "structural_tag", "format": {"type": "tag", "begin": "start", "content": {"type": "const_string", "value": "hello"}}}',
         "Tag format's end field must be a string",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "tag", "begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": 123}}',
+        '{"type": "structural_tag", "format": {"type": "tag", "begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": 123}}',
         "Tag format's end field must be a string",
     ),
     # TriggeredTagsFormat Errors
     (
-        '{"type": "structural_tag", "format": {"type": "triggered_tags", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}]}}',
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}]}}',
         "Triggered tags format must have a triggers field with an array",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": "not_array", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}]}}',
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": "not_array", "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}]}}',
         "Triggered tags format must have a triggers field with an array",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": [], "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}]}}',
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": [], "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}]}}',
         "Triggered tags format's triggers must be non-empty",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": [123], "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}]}}',
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": [123], "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}]}}',
         "Triggered tags format's triggers must be non-empty strings",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": [""], "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}]}}',
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": [""], "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}]}}',
         "Triggered tags format's triggers must be non-empty strings",
     ),
     (
@@ -1343,11 +1343,11 @@ json_format_error_test_data = [
         "Triggered tags format's tags must be non-empty",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"], "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}], "at_least_one": "not_boolean"}}',
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"], "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}], "at_least_one": "not_boolean"}}',
         "at_least_one must be a boolean",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"], "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}], "stop_after_first": "not_boolean"}}',
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"], "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}], "stop_after_first": "not_boolean"}}',
         "stop_after_first must be a boolean",
     ),
     # TagsWithSeparatorFormat Errors
@@ -1364,23 +1364,23 @@ json_format_error_test_data = [
         "Tags with separator format's tags must be non-empty",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}]}}',
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}]}}',
         "Tags with separator format's separator field must be a non-empty string",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}], "separator": 123}}',
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}], "separator": 123}}',
         "Tags with separator format's separator field must be a non-empty string",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}], "separator": ""}}',
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}], "separator": ""}}',
         "Tags with separator format's separator field must be a non-empty string",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}], "separator": "sep", "at_least_one": "not_boolean"}}',
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}], "separator": "sep", "at_least_one": "not_boolean"}}',
         "at_least_one must be a boolean",
     ),
     (
-        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}], "separator": "sep", "stop_after_first": "not_boolean"}}',
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}], "separator": "sep", "stop_after_first": "not_boolean"}}',
         "stop_after_first must be a boolean",
     ),
 ]
@@ -1399,16 +1399,16 @@ structural_tag_error_test_data = [
     {
         "type": "sequence",
         "elements": [
-            {"type": "const_string", "text": "start"},
+            {"type": "const_string", "value": "start"},
             {"type": "any_text"},  # This unlimited element in middle will cause error
-            {"type": "const_string", "text": "end"},
+            {"type": "const_string", "value": "end"},
         ],
     },
     # Analyzer Errors - Or format with mixed unlimited and limited elements
     {
         "type": "or",
         "elements": [
-            {"type": "const_string", "text": "limited"},  # Limited element
+            {"type": "const_string", "value": "limited"},  # Limited element
             {"type": "any_text"},  # Unlimited element - mix not allowed
         ],
     },
@@ -1424,7 +1424,7 @@ structural_tag_error_test_data = [
         "type": "triggered_tags",
         "triggers": ["A", "AB"],  # Both will match tag beginning with "ABC"
         "tags": [
-            {"begin": "ABC", "content": {"type": "const_string", "text": "hello"}, "end": "end"}
+            {"begin": "ABC", "content": {"type": "const_string", "value": "hello"}, "end": "end"}
         ],
     },
     # Converter Errors - Tag matches no trigger
@@ -1432,7 +1432,7 @@ structural_tag_error_test_data = [
         "type": "triggered_tags",
         "triggers": ["X", "Y"],  # Neither matches "ABC" begin
         "tags": [
-            {"begin": "ABC", "content": {"type": "const_string", "text": "hello"}, "end": "end"}
+            {"begin": "ABC", "content": {"type": "const_string", "value": "hello"}, "end": "end"}
         ],
     },
     # Cannot detect end string of tags_with_separator in sequence
@@ -1444,13 +1444,13 @@ structural_tag_error_test_data = [
                 "tags": [
                     {
                         "begin": "<start>",
-                        "content": {"type": "const_string", "text": "[TEXT]"},
+                        "content": {"type": "const_string", "value": "[TEXT]"},
                         "end": "<end>",
                     }
                 ],
                 "separator": "<sep>",
             },
-            {"type": "const_string", "text": "[TEXT]"},
+            {"type": "const_string", "value": "[TEXT]"},
         ],
     },
     # Cannot detect end string of tags_with_separator in or
@@ -1462,13 +1462,13 @@ structural_tag_error_test_data = [
                 "tags": [
                     {
                         "begin": "<start>",
-                        "content": {"type": "const_string", "text": "[TEXT]"},
+                        "content": {"type": "const_string", "value": "[TEXT]"},
                         "end": "<end>",
                     }
                 ],
                 "separator": "<sep>",
             },
-            {"type": "const_string", "text": "[TEXT]"},
+            {"type": "const_string", "value": "[TEXT]"},
         ],
     },
     # Original test cases - Detected end string of tags_with_separator is empty
@@ -1480,7 +1480,7 @@ structural_tag_error_test_data = [
             "tags": [
                 {
                     "begin": "<start2>",
-                    "content": {"type": "const_string", "text": "[TEXT]"},
+                    "content": {"type": "const_string", "value": "[TEXT]"},
                     "end": "<end2>",
                 }
             ],

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -1,0 +1,1503 @@
+import sys
+import time
+from typing import Any, Dict, List, Tuple
+
+import pytest
+from transformers import AutoTokenizer
+
+import xgrammar as xgr
+from xgrammar.testing import _is_grammar_accept_string
+
+PROFILER_ON = True
+tokenizer_id = "meta-llama/Llama-3.1-8B-Instruct"
+
+
+class Profiler:
+    def __init__(self, tokenizer_id: str):
+        tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_id, use_fast=True, trust_remote_code=True
+        )
+        self.tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
+        self.compiler = xgr.GrammarCompiler(
+            self.tokenizer_info, max_threads=16, cache_enabled=False
+        )
+
+    def profile_stag(self, structural_tag_format: Dict[str, Any], instance: str):
+        structural_tag = {"type": "structural_tag", "format": structural_tag_format}
+        time_begin = time.monotonic_ns()
+        compiled_grammar = self.compiler.compile_structural_tag(structural_tag)
+        time_end = time.monotonic_ns()
+        compiler_duration = time_end - time_begin
+        print(f"Compiling structural tag {structural_tag_format}")
+        print(f"Compile time: {compiler_duration / 1000 / 1000} ms")
+        matcher = xgr.GrammarMatcher(compiled_grammar)
+        token_bitmask = xgr.allocate_token_bitmask(1, self.tokenizer_info.vocab_size)
+
+        print(f"Matching instance: {instance}")
+
+        for char in instance:
+            matcher.accept_string(char)
+            time_begin = time.monotonic_ns()
+            matcher.fill_next_token_bitmask(token_bitmask)
+            time_end = time.monotonic_ns()
+
+            duration = time_end - time_begin
+            print(f"Time to generate mask: {duration / 1000} us, Character: '{char}'")
+
+
+if PROFILER_ON:
+    profiler = Profiler(tokenizer_id)
+
+
+def check_stag_with_grammar(structural_tag_format: Dict[str, Any], expected_grammar_ebnf: str):
+    structural_tag = {"type": "structural_tag", "format": structural_tag_format}
+    stag_ebnf = xgr.Grammar.from_structural_tag(structural_tag)
+    assert str(stag_ebnf) == expected_grammar_ebnf
+
+
+def check_stag_with_instance(
+    structural_tag_format: Dict[str, Any],
+    instance: str,
+    is_accepted: bool = True,
+    debug_print: bool = False,
+):
+    structural_tag = {"type": "structural_tag", "format": structural_tag_format}
+    stag_grammar = xgr.Grammar.from_structural_tag(structural_tag)
+    accepted = _is_grammar_accept_string(stag_grammar, instance, debug_print=debug_print)
+    assert accepted == is_accepted
+    if PROFILER_ON:
+        profiler.profile_stag(structural_tag_format, instance)
+
+
+const_string_stag_grammar = [
+    (
+        {"type": "const_string", "text": "Hello!"},
+        r"""const_string ::= (("Hello!"))
+root ::= ((const_string))
+""",
+    )
+]
+
+const_string_instance_is_accepted = [
+    ("Hello!", True),
+    ("Hello", False),
+    ("Hello!!", False),
+    ("HELLO!", False),
+]
+
+
+@pytest.mark.parametrize("stag_format, expected_grammar", const_string_stag_grammar)
+@pytest.mark.parametrize("instance, is_accepted", const_string_instance_is_accepted)
+def test_const_string_format(
+    stag_format: Dict[str, Any], expected_grammar: str, instance: str, is_accepted: bool
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, is_accepted, debug_print=True)
+
+
+json_schema_stag_grammar = [
+    (
+        {
+            "type": "json_schema",
+            "json_schema": {"type": "object", "properties": {"a": {"type": "string"}}},
+        },
+        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9])) (=(basic_string_sub))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
+basic_string ::= (("\"" basic_string_sub)) (=([ \n\t]* "}"))
+root ::= (("{" [ \n\t]* "\"a\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
+root_1 ::= ((root))
+""",
+    )
+]
+
+
+json_schema_instance_is_accepted = [
+    ('{"a": "hello"}', True),
+    ('{"a": 123}', False),
+    ('{"b": "hello"}', False),
+    ("invalid json", False),
+]
+
+
+@pytest.mark.parametrize("stag_format, expected_grammar", json_schema_stag_grammar)
+@pytest.mark.parametrize("instance, is_accepted", json_schema_instance_is_accepted)
+def test_json_schema_format(
+    stag_format: Dict[str, Any], expected_grammar: str, instance: str, is_accepted: bool
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, is_accepted)
+
+
+sequence_stag_grammar = [
+    (
+        {
+            "type": "sequence",
+            "elements": [
+                {"type": "const_string", "text": "Hello!"},
+                {"type": "json_schema", "json_schema": {"type": "number"}},
+            ],
+        },
+        r"""const_string ::= (("Hello!"))
+basic_number ::= ((basic_number_7 basic_number_3 basic_number_6))
+root ::= ((basic_number))
+basic_number_1 ::= ("" | ("-")) (=([1-9] [0-9]*))
+basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
+basic_number_3 ::= ("" | ("." basic_number_2)) (=(basic_number_6))
+basic_number_4 ::= ("" | ([+\-])) (=(basic_number_5))
+basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
+basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
+basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*)) (=(basic_number_3 basic_number_6))
+sequence ::= ((const_string root))
+root_1 ::= ((sequence))
+""",
+    )
+]
+
+
+sequence_instance_is_accepted = [
+    ("Hello!123", True),
+    ("Hello!Hello!", False),
+    ("Hello!", False),
+    ("123Hello!", False),
+    ("???", False),
+]
+
+
+@pytest.mark.parametrize("stag_format, expected_grammar", sequence_stag_grammar)
+@pytest.mark.parametrize("instance, is_accepted", sequence_instance_is_accepted)
+def test_sequence_format(
+    stag_format: Dict[str, Any], expected_grammar: str, instance: str, is_accepted: bool
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, is_accepted)
+
+
+or_stag_grammar = [
+    (
+        {
+            "type": "or",
+            "elements": [
+                {"type": "const_string", "text": "Hello!"},
+                {"type": "json_schema", "json_schema": {"type": "number"}},
+            ],
+        },
+        r"""const_string ::= (("Hello!"))
+basic_number ::= ((basic_number_7 basic_number_3 basic_number_6))
+root ::= ((basic_number))
+basic_number_1 ::= ("" | ("-")) (=([1-9] [0-9]*))
+basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
+basic_number_3 ::= ("" | ("." basic_number_2)) (=(basic_number_6))
+basic_number_4 ::= ("" | ([+\-])) (=(basic_number_5))
+basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
+basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
+basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*)) (=(basic_number_3 basic_number_6))
+or ::= ((const_string) | (root))
+root_1 ::= ((or))
+""",
+    )
+]
+
+
+or_instance_is_accepted = [
+    ("Hello!", True),
+    ("123", True),
+    ("Hello!Hello!", False),
+    ("123Hello!", False),
+    ("???", False),
+]
+
+
+@pytest.mark.parametrize("stag_format, expected_grammar", or_stag_grammar)
+@pytest.mark.parametrize("instance, is_accepted", or_instance_is_accepted)
+def test_or_format(
+    stag_format: Dict[str, Any], expected_grammar: str, instance: str, is_accepted: bool
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, is_accepted)
+
+
+tag_stag_grammar = [
+    (
+        {
+            "type": "tag",
+            "begin": "BEG",
+            "content": {"type": "json_schema", "json_schema": {"type": "number"}},
+            "end": "END",
+        },
+        r"""basic_number ::= ((basic_number_7 basic_number_3 basic_number_6))
+root ::= ((basic_number))
+basic_number_1 ::= ("" | ("-")) (=([1-9] [0-9]*))
+basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
+basic_number_3 ::= ("" | ("." basic_number_2)) (=(basic_number_6))
+basic_number_4 ::= ("" | ([+\-])) (=(basic_number_5))
+basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
+basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
+basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*)) (=(basic_number_3 basic_number_6))
+tag ::= (("BEG" root "END"))
+root_1 ::= ((tag))
+""",
+    )
+]
+
+
+tag_instance_is_accepted = [
+    ("BEG12345END", True),
+    ("BEG123456END", True),
+    ("BEG1234567END", True),
+    ("BEG???END", False),
+    ("BEG12345ENDEND", False),
+]
+
+
+@pytest.mark.parametrize("stag_format, expected_grammar", tag_stag_grammar)
+@pytest.mark.parametrize("instance, is_accepted", tag_instance_is_accepted)
+def test_tag_format(
+    stag_format: Dict[str, Any], expected_grammar: str, instance: str, is_accepted: bool
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, is_accepted)
+
+
+any_text_stag_grammar = [
+    (
+        {"type": "tag", "begin": "BEG", "content": {"type": "any_text"}, "end": "END"},
+        r"""any_text ::= TagDispatch(
+  stop_eos=false,
+  stop_str=("END"),
+  loop_after_dispatch=false
+)
+tag ::= (("BEG" any_text))
+root ::= ((tag))
+""",
+    )
+]
+
+
+any_text_instance_is_accepted = [
+    ("BEGHello!END", True),
+    ("BEGENENNDENEND", True),
+    ("BEGENENDEN", False),
+    ("BEGBEGENDEND", False),
+]
+
+
+@pytest.mark.parametrize("stag_format, expected_grammar", any_text_stag_grammar)
+@pytest.mark.parametrize("instance, is_accepted", any_text_instance_is_accepted)
+def test_any_text_format(
+    stag_format: Dict[str, Any], expected_grammar: str, instance: str, is_accepted: bool
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, is_accepted)
+
+
+any_text_only_stag_grammar = [
+    (
+        {"type": "any_text"},
+        r"""any_text ::= (([\0-\U0010ffff]*))
+root ::= ((any_text))
+""",
+    )
+]
+
+
+any_text_only_instance_is_accepted = [("ABCDEF", True), ("123456", True), ("", True)]
+
+
+@pytest.mark.parametrize("stag_format, expected_grammar", any_text_only_stag_grammar)
+@pytest.mark.parametrize("instance, is_accepted", any_text_only_instance_is_accepted)
+def test_any_text_only_format(
+    stag_format: Dict[str, Any], expected_grammar: str, instance: str, is_accepted: bool
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, is_accepted)
+
+
+def _get_triggered_tag_format(at_least_one: bool, stop_after_first: bool):
+    return {
+        "type": "triggered_tags",
+        "triggers": ["A"],
+        "tags": [
+            {"begin": "A1", "content": {"type": "const_string", "text": "L1"}, "end": "A"},
+            {"begin": "A2", "content": {"type": "const_string", "text": "L2"}, "end": "A"},
+        ],
+        "at_least_one": at_least_one,
+        "stop_after_first": stop_after_first,
+    }
+
+
+triggered_tag_stag_grammar = [
+    (
+        0,
+        _get_triggered_tag_format(at_least_one=False, stop_after_first=False),
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+triggered_tags_group ::= (("1" const_string "A") | ("2" const_string_1 "A"))
+triggered_tags ::= TagDispatch(
+  ("A", triggered_tags_group),
+  stop_eos=true,
+  stop_str=(),
+  loop_after_dispatch=true
+)
+root ::= ((triggered_tags))
+""",
+    ),
+    (
+        1,
+        _get_triggered_tag_format(at_least_one=True, stop_after_first=False),
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+triggered_tags_group ::= (("1" const_string "A") | ("2" const_string_1 "A"))
+triggered_tags_first ::= (("A1" const_string "A") | ("A2" const_string_1 "A"))
+triggered_tags_sub ::= TagDispatch(
+  ("A", triggered_tags_group),
+  stop_eos=true,
+  stop_str=(),
+  loop_after_dispatch=true
+)
+triggered_tags ::= ((triggered_tags_first triggered_tags_sub))
+root ::= ((triggered_tags))
+""",
+    ),
+    (
+        2,
+        _get_triggered_tag_format(at_least_one=False, stop_after_first=True),
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+triggered_tags_group ::= (("1" const_string "A") | ("2" const_string_1 "A"))
+triggered_tags ::= TagDispatch(
+  ("A", triggered_tags_group),
+  stop_eos=true,
+  stop_str=(),
+  loop_after_dispatch=false
+)
+root ::= ((triggered_tags))
+""",
+    ),
+    (
+        3,
+        _get_triggered_tag_format(at_least_one=True, stop_after_first=True),
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+triggered_tags ::= (("A1" const_string "A") | ("A2" const_string_1 "A"))
+root ::= ((triggered_tags))
+""",
+    ),
+]
+
+
+triggered_tag_instance_accepted_results = [
+    ("textA1L1AtextA2L2AText", [True, False, False, False]),
+    ("textA1L1AtextA2L2A", [True, False, False, False]),
+    ("A1L1Atext", [True, True, False, False]),
+    ("A1L1AtextA2L2A", [True, True, False, False]),
+    ("A1L1A", [True, True, True, True]),
+    ("text", [True, False, True, False]),
+    ("", [True, False, True, False]),
+    ("AA", [False, False, False, False]),
+    ("A1L2A", [False, False, False, False]),
+    ("A1L1A2L2A", [False, False, False, False]),
+]
+
+
+@pytest.mark.parametrize("stag_id, stag_format, expected_grammar", triggered_tag_stag_grammar)
+@pytest.mark.parametrize("instance, accepted_results", triggered_tag_instance_accepted_results)
+def test_triggered_tag_format(
+    stag_id: int,
+    stag_format: Dict[str, Any],
+    expected_grammar: str,
+    instance: str,
+    accepted_results: List[bool],
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, accepted_results[stag_id])
+
+
+test_triggered_tags_corner_case_data = [
+    (
+        {
+            "type": "triggered_tags",
+            "triggers": ["<start>"],
+            "tags": [
+                {
+                    "begin": "<start>",
+                    "content": {"type": "const_string", "text": "[TEXT]"},
+                    "end": "<end>",
+                }
+            ],
+        },
+        r"""const_string ::= (("[TEXT]"))
+triggered_tags_group ::= (("" const_string "<end>"))
+triggered_tags ::= TagDispatch(
+  ("<start>", triggered_tags_group),
+  stop_eos=true,
+  stop_str=(),
+  loop_after_dispatch=true
+)
+root ::= ((triggered_tags))
+""",
+        [("<start>[TEXT]<end>[TEXT]<start>[TEXT]<end>[TEXT]", True)],
+    )
+]
+
+
+@pytest.mark.parametrize(
+    "stag_format, expected_grammar, instance_is_accepted_tuples",
+    test_triggered_tags_corner_case_data,
+)
+def test_triggered_tags_corner_case(
+    stag_format: Dict[str, Any],
+    expected_grammar: str,
+    instance_is_accepted_tuples: List[Tuple[str, bool]],
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    for instance, is_accepted in instance_is_accepted_tuples:
+        check_stag_with_instance(stag_format, instance, is_accepted)
+
+
+triggered_tag_format = {
+    "type": "triggered_tags",
+    "triggers": ["A"],
+    "tags": [
+        {"begin": "A1", "content": {"type": "const_string", "text": "L1"}, "end": "A"},
+        {"begin": "A2", "content": {"type": "const_string", "text": "L2"}, "end": "A"},
+    ],
+}
+
+
+def _get_triggered_tag_with_outside_tag(at_least_one: bool, stop_after_first: bool):
+    return {
+        "type": "tag",
+        "begin": "begin",
+        "content": {
+            "type": "triggered_tags",
+            "triggers": ["A"],
+            "tags": [
+                {"begin": "A1", "content": {"type": "const_string", "text": "L1"}, "end": "A"},
+                {"begin": "A2", "content": {"type": "const_string", "text": "L2"}, "end": "A"},
+            ],
+            "at_least_one": at_least_one,
+            "stop_after_first": stop_after_first,
+        },
+        "end": "end",
+    }
+
+
+triggered_tag_with_outside_tag_stag_grammar = [
+    (
+        0,
+        _get_triggered_tag_with_outside_tag(at_least_one=False, stop_after_first=False),
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+triggered_tags_group ::= (("1" const_string "A") | ("2" const_string_1 "A"))
+triggered_tags ::= TagDispatch(
+  ("A", triggered_tags_group),
+  stop_eos=false,
+  stop_str=("end"),
+  loop_after_dispatch=true
+)
+tag ::= (("begin" triggered_tags))
+root ::= ((tag))
+""",
+    ),
+    (
+        1,
+        _get_triggered_tag_with_outside_tag(at_least_one=True, stop_after_first=False),
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+triggered_tags_group ::= (("1" const_string "A") | ("2" const_string_1 "A"))
+triggered_tags_first ::= (("A1" const_string "A") | ("A2" const_string_1 "A"))
+triggered_tags_sub ::= TagDispatch(
+  ("A", triggered_tags_group),
+  stop_eos=false,
+  stop_str=("end"),
+  loop_after_dispatch=true
+)
+triggered_tags ::= ((triggered_tags_first triggered_tags_sub))
+tag ::= (("begin" triggered_tags))
+root ::= ((tag))
+""",
+    ),
+    (
+        2,
+        _get_triggered_tag_with_outside_tag(at_least_one=False, stop_after_first=True),
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+triggered_tags_group ::= (("1" const_string "A") | ("2" const_string_1 "A"))
+triggered_tags ::= TagDispatch(
+  ("A", triggered_tags_group),
+  stop_eos=false,
+  stop_str=("end"),
+  loop_after_dispatch=false
+)
+tag ::= (("begin" triggered_tags))
+root ::= ((tag))
+""",
+    ),
+    (
+        3,
+        _get_triggered_tag_with_outside_tag(at_least_one=True, stop_after_first=True),
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+triggered_tags_sub ::= (("A1" const_string "A") | ("A2" const_string_1 "A"))
+triggered_tags ::= ((triggered_tags_sub "end"))
+tag ::= (("begin" triggered_tags))
+root ::= ((tag))
+""",
+    ),
+]
+
+
+triggered_tag_with_outside_tag_instance_accepted_results = [
+    ("beginabcA1L1Atextend", [True, False, False, False]),
+    ("beginA1L1AtextA2L2Aend", [True, True, False, False]),
+    ("beginA1L1Aend", [True, True, True, True]),
+    ("beginend", [True, False, True, False]),
+    ("beginA1L1Aendabc", [False, False, False, False]),
+    ("beginA1L2end", [False, False, False, False]),
+]
+
+
+@pytest.mark.parametrize(
+    "stag_id, stag_format, expected_grammar", triggered_tag_with_outside_tag_stag_grammar
+)
+@pytest.mark.parametrize(
+    "instance, accepted_results", triggered_tag_with_outside_tag_instance_accepted_results
+)
+def test_triggered_tag_with_outside_tag(
+    stag_id: int,
+    stag_format: Dict[str, Any],
+    expected_grammar: str,
+    instance: str,
+    accepted_results: List[bool],
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, accepted_results[stag_id])
+
+
+def _get_tags_with_separator_format(at_least_one: bool, stop_after_first: bool):
+    return {
+        "type": "tags_with_separator",
+        "tags": [
+            {"begin": "A1", "content": {"type": "const_string", "text": "L1"}, "end": "A"},
+            {"begin": "A2", "content": {"type": "const_string", "text": "L2"}, "end": "A"},
+        ],
+        "separator": "AA",
+        "at_least_one": at_least_one,
+        "stop_after_first": stop_after_first,
+    }
+
+
+tags_with_separator_stag_grammar = [
+    (
+        0,
+        _get_tags_with_separator_format(at_least_one=False, stop_after_first=False),
+        r"""const_string ::= (("L1"))
+tag ::= (("A1" const_string "A"))
+const_string_1 ::= (("L2"))
+tag_1 ::= (("A2" const_string_1 "A"))
+tags_with_separator_tags ::= ((tag) | (tag_1))
+tags_with_separator_sub ::= (("AA" tags_with_separator_tags tags_with_separator_sub) | "")
+tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub) | "")
+root ::= ((tags_with_separator))
+""",
+    ),
+    (
+        1,
+        _get_tags_with_separator_format(at_least_one=True, stop_after_first=False),
+        r"""const_string ::= (("L1"))
+tag ::= (("A1" const_string "A"))
+const_string_1 ::= (("L2"))
+tag_1 ::= (("A2" const_string_1 "A"))
+tags_with_separator_tags ::= ((tag) | (tag_1))
+tags_with_separator_sub ::= (("AA" tags_with_separator_tags tags_with_separator_sub) | "")
+tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
+root ::= ((tags_with_separator))
+""",
+    ),
+    (
+        2,
+        _get_tags_with_separator_format(at_least_one=False, stop_after_first=True),
+        r"""const_string ::= (("L1"))
+tag ::= (("A1" const_string "A"))
+const_string_1 ::= (("L2"))
+tag_1 ::= (("A2" const_string_1 "A"))
+tags_with_separator_tags ::= ((tag) | (tag_1))
+tags_with_separator ::= ((tags_with_separator_tags) | "")
+root ::= ((tags_with_separator))
+""",
+    ),
+    (
+        3,
+        _get_tags_with_separator_format(at_least_one=True, stop_after_first=True),
+        r"""const_string ::= (("L1"))
+tag ::= (("A1" const_string "A"))
+const_string_1 ::= (("L2"))
+tag_1 ::= (("A2" const_string_1 "A"))
+tags_with_separator_tags ::= ((tag) | (tag_1))
+tags_with_separator ::= ((tags_with_separator_tags))
+root ::= ((tags_with_separator))
+""",
+    ),
+]
+
+
+tags_with_separator_instance_accepted_results = [
+    ("", [True, False, True, False]),
+    ("A1L1A", [True, True, True, True]),
+    ("A1L1AAAA2L2A", [True, True, False, False]),
+    ("A1L1AA2L2A", [False, False, False, False]),
+]
+
+
+@pytest.mark.parametrize("stag_id, stag_format, expected_grammar", tags_with_separator_stag_grammar)
+@pytest.mark.parametrize(
+    "instance, accepted_results", tags_with_separator_instance_accepted_results
+)
+def test_tags_with_separator_format(
+    stag_id: int,
+    stag_format: Dict[str, Any],
+    expected_grammar: str,
+    instance: str,
+    accepted_results: List[bool],
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, accepted_results[stag_id])
+
+
+def _get_tags_with_separator_format_with_outside_tag(at_least_one: bool, stop_after_first: bool):
+    return {
+        "type": "tag",
+        "begin": "begin",
+        "content": {
+            "type": "tags_with_separator",
+            "tags": [
+                {"begin": "A1", "content": {"type": "const_string", "text": "L1"}, "end": "A"},
+                {"begin": "A2", "content": {"type": "const_string", "text": "L2"}, "end": "A"},
+            ],
+            "separator": "AA",
+            "at_least_one": at_least_one,
+            "stop_after_first": stop_after_first,
+        },
+        "end": "end",
+    }
+
+
+tags_with_separator_with_outside_tag_stag_grammar = [
+    (
+        0,
+        _get_tags_with_separator_format_with_outside_tag(
+            at_least_one=False, stop_after_first=False
+        ),
+        r"""const_string ::= (("L1"))
+tag ::= (("A1" const_string "A"))
+const_string_1 ::= (("L2"))
+tag_1 ::= (("A2" const_string_1 "A"))
+tags_with_separator_tags ::= ((tag) | (tag_1))
+tags_with_separator_sub ::= (("AA" tags_with_separator_tags tags_with_separator_sub) | ("end"))
+tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub) | ("end"))
+tag_2 ::= (("begin" tags_with_separator))
+root ::= ((tag_2))
+""",
+    ),
+    (
+        1,
+        _get_tags_with_separator_format_with_outside_tag(at_least_one=True, stop_after_first=False),
+        r"""const_string ::= (("L1"))
+tag ::= (("A1" const_string "A"))
+const_string_1 ::= (("L2"))
+tag_1 ::= (("A2" const_string_1 "A"))
+tags_with_separator_tags ::= ((tag) | (tag_1))
+tags_with_separator_sub ::= (("AA" tags_with_separator_tags tags_with_separator_sub) | ("end"))
+tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
+tag_2 ::= (("begin" tags_with_separator))
+root ::= ((tag_2))
+""",
+    ),
+    (
+        2,
+        _get_tags_with_separator_format_with_outside_tag(at_least_one=False, stop_after_first=True),
+        r"""const_string ::= (("L1"))
+tag ::= (("A1" const_string "A"))
+const_string_1 ::= (("L2"))
+tag_1 ::= (("A2" const_string_1 "A"))
+tags_with_separator_tags ::= ((tag) | (tag_1))
+tags_with_separator ::= ((tags_with_separator_tags "end") | ("end"))
+tag_2 ::= (("begin" tags_with_separator))
+root ::= ((tag_2))
+""",
+    ),
+    (
+        3,
+        _get_tags_with_separator_format_with_outside_tag(at_least_one=True, stop_after_first=True),
+        r"""const_string ::= (("L1"))
+tag ::= (("A1" const_string "A"))
+const_string_1 ::= (("L2"))
+tag_1 ::= (("A2" const_string_1 "A"))
+tags_with_separator_tags ::= ((tag) | (tag_1))
+tags_with_separator ::= ((tags_with_separator_tags "end"))
+tag_2 ::= (("begin" tags_with_separator))
+root ::= ((tag_2))
+""",
+    ),
+]
+
+
+tags_with_separator_with_outside_tag_instance_accepted_results = [
+    ("beginend", [True, False, True, False]),
+    ("beginA1L1Aend", [True, True, True, True]),
+    ("beginA1L1AAAA2L2Aend", [True, True, False, False]),
+    ("beginA1L1A", [False, False, False, False]),
+    ("beginA1L1AA2L2Aend", [False, False, False, False]),
+]
+
+
+@pytest.mark.parametrize(
+    "stag_id, stag_format, expected_grammar", tags_with_separator_with_outside_tag_stag_grammar
+)
+@pytest.mark.parametrize(
+    "instance, accepted_results", tags_with_separator_with_outside_tag_instance_accepted_results
+)
+def test_tags_with_separator_format_with_outside_tag(
+    stag_id: int,
+    stag_format: Dict[str, Any],
+    expected_grammar: str,
+    instance: str,
+    accepted_results: List[bool],
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, accepted_results[stag_id])
+
+
+compound_stag_instance_is_accepted = [
+    # Llama JSON-based tool calling
+    (
+        {
+            "type": "triggered_tags",
+            "triggers": ['{"name":'],
+            "tags": [
+                {
+                    "begin": '{"name": "func1", "parameters": ',
+                    "content": {"type": "json_schema", "json_schema": {"type": "object"}},
+                    "end": "}",
+                },
+                {
+                    "begin": '{"name": "func2", "parameters": ',
+                    "content": {"type": "json_schema", "json_schema": {"type": "object"}},
+                    "end": "}",
+                },
+            ],
+        },
+        [
+            (
+                '<text>{"name": "func2", "parameters": {"arg": 10}}<text>{"name": "func1", "parameters": {"arg": "123"}}<text>',
+                True,
+            ),
+            ('<text>{"name": "func3", "parameters": {"arg": 10}}', False),
+        ],
+    ),
+    # Force think
+    (
+        {
+            "type": "sequence",
+            "elements": [
+                {
+                    "type": "tag",
+                    "begin": "<think>",
+                    "content": {"type": "any_text"},
+                    "end": "</think>",
+                },
+                {
+                    "type": "triggered_tags",
+                    "triggers": ["<function="],
+                    "tags": [
+                        {
+                            "begin": "<function=func1>",
+                            "content": {"type": "json_schema", "json_schema": {"type": "object"}},
+                            "end": "</function>",
+                        },
+                        {
+                            "begin": "<function=func2>",
+                            "content": {"type": "json_schema", "json_schema": {"type": "object"}},
+                            "end": "</function>",
+                        },
+                    ],
+                },
+            ],
+        },
+        [
+            (
+                '<think>[any_text]</think>[any_text]<function=func2>{"arg": 10}</function>[any_text]<function=func1>{"arg": 10}</function>[any_text]',
+                True,
+            ),
+            (
+                '[any_text]<function=func2>{"arg": 10}</function>[any_text]<function=func1>{"arg": 10}</function>[any_text]',
+                False,
+            ),
+            ('<think>[any_text]</think>[any_text]<function=func3>{"arg": 10}', False),
+        ],
+    ),
+    # Think & Force tool calling (Llama style)
+    (
+        {
+            "type": "sequence",
+            "elements": [
+                {
+                    "type": "tag",
+                    "begin": "<think>",
+                    "content": {"type": "any_text"},
+                    "end": "</think>",
+                },
+                {
+                    "type": "triggered_tags",
+                    "triggers": ["<function="],
+                    "tags": [
+                        {
+                            "begin": "<function=func1>",
+                            "content": {"type": "json_schema", "json_schema": {"type": "object"}},
+                            "end": "</function>",
+                        },
+                        {
+                            "begin": "<function=func2>",
+                            "content": {"type": "json_schema", "json_schema": {"type": "object"}},
+                            "end": "</function>",
+                        },
+                    ],
+                    "stop_after_first": True,
+                    "at_least_one": True,
+                },
+            ],
+        },
+        [
+            ('<think>[any_text]</think><function=func2>{"arg": 10}</function>', True),
+            ('<think>[any_text]</think>[any_text]<function=func2>{"arg": 10}</function>', False),
+            ('<think>[any_text]</think><function=func2>{"arg": 10}</function>[any_text]', False),
+        ],
+    ),
+    # Think & force tool calling (DeepSeek style)
+    (
+        {
+            "type": "sequence",
+            "elements": [
+                {
+                    "type": "tag",
+                    "begin": "<think>",
+                    "content": {"type": "any_text"},
+                    "end": "</think>",
+                },
+                {
+                    "type": "triggered_tags",
+                    "triggers": ["<｜tool▁calls▁begin｜>"],
+                    "tags": [
+                        {
+                            "begin": "<｜tool▁calls▁begin｜>",
+                            "end": "<｜tool▁calls▁end｜>",
+                            "content": {
+                                "type": "tags_with_separator",
+                                "separator": "\n",
+                                "tags": [
+                                    {
+                                        "begin": "<｜tool▁call▁begin｜>function<｜tool▁sep｜>function_name_1\n```json\n",
+                                        "content": {
+                                            "type": "json_schema",
+                                            "json_schema": {"type": "object"},
+                                        },
+                                        "end": "\n```<｜tool▁call▁end｜>",
+                                    },
+                                    {
+                                        "begin": "<｜tool▁call▁begin｜>function<｜tool▁sep｜>function_name_2\n```json\n",
+                                        "content": {
+                                            "type": "json_schema",
+                                            "json_schema": {"type": "object"},
+                                        },
+                                        "end": "\n```<｜tool▁call▁end｜>",
+                                    },
+                                ],
+                            },
+                        }
+                    ],
+                    "stop_after_first": True,
+                },
+            ],
+        },
+        [
+            ("<think>[any_text]</think>[any_text]", True),
+            ("<think>[any_text]</think>[any_text]<｜tool▁calls▁begin｜><｜tool▁calls▁end｜>", True),
+            (
+                """<think>[any_text]</think>[any_text]<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>function_name_1
+```json
+{"arg": 10}
+```<｜tool▁call▁end｜>
+<｜tool▁call▁begin｜>function<｜tool▁sep｜>function_name_2
+```json
+{"arg": 10}
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>""",
+                True,
+            ),
+            (
+                """<think>[any_text]</think>[any_text]<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>function_name_3
+```json
+{"arg": 10}
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>""",
+                False,
+            ),
+            (
+                """<think>[any_text]</think>[any_text]<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>function_name_2
+```json
+{"arg": 10}
+```<｜tool▁call▁end｜><｜tool▁calls▁end｜>[any_text]""",
+                False,
+            ),
+        ],
+    ),
+    # Force non-think mode
+    (
+        {
+            "type": "sequence",
+            "elements": [
+                {"type": "const_string", "text": "<think></think>"},
+                {
+                    "type": "triggered_tags",
+                    "triggers": ["<tool_call>"],
+                    "tags": [
+                        {
+                            "begin": '<tool_call>\n{"name": "func1", "arguments": ',
+                            "content": {"type": "json_schema", "json_schema": {"type": "object"}},
+                            "end": "}\n</tool_call>",
+                        },
+                        {
+                            "begin": '<tool_call>\n{"name": "func2", "arguments": ',
+                            "content": {"type": "json_schema", "json_schema": {"type": "object"}},
+                            "end": "}\n</tool_call>",
+                        },
+                    ],
+                },
+            ],
+        },
+        [
+            (
+                '<think></think>[any_text]<tool_call>\n{"name": "func1", "arguments": {"arg": 10}}\n</tool_call>[any_text]',
+                True,
+            ),
+            (
+                '<think>abcd</think>[any_text]<tool_call>\n{"name": "func1", "arguments": {"arg": 10}}\n</tool_call>[any_text]',
+                False,
+            ),
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "stag_format, instance_is_accepted_tuples", compound_stag_instance_is_accepted
+)
+def test_compound_format(
+    stag_format: Dict[str, Any], instance_is_accepted_tuples: List[Tuple[str, bool]]
+):
+    for instance, is_accepted in instance_is_accepted_tuples:
+        check_stag_with_instance(stag_format, instance, is_accepted)
+
+
+end_string_detector_test_data = [
+    (
+        {
+            "type": "tag",
+            "begin": "<start>",
+            "content": {
+                "type": "sequence",
+                "elements": [{"type": "const_string", "text": "[TEXT]"}, {"type": "any_text"}],
+            },
+            "end": "<end>",
+        },
+        r"""const_string ::= (("[TEXT]"))
+any_text ::= TagDispatch(
+  stop_eos=false,
+  stop_str=("<end>"),
+  loop_after_dispatch=false
+)
+sequence ::= ((const_string any_text))
+tag ::= (("<start>" sequence))
+root ::= ((tag))
+""",
+        [
+            ("<start>[TEXT]<end>", True),
+            ("<start>[TEXT]abcde<end>", True),
+            ("<start>[TEXT]abcde", False),
+            ("<start><end>", False),
+        ],
+    ),
+    (
+        # Detect the end string for nested structures
+        {
+            "type": "tag",
+            "begin": "<start>",
+            "content": {
+                "type": "or",
+                "elements": [
+                    {
+                        "type": "triggered_tags",
+                        "triggers": ["<start2"],
+                        "tags": [
+                            {"begin": "<start2>", "content": {"type": "any_text"}, "end": "<end2>"}
+                        ],
+                        "at_least_one": True,
+                    },
+                    {
+                        "type": "sequence",
+                        "elements": [
+                            {"type": "const_string", "text": "[TEXT2]"},
+                            {"type": "any_text"},
+                        ],
+                    },
+                    {
+                        "type": "tags_with_separator",
+                        "tags": [
+                            {"begin": "<start3>", "content": {"type": "any_text"}, "end": "<end3>"}
+                        ],
+                        "separator": "<sep>",
+                    },
+                ],
+            },
+            "end": "<end>",
+        },
+        r"""any_text ::= TagDispatch(
+  stop_eos=false,
+  stop_str=("<end2>"),
+  loop_after_dispatch=false
+)
+triggered_tags_group ::= ((">" any_text ""))
+triggered_tags_first ::= (("<start2>" any_text ""))
+triggered_tags_sub ::= TagDispatch(
+  ("<start2", triggered_tags_group),
+  stop_eos=false,
+  stop_str=("<end>"),
+  loop_after_dispatch=true
+)
+triggered_tags ::= ((triggered_tags_first triggered_tags_sub))
+const_string ::= (("[TEXT2]"))
+any_text_1 ::= TagDispatch(
+  stop_eos=false,
+  stop_str=("<end>"),
+  loop_after_dispatch=false
+)
+sequence ::= ((const_string any_text_1))
+any_text_2 ::= TagDispatch(
+  stop_eos=false,
+  stop_str=("<end3>"),
+  loop_after_dispatch=false
+)
+tag ::= (("<start3>" any_text_2))
+tags_with_separator_tags ::= ((tag))
+tags_with_separator_sub ::= (("<sep>" tags_with_separator_tags tags_with_separator_sub) | ("<end>"))
+tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub) | ("<end>"))
+or ::= ((triggered_tags) | (sequence) | (tags_with_separator))
+tag_1 ::= (("<start>" or))
+root ::= ((tag_1))
+""",
+        [
+            ("<start><start2>[TEXT]<end2><end>", True),
+            ("<start><start2><end2><end>", True),
+            ("<start>[TEXT2]abc<end>", True),
+            ("<start><start3>abc<end3><end>", True),
+            ("<start><start3><end3><end>", True),
+            ("<start><end>", True),
+            ("<start>[TEXT2]", False),
+        ],
+    ),
+    (
+        # Also in nested structures, but none end string can be detected
+        {
+            "type": "or",
+            "elements": [
+                {
+                    "type": "triggered_tags",
+                    "triggers": ["<start2"],
+                    "tags": [
+                        {"begin": "<start2>", "content": {"type": "any_text"}, "end": "<end2>"}
+                    ],
+                    "at_least_one": True,
+                },
+                {
+                    "type": "sequence",
+                    "elements": [{"type": "const_string", "text": "[TEXT]"}, {"type": "any_text"}],
+                },
+                {
+                    "type": "or",
+                    "elements": [
+                        {
+                            "type": "tags_with_separator",
+                            "tags": [
+                                {
+                                    "begin": "<start3>",
+                                    "content": {"type": "any_text"},
+                                    "end": "<end3>",
+                                }
+                            ],
+                            "separator": "<sep>",
+                            "at_least_one": True,
+                        },
+                        {
+                            "type": "sequence",
+                            "elements": [
+                                {"type": "const_string", "text": "[TEXT2]"},
+                                {"type": "any_text"},
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        r"""any_text ::= TagDispatch(
+  stop_eos=false,
+  stop_str=("<end2>"),
+  loop_after_dispatch=false
+)
+triggered_tags_group ::= ((">" any_text ""))
+triggered_tags_first ::= (("<start2>" any_text ""))
+triggered_tags_sub ::= TagDispatch(
+  ("<start2", triggered_tags_group),
+  stop_eos=true,
+  stop_str=(),
+  loop_after_dispatch=true
+)
+triggered_tags ::= ((triggered_tags_first triggered_tags_sub))
+const_string ::= (("[TEXT]"))
+any_text_1 ::= (([\0-\U0010ffff]*))
+sequence ::= ((const_string any_text_1))
+any_text_2 ::= TagDispatch(
+  stop_eos=false,
+  stop_str=("<end3>"),
+  loop_after_dispatch=false
+)
+tag ::= (("<start3>" any_text_2))
+tags_with_separator_tags ::= ((tag))
+tags_with_separator_sub ::= (("<sep>" tags_with_separator_tags tags_with_separator_sub) | "")
+tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
+const_string_1 ::= (("[TEXT2]"))
+any_text_3 ::= (([\0-\U0010ffff]*))
+sequence_1 ::= ((const_string_1 any_text_3))
+or ::= ((tags_with_separator) | (sequence_1))
+or_1 ::= ((triggered_tags) | (sequence) | (or))
+root ::= ((or_1))
+""",
+        [
+            ("<start2>abc<end2>abcdef", True),
+            ("[TEXT]abc", True),
+            ("[TEXT]", True),
+            ("<start3>abc<end3>", True),
+            ("<start3>abc<end3><sep><start3>def<end3>", True),
+            ("[TEXT2]def", True),
+            ("[TEXT2]", True),
+            ("<start>abc<end>", False),
+            ("<start2>abc", False),
+            ("abc<end2>", False),
+            ("<start3>abc", False),
+            ("<start3>abc<end3><start3>def<end3>", False),
+            ("random text", False),
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "stag_format, expected_grammar, instance_is_accepted_tuples", end_string_detector_test_data
+)
+def test_end_string_detector(
+    stag_format: Dict[str, Any],
+    expected_grammar: str,
+    instance_is_accepted_tuples: List[Tuple[str, bool]],
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    for instance, is_accepted in instance_is_accepted_tuples:
+        check_stag_with_instance(stag_format, instance, is_accepted)
+
+
+# Test cases for JSON format and parsing errors (need string input)
+json_format_error_test_data = [
+    # JSON Parsing Errors
+    (
+        '{"type": "structural_tag", "format": {"type": "const_string", "text": "hello"',
+        "Failed to parse JSON",
+    ),
+    ('"not_an_object"', "Structural tag must be an object"),
+    (
+        '{"type": "wrong_type", "format": {"type": "const_string", "text": "hello"}}',
+        'Structural tag\'s type must be a string "structural_tag"',
+    ),
+    ('{"type": "structural_tag"}', "Structural tag must have a format field"),
+    # Format Parsing Errors
+    ('{"type": "structural_tag", "format": "not_an_object"}', "Format must be an object"),
+    (
+        '{"type": "structural_tag", "format": {"type": 123, "text": "hello"}}',
+        "Format's type must be a string",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "unknown_format"}}',
+        "Format type not recognized: unknown_format",
+    ),
+    ('{"type": "structural_tag", "format": {"invalid_field": "value"}}', "Invalid format"),
+    # ConstStringFormat Errors
+    (
+        '{"type": "structural_tag", "format": {"type": "const_string"}}',
+        "ConstString format must have a text field with a non-empty string",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "const_string", "text": 123}}',
+        "ConstString format must have a text field with a non-empty string",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "const_string", "text": ""}}',
+        "ConstString format must have a text field with a non-empty string",
+    ),
+    # JSONSchemaFormat Errors
+    (
+        '{"type": "structural_tag", "format": {"type": "json_schema"}}',
+        "JSON schema format must have a json_schema field with a object or boolean value",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "json_schema", "json_schema": "invalid"}}',
+        "JSON schema format must have a json_schema field with a object or boolean value",
+    ),
+    # AnyTextFormat Errors
+    (
+        '{"type": "structural_tag", "format": {"type": "any_text", "extra_field": "value"}}',
+        "Any text format should not have any fields other than type",
+    ),
+    # SequenceFormat Errors
+    (
+        '{"type": "structural_tag", "format": {"type": "sequence"}}',
+        "Sequence format must have an elements field with an array",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "sequence", "elements": "not_array"}}',
+        "Sequence format must have an elements field with an array",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "sequence", "elements": []}}',
+        "Sequence format must have at least one element",
+    ),
+    # OrFormat Errors
+    (
+        '{"type": "structural_tag", "format": {"type": "or"}}',
+        "Or format must have an elements field with an array",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "or", "elements": "not_array"}}',
+        "Or format must have an elements field with an array",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "or", "elements": []}}',
+        "Or format must have at least one element",
+    ),
+    # TagFormat Errors
+    (
+        '{"type": "structural_tag", "format": {"type": "tag", "content": {"type": "const_string", "text": "hello"}, "end": "end"}}',
+        "Tag format's begin field must be a string",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "tag", "begin": 123, "content": {"type": "const_string", "text": "hello"}, "end": "end"}}',
+        "Tag format's begin field must be a string",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "tag", "begin": "start", "end": "end"}}',
+        "Tag format must have a content field",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "tag", "begin": "start", "content": {"type": "const_string", "text": "hello"}}}',
+        "Tag format's end field must be a string",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "tag", "begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": 123}}',
+        "Tag format's end field must be a string",
+    ),
+    # TriggeredTagsFormat Errors
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}]}}',
+        "Triggered tags format must have a triggers field with an array",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": "not_array", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}]}}',
+        "Triggered tags format must have a triggers field with an array",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": [], "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}]}}',
+        "Triggered tags format's triggers must be non-empty",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": [123], "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}]}}',
+        "Triggered tags format's triggers must be non-empty strings",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": [""], "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}]}}',
+        "Triggered tags format's triggers must be non-empty strings",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"]}}',
+        "Triggered tags format must have a tags field with an array",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"], "tags": "not_array"}}',
+        "Triggered tags format must have a tags field with an array",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"], "tags": []}}',
+        "Triggered tags format's tags must be non-empty",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"], "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}], "at_least_one": "not_boolean"}}',
+        "at_least_one must be a boolean",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"], "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}], "stop_after_first": "not_boolean"}}',
+        "stop_after_first must be a boolean",
+    ),
+    # TagsWithSeparatorFormat Errors
+    (
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "separator": "sep"}}',
+        "Tags with separator format must have a tags field with an array",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": "not_array", "separator": "sep"}}',
+        "Tags with separator format must have a tags field with an array",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [], "separator": "sep"}}',
+        "Tags with separator format's tags must be non-empty",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}]}}',
+        "Tags with separator format's separator field must be a non-empty string",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}], "separator": 123}}',
+        "Tags with separator format's separator field must be a non-empty string",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}], "separator": ""}}',
+        "Tags with separator format's separator field must be a non-empty string",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}], "separator": "sep", "at_least_one": "not_boolean"}}',
+        "at_least_one must be a boolean",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "tags_with_separator", "tags": [{"begin": "start", "content": {"type": "const_string", "text": "hello"}, "end": "end"}], "separator": "sep", "stop_after_first": "not_boolean"}}',
+        "stop_after_first must be a boolean",
+    ),
+]
+
+
+@pytest.mark.parametrize("json_input, expected_error", json_format_error_test_data)
+def test_structural_tag_json_format_errors(json_input: str, expected_error: str):
+    """Test JSON format and parsing errors that occur during JSON parsing phase"""
+    with pytest.raises(Exception) as exc_info:
+        xgr.Grammar.from_structural_tag(json_input)
+    assert expected_error in str(exc_info.value)
+
+
+structural_tag_error_test_data = [
+    # Analyzer Errors - Only last element in sequence can be unlimited
+    {
+        "type": "sequence",
+        "elements": [
+            {"type": "const_string", "text": "start"},
+            {"type": "any_text"},  # This unlimited element in middle will cause error
+            {"type": "const_string", "text": "end"},
+        ],
+    },
+    # Analyzer Errors - Or format with mixed unlimited and limited elements
+    {
+        "type": "or",
+        "elements": [
+            {"type": "const_string", "text": "limited"},  # Limited element
+            {"type": "any_text"},  # Unlimited element - mix not allowed
+        ],
+    },
+    # Analyzer Errors - Tag format with unlimited content but empty end
+    {
+        "type": "tag",
+        "begin": "start",
+        "content": {"type": "any_text"},  # Unlimited content
+        "end": "",  # Empty end with unlimited content causes error
+    },
+    # Converter Errors - Tag matches multiple triggers
+    {
+        "type": "triggered_tags",
+        "triggers": ["A", "AB"],  # Both will match tag beginning with "ABC"
+        "tags": [
+            {"begin": "ABC", "content": {"type": "const_string", "text": "hello"}, "end": "end"}
+        ],
+    },
+    # Converter Errors - Tag matches no trigger
+    {
+        "type": "triggered_tags",
+        "triggers": ["X", "Y"],  # Neither matches "ABC" begin
+        "tags": [
+            {"begin": "ABC", "content": {"type": "const_string", "text": "hello"}, "end": "end"}
+        ],
+    },
+    # Cannot detect end string of tags_with_separator in sequence
+    {
+        "type": "sequence",
+        "elements": [
+            {
+                "type": "tags_with_separator",
+                "tags": [
+                    {
+                        "begin": "<start>",
+                        "content": {"type": "const_string", "text": "[TEXT]"},
+                        "end": "<end>",
+                    }
+                ],
+                "separator": "<sep>",
+            },
+            {"type": "const_string", "text": "[TEXT]"},
+        ],
+    },
+    # Cannot detect end string of tags_with_separator in or
+    {
+        "type": "or",
+        "elements": [
+            {
+                "type": "tags_with_separator",
+                "tags": [
+                    {
+                        "begin": "<start>",
+                        "content": {"type": "const_string", "text": "[TEXT]"},
+                        "end": "<end>",
+                    }
+                ],
+                "separator": "<sep>",
+            },
+            {"type": "const_string", "text": "[TEXT]"},
+        ],
+    },
+    # Original test cases - Detected end string of tags_with_separator is empty
+    {
+        "type": "tag",
+        "begin": "<start>",
+        "content": {
+            "type": "tags_with_separator",
+            "tags": [
+                {
+                    "begin": "<start2>",
+                    "content": {"type": "const_string", "text": "[TEXT]"},
+                    "end": "<end2>",
+                }
+            ],
+            "separator": "<sep>",
+        },
+        "end": "",
+    },
+]
+
+
+@pytest.mark.parametrize("stag_format", structural_tag_error_test_data)
+def test_structural_tag_error(stag_format: Dict[str, Any]):
+    """Test analyzer and converter errors that occur after successful parsing"""
+    structural_tag = {"type": "structural_tag", "format": stag_format}
+    with pytest.raises(Exception, match="Invalid structural tag error"):
+        xgr.Grammar.from_structural_tag(structural_tag)
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)


### PR DESCRIPTION
This PR brings the structural tag. See the docs for its details.

It also refactors GrammarCompiler, the printing methods in EarleyParser and GrammarMatcher, the hashing utils, the exception library.

Although introducing the new structural tag API, the API is still backward compatible.

Signed-off-by: Ubospica <ubospica@gmail.com>