### PR TITLE
[Refac] Refactor the matcher for better efficiency.

### DIFF
--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -543,6 +543,24 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
       for (auto idx : adaptive_token_mask.accepted_indices) {
         tmp_accepted_bitset_.Set(sorted_decoded_vocab[idx].first, true);
       }
+    } else {
+      XGRAMMAR_DCHECK(adaptive_token_mask.store_type == StoreType::kRejected)
+          << "The store type should be kRejected, but got "
+          << static_cast<int>(adaptive_token_mask.store_type);
+      IntsetIntersection(&tmp_rejected_indices_, adaptive_token_mask.rejected_indices);
+    }
+  }
+
+  int current_ptr = 0;
+
+  if (tmp_rejected_indices_.size() != 1 || tmp_rejected_indices_[0] != -1) {
+    for (int i = 0; i < static_cast<int>(sorted_decoded_vocab.size()); i++) {
+      if (current_ptr < static_cast<int>(tmp_rejected_indices_.size()) &&
+          i == tmp_rejected_indices_[current_ptr]) {
+        current_ptr++;
+        continue;
+      }
+      tmp_accepted_bitset_.Set(sorted_decoded_vocab[i].first, true);
     }
   }
 

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -619,7 +619,6 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
 
   // Finally update the rejected_ids bitset
   bool can_reach_end = IsCompleted();
-  tmp_rejected_indices_ = {-1};
   SetTokenBitmask(bitmask_data_ptr, tmp_accepted_bitset_, can_reach_end, false);
   if (debug_print) {
     XGRAMMAR_LOG(INFO) << "Filled bitmask: " << PrintBitmask(bitmask_data_ptr, tokenizer_info_);

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -534,6 +534,10 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
 
   for (const auto& state : latest_states) {
     auto adaptive_token_mask_it = adaptive_token_mask_cache.find(state);
+    if (debug_print) {
+      XGRAMMAR_LOG(INFO) << "The ParserState is " << state << ", the mask is "
+                         << adaptive_token_mask_it->second.Print(tokenizer_info_);
+    }
     XGRAMMAR_CHECK(adaptive_token_mask_it != adaptive_token_mask_cache.end()) << state;
     const auto& adaptive_token_mask = adaptive_token_mask_it->second;
     latest_states_with_masks.push_back(std::make_pair(state, adaptive_token_mask_it));

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -106,7 +106,7 @@ def test_fill_next_token_bitmask(
     rejected_sizes = []
 
     for i, c in enumerate(input_bytes):
-        matcher.fill_next_token_bitmask(token_bitmask)
+        matcher.fill_next_token_bitmask(token_bitmask, debug_print=True)
         rejected_token_ids = _get_masked_tokens_from_bitmask(
             token_bitmask, tokenizer_info.vocab_size
         )

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -106,7 +106,7 @@ def test_fill_next_token_bitmask(
     rejected_sizes = []
 
     for i, c in enumerate(input_bytes):
-        matcher.fill_next_token_bitmask(token_bitmask, debug_print=True)
+        matcher.fill_next_token_bitmask(token_bitmask)
         rejected_token_ids = _get_masked_tokens_from_bitmask(
             token_bitmask, tokenizer_info.vocab_size
         )


### PR DESCRIPTION
This PR refactors the logic of the matcher for better efficiency in long tail cases. At present, we'll check each state's uncertain tokens one by one. In this PR, it will collect the global uncertain tokens, and check only for once. It can lead to efficiency improvement especially there are a lot of states.