### PR TITLE
[Feature] Enhance structural tags by providing xml-style tags.

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -3441,4 +3441,28 @@ std::string GenerateFloatRangeRegex(std::optional<double> start, std::optional<d
   return JSONSchemaConverter::GenerateFloatRangeRegex(start, end, 6);
 }
 
+std::string QwenXMLToolCallingToEBNF(const std::string& schema) {
+  // Convert the schema string to picojson value.
+  picojson::value json_value;
+  std::string err = picojson::parse(json_value, schema);
+  if (!err.empty()) {
+    XGRAMMAR_LOG(FATAL) << "Failed to parse JSON schema: " << err;
+  }
+  if (json_value.is<bool>()) {
+    XGRAMMAR_LOG(FATAL) << "Expected JSON schema object, got boolean: " << json_value.to_str();
+  }
+  const auto& schema_obj = json_value.get<picojson::object>();
+  if (!schema_obj.count("type")) {
+    XGRAMMAR_LOG(FATAL) << "Function calling must have a 'type' field of 'object': "
+                        << json_value.to_str();
+  }
+  if (schema_obj.at("type").get<std::string>() != "object") {
+    XGRAMMAR_LOG(FATAL) << "Function calling must have a 'type' field of 'object': "
+                        << json_value.to_str();
+  }
+  return JSONSchemaToEBNF(
+      json_value, true, std::nullopt, std::nullopt, true, std::nullopt, JSONFormat::kXML
+  );
+}
+
 }  // namespace xgrammar

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -91,6 +91,14 @@ std::string GenerateRangeRegex(std::optional<int64_t> start, std::optional<int64
 
 std::string GenerateFloatRangeRegex(std::optional<double> start, std::optional<double> end);
 
+/*!
+ * \brief Convert a function call to a Grammar.
+ * \param schema The schema of the parameters of the function call.
+ * \return The ebnf-grammar to match the requirements of the schema, and
+ * in Qwen xml style.
+ */
+std::string QwenXMLToolCallingToEBNF(const std::string& schema);
+
 }  // namespace xgrammar
 
 #endif  // XGRAMMAR_JSON_SCHEMA_CONVERTER_H_

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -287,7 +287,7 @@ NB_MODULE(xgrammar_bindings, m) {
           nb::arg("start").none(),
           nb::arg("end").none()
       )
-      .def("_qwen_xml_tool_calling_to_ebnf", &_QwenXMLToolCallingToEBNF, nb::arg("schema"))
+      .def("_qwen_xml_tool_calling_to_ebnf", &QwenXMLToolCallingToEBNF, nb::arg("schema"))
       .def(
           "_generate_float_regex",
           [](std::optional<double> start, std::optional<double> end) {

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -42,6 +42,7 @@ class StructuralTagParser {
   Result<Format, ISTError> ParseFormat(const picojson::value& value);
   Result<ConstStringFormat, ISTError> ParseConstStringFormat(const picojson::object& value);
   Result<JSONSchemaFormat, ISTError> ParseJSONSchemaFormat(const picojson::object& value);
+  Result<QwenXmlFormat, ISTError> ParseQwenXmlFormat(const picojson::object& value);
   Result<AnyTextFormat, ISTError> ParseAnyTextFormat(const picojson::object& value);
   Result<SequenceFormat, ISTError> ParseSequenceFormat(const picojson::object& value);
   Result<OrFormat, ISTError> ParseOrFormat(const picojson::object& value);
@@ -118,6 +119,8 @@ Result<Format, ISTError> StructuralTagParser::ParseFormat(const picojson::value&
       return Result<Format, ISTError>::Convert(ParseTriggeredTagsFormat(obj));
     } else if (type == "tags_with_separator") {
       return Result<Format, ISTError>::Convert(ParseTagsWithSeparatorFormat(obj));
+    } else if (type == "qwen_xml") {
+      return Result<Format, ISTError>::Convert(ParseQwenXmlFormat(obj));
     } else {
       return ResultErr<ISTError>("Format type not recognized: " + type);
     }
@@ -185,6 +188,20 @@ Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
   }
   // here introduces a serialization/deserialization overhead; try to avoid it in the future.
   return ResultOk<JSONSchemaFormat>(json_schema_it->second.serialize(false));
+}
+
+Result<QwenXmlFormat, ISTError> StructuralTagParser::ParseQwenXmlFormat(const picojson::object& obj
+) {
+  // json_schema is required.
+  auto json_schema_it = obj.find("parameter_schema");
+  if (json_schema_it == obj.end() ||
+      !(json_schema_it->second.is<picojson::object>() || json_schema_it->second.is<bool>())) {
+    return ResultErr<ISTError>(
+        "JSON schema format must have a json_schema field with a object or boolean value"
+    );
+  }
+  // here introduces a serialization/deserialization overhead; try to avoid it in the future.
+  return ResultOk<QwenXmlFormat>(json_schema_it->second.serialize(false));
 }
 
 Result<AnyTextFormat, ISTError> StructuralTagParser::ParseAnyTextFormat(const picojson::object& obj

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -27,6 +27,7 @@ namespace xgrammar {
 
 struct ConstStringFormat;
 struct JSONSchemaFormat;
+struct QwenXmlFormat;
 struct AnyTextFormat;
 struct SequenceFormat;
 struct OrFormat;
@@ -37,6 +38,7 @@ struct TagsWithSeparatorFormat;
 using Format = std::variant<
     ConstStringFormat,
     JSONSchemaFormat,
+    QwenXmlFormat,
     AnyTextFormat,
     SequenceFormat,
     OrFormat,
@@ -56,6 +58,12 @@ struct JSONSchemaFormat {
   static constexpr const char* type = "json_schema";
   std::string json_schema;
   JSONSchemaFormat(std::string json_schema) : json_schema(std::move(json_schema)) {}
+};
+
+struct QwenXmlFormat {
+  static constexpr const char* type = "qwen_xml";
+  std::string xml_schema;
+  QwenXmlFormat(std::string xml_schema) : xml_schema(std::move(xml_schema)) {}
 };
 
 struct AnyTextFormat {

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -27,7 +27,7 @@ namespace xgrammar {
 
 struct ConstStringFormat;
 struct JSONSchemaFormat;
-struct QwenXmlFormat;
+struct QwenXmlParameterFormat;
 struct AnyTextFormat;
 struct SequenceFormat;
 struct OrFormat;
@@ -38,7 +38,7 @@ struct TagsWithSeparatorFormat;
 using Format = std::variant<
     ConstStringFormat,
     JSONSchemaFormat,
-    QwenXmlFormat,
+    QwenXmlParameterFormat,
     AnyTextFormat,
     SequenceFormat,
     OrFormat,
@@ -60,10 +60,10 @@ struct JSONSchemaFormat {
   JSONSchemaFormat(std::string json_schema) : json_schema(std::move(json_schema)) {}
 };
 
-struct QwenXmlFormat {
+struct QwenXmlParameterFormat {
   static constexpr const char* type = "qwen_xml";
   std::string xml_schema;
-  QwenXmlFormat(std::string xml_schema) : xml_schema(std::move(xml_schema)) {}
+  QwenXmlParameterFormat(std::string xml_schema) : xml_schema(std::move(xml_schema)) {}
 };
 
 struct AnyTextFormat {

--- a/cpp/testing.cc
+++ b/cpp/testing.cc
@@ -56,28 +56,4 @@ std::string _PrintGrammarFSMs(const Grammar& grammar) {
   return result;
 }
 
-std::string _QwenXMLToolCallingToEBNF(const std::string& schema) {
-  // Convert the schema string to picojson value.
-  picojson::value json_value;
-  std::string err = picojson::parse(json_value, schema);
-  if (!err.empty()) {
-    XGRAMMAR_LOG(FATAL) << "Failed to parse JSON schema: " << err;
-  }
-  if (json_value.is<bool>()) {
-    XGRAMMAR_LOG(FATAL) << "Expected JSON schema object, got boolean: " << json_value.to_str();
-  }
-  const auto& schema_obj = json_value.get<picojson::object>();
-  if (!schema_obj.count("type")) {
-    XGRAMMAR_LOG(FATAL) << "Function calling must have a 'type' field of 'object': "
-                        << json_value.to_str();
-  }
-  if (schema_obj.at("type").get<std::string>() != "object") {
-    XGRAMMAR_LOG(FATAL) << "Function calling must have a 'type' field of 'object': "
-                        << json_value.to_str();
-  }
-  return JSONSchemaToEBNF(
-      json_value, true, std::nullopt, std::nullopt, true, std::nullopt, JSONFormat::kXML
-  );
-}
-
 }  // namespace xgrammar

--- a/cpp/testing.cc
+++ b/cpp/testing.cc
@@ -4,14 +4,12 @@
  */
 #include <xgrammar/xgrammar.h>
 
-#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
 
 #include "grammar_impl.h"
 #include "grammar_parser.h"
-#include "json_schema_converter.h"
 #include "support/encoding.h"
 
 namespace xgrammar {

--- a/cpp/testing.h
+++ b/cpp/testing.h
@@ -23,14 +23,6 @@ Grammar _EBNFToGrammarNoNormalization(
 
 std::string _PrintGrammarFSMs(const Grammar& grammar);
 
-/*!
- * \brief Convert a function call to a Grammar.
- * \param schema The schema of the parameters of the function call.
- * \return The ebnf-grammar to match the requirements of the schema, and
- * in Qwen xml style.
- */
-std::string _QwenXMLToolCallingToEBNF(const std::string& schema);
-
 }  // namespace xgrammar
 
 #endif  // XGRAMMAR_TESTING_H_

--- a/docs/api/python/structural_tag.rst
+++ b/docs/api/python/structural_tag.rst
@@ -18,6 +18,10 @@ Basic Formats
    :show-inheritance:
    :exclude-members: model_config
 
+.. autoclass:: QwenXMLParameterFormat
+   :show-inheritance:
+   :exclude-members: model_config
+
 Combinatorial Formats
 ---------------------
 

--- a/docs/tutorials/structural_tag.md
+++ b/docs/tutorials/structural_tag.md
@@ -275,6 +275,70 @@ The format field requires a format object. We provide several basic format objec
     tag is generated. If there are following tags, they will still be generated; otherwise, the
     generation will stop.
 
+
+9. `QwenXMLParameterFormat`
+
+    This is designed for the parameter format of Qwen3-coder. The output should match the given JSON schema in XML style.
+
+    ```json
+    {
+        "type": "qwen_xml_parameter",
+        "json_schema": {
+            ...
+        }
+    }
+    ```
+
+    For example,
+    ```json
+    {
+        "type": "qwen_xml_parameter",
+        "json_schema": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+            "required": ["name", "age"],
+        },
+    }
+    ```
+
+    This can accept outputs such like:
+    ```xml
+    <parameter=name>Bob</parameter><parameter=age>\t100\n</parameter>
+    <parameter=name>Bob</parameter>\t\n<parameter=age>\t100\n</parameter>
+    <parameter=name>Bob</parameter><parameter=age>100</parameter>
+    <parameter=name>"Bob&lt;"</parameter><parameter=age>100</parameter>
+    ```
+
+    Note that strings here are in XML style. Moreover, if the parameter's type is `object`, the inner `object` will still be in JSON style. For example:
+
+    ```json
+    {
+        "type": "qwen_xml_parameter",
+        "json_schema": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "properties": {"street": {"type": "string"}, "city": {"type": "string"}},
+                    "required": ["street", "city"],
+                }
+            },
+            "required": ["address"],
+        },
+    }
+    ```
+
+    These are valid outputs:
+    ```xml
+    <parameter=address>{"street": "Main St", "city": "New York"}</parameter>
+    <parameter=address>{"street": "Main St", "city": "No more xml escape&<>"}</parameter>
+    ```
+
+    And this is an invalid output:
+    ```xml
+    <parameter=address><parameter=street>Main St</parameter><parameter=city>New York</parameter></parameter>
+    ```
+
 ## Examples
 
 ### Example 1: Tool calling

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -74,14 +74,14 @@ class TagFormat(BaseModel):
     """The end tag."""
 
 
-class QwenXmlFormat(BaseModel):
+class QwenXMLParameterFormat(BaseModel):
     """A format that matches Qwen XML function calls."""
 
-    type: Literal["qwen_xml"] = "qwen_xml"
+    type: Literal["qwen_xml_parameter"] = "qwen_xml_parameter"
     """The type of the format."""
 
-    parameter_schema: Union[bool, Dict[str, Any]]
-    """The JSON schema for the parameters of the function call."""
+    json_schema: Union[bool, Dict[str, Any]]
+    """The JSON schema for the parameters of the function calling."""
 
 
 class TriggeredTagsFormat(BaseModel):
@@ -181,7 +181,7 @@ Format = Annotated[
         AnyTextFormat,
         ConstStringFormat,
         JSONSchemaFormat,
-        QwenXmlFormat,
+        QwenXMLParameterFormat,
         OrFormat,
         SequenceFormat,
         TagFormat,

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -77,7 +77,7 @@ class TagFormat(BaseModel):
 class QwenXmlFormat(BaseModel):
     """A format that matches Qwen XML function calls."""
 
-    type: Literal["any_text"] = "any_text"
+    type: Literal["qwen_xml"] = "qwen_xml"
     """The type of the format."""
 
     parameter_schema: Union[bool, Dict[str, Any]]
@@ -181,6 +181,7 @@ Format = Annotated[
         AnyTextFormat,
         ConstStringFormat,
         JSONSchemaFormat,
+        QwenXmlFormat,
         OrFormat,
         SequenceFormat,
         TagFormat,

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -53,8 +53,6 @@ class QwenXMLParameterFormat(BaseModel):
 
     The above structural tag can accept the following outputs::
 
-        <parameter=name>Bob</parameter><parameter=age>\t100\n</parameter>
-        <parameter=name>Bob</parameter>\t\n<parameter=age>\t100\n</parameter>
         <parameter=name>Bob</parameter><parameter=age>100</parameter>
         <parameter=name>"Bob&lt;"</parameter><parameter=age>100</parameter>
 

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -74,6 +74,16 @@ class TagFormat(BaseModel):
     """The end tag."""
 
 
+class QwenXmlFormat(BaseModel):
+    """A format that matches Qwen XML function calls."""
+
+    type: Literal["any_text"] = "any_text"
+    """The type of the format."""
+
+    parameter_schema: Union[bool, Dict[str, Any]]
+    """The JSON schema for the parameters of the function call."""
+
+
 class TriggeredTagsFormat(BaseModel):
     """A format that matches triggered tags. It can allow any output until a trigger is
     encountered, then dispatch to the corresponding tag; when the end tag is encountered, the

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -33,6 +33,40 @@ class JSONSchemaFormat(BaseModel):
     """The JSON schema."""
 
 
+class QwenXMLParameterFormat(BaseModel):
+    """A format that matches Qwen XML function calls.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        structural_tag = QwenXMLParameterFormat(
+            json_schema={
+                "type": "qwen_xml_parameter",
+                "json_schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+                    "required": ["name", "age"],
+                },
+            }
+        )
+
+    The above structural tag can accept the following outputs::
+
+        <parameter=name>Bob</parameter><parameter=age>\t100\n</parameter>
+        <parameter=name>Bob</parameter>\t\n<parameter=age>\t100\n</parameter>
+        <parameter=name>Bob</parameter><parameter=age>100</parameter>
+        <parameter=name>"Bob&lt;"</parameter><parameter=age>100</parameter>
+
+    """
+
+    type: Literal["qwen_xml_parameter"] = "qwen_xml_parameter"
+    """The type of the format."""
+
+    json_schema: Union[bool, Dict[str, Any]]
+    """The JSON schema for the parameters of the function calling."""
+
+
 class AnyTextFormat(BaseModel):
     """A format that matches any text."""
 
@@ -72,16 +106,6 @@ class TagFormat(BaseModel):
     """The content of the tag. It can be any of the formats."""
     end: str
     """The end tag."""
-
-
-class QwenXMLParameterFormat(BaseModel):
-    """A format that matches Qwen XML function calls."""
-
-    type: Literal["qwen_xml_parameter"] = "qwen_xml_parameter"
-    """The type of the format."""
-
-    json_schema: Union[bool, Dict[str, Any]]
-    """The JSON schema for the parameters of the function calling."""
 
 
 class TriggeredTagsFormat(BaseModel):

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -283,6 +283,7 @@ class StructuralTag(BaseModel):
 __all__ = [
     "ConstStringFormat",
     "JSONSchemaFormat",
+    "QwenXMLParameterFormat",
     "AnyTextFormat",
     "SequenceFormat",
     "OrFormat",

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -128,11 +128,11 @@ def test_json_schema_format(
     check_stag_with_instance(stag_format, instance, is_accepted)
 
 
-qwen_xml_stag_grammar = [
+qwen_parameter_xml_stag_grammar = [
     (
         {
-            "type": "qwen_xml",
-            "parameter_schema": {
+            "type": "qwen_xml_parameter",
+            "json_schema": {
                 "type": "object",
                 "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
                 "required": ["name", "age"],
@@ -149,7 +149,7 @@ root_1 ::= ((root))
 """,
     )
 ]
-qwen_xml_instance_is_accepted = [
+qwen_parameter_xml_instance_is_accepted = [
     ("<parameter=name>Bob</parameter><parameter=age>\t100\n</parameter>", True),
     ("<parameter=name>Bob</parameter>\t\n<parameter=age>\t100\n</parameter>", True),
     ("<parameter=name>Bob</parameter><parameter=age>100</parameter>", True),
@@ -160,9 +160,9 @@ qwen_xml_instance_is_accepted = [
 ]
 
 
-@pytest.mark.parametrize("stag_format, expected_grammar", qwen_xml_stag_grammar)
-@pytest.mark.parametrize("instance, is_accepted", qwen_xml_instance_is_accepted)
-def test_qwen_xml_format(
+@pytest.mark.parametrize("stag_format, expected_grammar", qwen_parameter_xml_stag_grammar)
+@pytest.mark.parametrize("instance, is_accepted", qwen_parameter_xml_instance_is_accepted)
+def test_qwen_parameter_xml_format(
     stag_format: Dict[str, Any], expected_grammar: str, instance: str, is_accepted: bool
 ):
     check_stag_with_grammar(stag_format, expected_grammar)

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -52,7 +52,6 @@ if PROFILER_ON:
 def check_stag_with_grammar(structural_tag_format: Dict[str, Any], expected_grammar_ebnf: str):
     structural_tag = {"type": "structural_tag", "format": structural_tag_format}
     stag_ebnf = xgr.Grammar.from_structural_tag(structural_tag)
-    print(stag_ebnf)
     assert str(stag_ebnf) == expected_grammar_ebnf
 
 


### PR DESCRIPTION
This PR is based on #387 and #420. This PR provides a new schema, which allows users to constrain the output with Qwen's xml-style function callings' parameters. For example:
```
xml_style = {
    "type": "qwen_xml_parameter",
    "json_schema": {
        "type": "object",
        "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
        "required": ["name", "age"],
    },
},
structural_tag = {"type": "structural_tag", "format": xml_style}
stag_ebnf = xgr.Grammar.from_structural_tag(structural_tag)
```
Then, we can use `stag_ebnf` to constrain the outputs. For example, `"<parameter=name>Bob</parameter><parameter=age>\t100\n</parameter>` is a valid output.