### PR TITLE
[Refac] Refactor the pipeline.

### DIFF
--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -241,6 +241,10 @@ EarleyParser::EarleyParser(
     const Grammar& grammar, const ParserState& init_state, const bool need_expand
 )
     : grammar_(grammar) {
+  if (!grammar->optimized) {
+    XGRAMMAR_LOG(FATAL) << "The grammar is not optimized. Please optimize the grammar before using "
+                           "the Earley parser.";
+  }
   // Check if the initial state is valid. If invalid, then we choose the root state as default.
   ParserState init = init_state;
   if (init_state.IsInvalid()) {

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -645,16 +645,13 @@ class GrammarCompilerNoCache {
   std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
 };
 
-CompiledGrammar GrammarCompilerNoCache::MultiThreadCompileGrammar(Grammar grammar) {
+CompiledGrammar GrammarCompilerNoCache::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
   using GrammarExprType = Grammar::Impl::GrammarExprType;
 
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
 
-  compiled_grammar_impl->grammar = grammar;
+  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
-  grammar->allow_empty_rule_ids = AllowEmptyRuleAnalyzer::Apply(compiled_grammar_impl->grammar);
-  RepetitionNormalizer::Apply(&compiled_grammar_impl->grammar);
-  GrammarFSMBuilder::Apply(&compiled_grammar_impl->grammar);
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
   }
@@ -711,7 +708,6 @@ CompiledGrammar GrammarCompilerNoCache::MultiThreadCompileGrammar(Grammar gramma
   // not need ThreadPool or std::mutex, which throws error in runtime in WebAssembly.
   std::optional<ThreadPool> thread_pool;
   std::optional<std::mutex> adaptive_token_mask_cache_mutex;
-
   if (max_threads_ > 1) {
     thread_pool.emplace(max_threads_);
     adaptive_token_mask_cache_mutex.emplace();
@@ -719,7 +715,7 @@ CompiledGrammar GrammarCompilerNoCache::MultiThreadCompileGrammar(Grammar gramma
 
   auto add_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
     auto grammar_matcher = GrammarMatcherForTokenMaskCache(
-        grammar, state, tag_dispatch_rule_id_to_second_slicing_bitset, false
+        compiled_grammar_impl->grammar, state, tag_dispatch_rule_id_to_second_slicing_bitset, false
     );
     auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask(
         tokenizer_info_.GetVocabSize(),
@@ -746,12 +742,13 @@ CompiledGrammar GrammarCompilerNoCache::MultiThreadCompileGrammar(Grammar gramma
     }
   };
 
-  auto root_rule_id = grammar->GetRootRuleId();
+  auto root_rule_id = compiled_grammar_impl->grammar->GetRootRuleId();
 
-  for (int32_t rule_id = 0; rule_id < static_cast<int>(grammar->NumRules()); ++rule_id) {
-    auto rule = grammar->GetRule(rule_id);
-    auto rule_body = grammar->GetGrammarExpr(rule.body_expr_id);
-    const auto& rule_fsm = grammar->per_rule_fsms[rule_id];
+  for (int32_t rule_id = 0; rule_id < static_cast<int>(compiled_grammar_impl->grammar->NumRules());
+       ++rule_id) {
+    auto rule = compiled_grammar_impl->grammar->GetRule(rule_id);
+    auto rule_body = compiled_grammar_impl->grammar->GetGrammarExpr(rule.body_expr_id);
+    const auto& rule_fsm = compiled_grammar_impl->grammar->per_rule_fsms[rule_id];
     if (rule_fsm.has_value()) {
       auto cur_stack_element =
           ParserState(rule_id, rule.body_expr_id, 0, ParserState::kNoPrevInputPos, 0);
@@ -768,7 +765,7 @@ CompiledGrammar GrammarCompilerNoCache::MultiThreadCompileGrammar(Grammar gramma
     }
     XGRAMMAR_DCHECK(rule_body.type == GrammarExprType::kChoices);
     for (auto sequence_id : rule_body) {
-      const auto& sequence = grammar->GetGrammarExpr(sequence_id);
+      const auto& sequence = compiled_grammar_impl->grammar->GetGrammarExpr(sequence_id);
       if (sequence.type == GrammarExprType::kEmptyStr) {
         continue;
       }
@@ -776,7 +773,7 @@ CompiledGrammar GrammarCompilerNoCache::MultiThreadCompileGrammar(Grammar gramma
       auto state = ParserState(rule_id, sequence_id, 0, ParserState::kNoPrevInputPos, 0);
       for (int element_id = 0; element_id < sequence.size(); ++element_id) {
         state.element_id = element_id;
-        auto element = grammar->GetGrammarExpr(sequence[element_id]);
+        auto element = compiled_grammar_impl->grammar->GetGrammarExpr(sequence[element_id]);
         if (element.type == GrammarExprType::kRuleRef || element.type == GrammarExprType::kRepeat) {
           continue;
         }

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1537,17 +1537,18 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::TagDispatch(
 
 class RepetitionNormalizerImpl {
  public:
-  void Apply(Grammar& grammar) {
-    for (int i = 0; i < grammar->NumGrammarExprs(); ++i) {
-      auto expr = grammar->GetGrammarExpr(i);
+  void Apply(Grammar* grammar) {
+    auto& grammar_ref = *grammar;
+    for (int i = 0; i < grammar_ref->NumGrammarExprs(); ++i) {
+      auto expr = grammar_ref->GetGrammarExpr(i);
       if (expr.type != Grammar::Impl::GrammarExprType::kRepeat) {
         continue;
       }
       int repeat_rule_id = expr[0];
-      grammar->GetRule(repeat_rule_id).is_exact_lookahead = true;
+      grammar_ref->GetRule(repeat_rule_id).is_exact_lookahead = true;
       if (std::binary_search(
-              grammar->allow_empty_rule_ids.begin(),
-              grammar->allow_empty_rule_ids.end(),
+              grammar_ref->allow_empty_rule_ids.begin(),
+              grammar_ref->allow_empty_rule_ids.end(),
               repeat_rule_id
           )) {
         // The repeated rule can be empty, so we need to normalize it.
@@ -1565,7 +1566,7 @@ class GrammarOptimizerImpl {
     result = DeadCodeEliminator::Apply(result);
     result = LookaheadAssertionAnalyzer::Apply(result);
     result->allow_empty_rule_ids = AllowEmptyRuleAnalyzer::Apply(result);
-    RepetitionNormalizer::Apply(result);
+    RepetitionNormalizer::Apply(&result);
     GrammarFSMBuilder::Apply(&result);
     result->optimized = true;
     return result;
@@ -1633,7 +1634,7 @@ Grammar StructureNormalizer::Apply(const Grammar& grammar) {
 
 void GrammarFSMBuilder::Apply(Grammar* grammar) { GrammarFSMBuilderImpl().Apply(grammar); }
 
-void RepetitionNormalizer::Apply(Grammar& grammar) { RepetitionNormalizerImpl().Apply(grammar); }
+void RepetitionNormalizer::Apply(Grammar* grammar) { RepetitionNormalizerImpl().Apply(grammar); }
 
 FSMWithStartEnd GrammarFSMBuilder::RuleRef(const GrammarExpr& expr) {
   return GrammarFSMBuilderImpl::RuleRef(expr);

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -7,16 +7,12 @@
 
 #include <xgrammar/xgrammar.h>
 
-#include <algorithm>
 #include <bitset>
 #include <cstdint>
-#include <optional>
 #include <queue>
 #include <set>
-#include <unordered_set>
 #include <vector>
 
-#include "fsm.h"
 #include "fsm_builder.h"
 #include "grammar_builder.h"
 #include "grammar_impl.h"
@@ -29,7 +25,133 @@ namespace xgrammar {
 using GrammarExpr = Grammar::Impl::GrammarExpr;
 using ExprType = Grammar::Impl::GrammarExprType;
 
-/*************************** Impl of grammar functors ***************************/
+/*************************** Impl of grammar constructors ***************************/
+
+/*!
+ * \brief Base class for grammar mutators that add subgrammars.
+ *
+ * Provides functionality to visit a subgrammar and add its rules to the builder
+ * while maintaining proper rule references and names.
+ */
+class SubGrammarAdderImpl : public GrammarMutator {
+ public:
+  SubGrammarAdderImpl() = default;
+
+  /*!
+   * \brief Visit a subgrammar and add the rules to the builder.
+   * \param grammar The subgrammar to visit.
+   * \return The new id of the root rule of this subgrammar.
+   */
+  int32_t ApplyWithBuilder(GrammarBuilder* builder, const Grammar& sub_grammar) {
+    InitGrammar(sub_grammar);
+    InitBuilder(builder);
+    new_rule_ids_names.reserve(base_grammar_->NumRules());
+    new_rule_ids_names.clear();
+    for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
+      auto new_name = builder_->GetNewRuleName(base_grammar_->GetRule(i).name);
+      auto new_id = builder_->AddEmptyRule(new_name);
+      new_rule_ids_names.emplace_back(new_id, new_name);
+    }
+    for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
+      auto rule = base_grammar_->GetRule(i);
+      cur_rule_name_ = new_rule_ids_names[i].second;
+      auto new_body_expr_id = VisitExpr(rule.body_expr_id);
+      builder_->UpdateRuleBody(new_rule_ids_names[i].first, new_body_expr_id);
+      auto new_lookahead_assertion_id = VisitLookaheadAssertion(rule.lookahead_assertion_id);
+      builder_->UpdateLookaheadAssertion(new_rule_ids_names[i].first, new_lookahead_assertion_id);
+    }
+    return new_rule_ids_names[base_grammar_->GetRootRuleId()].first;
+  }
+
+  int32_t VisitRuleRef(const GrammarExpr& grammar_expr) final {
+    return builder_->AddRuleRef(new_rule_ids_names[grammar_expr[0]].first);
+  }
+
+  int32_t VisitRepeat(const GrammarExpr& grammar_expr) final {
+    return builder_->AddRepeat(
+        new_rule_ids_names[grammar_expr[0]].first, grammar_expr[1], grammar_expr[2]
+    );
+  }
+
+  std::vector<std::pair<int32_t, std::string>> new_rule_ids_names;
+};
+
+/*!
+ * \brief Implementation of grammar union operation.
+ *
+ * Creates a new grammar that accepts strings from any of the input grammars.
+ * The resulting grammar has a new root rule that chooses between the root rules
+ * of all input grammars.
+ */
+class GrammarUnionFunctorImpl : public GrammarMutator {
+ public:
+  GrammarUnionFunctorImpl() = default;
+
+  Grammar Apply(const std::vector<Grammar>& grammars) {
+    InitGrammar();
+    InitBuilder();
+    auto root_rule_id = builder_->AddEmptyRule("root");
+
+    std::vector<int32_t> new_root_choices;
+    new_root_choices.reserve(grammars.size());
+
+    for (const auto& grammar : grammars) {
+      auto new_root_id_for_grammar = SubGrammarAdderImpl().ApplyWithBuilder(builder_, grammar);
+      auto new_rule_ref = builder_->AddRuleRef(new_root_id_for_grammar);
+      auto new_rule_ref_seq = builder_->AddSequence({new_rule_ref});
+      new_root_choices.push_back(new_rule_ref_seq);
+    }
+
+    builder_->UpdateRuleBody(root_rule_id, builder_->AddChoices(new_root_choices));
+    return builder_->Get(root_rule_id);
+  }
+
+  // Avoid hiding the original Apply(const Grammar&)
+  Grammar Apply(const Grammar& grammar) final {
+    XGRAMMAR_LOG(FATAL) << "Should not be called";
+    XGRAMMAR_UNREACHABLE();
+  }
+};
+
+/*!
+ * \brief Implementation of grammar concatenation operation.
+ *
+ * Creates a new grammar that accepts strings that are concatenations of strings
+ * from the input grammars in order. The resulting grammar has a new root rule
+ * that concatenates the root rules of all input grammars.
+ */
+class GrammarConcatFunctorImpl : public GrammarMutator {
+ public:
+  GrammarConcatFunctorImpl() = default;
+
+  Grammar Apply(const std::vector<Grammar>& grammars) {
+    InitGrammar();
+    InitBuilder();
+    auto root_rule_id = builder_->AddEmptyRule("root");
+
+    std::vector<int32_t> new_root_sequence;
+    new_root_sequence.reserve(grammars.size());
+
+    for (const auto& grammar : grammars) {
+      auto new_root_id_for_grammar = SubGrammarAdderImpl().ApplyWithBuilder(builder_, grammar);
+      auto new_rule_ref = builder_->AddRuleRef(new_root_id_for_grammar);
+      new_root_sequence.push_back(new_rule_ref);
+    }
+
+    auto new_root_seq = builder_->AddSequence(new_root_sequence);
+    builder_->UpdateRuleBody(root_rule_id, builder_->AddChoices({new_root_seq}));
+
+    return builder_->Get(root_rule_id);
+  }
+
+  // Avoid hiding the original Apply(const Grammar&)
+  Grammar Apply(const Grammar& grammar) final {
+    XGRAMMAR_LOG(FATAL) << "Should not be called";
+    XGRAMMAR_UNREACHABLE();
+  }
+};
+
+/*************************** Impl of grammar normalizers ***************************/
 
 /*!
  * \brief Eliminates single-element sequence or choice or character class in the grammar.
@@ -101,12 +223,13 @@ class SingleElementExprEliminator : public GrammarMutator {
  * \example `A ::= (a | TagDispatch((tag1, rule1)))` -> `A ::= ((a) | (A_1)), A_1 ::=
  * TagDispatch((tag1, rule1))`
  */
-class StructureNormalizerSub : public GrammarMutator {
+class StructureNormalizerImpl : public GrammarMutator {
  public:
   using GrammarMutator::GrammarMutator;
 
   Grammar Apply(const Grammar& grammar) final {
-    InitGrammar(grammar);
+    auto grammar_new = SingleElementExprEliminator().Apply(grammar);
+    InitGrammar(grammar_new);
     InitBuilder();
     for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
       builder_->AddEmptyRule(base_grammar_->GetRule(i).name);
@@ -333,49 +456,21 @@ class StructureNormalizerSub : public GrammarMutator {
   }
 };
 
-class StructureNormalizerImpl : public GrammarMutator {
+/*!
+ * \brief A class that normalizes a grammar by applying a series of transformations.
+ *
+ * The normalizer applies the following transformations in order:
+ * 1. SingleElementExprEliminator - Eliminates single element expressions
+ * 2. NestedRuleUnwrapper - Unwraps nested rules
+ */
+class GrammarNormalizerImpl {
  public:
-  using GrammarMutator::Apply;
-  using GrammarMutator::GrammarMutator;
+  GrammarNormalizerImpl() = default;
 
-  Grammar Apply(const Grammar& grammar) final {
-    auto grammar_new = SingleElementExprEliminator().Apply(grammar);
-    return StructureNormalizerSub().Apply(grammar_new);
-  }
+  Grammar Apply(const Grammar& grammar) { return StructureNormalizerImpl().Apply(grammar); }
 };
 
-class ByteStringFuserImpl : public GrammarMutator {
- public:
-  using GrammarMutator::Apply;
-  using GrammarMutator::GrammarMutator;
-
- private:
-  /*!
-   * \brief Visit a GrammarExpr containing a sequence.
-   * \returns A list of new sequence GrammarExpr ids.
-   */
-  int32_t VisitSequence(const GrammarExpr& grammar_expr) final {
-    std::vector<int32_t> new_sequence_ids;
-    std::vector<int32_t> cur_byte_string;
-    for (auto i : grammar_expr) {
-      auto element_expr = base_grammar_->GetGrammarExpr(i);
-      if (element_expr.type == GrammarExprType::kByteString) {
-        cur_byte_string.insert(cur_byte_string.end(), element_expr.begin(), element_expr.end());
-        continue;
-      } else {
-        if (!cur_byte_string.empty()) {
-          new_sequence_ids.push_back(builder_->AddByteString(cur_byte_string));
-          cur_byte_string.clear();
-        }
-        new_sequence_ids.push_back(builder_->AddGrammarExpr(element_expr));
-      }
-    }
-    if (!cur_byte_string.empty()) {
-      new_sequence_ids.push_back(builder_->AddByteString(cur_byte_string));
-    }
-    return builder_->AddSequence(new_sequence_ids);
-  }
-};
+/*************************** Impl of grammar optimizers ***************************/
 
 /*!
  * \brief Inline rules that can be inlined.
@@ -682,164 +777,6 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
       return -1;
     }
     return builder_->AddSequence(found_sequence);
-  }
-};
-
-/*!
- * \brief A class that normalizes a grammar by applying a series of transformations.
- *
- * The normalizer applies the following transformations in order:
- * 1. SingleElementExprEliminator - Eliminates single element expressions
- * 2. NestedRuleUnwrapper - Unwraps nested rules
- * 3. ByteStringFuser - Fuses consecutive byte strings
- */
-class GrammarNormalizerImpl : public GrammarMutator {
- public:
-  GrammarNormalizerImpl() = default;
-
-  Grammar Apply(const Grammar& grammar) final {
-    std::vector<std::unique_ptr<GrammarMutator>> normalizer_mutators = GetNormalizerList();
-    InitGrammar(grammar);
-    for (auto& mutator : normalizer_mutators) {
-      base_grammar_ = mutator->Apply(base_grammar_);
-    }
-    return base_grammar_;
-  }
-
- private:
-  // Return the list of all normalizers in the class. The normalizers are applied one by one.
-  std::vector<std::unique_ptr<GrammarMutator>> GetNormalizerList() {
-    std::vector<std::unique_ptr<GrammarMutator>> normalizer_mutators;
-    normalizer_mutators.emplace_back(std::make_unique<StructureNormalizerImpl>());
-    normalizer_mutators.emplace_back(std::make_unique<ByteStringFuserImpl>());
-    normalizer_mutators.emplace_back(std::make_unique<RuleInlinerImpl>());
-    normalizer_mutators.emplace_back(std::make_unique<DeadCodeEliminatorImpl>());
-    normalizer_mutators.emplace_back(std::make_unique<LookaheadAssertionAnalyzerImpl>());
-    return normalizer_mutators;
-  }
-};
-
-/*!
- * \brief Base class for grammar mutators that add subgrammars.
- *
- * Provides functionality to visit a subgrammar and add its rules to the builder
- * while maintaining proper rule references and names.
- */
-class SubGrammarAdderImpl : public GrammarMutator {
- public:
-  SubGrammarAdderImpl() = default;
-
-  /*!
-   * \brief Visit a subgrammar and add the rules to the builder.
-   * \param grammar The subgrammar to visit.
-   * \return The new id of the root rule of this subgrammar.
-   */
-  int32_t ApplyWithBuilder(GrammarBuilder* builder, const Grammar& sub_grammar) {
-    InitGrammar(sub_grammar);
-    InitBuilder(builder);
-    new_rule_ids_names.reserve(base_grammar_->NumRules());
-    new_rule_ids_names.clear();
-    for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
-      auto new_name = builder_->GetNewRuleName(base_grammar_->GetRule(i).name);
-      auto new_id = builder_->AddEmptyRule(new_name);
-      new_rule_ids_names.emplace_back(new_id, new_name);
-    }
-    for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
-      auto rule = base_grammar_->GetRule(i);
-      cur_rule_name_ = new_rule_ids_names[i].second;
-      auto new_body_expr_id = VisitExpr(rule.body_expr_id);
-      builder_->UpdateRuleBody(new_rule_ids_names[i].first, new_body_expr_id);
-      auto new_lookahead_assertion_id = VisitLookaheadAssertion(rule.lookahead_assertion_id);
-      builder_->UpdateLookaheadAssertion(new_rule_ids_names[i].first, new_lookahead_assertion_id);
-    }
-    return new_rule_ids_names[base_grammar_->GetRootRuleId()].first;
-  }
-
-  int32_t VisitRuleRef(const GrammarExpr& grammar_expr) final {
-    return builder_->AddRuleRef(new_rule_ids_names[grammar_expr[0]].first);
-  }
-
-  int32_t VisitRepeat(const GrammarExpr& grammar_expr) final {
-    return builder_->AddRepeat(
-        new_rule_ids_names[grammar_expr[0]].first, grammar_expr[1], grammar_expr[2]
-    );
-  }
-
-  std::vector<std::pair<int32_t, std::string>> new_rule_ids_names;
-};
-
-/*!
- * \brief Implementation of grammar union operation.
- *
- * Creates a new grammar that accepts strings from any of the input grammars.
- * The resulting grammar has a new root rule that chooses between the root rules
- * of all input grammars.
- */
-class GrammarUnionFunctorImpl : public GrammarMutator {
- public:
-  GrammarUnionFunctorImpl() = default;
-
-  Grammar Apply(const std::vector<Grammar>& grammars) {
-    InitGrammar();
-    InitBuilder();
-    auto root_rule_id = builder_->AddEmptyRule("root");
-
-    std::vector<int32_t> new_root_choices;
-    new_root_choices.reserve(grammars.size());
-
-    for (const auto& grammar : grammars) {
-      auto new_root_id_for_grammar = SubGrammarAdderImpl().ApplyWithBuilder(builder_, grammar);
-      auto new_rule_ref = builder_->AddRuleRef(new_root_id_for_grammar);
-      auto new_rule_ref_seq = builder_->AddSequence({new_rule_ref});
-      new_root_choices.push_back(new_rule_ref_seq);
-    }
-
-    builder_->UpdateRuleBody(root_rule_id, builder_->AddChoices(new_root_choices));
-    return builder_->Get(root_rule_id);
-  }
-
-  // Avoid hiding the original Apply(const Grammar&)
-  Grammar Apply(const Grammar& grammar) final {
-    XGRAMMAR_LOG(FATAL) << "Should not be called";
-    XGRAMMAR_UNREACHABLE();
-  }
-};
-
-/*!
- * \brief Implementation of grammar concatenation operation.
- *
- * Creates a new grammar that accepts strings that are concatenations of strings
- * from the input grammars in order. The resulting grammar has a new root rule
- * that concatenates the root rules of all input grammars.
- */
-class GrammarConcatFunctorImpl : public GrammarMutator {
- public:
-  GrammarConcatFunctorImpl() = default;
-
-  Grammar Apply(const std::vector<Grammar>& grammars) {
-    InitGrammar();
-    InitBuilder();
-    auto root_rule_id = builder_->AddEmptyRule("root");
-
-    std::vector<int32_t> new_root_sequence;
-    new_root_sequence.reserve(grammars.size());
-
-    for (const auto& grammar : grammars) {
-      auto new_root_id_for_grammar = SubGrammarAdderImpl().ApplyWithBuilder(builder_, grammar);
-      auto new_rule_ref = builder_->AddRuleRef(new_root_id_for_grammar);
-      new_root_sequence.push_back(new_rule_ref);
-    }
-
-    auto new_root_seq = builder_->AddSequence(new_root_sequence);
-    builder_->UpdateRuleBody(root_rule_id, builder_->AddChoices({new_root_seq}));
-
-    return builder_->Get(root_rule_id);
-  }
-
-  // Avoid hiding the original Apply(const Grammar&)
-  Grammar Apply(const Grammar& grammar) final {
-    XGRAMMAR_LOG(FATAL) << "Should not be called";
-    XGRAMMAR_UNREACHABLE();
   }
 };
 
@@ -1600,17 +1537,17 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::TagDispatch(
 
 class RepetitionNormalizerImpl {
  public:
-  void Apply(Grammar* grammar) {
-    for (int i = 0; i < (*grammar)->NumGrammarExprs(); ++i) {
-      auto expr = (*grammar)->GetGrammarExpr(i);
+  void Apply(Grammar& grammar) {
+    for (int i = 0; i < grammar->NumGrammarExprs(); ++i) {
+      auto expr = grammar->GetGrammarExpr(i);
       if (expr.type != Grammar::Impl::GrammarExprType::kRepeat) {
         continue;
       }
       int repeat_rule_id = expr[0];
-      grammar->ImplPtr()->GetRule(repeat_rule_id).is_exact_lookahead = true;
+      grammar->GetRule(repeat_rule_id).is_exact_lookahead = true;
       if (std::binary_search(
-              (*grammar)->allow_empty_rule_ids.begin(),
-              (*grammar)->allow_empty_rule_ids.end(),
+              grammar->allow_empty_rule_ids.begin(),
+              grammar->allow_empty_rule_ids.end(),
               repeat_rule_id
           )) {
         // The repeated rule can be empty, so we need to normalize it.
@@ -1620,11 +1557,55 @@ class RepetitionNormalizerImpl {
   }
 };
 
-/*************************** Forward grammar functors to their impl ***************************/
+class GrammarOptimizerImpl {
+ public:
+  static Grammar Apply(const Grammar& grammar) {
+    Grammar result = ByteStringFuser::Apply(grammar);
+    result = RuleInliner::Apply(result);
+    result = DeadCodeEliminator::Apply(result);
+    result = LookaheadAssertionAnalyzer::Apply(result);
+    result->allow_empty_rule_ids = AllowEmptyRuleAnalyzer::Apply(result);
+    RepetitionNormalizer::Apply(result);
+    GrammarFSMBuilder::Apply(&result);
+    result->optimized = true;
+    return result;
+  }
+};
 
-Grammar GrammarNormalizer::Apply(const Grammar& grammar) {
-  return GrammarNormalizerImpl().Apply(grammar);
-}
+class ByteStringFuserImpl : public GrammarMutator {
+ public:
+  using GrammarMutator::Apply;
+  using GrammarMutator::GrammarMutator;
+
+ private:
+  /*!
+   * \brief Visit a GrammarExpr containing a sequence.
+   * \returns A list of new sequence GrammarExpr ids.
+   */
+  int32_t VisitSequence(const GrammarExpr& grammar_expr) final {
+    std::vector<int32_t> new_sequence_ids;
+    std::vector<int32_t> cur_byte_string;
+    for (auto i : grammar_expr) {
+      auto element_expr = base_grammar_->GetGrammarExpr(i);
+      if (element_expr.type == GrammarExprType::kByteString) {
+        cur_byte_string.insert(cur_byte_string.end(), element_expr.begin(), element_expr.end());
+        continue;
+      } else {
+        if (!cur_byte_string.empty()) {
+          new_sequence_ids.push_back(builder_->AddByteString(cur_byte_string));
+          cur_byte_string.clear();
+        }
+        new_sequence_ids.push_back(builder_->AddGrammarExpr(element_expr));
+      }
+    }
+    if (!cur_byte_string.empty()) {
+      new_sequence_ids.push_back(builder_->AddByteString(cur_byte_string));
+    }
+    return builder_->AddSequence(new_sequence_ids);
+  }
+};
+
+/*************************** Forward grammar constructors to their impl ***************************/
 
 Grammar GrammarUnionFunctor::Apply(const std::vector<Grammar>& grammars) {
   return GrammarUnionFunctorImpl().Apply(grammars);
@@ -1634,35 +1615,25 @@ Grammar GrammarConcatFunctor::Apply(const std::vector<Grammar>& grammars) {
   return GrammarConcatFunctorImpl().Apply(grammars);
 }
 
-std::vector<int32_t> AllowEmptyRuleAnalyzer::Apply(const Grammar& grammar) {
-  return AllowEmptyRuleAnalyzerImpl().Apply(grammar);
+int32_t SubGrammarAdder::Apply(GrammarBuilder* builder, const Grammar& sub_grammar) {
+  return SubGrammarAdderImpl().ApplyWithBuilder(builder, sub_grammar);
 }
 
-Grammar RuleInliner::Apply(const Grammar& grammar) { return RuleInlinerImpl().Apply(grammar); }
+/*************************** Forward grammar Normalizers to their impl ***************************/
 
-Grammar ByteStringFuser::Apply(const Grammar& grammar) {
-  return ByteStringFuserImpl().Apply(grammar);
-}
-
-Grammar DeadCodeEliminator::Apply(const Grammar& grammar) {
-  return DeadCodeEliminatorImpl().Apply(grammar);
+Grammar GrammarNormalizer::Apply(const Grammar& grammar) {
+  return GrammarNormalizerImpl().Apply(grammar);
 }
 
 Grammar StructureNormalizer::Apply(const Grammar& grammar) {
   return StructureNormalizerImpl().Apply(grammar);
 }
 
-Grammar LookaheadAssertionAnalyzer::Apply(const Grammar& grammar) {
-  return LookaheadAssertionAnalyzerImpl().Apply(grammar);
-}
-
-int32_t SubGrammarAdder::Apply(GrammarBuilder* builder, const Grammar& sub_grammar) {
-  return SubGrammarAdderImpl().ApplyWithBuilder(builder, sub_grammar);
-}
+/*************************** Forward grammar optimizers to their impl ***************************/
 
 void GrammarFSMBuilder::Apply(Grammar* grammar) { GrammarFSMBuilderImpl().Apply(grammar); }
 
-void RepetitionNormalizer::Apply(Grammar* grammar) { RepetitionNormalizerImpl().Apply(grammar); }
+void RepetitionNormalizer::Apply(Grammar& grammar) { RepetitionNormalizerImpl().Apply(grammar); }
 
 FSMWithStartEnd GrammarFSMBuilder::RuleRef(const GrammarExpr& expr) {
   return GrammarFSMBuilderImpl::RuleRef(expr);
@@ -1692,6 +1663,28 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilder::TagDispatch(
     const Grammar::Impl::TagDispatch& tag_dispatch
 ) {
   return GrammarFSMBuilderImpl::TagDispatch(tag_dispatch);
+}
+
+std::vector<int32_t> AllowEmptyRuleAnalyzer::Apply(const Grammar& grammar) {
+  return AllowEmptyRuleAnalyzerImpl().Apply(grammar);
+}
+
+Grammar RuleInliner::Apply(const Grammar& grammar) { return RuleInlinerImpl().Apply(grammar); }
+
+Grammar DeadCodeEliminator::Apply(const Grammar& grammar) {
+  return DeadCodeEliminatorImpl().Apply(grammar);
+}
+
+Grammar LookaheadAssertionAnalyzer::Apply(const Grammar& grammar) {
+  return LookaheadAssertionAnalyzerImpl().Apply(grammar);
+}
+
+Grammar GrammarOptimizer::Apply(const Grammar& grammar) {
+  return GrammarOptimizerImpl::Apply(grammar);
+}
+
+Grammar ByteStringFuser::Apply(const Grammar& grammar) {
+  return ByteStringFuserImpl().Apply(grammar);
 }
 
 }  // namespace xgrammar

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -358,7 +358,7 @@ class GrammarFSMBuilder {
  */
 class RepetitionNormalizer {
  public:
-  static void Apply(Grammar& grammar);
+  static void Apply(Grammar* grammar);
 };
 
 /*!

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -257,6 +257,9 @@ class Grammar::Impl {
   /*! \brief The ids of the rules that are allowed to be empty. */
   std::vector<int32_t> allow_empty_rule_ids;
 
+  /*! \brief Whether the grammar is optimized. */
+  bool optimized = false;
+
   friend class GrammarBuilder;
   friend class GrammarCompiler;
 
@@ -287,7 +290,9 @@ XGRAMMAR_MEMBER_TABLE(
     "per_rule_fsms",
     &Grammar::Impl::per_rule_fsms,
     "allow_empty_rule_ids",
-    &Grammar::Impl::allow_empty_rule_ids
+    &Grammar::Impl::allow_empty_rule_ids,
+    "optimized",
+    &Grammar::Impl::optimized
 );
 
 }  // namespace xgrammar

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -305,7 +305,9 @@ NB_MODULE(xgrammar_bindings, m) {
       .def("byte_string_fuser", &ByteStringFuser::Apply)
       .def("rule_inliner", &RuleInliner::Apply)
       .def("dead_code_eliminator", &DeadCodeEliminator::Apply)
-      .def("lookahead_assertion_analyzer", &LookaheadAssertionAnalyzer::Apply);
+      .def("lookahead_assertion_analyzer", &LookaheadAssertionAnalyzer::Apply)
+      .def("grammar_optimizer", &GrammarOptimizer::Apply)
+      .def("repetition_normalizer", &RepetitionNormalizer::Apply);
 
   auto pyKernelsModule = m.def_submodule("kernels");
   pyKernelsModule.def(

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v6";
+  static constexpr const char kXGrammarSerializeVersion[] = "v7";
 };
 
 /*!

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -388,3 +388,17 @@ class GrammarFunctor:
         return Grammar._create_from_handle(
             _core.testing.grammar_functor.lookahead_assertion_analyzer(grammar._handle)
         )
+
+    @staticmethod
+    def grammar_optimizer(grammar: Grammar) -> Grammar:
+        """Optimize the grammar."""
+        return Grammar._create_from_handle(
+            _core.testing.grammar_functor.grammar_optimizer(grammar._handle)
+        )
+
+    @staticmethod
+    def repetition_normalizer(grammar: Grammar) -> None:
+        """Normalize the repetition expression."""
+        Grammar._create_from_handle(
+            _core.testing.grammar_functor.repetition_normalizer(grammar._handle)
+        )

--- a/tests/cpp/test_fsm_builder.cc
+++ b/tests/cpp/test_fsm_builder.cc
@@ -5,15 +5,12 @@
 
 #include <gtest/gtest.h>
 
-#include <chrono>
 #include <cstdint>
-#include <iostream>
 #include <vector>
 
 #include "fsm.h"
 #include "fsm_builder.h"
 #include "grammar_functor.h"
-#include "support/logging.h"
 #include "xgrammar/grammar.h"
 
 using namespace xgrammar;

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -8,11 +8,7 @@ from pydantic import BaseModel
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
-from xgrammar.testing import (
-    GrammarFunctor,
-    _get_masked_tokens_from_bitmask,
-    _is_grammar_accept_string,
-)
+from xgrammar.testing import _get_masked_tokens_from_bitmask, _is_grammar_accept_string
 
 
 def test_utf8():

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -8,7 +8,11 @@ from pydantic import BaseModel
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
-from xgrammar.testing import _get_masked_tokens_from_bitmask, _is_grammar_accept_string
+from xgrammar.testing import (
+    GrammarFunctor,
+    _get_masked_tokens_from_bitmask,
+    _is_grammar_accept_string,
+)
 
 
 def test_utf8():
@@ -37,7 +41,7 @@ def test_utf8():
         assert _is_grammar_accept_string(grammar, input_str, print_time=True)
 
 
-expected_grammar_test_structural_tag = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9])) (=(basic_string_sub))
+expected_grammar_test_structural_tag_after_optimization = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9])) (=(basic_string_sub))
 basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
 basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
 basic_string ::= (("\"" basic_string_sub)) (=(root_part_0 [ \n\t]* "}"))
@@ -53,19 +57,99 @@ root_1 ::= (("{" [ \n\t]* "\"arg1\"" [ \n\t]* ":" [ \n\t]* basic_string_1 root_p
 basic_integer_1_1 ::= ("" | ("-")) (=([1-9] [0-9]*))
 basic_escape_2 ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9])) (=(basic_string_sub_2))
 basic_string_sub_2 ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub_2) | ("\\" basic_escape_2 basic_string_sub_2)) (=([ \n\t]* [,}\]:]))
-basic_number ::= ((basic_number_7 basic_number_3 basic_number_6)) (=(root_part_0_2 [ \n\t]* "}"))
+basic_number_9 ::= ((basic_number_7_2 basic_number_3_2 basic_number_6_2)) (=(root_part_0_2 [ \n\t]* "}"))
 basic_string_2 ::= (("\"" basic_string_sub_2))
 root_prop_1 ::= (("[" [ \n\t]* basic_string_2 root_prop_1_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 root_part_0_2 ::= (([ \n\t]* "," [ \n\t]* "\"arg4\"" [ \n\t]* ":" [ \n\t]* root_prop_1)) (=([ \n\t]* "}"))
-root_2 ::= (("{" [ \n\t]* "\"arg3\"" [ \n\t]* ":" [ \n\t]* basic_number root_part_0_2 [ \n\t]* "}")) (=("</function>"))
-basic_number_1 ::= ("" | ("-")) (=([1-9] [0-9]*))
+root_2 ::= (("{" [ \n\t]* "\"arg3\"" [ \n\t]* ":" [ \n\t]* basic_number_9 root_part_0_2 [ \n\t]* "}")) (=("</function>"))
+basic_number_1_2 ::= ("" | ("-")) (=([1-9] [0-9]*))
+basic_number_2_2 ::= (([0-9] basic_number_2_2) | ([0-9]))
+basic_number_3_2 ::= ("" | ("." basic_number_2_2)) (=(basic_number_6_2))
+basic_number_4_2 ::= ("" | ([+\-])) (=(basic_number_5_2))
+basic_number_5_2 ::= (([0-9] basic_number_5_2) | ([0-9]))
+basic_number_6_2 ::= ("" | ([eE] basic_number_4_2 basic_number_5_2))
+root_prop_1_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string_2 root_prop_1_1)) (=([ \n\t]* "]"))
+basic_number_7_2 ::= (("0") | (basic_number_1_2 [1-9] [0-9]*)) (=(basic_number_3_2 basic_number_6_2))
+triggered_tags_group ::= (("1>" root "</function>") | ("2>" root_1 "</function>"))
+triggered_tags_group_1 ::= ((">" root_2 "</function>"))
+triggered_tags ::= TagDispatch(
+  ("<function=f", triggered_tags_group),
+  ("<function=g", triggered_tags_group_1),
+  stop_eos=true,
+  stop_str=(),
+  loop_after_dispatch=true
+)
+root_3 ::= ((triggered_tags))
+"""
+
+expected_grammar_test_structural_tag_before_optimization = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_7 basic_number_3 basic_number_6))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
+basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
+root_part_0 ::= (([ \n\t]* "," [ \n\t]* "\"arg2\"" [ \n\t]* ":" [ \n\t]* basic_integer))
+root ::= (("{" [ \n\t]* "\"arg1\"" [ \n\t]* ":" [ \n\t]* basic_string root_part_0 [ \n\t]* "}"))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
 basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2)) (=(basic_number_6))
-basic_number_4 ::= ("" | ([+\-])) (=(basic_number_5))
+basic_number_3 ::= ("" | ("." basic_number_2))
+basic_number_4 ::= ("" | ([+\-]))
 basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
 basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-root_prop_1_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string_2 root_prop_1_1)) (=([ \n\t]* "]"))
-basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*)) (=(basic_number_3 basic_number_6))
+basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
+basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
+basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*))
+basic_escape_1 ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub_1 ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub_1) | ("\\" basic_escape_1 basic_string_sub_1)) (=([ \n\t]* [,}\]:]))
+basic_any_1 ::= ((basic_number_8) | (basic_string_1) | (basic_boolean_1) | (basic_null_1) | (basic_array_2) | (basic_object_2))
+basic_integer_2 ::= (("0") | (basic_integer_1_1 [1-9] [0-9]*))
+basic_number_8 ::= ((basic_number_7_1 basic_number_3_1 basic_number_6_1))
+basic_string_1 ::= (("\"" basic_string_sub_1))
+basic_boolean_1 ::= (("true") | ("false"))
+basic_null_1 ::= (("null"))
+basic_array_2 ::= (("[" [ \n\t]* basic_any_1 basic_array_1_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
+basic_object_2 ::= (("{" [ \n\t]* basic_string_1 [ \n\t]* ":" [ \n\t]* basic_any_1 basic_object_1_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
+root_part_0_1 ::= (([ \n\t]* "," [ \n\t]* "\"arg2\"" [ \n\t]* ":" [ \n\t]* basic_integer_2))
+root_1 ::= (("{" [ \n\t]* "\"arg1\"" [ \n\t]* ":" [ \n\t]* basic_string_1 root_part_0_1 [ \n\t]* "}"))
+basic_integer_1_1 ::= ("" | ("-"))
+basic_number_1_1 ::= ("" | ("-"))
+basic_number_2_1 ::= (([0-9] basic_number_2_1) | ([0-9]))
+basic_number_3_1 ::= ("" | ("." basic_number_2_1))
+basic_number_4_1 ::= ("" | ([+\-]))
+basic_number_5_1 ::= (([0-9] basic_number_5_1) | ([0-9]))
+basic_number_6_1 ::= ("" | ([eE] basic_number_4_1 basic_number_5_1))
+basic_array_1_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any_1 basic_array_1_1))
+basic_object_1_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string_1 [ \n\t]* ":" [ \n\t]* basic_any_1 basic_object_1_1))
+basic_number_7_1 ::= (("0") | (basic_number_1_1 [1-9] [0-9]*))
+basic_escape_2 ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub_2 ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub_2) | ("\\" basic_escape_2 basic_string_sub_2)) (=([ \n\t]* [,}\]:]))
+basic_any_2 ::= ((basic_number_9) | (basic_string_2) | (basic_boolean_2) | (basic_null_2) | (basic_array_3) | (basic_object_3))
+basic_integer_3 ::= (("0") | (basic_integer_1_2 [1-9] [0-9]*))
+basic_number_9 ::= ((basic_number_7_2 basic_number_3_2 basic_number_6_2))
+basic_string_2 ::= (("\"" basic_string_sub_2))
+basic_boolean_2 ::= (("true") | ("false"))
+basic_null_2 ::= (("null"))
+basic_array_3 ::= (("[" [ \n\t]* basic_any_2 basic_array_1_2 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
+basic_object_3 ::= (("{" [ \n\t]* basic_string_2 [ \n\t]* ":" [ \n\t]* basic_any_2 basic_object_1_2 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
+root_prop_1 ::= (("[" [ \n\t]* basic_string_2 root_prop_1_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
+root_part_0_2 ::= (([ \n\t]* "," [ \n\t]* "\"arg4\"" [ \n\t]* ":" [ \n\t]* root_prop_1))
+root_2 ::= (("{" [ \n\t]* "\"arg3\"" [ \n\t]* ":" [ \n\t]* basic_number_9 root_part_0_2 [ \n\t]* "}"))
+basic_integer_1_2 ::= ("" | ("-"))
+basic_number_1_2 ::= ("" | ("-"))
+basic_number_2_2 ::= (([0-9] basic_number_2_2) | ([0-9]))
+basic_number_3_2 ::= ("" | ("." basic_number_2_2))
+basic_number_4_2 ::= ("" | ([+\-]))
+basic_number_5_2 ::= (([0-9] basic_number_5_2) | ([0-9]))
+basic_number_6_2 ::= ("" | ([eE] basic_number_4_2 basic_number_5_2))
+basic_array_1_2 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any_2 basic_array_1_2))
+basic_object_1_2 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string_2 [ \n\t]* ":" [ \n\t]* basic_any_2 basic_object_1_2))
+root_prop_1_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string_2 root_prop_1_1))
+basic_number_7_2 ::= (("0") | (basic_number_1_2 [1-9] [0-9]*))
 triggered_tags_group ::= (("1>" root "</function>") | ("2>" root_1 "</function>"))
 triggered_tags_group_1 ::= ((">" root_2 "</function>"))
 triggered_tags ::= TagDispatch(
@@ -98,7 +182,8 @@ def test_structural_tag():
     triggers = ["<function=f", "<function=g"]
 
     grammar = xgr.Grammar.from_structural_tag(tags, triggers)
-    assert str(grammar) == expected_grammar_test_structural_tag
+
+    assert str(grammar) == expected_grammar_test_structural_tag_before_optimization
 
     accepted_inputs = [
         '<function=f1>{"arg1": "abc", "arg2": 1}</function>',
@@ -132,7 +217,7 @@ def test_structural_tag_compiler():
     compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]))
     compiled_grammar = compiler.compile_structural_tag(tags, triggers)
 
-    assert str(compiled_grammar.grammar) == expected_grammar_test_structural_tag
+    assert str(compiled_grammar.grammar) == expected_grammar_test_structural_tag_after_optimization
 
 
 @pytest.mark.hf_token_required

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, TypeAdapter, create_model
 
 import xgrammar as xgr
 from xgrammar.testing import (
+    GrammarFunctor,
     _generate_float_regex,
     _generate_range_regex,
     _is_grammar_accept_string,
@@ -2192,7 +2193,7 @@ root_repeat_2_3 ::= ("" | ([ \n\t])) (=("}"))
 """
     schema = {"type": "object", "properties": {"key": {"type": "string"}}, "required": ["key"]}
     grammar = xgr.Grammar.from_json_schema(schema, any_whitespace=True, max_whitespace_cnt=2)
-
+    grammar = GrammarFunctor.grammar_optimizer(grammar)
     assert grammar is not None
     assert str(grammar) == expected_grammar
     assert _is_grammar_accept_string(grammar, '{  "key"  :  "value"  }')

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -42,7 +42,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v6"
+    assert xgr.get_serialization_version() == "v7"
 
 
 def test_serialize_grammar():
@@ -50,18 +50,19 @@ def test_serialize_grammar():
     grammar = construct_grammar()
     serialized = grammar.serialize_json()
     expected_json = {
-        "rules": [["rule1", 4, 9, True], ["root_rule", 8, -1, False]],
-        "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 28, 31],
+        "rules": [["rule1", 4, -1, False], ["root_rule", 8, -1, False]],
+        "grammar_expr_data": [0, 5, 8, 12, 14, 18, 21, 24, 28],
         "grammar_expr_indptr": [
             # fmt: off
-            3,0,1,3,1,48,57,4,1,0,5,2,1,2,6,2,0,3,4,1,0,0,1,97,5,2,5,6,6,1,7,5,1,6
+            1,3,1,48,57,4,1,0,5,2,0,1,3,0,6,2,3,2,4,1,0,0,1,97,5,2,5,6,6,1,7
             # fmt: on
         ],
         "root_rule_id": 1,
         "complete_fsm": None,
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
-        "__VERSION__": "v6",
+        "optimized": False,
+        "__VERSION__": "v7",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -81,14 +82,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v6",
+        "__VERSION__": "v7",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v6"
+    expected_json["__VERSION__"] = "v7"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -140,7 +141,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v6"}'
+        '"__VERSION__":"v7"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -194,11 +195,11 @@ def test_serialize_compiled_grammar():
 
     expected_json = {
         "grammar": {
-            "rules": [["rule1", 4, 6, True], ["root_rule", 10, -1, False]],
-            "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 27, 30, 34],
+            "rules": [["rule1", 4, 9, True], ["root_rule", 8, -1, False]],
+            "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 28, 31],
             "grammar_expr_indptr": [
                 # fmt: off
-                3,0,1,3,1,48,57,4,1,0,5,2,1,2,6,2,0,3,0,1,97,5,1,5,4,1,0,0,1,97,5,2,7,8,6,1,9
+                3,0,1,3,1,48,57,4,1,0,5,2,1,2,6,2,0,3,4,1,0,0,1,97,5,2,5,6,6,1,7,5,1,6
                 # fmt: on
             ],
             "root_rule_id": 1,
@@ -214,6 +215,7 @@ def test_serialize_compiled_grammar():
                 [{'data_': [[0, 47, 3], [58, 127, 3], [192, 223, 1], [224, 239, 4], [240, 247, 5], [128, 191, 3], [-2, 0, 2], [128, 191, 1], [128, 191, 4], [-2, 0, 8], [97, 97, 6]],
                 'indptr_': [0, 5, 6, 6, 7, 8, 9, 9, 10, 11]}, 7, [6], False]],
             # fmt: on
+            "optimized": True,
         },
         "tokenizer_metadata": {
             "vocab_type": 1,
@@ -221,7 +223,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v6",
+        "__VERSION__": "v7",
     }
 
     class AdaptiveTokenMask(BaseModel):

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -6,7 +6,7 @@ import pytest
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
-from xgrammar.testing import GrammarFunctor, _is_grammar_accept_string
+from xgrammar.testing import _is_grammar_accept_string
 
 PROFILER_ON = True
 tokenizer_id = "meta-llama/Llama-3.1-8B-Instruct"

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -6,7 +6,7 @@ import pytest
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
-from xgrammar.testing import _is_grammar_accept_string
+from xgrammar.testing import GrammarFunctor, _is_grammar_accept_string
 
 PROFILER_ON = True
 tokenizer_id = "meta-llama/Llama-3.1-8B-Instruct"
@@ -72,7 +72,8 @@ def check_stag_with_instance(
 const_string_stag_grammar = [
     (
         {"type": "const_string", "value": "Hello!"},
-        r"""root ::= (("Hello!"))
+        r"""const_string ::= (("Hello!"))
+root ::= ((const_string))
 """,
     )
 ]
@@ -100,10 +101,27 @@ json_schema_stag_grammar = [
             "type": "json_schema",
             "json_schema": {"type": "object", "properties": {"a": {"type": "string"}}},
         },
-        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9])) (=(basic_string_sub))
+        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
 basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_string ::= (("\"" basic_string_sub)) (=([ \n\t]* "}"))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_7 basic_number_3 basic_number_6))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
+basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
 root ::= (("{" [ \n\t]* "\"a\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
+basic_number_3 ::= ("" | ("." basic_number_2))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
+basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
+basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
+basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
+basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*))
 root_1 ::= ((root))
 """,
     )
@@ -137,13 +155,36 @@ qwen_parameter_xml_stag_grammar = [
                 "required": ["name", "age"],
             },
         },
-        r"""xml_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9])) (=(xml_string))
-xml_string ::= ("" | ([^<>&\0-\x1f\\\r\n] xml_string) | ("\\" xml_escape xml_string) | ("&lt;" xml_string) | ("&gt;" xml_string) | ("&amp;" xml_string) | ("&quot;" xml_string) | ("&apos;" xml_string)) (=([ \n\t]*))
-xml_string_0 ::= ((xml_string)) (=([ \n\t]* "</parameter>" root_part_0))
-root_prop_1 ::= (("0") | (root_prop_1_1 [1-9] [0-9]*)) (=([ \n\t]* "</parameter>"))
+        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
+xml_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+xml_entity ::= (("&lt;") | ("&gt;") | ("&amp;") | ("&quot;") | ("&apos;"))
+xml_string ::= ("" | ([^<>&\0-\x1f\\\r\n] xml_string) | ("\\" xml_escape xml_string) | (xml_entity xml_string)) (=([ \n\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+xml_string_0 ::= ((xml_string))
+xml_any ::= ((basic_number) | (xml_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_7 basic_number_3 basic_number_6))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
+basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
+root_prop_1 ::= (("0") | (root_prop_1_1 [1-9] [0-9]*))
 root_part_0 ::= (([ \n\t]* "<parameter=age>" [ \n\t]* root_prop_1 [ \n\t]* "</parameter>"))
 root ::= (([ \n\t]* "<parameter=name>" [ \n\t]* xml_string_0 [ \n\t]* "</parameter>" root_part_0))
-root_prop_1_1 ::= ("" | ("-")) (=([1-9] [0-9]*))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
+basic_number_3 ::= ("" | ("." basic_number_2))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
+basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
+basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
+basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
+root_prop_1_1 ::= ("" | ("-"))
+basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*))
 root_1 ::= ((root))
 """,
     )
@@ -237,20 +278,30 @@ sequence_stag_grammar = [
                 {"type": "regex", "pattern": "[simple]?"},
             ],
         },
-        r"""basic_number ::= ((basic_number_7 basic_number_3 basic_number_6))
-root ::= ((basic_number)) (=(root_1 root_2))
-basic_number_1 ::= ("" | ("-")) (=([1-9] [0-9]*))
+        r"""const_string ::= (("Hello!"))
+basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_7 basic_number_3 basic_number_6))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
+basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
+root ::= ((basic_number))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
 basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2)) (=(basic_number_6))
-basic_number_4 ::= ("" | ([+\-])) (=(basic_number_5))
+basic_number_3 ::= ("" | ("." basic_number_2))
+basic_number_4 ::= ("" | ([+\-]))
 basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
 basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*)) (=(basic_number_3 basic_number_6))
-root_1 ::= ("" | ([\-+*/])) (=(root_2))
-root_2 ::= ((root_1_1))
-root_1_1 ::= ("" | ([simple]))
-sequence ::= (("Hello!" root root_1 root_2))
-root_3 ::= ((sequence))
+basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
+basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
+basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*))
+sequence ::= ((const_string root))
+root_1 ::= ((sequence))
 """,
     )
 ]
@@ -289,16 +340,29 @@ or_stag_grammar = [
                 {"type": "json_schema", "json_schema": {"type": "number"}},
             ],
         },
-        r"""basic_number ::= ((basic_number_7 basic_number_3 basic_number_6))
+        r"""const_string ::= (("Hello!"))
+basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_7 basic_number_3 basic_number_6))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
+basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
 root ::= ((basic_number))
-basic_number_1 ::= ("" | ("-")) (=([1-9] [0-9]*))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
 basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2)) (=(basic_number_6))
-basic_number_4 ::= ("" | ([+\-])) (=(basic_number_5))
+basic_number_3 ::= ("" | ("." basic_number_2))
+basic_number_4 ::= ("" | ([+\-]))
 basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
 basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*)) (=(basic_number_3 basic_number_6))
-or ::= (("Hello!") | (root))
+basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
+basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
+basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*))
+or ::= ((const_string) | (root))
 root_1 ::= ((or))
 """,
     )
@@ -331,15 +395,27 @@ tag_stag_grammar = [
             "content": {"type": "json_schema", "json_schema": {"type": "number"}},
             "end": "END",
         },
-        r"""basic_number ::= ((basic_number_7 basic_number_3 basic_number_6))
-root ::= ((basic_number)) (=("END"))
-basic_number_1 ::= ("" | ("-")) (=([1-9] [0-9]*))
+        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_7 basic_number_3 basic_number_6))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
+basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
+root ::= ((basic_number))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
 basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2)) (=(basic_number_6))
-basic_number_4 ::= ("" | ([+\-])) (=(basic_number_5))
+basic_number_3 ::= ("" | ("." basic_number_2))
+basic_number_4 ::= ("" | ([+\-]))
 basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
 basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*)) (=(basic_number_3 basic_number_6))
+basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
+basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
+basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*))
 tag ::= (("BEG" root "END"))
 root_1 ::= ((tag))
 """,
@@ -426,7 +502,8 @@ def test_any_text_format(
 any_text_only_stag_grammar = [
     (
         {"type": "any_text"},
-        r"""root ::= (([\0-\U0010ffff]*))
+        r"""any_text ::= (([\0-\U0010ffff]*))
+root ::= ((any_text))
 """,
     )
 ]
@@ -461,8 +538,8 @@ triggered_tag_stag_grammar = [
     (
         0,
         _get_triggered_tag_format(at_least_one=False, stop_after_first=False),
-        r"""const_string ::= (("L1")) (=("A"))
-const_string_1 ::= (("L2")) (=("A"))
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
 triggered_tags_group ::= (("1" const_string "A") | ("2" const_string_1 "A"))
 triggered_tags ::= TagDispatch(
   ("A", triggered_tags_group),
@@ -479,7 +556,7 @@ root ::= ((triggered_tags))
         r"""const_string ::= (("L1"))
 const_string_1 ::= (("L2"))
 triggered_tags_group ::= (("1" const_string "A") | ("2" const_string_1 "A"))
-triggered_tags_first ::= (("A1" const_string "A") | ("A2" const_string_1 "A")) (=(triggered_tags_sub))
+triggered_tags_first ::= (("A1" const_string "A") | ("A2" const_string_1 "A"))
 triggered_tags_sub ::= TagDispatch(
   ("A", triggered_tags_group),
   stop_eos=true,
@@ -493,8 +570,8 @@ root ::= ((triggered_tags))
     (
         2,
         _get_triggered_tag_format(at_least_one=False, stop_after_first=True),
-        r"""const_string ::= (("L1")) (=("A"))
-const_string_1 ::= (("L2")) (=("A"))
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
 triggered_tags_group ::= (("1" const_string "A") | ("2" const_string_1 "A"))
 triggered_tags ::= TagDispatch(
   ("A", triggered_tags_group),
@@ -508,8 +585,8 @@ root ::= ((triggered_tags))
     (
         3,
         _get_triggered_tag_format(at_least_one=True, stop_after_first=True),
-        r"""const_string ::= (("L1")) (=("A"))
-const_string_1 ::= (("L2")) (=("A"))
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
 triggered_tags ::= (("A1" const_string "A") | ("A2" const_string_1 "A"))
 root ::= ((triggered_tags))
 """,
@@ -557,7 +634,8 @@ test_triggered_tags_corner_case_data = [
                 }
             ],
         },
-        r"""triggered_tags_group ::= (("[TEXT]" "<end>"))
+        r"""const_string ::= (("[TEXT]"))
+triggered_tags_group ::= (("" const_string "<end>"))
 triggered_tags ::= TagDispatch(
   ("<start>", triggered_tags_group),
   stop_eos=true,
@@ -617,8 +695,8 @@ triggered_tag_with_outside_tag_stag_grammar = [
     (
         0,
         _get_triggered_tag_with_outside_tag(at_least_one=False, stop_after_first=False),
-        r"""const_string ::= (("L1")) (=("A"))
-const_string_1 ::= (("L2")) (=("A"))
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
 triggered_tags_group ::= (("1" const_string "A") | ("2" const_string_1 "A"))
 triggered_tags ::= TagDispatch(
   ("A", triggered_tags_group),
@@ -636,7 +714,7 @@ root ::= ((tag))
         r"""const_string ::= (("L1"))
 const_string_1 ::= (("L2"))
 triggered_tags_group ::= (("1" const_string "A") | ("2" const_string_1 "A"))
-triggered_tags_first ::= (("A1" const_string "A") | ("A2" const_string_1 "A")) (=(triggered_tags_sub))
+triggered_tags_first ::= (("A1" const_string "A") | ("A2" const_string_1 "A"))
 triggered_tags_sub ::= TagDispatch(
   ("A", triggered_tags_group),
   stop_eos=false,
@@ -651,8 +729,8 @@ root ::= ((tag))
     (
         2,
         _get_triggered_tag_with_outside_tag(at_least_one=False, stop_after_first=True),
-        r"""const_string ::= (("L1")) (=("A"))
-const_string_1 ::= (("L2")) (=("A"))
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
 triggered_tags_group ::= (("1" const_string "A") | ("2" const_string_1 "A"))
 triggered_tags ::= TagDispatch(
   ("A", triggered_tags_group),
@@ -667,9 +745,9 @@ root ::= ((tag))
     (
         3,
         _get_triggered_tag_with_outside_tag(at_least_one=True, stop_after_first=True),
-        r"""const_string ::= (("L1")) (=("A"))
-const_string_1 ::= (("L2")) (=("A"))
-triggered_tags_sub ::= (("A1" const_string "A") | ("A2" const_string_1 "A")) (=("end"))
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+triggered_tags_sub ::= (("A1" const_string "A") | ("A2" const_string_1 "A"))
 triggered_tags ::= ((triggered_tags_sub "end"))
 tag ::= (("begin" triggered_tags))
 root ::= ((tag))
@@ -722,9 +800,9 @@ tags_with_separator_stag_grammar = [
     (
         0,
         _get_tags_with_separator_format(at_least_one=False, stop_after_first=False),
-        r"""const_string ::= (("L1")) (=("A"))
+        r"""const_string ::= (("L1"))
 tag ::= (("A1" const_string "A"))
-const_string_1 ::= (("L2")) (=("A"))
+const_string_1 ::= (("L2"))
 tag_1 ::= (("A2" const_string_1 "A"))
 tags_with_separator_tags ::= ((tag) | (tag_1))
 tags_with_separator_sub ::= ("" | ("AA" tags_with_separator_tags tags_with_separator_sub))
@@ -735,9 +813,9 @@ root ::= ((tags_with_separator))
     (
         1,
         _get_tags_with_separator_format(at_least_one=True, stop_after_first=False),
-        r"""const_string ::= (("L1")) (=("A"))
+        r"""const_string ::= (("L1"))
 tag ::= (("A1" const_string "A"))
-const_string_1 ::= (("L2")) (=("A"))
+const_string_1 ::= (("L2"))
 tag_1 ::= (("A2" const_string_1 "A"))
 tags_with_separator_tags ::= ((tag) | (tag_1))
 tags_with_separator_sub ::= ("" | ("AA" tags_with_separator_tags tags_with_separator_sub))
@@ -748,9 +826,9 @@ root ::= ((tags_with_separator))
     (
         2,
         _get_tags_with_separator_format(at_least_one=False, stop_after_first=True),
-        r"""const_string ::= (("L1")) (=("A"))
+        r"""const_string ::= (("L1"))
 tag ::= (("A1" const_string "A"))
-const_string_1 ::= (("L2")) (=("A"))
+const_string_1 ::= (("L2"))
 tag_1 ::= (("A2" const_string_1 "A"))
 tags_with_separator_tags ::= ((tag) | (tag_1))
 tags_with_separator ::= ("" | (tags_with_separator_tags))
@@ -760,9 +838,9 @@ root ::= ((tags_with_separator))
     (
         3,
         _get_tags_with_separator_format(at_least_one=True, stop_after_first=True),
-        r"""const_string ::= (("L1")) (=("A"))
+        r"""const_string ::= (("L1"))
 tag ::= (("A1" const_string "A"))
-const_string_1 ::= (("L2")) (=("A"))
+const_string_1 ::= (("L2"))
 tag_1 ::= (("A2" const_string_1 "A"))
 tags_with_separator_tags ::= ((tag) | (tag_1))
 tags_with_separator ::= ((tags_with_separator_tags))
@@ -819,9 +897,9 @@ tags_with_separator_with_outside_tag_stag_grammar = [
         _get_tags_with_separator_format_with_outside_tag(
             at_least_one=False, stop_after_first=False
         ),
-        r"""const_string ::= (("L1")) (=("A"))
+        r"""const_string ::= (("L1"))
 tag ::= (("A1" const_string "A"))
-const_string_1 ::= (("L2")) (=("A"))
+const_string_1 ::= (("L2"))
 tag_1 ::= (("A2" const_string_1 "A"))
 tags_with_separator_tags ::= ((tag) | (tag_1))
 tags_with_separator_sub ::= (("AA" tags_with_separator_tags tags_with_separator_sub) | ("end"))
@@ -833,9 +911,9 @@ root ::= ((tag_2))
     (
         1,
         _get_tags_with_separator_format_with_outside_tag(at_least_one=True, stop_after_first=False),
-        r"""const_string ::= (("L1")) (=("A"))
+        r"""const_string ::= (("L1"))
 tag ::= (("A1" const_string "A"))
-const_string_1 ::= (("L2")) (=("A"))
+const_string_1 ::= (("L2"))
 tag_1 ::= (("A2" const_string_1 "A"))
 tags_with_separator_tags ::= ((tag) | (tag_1))
 tags_with_separator_sub ::= (("AA" tags_with_separator_tags tags_with_separator_sub) | ("end"))
@@ -847,11 +925,11 @@ root ::= ((tag_2))
     (
         2,
         _get_tags_with_separator_format_with_outside_tag(at_least_one=False, stop_after_first=True),
-        r"""const_string ::= (("L1")) (=("A"))
+        r"""const_string ::= (("L1"))
 tag ::= (("A1" const_string "A"))
-const_string_1 ::= (("L2")) (=("A"))
+const_string_1 ::= (("L2"))
 tag_1 ::= (("A2" const_string_1 "A"))
-tags_with_separator_tags ::= ((tag) | (tag_1)) (=("end"))
+tags_with_separator_tags ::= ((tag) | (tag_1))
 tags_with_separator ::= ((tags_with_separator_tags "end") | ("end"))
 tag_2 ::= (("begin" tags_with_separator))
 root ::= ((tag_2))
@@ -860,11 +938,11 @@ root ::= ((tag_2))
     (
         3,
         _get_tags_with_separator_format_with_outside_tag(at_least_one=True, stop_after_first=True),
-        r"""const_string ::= (("L1")) (=("A"))
+        r"""const_string ::= (("L1"))
 tag ::= (("A1" const_string "A"))
-const_string_1 ::= (("L2")) (=("A"))
+const_string_1 ::= (("L2"))
 tag_1 ::= (("A2" const_string_1 "A"))
-tags_with_separator_tags ::= ((tag) | (tag_1)) (=("end"))
+tags_with_separator_tags ::= ((tag) | (tag_1))
 tags_with_separator ::= ((tags_with_separator_tags "end"))
 tag_2 ::= (("begin" tags_with_separator))
 root ::= ((tag_2))
@@ -1139,12 +1217,13 @@ end_string_detector_test_data = [
             },
             "end": "<end>",
         },
-        r"""any_text ::= TagDispatch(
+        r"""const_string ::= (("[TEXT]"))
+any_text ::= TagDispatch(
   stop_eos=false,
   stop_str=("<end>"),
   loop_after_dispatch=false
 )
-sequence ::= (("[TEXT]" any_text))
+sequence ::= ((const_string any_text))
 tag ::= (("<start>" sequence))
 root ::= ((tag))
 """,
@@ -1194,8 +1273,8 @@ root ::= ((tag))
   stop_str=("<end2>"),
   loop_after_dispatch=false
 )
-triggered_tags_group ::= ((">" any_text))
-triggered_tags_first ::= (("<start2>" any_text)) (=(triggered_tags_sub))
+triggered_tags_group ::= ((">" any_text ""))
+triggered_tags_first ::= (("<start2>" any_text ""))
 triggered_tags_sub ::= TagDispatch(
   ("<start2", triggered_tags_group),
   stop_eos=false,
@@ -1203,12 +1282,13 @@ triggered_tags_sub ::= TagDispatch(
   loop_after_dispatch=true
 )
 triggered_tags ::= ((triggered_tags_first triggered_tags_sub))
+const_string ::= (("[TEXT2]"))
 any_text_1 ::= TagDispatch(
   stop_eos=false,
   stop_str=("<end>"),
   loop_after_dispatch=false
 )
-sequence ::= (("[TEXT2]" any_text_1))
+sequence ::= ((const_string any_text_1))
 any_text_2 ::= TagDispatch(
   stop_eos=false,
   stop_str=("<end3>"),
@@ -1280,8 +1360,8 @@ root ::= ((tag_1))
   stop_str=("<end2>"),
   loop_after_dispatch=false
 )
-triggered_tags_group ::= ((">" any_text))
-triggered_tags_first ::= (("<start2>" any_text)) (=(triggered_tags_sub))
+triggered_tags_group ::= ((">" any_text ""))
+triggered_tags_first ::= (("<start2>" any_text ""))
 triggered_tags_sub ::= TagDispatch(
   ("<start2", triggered_tags_group),
   stop_eos=true,
@@ -1289,8 +1369,9 @@ triggered_tags_sub ::= TagDispatch(
   loop_after_dispatch=true
 )
 triggered_tags ::= ((triggered_tags_first triggered_tags_sub))
+const_string ::= (("[TEXT]"))
 any_text_1 ::= (([\0-\U0010ffff]*))
-sequence ::= (("[TEXT]" any_text_1))
+sequence ::= ((const_string any_text_1))
 any_text_2 ::= TagDispatch(
   stop_eos=false,
   stop_str=("<end3>"),
@@ -1300,8 +1381,9 @@ tag ::= (("<start3>" any_text_2))
 tags_with_separator_tags ::= ((tag))
 tags_with_separator_sub ::= ("" | ("<sep>" tags_with_separator_tags tags_with_separator_sub))
 tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
+const_string_1 ::= (("[TEXT2]"))
 any_text_3 ::= (([\0-\U0010ffff]*))
-sequence_1 ::= (("[TEXT2]" any_text_3))
+sequence_1 ::= ((const_string_1 any_text_3))
 or ::= ((tags_with_separator) | (sequence_1))
 or_1 ::= ((triggered_tags) | (sequence) | (or))
 root ::= ((or_1))

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -52,7 +52,6 @@ if PROFILER_ON:
 def check_stag_with_grammar(structural_tag_format: Dict[str, Any], expected_grammar_ebnf: str):
     structural_tag = {"type": "structural_tag", "format": structural_tag_format}
     stag_ebnf = xgr.Grammar.from_structural_tag(structural_tag)
-    print(stag_ebnf)
     assert str(stag_ebnf) == expected_grammar_ebnf
 
 

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -52,6 +52,7 @@ if PROFILER_ON:
 def check_stag_with_grammar(structural_tag_format: Dict[str, Any], expected_grammar_ebnf: str):
     structural_tag = {"type": "structural_tag", "format": structural_tag_format}
     stag_ebnf = xgr.Grammar.from_structural_tag(structural_tag)
+    print(stag_ebnf)
     assert str(stag_ebnf) == expected_grammar_ebnf
 
 
@@ -243,7 +244,7 @@ def test_ebnf_grammar_format(
 regex_stag_grammar = [
     (
         {"type": "regex", "pattern": "Hello![0-9]+"},
-        r"""root ::= (("Hello!" root_1))
+        r"""root ::= (("H" "e" "l" "l" "o" "!" root_1))
 root_1 ::= (([0-9] root_1) | ([0-9]))
 root_2 ::= ((root))
 """,
@@ -300,8 +301,11 @@ basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
 basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
 basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
 basic_number_7 ::= (("0") | (basic_number_1 [1-9] [0-9]*))
-sequence ::= ((const_string root))
-root_1 ::= ((sequence))
+root_1 ::= ("" | ([\-+*/]))
+root_2 ::= ((root_1_1))
+root_1_1 ::= ("" | ([simple]))
+sequence ::= ((const_string root root_1 root_2))
+root_3 ::= ((sequence))
 """,
     )
 ]
@@ -427,8 +431,8 @@ root_1 ::= ((tag))
             "content": {"type": "grammar", "grammar": "root ::= [+\\-]?[1-9][0-9]*"},
             "end": "END",
         },
-        r"""root ::= ((root_1 [1-9] [0-9]*)) (=("END"))
-root_1 ::= ("" | ([+\-])) (=([1-9] [0-9]*))
+        r"""root ::= ((root_1 [1-9] [0-9]*))
+root_1 ::= ("" | ([+\-]))
 tag ::= (("BEG" root "END"))
 root_2 ::= ((tag))
 """,
@@ -440,8 +444,8 @@ root_2 ::= ((tag))
             "content": {"type": "regex", "pattern": "[+\\-]?[1-9][0-9]*"},
             "end": "END",
         },
-        r"""root ::= ((root_1 [1-9] [0-9]*)) (=("END"))
-root_1 ::= ("" | ([+\-])) (=([1-9] [0-9]*))
+        r"""root ::= ((root_1 [1-9] [0-9]*))
+root_1 ::= ("" | ([+\-]))
 tag ::= (("BEG" root "END"))
 root_2 ::= ((tag))
 """,


### PR DESCRIPTION
This is a rebased version of #383.
This PR refactors the pipeline. The functors in `grammar_functor` are divided into three types:
- `grammar_normalizer`: When a grammar is constructed, they should be called immediately.
- `grammar_optimizer`: When a grammar is going to be compiled, they will be called.
- `grammar_constructor`: They are used to construct a new grammar, like constructing the union of two grammars.
  