### PR TITLE
[Fix] Fix from_structural_tag when the parameter is a StructuralTag.

### DIFF
--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -71,8 +71,14 @@ def _get_structural_tag_str_from_args(args: List[Any], kwargs: Dict[str, Any]) -
     TypeError
         When the arguments are invalid.
     """
-    if len(args) == 1 and isinstance(args[0], (StructuralTag, str, dict)):
-        return _convert_schema_to_str(args[0])
+    if len(args) == 1:
+        if isinstance(args[0], (str, dict)):
+            return _convert_schema_to_str(args[0])
+        elif isinstance(args[0], StructuralTag):
+            dict_represent = {"type": "structural_tag", "format": args[0].format.model_dump()}
+            return _convert_schema_to_str(dict_represent)
+        else:
+            raise TypeError("Invalid argument type for from_structural_tag")
     elif len(args) == 2 and isinstance(args[0], list) and isinstance(args[1], list):
         return StructuralTag.from_legacy_structural_tag(args[0], args[1]).model_dump_json(
             indent=None

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -10,15 +10,39 @@ from .base import XGRObject, _core
 from .structural_tag import StructuralTag, StructuralTagItem
 
 
-def _convert_instance_to_str(schema: Union[str, Dict[str, Any], StructuralTag]) -> str:
-    if isinstance(schema, dict):
-        return json.dumps(schema)
-    elif isinstance(schema, str):
-        return schema
-    elif isinstance(schema, StructuralTag):
-        return schema.model_dump_json()
+def _convert_instance_to_str(instance: Union[str, Dict[str, Any], StructuralTag]) -> str:
+    """Convert a schema to a string representation. It returns the schema in string format because
+    it's faster to send to C++.
+
+    This function handles different schema input types and converts them to a JSON string:
+    - StructuralTag.
+    - String inputs are returned as-is (assumed to be valid JSON)
+    - Dictionary inputs are converted to JSON strings
+
+    Parameters
+    ----------
+    instance : Union[str, StructuralTag, Dict[str, Any]]
+        The schema to convert, which can be a StructuralTag,
+        a JSON schema string, or a dictionary representing a JSON schema.
+
+    Returns
+    -------
+    str
+        The JSON schema as a string.
+
+    Raises
+    ------
+    ValueError, TypeError
+        If the schema type is not supported, or the dictionary is not serializable.
+    """
+    if isinstance(instance, dict):
+        return json.dumps(instance)
+    elif isinstance(instance, str):
+        return instance
+    elif isinstance(instance, StructuralTag):
+        return instance.model_dump_json()
     else:
-        raise ValueError("Invalid schema type")
+        raise ValueError("Invalid instance type")
 
 
 def _convert_schema_to_str(schema: Union[str, Type[BaseModel], Dict[str, Any]]) -> str:

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -11,10 +11,10 @@ from .structural_tag import StructuralTag, StructuralTagItem
 
 
 def _convert_instance_to_str(instance: Union[str, Dict[str, Any], StructuralTag]) -> str:
-    """Convert a schema to a string representation. It returns the schema in string format because
+    """Convert a instance to a string representation. It returns the schema in string format because
     it's faster to send to C++.
 
-    This function handles different schema input types and converts them to a JSON string:
+    This function handles different instance input types and converts them to a JSON string:
     - StructuralTag.
     - String inputs are returned as-is (assumed to be valid JSON)
     - Dictionary inputs are converted to JSON strings
@@ -22,7 +22,7 @@ def _convert_instance_to_str(instance: Union[str, Dict[str, Any], StructuralTag]
     Parameters
     ----------
     instance : Union[str, StructuralTag, Dict[str, Any]]
-        The schema to convert, which can be a StructuralTag,
+        The instance to convert, which can be a StructuralTag,
         a JSON schema string, or a dictionary representing a JSON schema.
 
     Returns
@@ -33,7 +33,7 @@ def _convert_instance_to_str(instance: Union[str, Dict[str, Any], StructuralTag]
     Raises
     ------
     ValueError, TypeError
-        If the schema type is not supported, or the dictionary is not serializable.
+        If the instance type is not supported, or the dictionary is not serializable.
     """
     if isinstance(instance, dict):
         return json.dumps(instance)

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -32,8 +32,10 @@ def _convert_instance_to_str(instance: Union[str, Dict[str, Any], StructuralTag]
 
     Raises
     ------
-    ValueError, TypeError
-        If the instance type is not supported, or the dictionary is not serializable.
+    ValueError
+        When the instance type is not supported.
+    TypeError
+        When he dictionary is not serializable.
     """
     if isinstance(instance, dict):
         return json.dumps(instance)
@@ -67,8 +69,10 @@ def _convert_schema_to_str(schema: Union[str, Type[BaseModel], Dict[str, Any]]) 
 
     Raises
     ------
-    ValueError, TypeError
-        If the schema type is not supported, or the dictionary is not serializable.
+    ValueError
+        When the schema type is not supported.
+    TypeError
+        When the dictionary is not serializable.
     """
     if isinstance(schema, type) and issubclass(schema, BaseModel):
         if hasattr(schema, "model_json_schema"):

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -1655,5 +1655,30 @@ def test_basic_structural_tag_utf8(stag_format: Dict[str, Any], instance: str, i
     check_stag_with_instance(stag_format, instance, is_accepted)
 
 
+basic_structural_tags_instance_is_accepted = [
+    (xgr.structural_tag.ConstStringFormat(value="hello"), "hello", True),
+    (xgr.structural_tag.ConstStringFormat(value="hello"), "hello world", False),
+    (xgr.structural_tag.JSONSchemaFormat(json_schema={"type": "object"}), '{"key": "value"}', True),
+    (
+        xgr.structural_tag.JSONSchemaFormat(json_schema={"type": "object"}),
+        '["not", "an", "object"]',
+        False,
+    ),
+    (xgr.structural_tag.AnyTextFormat(), "", True),
+    (xgr.structural_tag.AnyTextFormat(), "any text here", True),
+]
+
+
+@pytest.mark.parametrize(
+    "stag_format, instance, is_accepted", basic_structural_tags_instance_is_accepted
+)
+def test_from_structural_tag_with_StructuralTagInstance(
+    stag_format: xgr.structural_tag.Format, instance: str, is_accepted: bool
+):
+    stag = xgr.structural_tag.StructuralTag(format=stag_format)
+    grammar = xgr.Grammar.from_structural_tag(stag)
+    assert _is_grammar_accept_string(grammar, instance) == is_accepted
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -1656,16 +1656,124 @@ def test_basic_structural_tag_utf8(stag_format: Dict[str, Any], instance: str, i
 
 
 basic_structural_tags_instance_is_accepted = [
+    # ConstStringFormat
     (xgr.structural_tag.ConstStringFormat(value="hello"), "hello", True),
     (xgr.structural_tag.ConstStringFormat(value="hello"), "hello world", False),
+    # JSONSchemaFormat
     (xgr.structural_tag.JSONSchemaFormat(json_schema={"type": "object"}), '{"key": "value"}', True),
-    (
-        xgr.structural_tag.JSONSchemaFormat(json_schema={"type": "object"}),
-        '["not", "an", "object"]',
-        False,
-    ),
+    (xgr.structural_tag.JSONSchemaFormat(json_schema={"type": "string"}), '"abc"', True),
+    (xgr.structural_tag.JSONSchemaFormat(json_schema={"type": "integer"}), "123", True),
+    (xgr.structural_tag.JSONSchemaFormat(json_schema={"type": "integer"}), "abc", False),
+    # AnyTextFormat
     (xgr.structural_tag.AnyTextFormat(), "", True),
     (xgr.structural_tag.AnyTextFormat(), "any text here", True),
+    # SequenceFormat
+    (
+        xgr.structural_tag.SequenceFormat(
+            elements=[
+                xgr.structural_tag.ConstStringFormat(value="A"),
+                xgr.structural_tag.ConstStringFormat(value="B"),
+            ]
+        ),
+        "AB",
+        True,
+    ),
+    (
+        xgr.structural_tag.SequenceFormat(
+            elements=[
+                xgr.structural_tag.ConstStringFormat(value="A"),
+                xgr.structural_tag.ConstStringFormat(value="B"),
+            ]
+        ),
+        "A",
+        False,
+    ),
+    # OrFormat
+    (
+        xgr.structural_tag.OrFormat(
+            elements=[
+                xgr.structural_tag.ConstStringFormat(value="A"),
+                xgr.structural_tag.ConstStringFormat(value="B"),
+            ]
+        ),
+        "A",
+        True,
+    ),
+    (
+        xgr.structural_tag.OrFormat(
+            elements=[
+                xgr.structural_tag.ConstStringFormat(value="A"),
+                xgr.structural_tag.ConstStringFormat(value="B"),
+            ]
+        ),
+        "B",
+        True,
+    ),
+    (
+        xgr.structural_tag.OrFormat(
+            elements=[
+                xgr.structural_tag.ConstStringFormat(value="A"),
+                xgr.structural_tag.ConstStringFormat(value="B"),
+            ]
+        ),
+        "C",
+        False,
+    ),
+    # TagFormat
+    (
+        xgr.structural_tag.TagFormat(
+            begin="<b>", content=xgr.structural_tag.AnyTextFormat(), end="</b>"
+        ),
+        "<b>text</b>",
+        True,
+    ),
+    (
+        xgr.structural_tag.TagFormat(
+            begin="<b>", content=xgr.structural_tag.AnyTextFormat(), end="</b>"
+        ),
+        "<b>text</b",
+        False,
+    ),
+    # TagsWithSeparatorFormat
+    (
+        xgr.structural_tag.TagsWithSeparatorFormat(
+            tags=[
+                xgr.structural_tag.TagFormat(
+                    begin="<b>", content=xgr.structural_tag.AnyTextFormat(), end="</b>"
+                )
+            ],
+            separator=",",
+        ),
+        '<b>"1"</b>,<b>"2"</b>',
+        True,
+    ),
+    (
+        xgr.structural_tag.TagsWithSeparatorFormat(
+            tags=[
+                xgr.structural_tag.TagFormat(
+                    begin="<b>", content=xgr.structural_tag.AnyTextFormat(), end="</b>"
+                )
+            ],
+            separator=",",
+        ),
+        '<b>"1"</b><b>"2"</b>',
+        False,
+    ),
+    # QwenXMLParameterFormat
+    (
+        xgr.structural_tag.QwenXMLParameterFormat(
+            json_schema={"type": "object", "properties": {"name": {"type": "string"}}}
+        ),
+        "<parameter=name>value</parameter>",
+        True,
+    ),
+    (
+        xgr.structural_tag.QwenXMLParameterFormat(
+            json_schema={"type": "object", "properties": {"name": {"type": "string"}}}
+        ),
+        "<parameter=name>value</param>",
+        False,
+    ),
 ]
 
 

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -1672,7 +1672,7 @@ basic_structural_tags_instance_is_accepted = [
 @pytest.mark.parametrize(
     "stag_format, instance, is_accepted", basic_structural_tags_instance_is_accepted
 )
-def test_from_structural_tag_with_StructuralTagInstance(
+def test_from_structural_tag_with_structural_tag_instance(
     stag_format: xgr.structural_tag.Format, instance: str, is_accepted: bool
 ):
     stag = xgr.structural_tag.StructuralTag(format=stag_format)


### PR DESCRIPTION
This PR fixes the behavior of `from_structural_tag` method when the parameter is a `StructuralTag`.