### PR TITLE
[Feature] Add a function to convert bitmasks to bool masks for development usage.

### DIFF
--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -262,6 +262,39 @@ def _bool_mask_to_bitmask(bool_mask: torch.Tensor) -> torch.Tensor:
     return bitmask.to(torch.int32)
 
 
+def _bitmask_to_bool_mask(bit_mask: torch.Tensor, vocab_size: Optional[int]) -> torch.Tensor:
+    """
+    Convert a bitmask tensor to a boolean mask tensor.
+
+    Parameters
+    ----------
+    bit_mask : torch.Tensor
+        The bitmask tensor to convert. Should be on CPU and of type int32.
+    vocab_size : Optional[int]
+        The size of the vocabulary. If provided, the output mask will be padded to this size.
+
+    Returns
+    -------
+    bool_mask : torch.Tensor
+        The converted boolean mask tensor.
+    """
+
+    # Validate input.
+    if bit_mask.device.type != "cpu":
+        raise ValueError("bit_mask should be on CPU.")
+    if bit_mask.dtype != bitmask_dtype:
+        raise ValueError("bit_mask should be of type torch.int32.")
+
+    if vocab_size is not None:
+        result = torch.zeros((vocab_size), dtype=torch.bool)
+    else:
+        result = torch.zeros((bit_mask.shape[1] * 32), dtype=torch.bool)
+
+    for i in range(result.shape[0]):
+        result[i] = (bit_mask[i // 32] & (1 << (i % 32))) != 0
+    return result
+
+
 def _get_matcher_from_grammar_and_tokenizer_info(
     grammar: Union[Grammar, str], tokenizer_info: Optional[TokenizerInfo] = None, **kwargs
 ) -> GrammarMatcher:

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -271,7 +271,7 @@ def _bitmask_to_bool_mask(bit_mask: torch.Tensor, vocab_size: Optional[int] = No
     bit_mask : torch.Tensor
         The bitmask tensor to convert. Should be on CPU and of type int32.
     vocab_size : Optional[int]
-        The size of the vocabulary. If provided, the output mask will be padded to this size.
+        The size of the vocabulary. If provided, the output mask will be cut to this size.
 
     Returns
     -------

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -270,7 +270,7 @@ def _bitmask_to_bool_mask(bit_mask: torch.Tensor, vocab_size: Optional[int] = No
     ----------
     bit_mask : torch.Tensor
         The bitmask tensor to convert. Should be on CPU and of type int32.
-    vocab_size : Optional[int]
+    vocab_size : Optional[int], default: None
         The size of the vocabulary. If provided, the output mask will be cut to this size.
 
     Returns

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -372,9 +372,17 @@ def test_bitmask_to_boolmask():
     assert torch.equal(bool_mask_50, expected_50)
 
 
-def test_bool_mask_bitmask_roundtrip():
-    batch_size = 4
-    vocab_size = 1000
+batch__size__vocab__size = [
+    (4, 1000),
+    (1, 1024),
+    (16, 1024),
+    # not a multiple of 16.
+    (3, 817),
+]
+
+
+@pytest.mark.parametrize("batch_size, vocab_size", batch__size__vocab__size)
+def test_bool_mask_bitmask_roundtrip(batch_size: int, vocab_size: int):
     bool_mask = torch.randint(0, 2, (batch_size, vocab_size), dtype=torch.bool)
     bitmask = _bool_mask_to_bitmask(bool_mask)
     bool_mask_converted = _bitmask_to_bool_mask(bitmask, vocab_size=vocab_size)

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -358,8 +358,9 @@ def test_apply_token_bitmask_inplace_indices(
         torch.testing.assert_close(logits, logits_expected)
 
 
-def test_bool_mask_to_bitmask():
-    bitmask = torch.tensor([[0xFFFF0000, 0x0000FFFF]], dtype=torch.int32)
+def test_bitmask_to_boolmask():
+    bitmask_raw = torch.tensor([[0xFFFF0000, 0x0000FFFF]], dtype=torch.uint32)
+    bitmask = bitmask_raw.view(torch.int32)
     expected = torch.tensor(
         [[False] * 16, [True] * 16, [True] * 16, [False] * 16], dtype=torch.bool
     ).reshape(1, -1)

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -359,8 +359,8 @@ def test_apply_token_bitmask_inplace_indices(
 
 
 def test_bitmask_to_boolmask():
-    bitmask_raw = torch.tensor([[0xFFFF0000, 0x0000FFFF]], dtype=torch.uint32)
-    bitmask = bitmask_raw.view(torch.int32)
+    # 0xFFFF0000, 0x0000FFFF
+    bitmask = torch.tensor([[-65536, 65535]], dtype=torch.int32)
     expected = torch.tensor(
         [[False] * 16, [True] * 16, [True] * 16, [False] * 16], dtype=torch.bool
     ).reshape(1, -1)


### PR DESCRIPTION
This PR provides a function to convert a  bitmask to bool mask, the API is:
```
def _bitmask_to_bool_mask(bit_mask: torch.Tensor, vocab_size: Optional[int] = None) -> torch.Tensor:
```