### PR TITLE
Add py.typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ sdist.include = [
   "/cpp/**/*.h",
   "/include/**/*",
   "/python/xgrammar/**/*.py",
+  "/python/xgrammar/py.typed",
 
   # Third party files
   "/3rdparty/**/*",


### PR DESCRIPTION
This pr adds py.typed to enable linters for downstream code.

Signed-off-by: Ubospica <ubospica@gmail.com>