### PR TITLE
[Feature] Provide batched fill next token mask and batched accept string/token methods.

### DIFF
--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -321,7 +321,7 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   std::string _DebugPrintInternalState() const { return PrintStates(); }
 
-  static std::vector<uint8_t> BatchedFillNextTokenBitmask(
+  static std::vector<uint8_t> BatchFillNextTokenBitmask(
       std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
       int index = 0,
@@ -901,7 +901,7 @@ int GrammarMatcher::Impl::GetNextUncertainToken(
   }
 }
 
-std::vector<uint8_t> GrammarMatcher::Impl::BatchedFillNextTokenBitmask(
+std::vector<uint8_t> GrammarMatcher::Impl::BatchFillNextTokenBitmask(
     std::vector<GrammarMatcher>* matchers,
     DLTensor* next_token_bitmask,
     int index,
@@ -1004,19 +1004,19 @@ std::string GrammarMatcher::_DebugPrintInternalState() const {
   return pimpl_->_DebugPrintInternalState();
 }
 
-std::vector<uint8_t> GrammarMatcher::BatchedFillNextTokenBitmask(
+std::vector<uint8_t> GrammarMatcher::BatchFillNextTokenBitmask(
     std::vector<GrammarMatcher>* matchers,
     DLTensor* next_token_bitmask,
     int index,
     int max_thread,
     bool debug_print
 ) {
-  return Impl::BatchedFillNextTokenBitmask(
+  return Impl::BatchFillNextTokenBitmask(
       matchers, next_token_bitmask, index, max_thread, debug_print
   );
 }
 
-std::vector<uint8_t> GrammarMatcher::BatchedAcceptString(
+std::vector<uint8_t> GrammarMatcher::BatchAcceptString(
     std::vector<GrammarMatcher>* matchers,
     const std::vector<std::string>& input_strs,
     bool debug_print
@@ -1024,7 +1024,7 @@ std::vector<uint8_t> GrammarMatcher::BatchedAcceptString(
   return Impl::BatchedAcceptString(matchers, input_strs, debug_print);
 }
 
-std::vector<uint8_t> GrammarMatcher::BatchedAcceptToken(
+std::vector<uint8_t> GrammarMatcher::BatchAcceptToken(
     std::vector<GrammarMatcher>* matchers, const std::vector<int32_t>& token_ids, bool debug_print
 ) {
   return Impl::BatchedAcceptToken(matchers, token_ids, debug_print);

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -292,6 +292,14 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   std::string _DebugPrintInternalState() const { return PrintStates(); }
 
+  static std::vector<uint8_t> BatchedFillNextTokenBitmask(
+      std::vector<GrammarMatcher>* matchers,
+      DLTensor* next_token_bitmask,
+      int index = 0,
+      int max_thread = 16,
+      bool debug_print = false
+  );
+
  private:
   using StoreType = AdaptiveTokenMask::StoreType;
 
@@ -852,6 +860,17 @@ int GrammarMatcher::Impl::GetNextUncertainToken(
   }
 }
 
+std::vector<uint8_t> GrammarMatcher::Impl::BatchedFillNextTokenBitmask(
+    std::vector<GrammarMatcher>* matchers,
+    DLTensor* next_token_bitmask,
+    int index,
+    int max_thread,
+    bool debug_print
+) {
+  // TODO(Linzhang): parallel implementation.
+  return {};
+}
+
 GrammarMatcher::GrammarMatcher(
     const CompiledGrammar& compiled_grammar,
     std::optional<std::vector<int>> override_stop_tokens,
@@ -892,6 +911,18 @@ const std::vector<int>& GrammarMatcher::GetStopTokenIds() const {
 
 std::string GrammarMatcher::_DebugPrintInternalState() const {
   return pimpl_->_DebugPrintInternalState();
+}
+
+std::vector<uint8_t> GrammarMatcher::BatchedFillNextTokenBitmask(
+    std::vector<GrammarMatcher>* matchers,
+    DLTensor* next_token_bitmask,
+    int index,
+    int max_thread,
+    bool debug_print
+) {
+  return Impl::BatchedFillNextTokenBitmask(
+      matchers, next_token_bitmask, index, max_thread, debug_print
+  );
 }
 
 }  // namespace xgrammar

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -322,7 +322,7 @@ class GrammarMatcher::Impl : public EarleyParser {
   std::string _DebugPrintInternalState() const { return PrintStates(); }
 
   static std::vector<uint8_t> BatchedFillNextTokenBitmask(
-      std::vector<GrammarMatcher>* matchers,
+      std::vector<GrammarMatcher*>* matchers,
       DLTensor* next_token_bitmask,
       int index = 0,
       int max_thread = 16,
@@ -890,7 +890,7 @@ int GrammarMatcher::Impl::GetNextUncertainToken(
 }
 
 std::vector<uint8_t> GrammarMatcher::Impl::BatchedFillNextTokenBitmask(
-    std::vector<GrammarMatcher>* matchers,
+    std::vector<GrammarMatcher*>* matchers,
     DLTensor* next_token_bitmask,
     int index,
     int max_thread,
@@ -899,7 +899,7 @@ std::vector<uint8_t> GrammarMatcher::Impl::BatchedFillNextTokenBitmask(
   std::vector<uint8_t> mask_applied(matchers->size());
   if (max_thread == 1) {
     for (int i = 0; i < static_cast<int32_t>(matchers->size()); i++) {
-      auto& matcher = matchers->at(i);
+      auto& matcher = *matchers->at(i);
       mask_applied[i] = matcher->FillNextTokenBitmask(next_token_bitmask, index, i, debug_print);
     }
   } else {
@@ -908,7 +908,7 @@ std::vector<uint8_t> GrammarMatcher::Impl::BatchedFillNextTokenBitmask(
         std::min(std::thread::hardware_concurrency(), static_cast<uint32_t>(max_thread))
     );
     auto fill_next_token_mask = [&](int32_t batch_id) {
-      auto& matcher = matchers->at(batch_id);
+      auto& matcher = *matchers->at(batch_id);
       mask_applied[batch_id] =
           matcher->FillNextTokenBitmask(next_token_bitmask, index, batch_id, debug_print);
     };
@@ -963,7 +963,7 @@ std::string GrammarMatcher::_DebugPrintInternalState() const {
 }
 
 std::vector<uint8_t> GrammarMatcher::BatchedFillNextTokenBitmask(
-    std::vector<GrammarMatcher>* matchers,
+    std::vector<GrammarMatcher*>* matchers,
     DLTensor* next_token_bitmask,
     int index,
     int max_thread,

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -915,6 +915,7 @@ std::vector<uint8_t> GrammarMatcher::Impl::BatchedFillNextTokenBitmask(
     for (int i = 0; i < static_cast<int32_t>(matchers->size()); i++) {
       thread_pool.Execute([fill_next_token_mask, i]() { fill_next_token_mask(i); });
     }
+    thread_pool.Join();
   }
   return mask_applied;
 }

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -300,7 +300,7 @@ class GrammarMatcher::Impl : public EarleyParser {
       std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
       const std::optional<std::vector<int32_t>>& indices = std::nullopt,
-      int max_thread = 16,
+      int max_threads = 16,
       bool debug_print = false
   );
 
@@ -880,14 +880,14 @@ void GrammarMatcher::Impl::BatchFillNextTokenBitmask(
     std::vector<GrammarMatcher>* matchers,
     DLTensor* next_token_bitmask,
     const std::optional<std::vector<int32_t>>& indices,
-    int max_thread,
+    int max_threads,
     bool debug_print
 ) {
   XGRAMMAR_CHECK(!indices.has_value() || indices->size() == matchers->size())
       << "The size of indices (" << (indices.has_value() ? indices->size() : 0)
       << ") should be the same as the size of matchers (" << matchers->size() << ").";
 
-  if (max_thread == 1) {
+  if (max_threads == 1) {
     for (int i = 0; i < static_cast<int32_t>(matchers->size()); i++) {
       auto& matcher = (*matchers)[i];
       int index = indices.has_value() ? (*indices)[i] : i;
@@ -897,9 +897,9 @@ void GrammarMatcher::Impl::BatchFillNextTokenBitmask(
       matcher->FillNextTokenBitmask(next_token_bitmask, index, debug_print);
     }
   } else {
-    XGRAMMAR_CHECK(max_thread > 0);
+    XGRAMMAR_CHECK(max_threads > 0);
     ThreadPool thread_pool(
-        std::min(std::thread::hardware_concurrency(), static_cast<uint32_t>(max_thread))
+        std::min(std::thread::hardware_concurrency(), static_cast<uint32_t>(max_threads))
     );
     auto fill_next_token_mask = [&](int32_t batch_id) {
       auto& matcher = (*matchers)[batch_id];
@@ -992,10 +992,10 @@ void GrammarMatcher::BatchFillNextTokenBitmask(
     std::vector<GrammarMatcher>* matchers,
     DLTensor* next_token_bitmask,
     const std::optional<std::vector<int32_t>>& indices,
-    int max_thread,
+    int max_threads,
     bool debug_print
 ) {
-  Impl::BatchFillNextTokenBitmask(matchers, next_token_bitmask, indices, max_thread, debug_print);
+  Impl::BatchFillNextTokenBitmask(matchers, next_token_bitmask, indices, max_threads, debug_print);
 }
 
 std::vector<uint8_t> GrammarMatcher::BatchAcceptString(

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -322,7 +322,7 @@ class GrammarMatcher::Impl : public EarleyParser {
   std::string _DebugPrintInternalState() const { return PrintStates(); }
 
   static std::vector<uint8_t> BatchedFillNextTokenBitmask(
-      std::vector<GrammarMatcher*>* matchers,
+      const std::vector<GrammarMatcher*>& matchers,
       DLTensor* next_token_bitmask,
       int index = 0,
       int max_thread = 16,
@@ -890,17 +890,18 @@ int GrammarMatcher::Impl::GetNextUncertainToken(
 }
 
 std::vector<uint8_t> GrammarMatcher::Impl::BatchedFillNextTokenBitmask(
-    std::vector<GrammarMatcher*>* matchers,
+    const std::vector<GrammarMatcher*>& matchers,
     DLTensor* next_token_bitmask,
     int index,
     int max_thread,
     bool debug_print
 ) {
-  std::vector<uint8_t> mask_applied(matchers->size());
+  std::vector<uint8_t> mask_applied(matchers.size());
   if (max_thread == 1) {
-    for (int i = 0; i < static_cast<int32_t>(matchers->size()); i++) {
-      auto& matcher = *matchers->at(i);
-      mask_applied[i] = matcher->FillNextTokenBitmask(next_token_bitmask, index, i, debug_print);
+    for (int i = 0; i < static_cast<int32_t>(matchers.size()); i++) {
+      auto& matcher = matchers[i];
+      mask_applied[i] =
+          matcher->ImplPtr()->FillNextTokenBitmask(next_token_bitmask, index, i, debug_print);
     }
   } else {
     XGRAMMAR_CHECK(max_thread > 0);
@@ -908,11 +909,12 @@ std::vector<uint8_t> GrammarMatcher::Impl::BatchedFillNextTokenBitmask(
         std::min(std::thread::hardware_concurrency(), static_cast<uint32_t>(max_thread))
     );
     auto fill_next_token_mask = [&](int32_t batch_id) {
-      auto& matcher = *matchers->at(batch_id);
-      mask_applied[batch_id] =
-          matcher->FillNextTokenBitmask(next_token_bitmask, index, batch_id, debug_print);
+      auto& matcher = matchers[batch_id];
+      mask_applied[batch_id] = matcher->ImplPtr()->FillNextTokenBitmask(
+          next_token_bitmask, index, batch_id, debug_print
+      );
     };
-    for (int i = 0; i < static_cast<int32_t>(matchers->size()); i++) {
+    for (int i = 0; i < static_cast<int32_t>(matchers.size()); i++) {
       thread_pool.Execute([fill_next_token_mask, i]() { fill_next_token_mask(i); });
     }
     thread_pool.Join();
@@ -963,7 +965,7 @@ std::string GrammarMatcher::_DebugPrintInternalState() const {
 }
 
 std::vector<uint8_t> GrammarMatcher::BatchedFillNextTokenBitmask(
-    std::vector<GrammarMatcher*>* matchers,
+    const std::vector<GrammarMatcher*>& matchers,
     DLTensor* next_token_bitmask,
     int index,
     int max_thread,

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -112,21 +112,16 @@ std::vector<uint8_t> GrammarMatcher_BatchAcceptString(
     const std::vector<std::variant<nb::bytes, std::string>>& input_strs,
     bool debug_print
 ) {
-  if (matchers->size() != input_strs.size()) {
-    throw std::runtime_error("The size of matchers and input_strs must be the same");
-  }
-  std::vector<uint8_t> accepted(matchers->size());
-  for (int i = 0; i < static_cast<int32_t>(matchers->size()); i++) {
-    std::string input_str;
-    if (std::holds_alternative<std::string>(input_strs[i])) {
-      input_str = std::get<std::string>(input_strs[i]);
+  std::vector<std::string> input_strs_converted;
+  input_strs_converted.reserve(input_strs.size());
+  for (const auto& str : input_strs) {
+    if (std::holds_alternative<std::string>(str)) {
+      input_strs_converted.emplace_back(std::get<std::string>(str));
     } else {
-      input_str = std::get<nb::bytes>(input_strs[i]).c_str();
+      input_strs_converted.emplace_back(std::get<nb::bytes>(str).c_str());
     }
-    auto& matcher = (*matchers)[i];
-    accepted[i] = matcher.AcceptString(input_str, debug_print);
   }
-  return accepted;
+  return GrammarMatcher::BatchAcceptString(matchers, input_strs_converted);
 }
 
 std::vector<nanobind::bytes> TokenizerInfo_GetDecodedVocab(const TokenizerInfo& tokenizer) {

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -79,7 +79,7 @@ bool GrammarMatcher_FillNextTokenBitmask(
 }
 
 std::vector<uint8_t> GrammarMatcher_BatchedFillNextTokenMask(
-    std::vector<GrammarMatcher*>* matchers,
+    const std::vector<GrammarMatcher*>& matchers,
     nb::ndarray<> arr,
     int32_t index,
     int32_t max_thread,

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -120,6 +120,30 @@ void GrammarMatcher_BatchFillNextTokenMask(
   );
 }
 
+std::vector<uint8_t> GrammarMatcher_BatchAcceptString(
+    std::vector<GrammarMatcher>* matchers,
+    const nb::typed<nb::list, std::variant<std::string, nb::bytes>>& input_strs,
+    bool debug_print
+) {
+  if (matchers->size() != input_strs.size()) {
+    throw std::runtime_error("The size of matchers and input_strs must be the same");
+  }
+  std::vector<uint8_t> accepted(matchers->size());
+  for (int i = 0; i < static_cast<int32_t>(matchers->size()); i++) {
+    std::string input_str;
+    if (nb::bytes result; nb::try_cast(input_strs[i], result)) {
+      input_str = result.c_str();
+    } else if (nb::str result; nb::try_cast(input_strs[i], result)) {
+      input_str = result.c_str();
+    } else {
+      throw nb::type_error("Expected str or bytes for input_strs");
+    }
+    auto& matcher = (*matchers)[i];
+    accepted[i] = matcher.AcceptString(input_str, debug_print);
+  }
+  return accepted;
+}
+
 std::vector<nanobind::bytes> TokenizerInfo_GetDecodedVocab(const TokenizerInfo& tokenizer) {
   const auto& decoded_vocab = tokenizer.GetDecodedVocab();
   std::vector<nanobind::bytes> py_result;

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -78,7 +78,7 @@ bool GrammarMatcher_FillNextTokenBitmask(
   return matcher.FillNextTokenBitmask(bitmask_dltensor_ptr, index, debug_print);
 }
 
-std::vector<uint8_t> GrammarMatcher_BatchFillNextTokenMask(
+void GrammarMatcher_BatchFillNextTokenMask(
     std::vector<GrammarMatcher>* matchers,
     nb::ndarray<> arr,
     int32_t index,
@@ -99,7 +99,7 @@ std::vector<uint8_t> GrammarMatcher_BatchFillNextTokenMask(
   DLTensor* bitmask_dltensor_ptr =
       reinterpret_cast<::DLTensor*>(reinterpret_cast<char*>(&arr) + sizeof(void*));
 
-  return GrammarMatcher::BatchFillNextTokenBitmask(
+  GrammarMatcher::BatchFillNextTokenBitmask(
       matchers, bitmask_dltensor_ptr, index, max_thread, debug_print
   );
 }

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -79,7 +79,7 @@ bool GrammarMatcher_FillNextTokenBitmask(
 }
 
 std::vector<uint8_t> GrammarMatcher_BatchedFillNextTokenMask(
-    const std::vector<GrammarMatcher*>& matchers,
+    std::vector<GrammarMatcher>* matchers,
     nb::ndarray<> arr,
     int32_t index,
     int32_t max_thread,

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -84,12 +84,12 @@ bool GrammarMatcher_FillNextTokenBitmask(
 void GrammarMatcher_BatchFillNextTokenMask(
     std::vector<GrammarMatcher>* matchers,
     nb::ndarray<> arr,
-    std::optional<std::vector<int32_t>> indices,
+    const std::optional<std::vector<int32_t>>& indices,
     std::variant<int32_t, std::string> max_thread,
     bool debug_print
 ) {
   if (arr.ndim() != 2) {
-    throw std::runtime_error("batched_token_bitmask tensor must be 2D");
+    throw std::runtime_error("batch_token_bitmask tensor must be 2D");
   }
   if (arr.device_type() != nb::device::cpu::value) {
     throw std::runtime_error("token_bitmask array must be on CPU");
@@ -306,11 +306,16 @@ NB_MODULE(xgrammar_bindings, m) {
       .def_static(
           "batch_fill_next_token_bitmask",
           &GrammarMatcher_BatchFillNextTokenMask,
+          nb::arg("matchers"),
+          nb::arg("batch_token_bitmask"),
+          nb::arg("indices").none(),
+          nb::arg("max_thread") = "auto",
+          nb::arg("debug_print") = false,
           nb::call_guard<nb::gil_scoped_release>()
       )
       .def_static(
           "batch_accept_string",
-          &GrammarMatcher::BatchAcceptString,
+          &GrammarMatcher_BatchAcceptString,
           nb::call_guard<nb::gil_scoped_release>()
       )
       .def_static(

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -268,6 +268,16 @@ NB_MODULE(xgrammar_bindings, m) {
           &GrammarMatcher_BatchedFillNextTokenMask,
           nb::call_guard<nb::gil_scoped_release>()
       )
+      .def_static(
+          "batched_accept_string",
+          &GrammarMatcher::BatchedAcceptString,
+          nb::call_guard<nb::gil_scoped_release>()
+      )
+      .def_static(
+          "batched_accept_token",
+          &GrammarMatcher::BatchedAcceptToken,
+          nb::call_guard<nb::gil_scoped_release>()
+      )
       .def(
           "find_jump_forward_string",
           &GrammarMatcher::FindJumpForwardString,

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -78,7 +78,7 @@ bool GrammarMatcher_FillNextTokenBitmask(
   return matcher.FillNextTokenBitmask(bitmask_dltensor_ptr, index, debug_print);
 }
 
-std::vector<uint8_t> GrammarMatcher_BatchedFillNextTokenMask(
+std::vector<uint8_t> GrammarMatcher_BatchFillNextTokenMask(
     std::vector<GrammarMatcher>* matchers,
     nb::ndarray<> arr,
     int32_t index,
@@ -99,7 +99,7 @@ std::vector<uint8_t> GrammarMatcher_BatchedFillNextTokenMask(
   DLTensor* bitmask_dltensor_ptr =
       reinterpret_cast<::DLTensor*>(reinterpret_cast<char*>(&arr) + sizeof(void*));
 
-  return GrammarMatcher::BatchedFillNextTokenBitmask(
+  return GrammarMatcher::BatchFillNextTokenBitmask(
       matchers, bitmask_dltensor_ptr, index, max_thread, debug_print
   );
 }
@@ -264,18 +264,18 @@ NB_MODULE(xgrammar_bindings, m) {
           nb::call_guard<nb::gil_scoped_release>()
       )
       .def_static(
-          "batched_fill_next_token_bitmask",
-          &GrammarMatcher_BatchedFillNextTokenMask,
+          "batch_fill_next_token_bitmask",
+          &GrammarMatcher_BatchFillNextTokenMask,
           nb::call_guard<nb::gil_scoped_release>()
       )
       .def_static(
-          "batched_accept_string",
-          &GrammarMatcher::BatchedAcceptString,
+          "batch_accept_string",
+          &GrammarMatcher::BatchAcceptString,
           nb::call_guard<nb::gil_scoped_release>()
       )
       .def_static(
-          "batched_accept_token",
-          &GrammarMatcher::BatchedAcceptToken,
+          "batch_accept_token",
+          &GrammarMatcher::BatchAcceptToken,
           nb::call_guard<nb::gil_scoped_release>()
       )
       .def(

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -122,7 +122,7 @@ void GrammarMatcher_BatchFillNextTokenMask(
 
 std::vector<uint8_t> GrammarMatcher_BatchAcceptString(
     std::vector<GrammarMatcher>* matchers,
-    const nb::typed<nb::list, std::variant<std::string, nb::bytes>>& input_strs,
+    const std::vector<std::variant<nb::bytes, std::string>>& input_strs,
     bool debug_print
 ) {
   if (matchers->size() != input_strs.size()) {
@@ -131,12 +131,10 @@ std::vector<uint8_t> GrammarMatcher_BatchAcceptString(
   std::vector<uint8_t> accepted(matchers->size());
   for (int i = 0; i < static_cast<int32_t>(matchers->size()); i++) {
     std::string input_str;
-    if (nb::bytes result; nb::try_cast(input_strs[i], result)) {
-      input_str = result.c_str();
-    } else if (nb::str result; nb::try_cast(input_strs[i], result)) {
-      input_str = result.c_str();
+    if (std::holds_alternative<std::string>(input_strs[i])) {
+      input_str = std::get<std::string>(input_strs[i]);
     } else {
-      throw nb::type_error("Expected str or bytes for input_strs");
+      input_str = std::get<nb::bytes>(input_strs[i]).c_str();
     }
     auto& matcher = (*matchers)[i];
     accepted[i] = matcher.AcceptString(input_str, debug_print);

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -85,7 +85,7 @@ void GrammarMatcher_BatchFillNextTokenMask(
     std::vector<GrammarMatcher>* matchers,
     nb::ndarray<> arr,
     const std::optional<std::vector<int32_t>>& indices,
-    std::variant<int32_t, std::string> max_thread,
+    std::variant<int32_t, std::string> max_threads,
     bool debug_print
 ) {
   if (arr.ndim() != 2) {
@@ -102,21 +102,8 @@ void GrammarMatcher_BatchFillNextTokenMask(
   DLTensor* bitmask_dltensor_ptr =
       reinterpret_cast<::DLTensor*>(reinterpret_cast<char*>(&arr) + sizeof(void*));
 
-  int unwrapped_max_thread;
-
-  if (std::holds_alternative<std::string>(max_thread)) {
-    if (std::get<std::string>(max_thread) == "auto") {
-      unwrapped_max_thread = std::min(std::thread::hardware_concurrency() / 2, 1u);
-    } else {
-      throw std::runtime_error("max_thread must be an integer or 'auto'");
-    }
-  } else {
-    XGRAMMAR_CHECK(std::get<int32_t>(max_thread) > 0) << "max_thread must be positive";
-    unwrapped_max_thread = std::get<int32_t>(max_thread);
-  }
-
   GrammarMatcher::BatchFillNextTokenBitmask(
-      matchers, bitmask_dltensor_ptr, indices, unwrapped_max_thread, debug_print
+      matchers, bitmask_dltensor_ptr, indices, max_threads, debug_print
   );
 }
 

--- a/cpp/nanobind/nanobind.cc
+++ b/cpp/nanobind/nanobind.cc
@@ -79,7 +79,7 @@ bool GrammarMatcher_FillNextTokenBitmask(
 }
 
 std::vector<uint8_t> GrammarMatcher_BatchedFillNextTokenMask(
-    std::vector<GrammarMatcher>& matchers,
+    std::vector<GrammarMatcher*>* matchers,
     nb::ndarray<> arr,
     int32_t index,
     int32_t max_thread,
@@ -100,7 +100,7 @@ std::vector<uint8_t> GrammarMatcher_BatchedFillNextTokenMask(
       reinterpret_cast<::DLTensor*>(reinterpret_cast<char*>(&arr) + sizeof(void*));
 
   return GrammarMatcher::BatchedFillNextTokenBitmask(
-      &matchers, bitmask_dltensor_ptr, index, max_thread, debug_print
+      matchers, bitmask_dltensor_ptr, index, max_thread, debug_print
   );
 }
 
@@ -263,7 +263,7 @@ NB_MODULE(xgrammar_bindings, m) {
           &GrammarMatcher_FillNextTokenBitmask,
           nb::call_guard<nb::gil_scoped_release>()
       )
-      .def(
+      .def_static(
           "batched_fill_next_token_bitmask",
           &GrammarMatcher_BatchedFillNextTokenMask,
           nb::call_guard<nb::gil_scoped_release>()

--- a/docs/xgrammar_features/runtime_safeguards.md
+++ b/docs/xgrammar_features/runtime_safeguards.md
@@ -27,7 +27,7 @@ with max_recursion_depth(10000):
     matcher.accept_token(token_id)
 ```
 
-After XGrammar v0.1.21, the pushdown automaton parser was replaced with an Earley parser, and the recursion depth cannot be infinite anymore. Thus, the feature was removed.
+After XGrammar v0.1.21, the pushdown automaton parser was replaced with an Earley parser, and there is no recursion involved. So the recursion will never be exceed during parsing, and the exception will not be raised.
 
 ## Cache Size Limit
 

--- a/docs/xgrammar_features/runtime_safeguards.md
+++ b/docs/xgrammar_features/runtime_safeguards.md
@@ -15,7 +15,7 @@ If the recursion depth exceeds the limit,
 the matcher operations (including [`xgr.GrammarMatcher.accept_token`](xgrammar.GrammarMatcher.accept_token),
 [`xgr.GrammarMatcher.accept_string`](xgrammar.GrammarMatcher.accept_string), [`xgr.GrammarMatcher.fill_next_token_bitmask`](xgrammar.GrammarMatcher.fill_next_token_bitmask),
 [`xgr.GrammarMatcher.find_jump_forward_string`](xgrammar.GrammarMatcher.find_jump_forward_string)) will raise
-`RuntimeError`.
+`RuntimeError`(before XGrammar v0.1.21).
 
 You can also use the [`xgr.max_recursion_depth`](xgrammar.max_recursion_depth) context manager to set the maximum
 recursion depth for a code block.
@@ -26,6 +26,8 @@ from xgrammar import max_recursion_depth
 with max_recursion_depth(10000):
     matcher.accept_token(token_id)
 ```
+
+After XGrammar v0.1.21, the pushdown automaton parser was replaced with an Earley parser, and the recursion depth cannot be infinite anymore. Thus, the feature was removed.
 
 ## Cache Size Limit
 

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -151,7 +151,7 @@ class GrammarMatcher {
     \param debug_print Whether to print debug information. Default is false.
     \return A vector of bytes indicating whether each bitmask needs to be applied (not all-true).
   */
-  static std::vector<uint8_t> BatchedFillNextTokenBitmask(
+  static std::vector<uint8_t> BatchFillNextTokenBitmask(
       std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
       int index = 0,
@@ -166,7 +166,7 @@ class GrammarMatcher {
    * \param debug_print Whether to print debug information. Default is false.
    * \return A vector of bytes indicating whether each string is accepted.
    */
-  static std::vector<uint8_t> BatchedAcceptString(
+  static std::vector<uint8_t> BatchAcceptString(
       std::vector<GrammarMatcher>* matchers,
       const std::vector<std::string>& input_strs,
       bool debug_print = false
@@ -179,7 +179,7 @@ class GrammarMatcher {
    * \param debug_print Whether to print debug information. Default is false.
    * \return A vector of bytes indicating whether each token is accepted.
    */
-  static std::vector<uint8_t> BatchedAcceptToken(
+  static std::vector<uint8_t> BatchAcceptToken(
       std::vector<GrammarMatcher>* matchers,
       const std::vector<int32_t>& token_ids,
       bool debug_print = false

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -146,14 +146,15 @@ class GrammarMatcher {
     \brief A batched version of FillNextTokenBitmask for better efficiency.
     \param matchers The array of GrammarMatcher objects.
     \param next_token_bitmask The pre-allocated DLTensor to store the result bitmasks.
-    \param index The index of the batch to process. Default is 0.
+    \param indices The optional array of indices to specify which matcher corresponds to which slice
+    of the bitmask tensor. If not provided, all matchers will write to the same slice (index 0).
     \param max_thread The maximum number of threads to use. Default is 16.
     \param debug_print Whether to print debug information. Default is false.
   */
   static void BatchFillNextTokenBitmask(
       std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
-      int index = 0,
+      const std::optional<std::vector<int32_t>>& indices = std::nullopt,
       int max_thread = 16,
       bool debug_print = false
   );

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -152,7 +152,7 @@ class GrammarMatcher {
     \return A vector of bytes indicating whether each bitmask needs to be applied (not all-true).
   */
   static std::vector<uint8_t> BatchedFillNextTokenBitmask(
-      std::vector<GrammarMatcher*>* matchers,
+      const std::vector<GrammarMatcher*>& matchers,
       DLTensor* next_token_bitmask,
       int index = 0,
       int max_thread = 16,

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -142,6 +142,23 @@ class GrammarMatcher {
    */
   std::string _DebugPrintInternalState() const;
 
+  /*!
+    \brief A batched version of FillNextTokenBitmask for better efficiency.
+    \param matchers The array of GrammarMatcher objects.
+    \param next_token_bitmask The pre-allocated DLTensor to store the result bitmasks.
+    \param index The index of the batch to process. Default is 0.
+    \param max_thread The maximum number of threads to use. Default is 16.
+    \param debug_print Whether to print debug information. Default is false.
+    \return A vector of bytes indicating whether each bitmask needs to be applied (not all-true).
+  */
+  static std::vector<uint8_t> BatchedFillNextTokenBitmask(
+      std::vector<GrammarMatcher>* matchers,
+      DLTensor* next_token_bitmask,
+      int index = 0,
+      int max_thread = 16,
+      bool debug_print = false
+  );
+
   XGRAMMAR_DEFINE_PIMPL_METHODS(GrammarMatcher);
 };
 

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -152,7 +152,7 @@ class GrammarMatcher {
     \return A vector of bytes indicating whether each bitmask needs to be applied (not all-true).
   */
   static std::vector<uint8_t> BatchedFillNextTokenBitmask(
-      const std::vector<GrammarMatcher*>& matchers,
+      std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
       int index = 0,
       int max_thread = 16,

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -149,14 +149,14 @@ class GrammarMatcher {
     \param indices The optional array of indices to specify which matcher corresponds to which slice
     of the bitmask tensor. If not provided, all matchers will write to the corresponding
     indices(matchers[i] to next_token_bitmask[i]).
-    \param max_thread The maximum number of threads to use. Default is 16.
+    \param max_threads The maximum number of threads to use. Default is 16.
     \param debug_print Whether to print debug information. Default is false.
   */
   static void BatchFillNextTokenBitmask(
       std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
       const std::optional<std::vector<int32_t>>& indices = std::nullopt,
-      int max_thread = 16,
+      int max_threads = 16,
       bool debug_print = false
   );
 

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -152,7 +152,7 @@ class GrammarMatcher {
     \return A vector of bytes indicating whether each bitmask needs to be applied (not all-true).
   */
   static std::vector<uint8_t> BatchedFillNextTokenBitmask(
-      std::vector<GrammarMatcher>* matchers,
+      std::vector<GrammarMatcher*>* matchers,
       DLTensor* next_token_bitmask,
       int index = 0,
       int max_thread = 16,

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -159,6 +159,32 @@ class GrammarMatcher {
       bool debug_print = false
   );
 
+  /*!
+   * \brief A batched version of AcceptString for better efficiency.
+   * \param matchers The array of GrammarMatcher objects.
+   * \param input_strs The array of input strings to be accepted.
+   * \param debug_print Whether to print debug information. Default is false.
+   * \return A vector of bytes indicating whether each string is accepted.
+   */
+  static std::vector<uint8_t> BatchedAcceptString(
+      std::vector<GrammarMatcher>* matchers,
+      const std::vector<std::string>& input_strs,
+      bool debug_print = false
+  );
+
+  /*!
+   * \brief A batched version of AcceptToken for better efficiency.
+   * \param matchers The array of GrammarMatcher objects.
+   * \param token_ids The array of token ids to be accepted.
+   * \param debug_print Whether to print debug information. Default is false.
+   * \return A vector of bytes indicating whether each token is accepted.
+   */
+  static std::vector<uint8_t> BatchedAcceptToken(
+      std::vector<GrammarMatcher>* matchers,
+      const std::vector<int32_t>& token_ids,
+      bool debug_print = false
+  );
+
   XGRAMMAR_DEFINE_PIMPL_METHODS(GrammarMatcher);
 };
 

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -143,6 +143,22 @@ class GrammarMatcher {
    */
   std::string _DebugPrintInternalState() const;
 
+  XGRAMMAR_DEFINE_PIMPL_METHODS(GrammarMatcher);
+};
+
+/*!
+ * \brief A batched version of GrammarMatcher for better efficiency. It supports batch processing
+ * of multiple GrammarMatcher objects in parallel.
+ *
+ * \details This class provides batched versions of the core methods of GrammarMatcher, including
+ * FillNextTokenBitmask, AcceptString, and AcceptToken. It utilizes multi-threading to process
+ * multiple GrammarMatcher objects simultaneously, significantly improving efficiency when dealing
+ * with a large number of matchers.
+ */
+class BatchGrammarMatcher {
+ public:
+  BatchGrammarMatcher(std::variant<std::string, int32_t> max_threads = "auto");
+
   /*!
     \brief A batched version of FillNextTokenBitmask for better efficiency.
     \param matchers The array of GrammarMatcher objects.
@@ -150,14 +166,12 @@ class GrammarMatcher {
     \param indices The optional array of indices to specify which matcher corresponds to which slice
     of the bitmask tensor. If not provided, all matchers will write to the corresponding
     indices(matchers[i] to next_token_bitmask[i]).
-    \param max_threads The maximum number of threads to use. Default is 16.
     \param debug_print Whether to print debug information. Default is false.
   */
-  static void BatchFillNextTokenBitmask(
+  void BatchFillNextTokenBitmask(
       std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
       const std::optional<std::vector<int32_t>>& indices = std::nullopt,
-      std::variant<int32_t, std::string> max_threads = 16,
       bool debug_print = false
   );
 
@@ -187,7 +201,7 @@ class GrammarMatcher {
       bool debug_print = false
   );
 
-  XGRAMMAR_DEFINE_PIMPL_METHODS(GrammarMatcher);
+  XGRAMMAR_DEFINE_PIMPL_METHODS(BatchGrammarMatcher);
 };
 
 }  // namespace xgrammar

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace xgrammar {
@@ -156,7 +157,7 @@ class GrammarMatcher {
       std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
       const std::optional<std::vector<int32_t>>& indices = std::nullopt,
-      int max_threads = 16,
+      std::variant<int32_t, std::string> max_threads = 16,
       bool debug_print = false
   );
 

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -147,7 +147,8 @@ class GrammarMatcher {
     \param matchers The array of GrammarMatcher objects.
     \param next_token_bitmask The pre-allocated DLTensor to store the result bitmasks.
     \param indices The optional array of indices to specify which matcher corresponds to which slice
-    of the bitmask tensor. If not provided, all matchers will write to the same slice (index 0).
+    of the bitmask tensor. If not provided, all matchers will write to the corresponding
+    indices(matchers[i] to next_token_bitmask[i]).
     \param max_thread The maximum number of threads to use. Default is 16.
     \param debug_print Whether to print debug information. Default is false.
   */

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -149,9 +149,8 @@ class GrammarMatcher {
     \param index The index of the batch to process. Default is 0.
     \param max_thread The maximum number of threads to use. Default is 16.
     \param debug_print Whether to print debug information. Default is false.
-    \return A vector of bytes indicating whether each bitmask needs to be applied (not all-true).
   */
-  static std::vector<uint8_t> BatchFillNextTokenBitmask(
+  static void BatchFillNextTokenBitmask(
       std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
       int index = 0,

--- a/python/xgrammar/__init__.py
+++ b/python/xgrammar/__init__.py
@@ -15,6 +15,7 @@ from .exception import (
 )
 from .grammar import Grammar, StructuralTagItem
 from .matcher import (
+    BatchGrammarMatcher,
     GrammarMatcher,
     allocate_token_bitmask,
     apply_token_bitmask_inplace,

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -404,8 +404,6 @@ class GrammarMatcher(XGRObject):
             Bitmask_batch_size could be larger than the actual batch size to allow padding.
             Bitmask_size equals to ceil(vocab_size/32), and could be computed through
             xgrammar.allocate_token_bitmask.
-
-
         indices : Optional[List[int]], default: None
             A list of indices to specify which rows in the bitmask to fill. If None, fill
             the bitmask [0:len(matchers))].

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -499,6 +499,15 @@ class GrammarMatcher(XGRObject):
         strings : List[str]
             The list of tokens to accept.
 
+        debug_print : bool, default: False
+            Whether to print information about generated bitmask. Helpful for debugging.
+
+        Returns
+        -------
+        accepted : List[bool]
+            A list of booleans indicating whether each string was accepted by its corresponding matcher.
+
+        Raises
         ------
         RuntimeError
             If the sizes of matchers and strings do not match.

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -443,8 +443,10 @@ class GrammarMatcher(XGRObject):
 
             If the recursion depth is exceeded.
         """
+        matcher_handles = [matcher._handle for matcher in matchers]
+
         return _core.GrammarMatcher.batched_fill_next_token_bitmask(
-            matchers, bitmask, index, max_threads, debug_print
+            matcher_handles, bitmask, index, max_threads, debug_print
         )
 
     @staticmethod

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -249,11 +249,6 @@ class GrammarMatcher(XGRObject):
         -------
         accepted : bool
             Whether the token is accepted.
-
-        Raises
-        ------
-        RuntimeError
-            If the recursion depth is exceeded.
         """
         return self._handle.accept_token(token_id, debug_print)
 
@@ -275,11 +270,6 @@ class GrammarMatcher(XGRObject):
         -------
         accepted : bool
             Whether the string is accepted.
-
-        Raises
-        ------
-        RuntimeError
-            If the recursion depth is exceeded.
         """
         return self._handle.accept_string(input_str, debug_print)
 
@@ -314,8 +304,6 @@ class GrammarMatcher(XGRObject):
         ------
         RuntimeError
             If the bitmask is invalid (not on CPU, not int32, shape mismatch).
-
-            If the recursion depth is exceeded.
         """
         return self._handle.fill_next_token_bitmask(bitmask, index, debug_print)
 
@@ -330,11 +318,6 @@ class GrammarMatcher(XGRObject):
         -------
         jump_forward_string : str
             The jump-forward string.
-
-        Raises
-        ------
-        RuntimeError
-            If the recursion depth is exceeded.
         """
         return self._handle.find_jump_forward_string()
 
@@ -445,8 +428,6 @@ class GrammarMatcher(XGRObject):
         ------
         RuntimeError
             If the bitmask is invalid (not on CPU, not int32, shape mismatch).
-
-            If the recursion depth is exceeded.
         """
         matcher_handles = [matcher._handle for matcher in matchers]
 
@@ -486,7 +467,9 @@ class GrammarMatcher(XGRObject):
 
     @staticmethod
     def batch_accept_string(
-        matchers: List["GrammarMatcher"], strings: List[str], debug_print: bool = False
+        matchers: List["GrammarMatcher"],
+        strings: List[Union[str, bytes]],
+        debug_print: bool = False,
     ) -> List[bool]:
         """Accept a batch of strings for multiple matchers.
 
@@ -495,8 +478,8 @@ class GrammarMatcher(XGRObject):
         matchers : List[GrammarMatcher]
             The list of matchers to accept tokens for.
 
-        strings : List[str]
-            The list of tokens to accept.
+        strings : List[Union[str, bytes]]
+            The list of strings to accept.
 
         debug_print : bool, default: False
             Whether to print information about generated bitmask. Helpful for debugging.

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -458,7 +458,18 @@ class GrammarMatcher(XGRObject):
 
         tokens : List[int]
             The list of tokens to accept.
+
+                    Raises
+        ------
+        RuntimeError
+            If the sizes of matchers and tokens do not match.
         """
+        if len(matchers) != len(tokens):
+            raise RuntimeError(
+                "The sizes of matchers and tokens do not match. "
+                + f"Got {len(matchers)} matchers and {len(tokens)} tokens."
+            )
+
         accept_token = []
         for matcher, token in zip(matchers, tokens):
             accept_token.append(matcher.accept_token(token))
@@ -475,8 +486,17 @@ class GrammarMatcher(XGRObject):
 
         strings : List[str]
             The list of tokens to accept.
+
+        ------
+        RuntimeError
+            If the sizes of matchers and strings do not match.
         """
+        if len(matchers) != len(strings):
+            raise RuntimeError(
+                "The sizes of matchers and strings do not match. "
+                + f"Got {len(matchers)} matchers and {len(strings)} strings."
+            )
         accept_string = []
-        for matcher, token in zip(matchers, strings):
-            accept_string.append(matcher.accept_string(token))
+        for matcher, string in zip(matchers, strings):
+            accept_string.append(matcher.accept_string(string))
         return accept_string

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -450,7 +450,9 @@ class GrammarMatcher(XGRObject):
         )
 
     @staticmethod
-    def batched_accept_token(matchers: List["GrammarMatcher"], tokens: List[int]) -> List[bool]:
+    def batched_accept_token(
+        matchers: List["GrammarMatcher"], tokens: List[int], debug_print: bool = False
+    ) -> List[bool]:
         """Accept a batch of tokens for multiple matchers.
 
         Parameters
@@ -461,7 +463,15 @@ class GrammarMatcher(XGRObject):
         tokens : List[int]
             The list of tokens to accept.
 
-                    Raises
+        debug_print : bool, default: False
+            Whether to print information about generated bitmask. Helpful for debugging.
+
+        Returns
+        -------
+        accepted : List[bool]
+            A list of booleans indicating whether each token was accepted by its corresponding matcher.
+
+        Raises
         ------
         RuntimeError
             If the sizes of matchers and tokens do not match.
@@ -472,13 +482,13 @@ class GrammarMatcher(XGRObject):
                 + f"Got {len(matchers)} matchers and {len(tokens)} tokens."
             )
 
-        accept_token = []
-        for matcher, token in zip(matchers, tokens):
-            accept_token.append(matcher.accept_token(token))
-        return accept_token
+        matcher_handles = [matcher._handle for matcher in matchers]
+        return _core.GrammarMatcher.batched_accept_token(matcher_handles, tokens, debug_print)
 
     @staticmethod
-    def batched_accept_string(matchers: List["GrammarMatcher"], strings: List[str]) -> List[bool]:
+    def batched_accept_string(
+        matchers: List["GrammarMatcher"], strings: List[str], debug_print: bool = False
+    ) -> List[bool]:
         """Accept a batch of strings for multiple matchers.
 
         Parameters
@@ -498,7 +508,5 @@ class GrammarMatcher(XGRObject):
                 "The sizes of matchers and strings do not match. "
                 + f"Got {len(matchers)} matchers and {len(strings)} strings."
             )
-        accept_string = []
-        for matcher, string in zip(matchers, strings):
-            accept_string.append(matcher.accept_string(string))
-        return accept_string
+        matcher_handles = [matcher._handle for matcher in matchers]
+        return _core.GrammarMatcher.batched_accept_string(matcher_handles, strings, debug_print)

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -400,3 +400,37 @@ class GrammarMatcher(XGRObject):
             The internal state of the matcher.
         """
         return self._handle._debug_print_internal_state()
+
+
+def batched_accept_token(matchers: List[GrammarMatcher], tokens: List[int]) -> None:
+    """Accept a batch of tokens for multiple matchers.
+
+    Parameters
+    ----------
+    matchers : List[GrammarMatcher]
+        The list of matchers to accept tokens for.
+
+    tokens : List[int]
+        The list of tokens to accept.
+    """
+    for matcher, token in zip(matchers, tokens):
+        matcher.accept_token(token)
+
+
+def batched_fill_next_token_bitmask(
+    matchers: List[GrammarMatcher], bitmask: ArrayLike, max_threads: int = 16
+) -> None:
+    """Fill the next token bitmask for multiple matchers.
+
+    Parameters
+    ----------
+    matchers : List[GrammarMatcher]
+        The list of matchers to fill the bitmask for.
+
+    bitmask : ArrayLike
+        The bitmask to fill.
+
+    max_threads : int, default: 16
+        The maximum number of threads to use for filling the bitmask.
+    """
+    pass

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -416,13 +416,6 @@ class GrammarMatcher(XGRObject):
 
         debug_print : bool, default: False
             Whether to print information about generated bitmask. Helpful for debugging.
-                    Returns
-
-        Returns
-        -------
-        need_apply : List[bool]
-            Whether the bitmask need to be applied (not all-true). An optimization: if False,
-            this means the bitmask is already all-true, so no need to apply it.
 
         Raises
         ------
@@ -431,7 +424,7 @@ class GrammarMatcher(XGRObject):
         """
         matcher_handles = [matcher._handle for matcher in matchers]
 
-        return _core.GrammarMatcher.batch_fill_next_token_bitmask(
+        _core.GrammarMatcher.batch_fill_next_token_bitmask(
             matcher_handles, bitmask, indices, max_threads, debug_print
         )
 

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -443,8 +443,8 @@ class GrammarMatcher(XGRObject):
 
             If the recursion depth is exceeded.
         """
-        return GrammarMatcher._create_from_handle(
-            _core.batched_fill_next_token_mask(matchers, bitmask, index, max_threads, debug_print)
+        return _core.GrammarMatcher.batched_fill_next_token_bitmask(
+            matchers, bitmask, index, max_threads, debug_print
         )
 
     @staticmethod

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -1,6 +1,7 @@
 """Test the basic functionality of GrammarMatcher."""
 
 import math
+import random
 import sys
 from typing import List, Optional, Union
 
@@ -560,6 +561,40 @@ def test_batch_fill_next_token_bitmask_pressure_single_thread():
     for i in range(len(matchers)):
         rejected_token_ids = _get_masked_tokens_from_bitmask(
             bitmask_2d[i], tokenizer_info.vocab_size
+        )
+        assert len(rejected_token_ids) == rejected_token_size[i], (
+            i,
+            len(rejected_token_ids),
+            rejected_token_size[i],
+        )
+
+
+@pytest.mark.hf_token_required
+def test_batch_fill_next_token_bitmask_pressure_shuffled():
+    tokenizer_path = "meta-llama/Llama-2-7b-chat-hf"
+    input_str = '{"id": 1,"name": "Example"}'
+    rejected_token_size = [
+        # fmt: off
+            31989, 31912, 270, 270, 270, 31973, 31846, 31846, 31948, 31915, 270, 270, 270, 270,
+            270, 31973, 31846, 31846, 263, 263, 263, 263, 263, 263, 263, 263, 31974, 31999,
+        # fmt: on
+    ]
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_fast=True, trust_remote_code=True)
+    tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
+    matchers = [
+        _get_matcher_from_grammar_and_tokenizer_info(json_grammar, tokenizer_info)
+        for _ in range(len(input_str) + 1)
+    ]
+    input_strs = [input_str[:i] for i in range(len(input_str))] + [input_str]
+    xgr.GrammarMatcher.batch_accept_string(matchers, input_strs)
+
+    shuffled_indices = [i for i in range(len(matchers))]
+    random.shuffle(shuffled_indices)
+    bitmask_2d = xgr.allocate_token_bitmask(len(matchers), tokenizer_info.vocab_size)
+    xgr.GrammarMatcher.batch_fill_next_token_bitmask(matchers, bitmask_2d, shuffled_indices)
+    for i in range(len(matchers)):
+        rejected_token_ids = _get_masked_tokens_from_bitmask(
+            bitmask_2d[shuffled_indices[i]], tokenizer_info.vocab_size
         )
         assert len(rejected_token_ids) == rejected_token_size[i], (
             i,

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -575,7 +575,7 @@ def test_batched_fill_next_token_bitmask_pressure():
         _get_matcher_from_grammar_and_tokenizer_info(json_grammar, tokenizer_info)
         for _ in range(len(input_str) + 1)
     ]
-    input_strs = list(input_str[:i] for i in range(len(input_str))) + [input_str]
+    input_strs = [input_str[:i] for i in range(len(input_str))] + [input_str]
     xgr.GrammarMatcher.batched_accept_string(matchers, input_strs)
 
     bitmask_2d = xgr.allocate_token_bitmask(len(matchers), tokenizer_info.vocab_size)
@@ -620,7 +620,7 @@ def test_batched_fill_next_token_bitmask_pressure_single_thread():
         _get_matcher_from_grammar_and_tokenizer_info(json_grammar, tokenizer_info)
         for _ in range(len(input_str) + 1)
     ]
-    input_strs = list(input_str[:i] for i in range(len(input_str))) + [input_str]
+    input_strs = [input_str[:i] for i in range(len(input_str))] + [input_str]
     xgr.GrammarMatcher.batched_accept_string(matchers, input_strs)
 
     bitmask_2d = xgr.allocate_token_bitmask(len(matchers), tokenizer_info.vocab_size)

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -604,5 +604,50 @@ def test_batched_fill_next_token_bitmask_pressure():
         )
 
 
+@pytest.mark.hf_token_required
+def test_batched_fill_next_token_bitmask_pressure_single_thread():
+    tokenizer_path = "meta-llama/Llama-2-7b-chat-hf"
+    input_str = '{"id": 1,"name": "Example"}'
+    rejected_token_size = [
+        # fmt: off
+            31989, 31912, 270, 270, 270, 31973, 31846, 31846, 31948, 31915, 270, 270, 270, 270,
+            270, 31973, 31846, 31846, 263, 263, 263, 263, 263, 263, 263, 263, 31974, 31999,
+        # fmt: on
+    ]
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_fast=True, trust_remote_code=True)
+    tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
+    matchers = [
+        _get_matcher_from_grammar_and_tokenizer_info(json_grammar, tokenizer_info)
+        for _ in range(len(input_str) + 1)
+    ]
+    input_strs = list(input_str[:i] for i in range(len(input_str))) + [input_str]
+    xgr.GrammarMatcher.batched_accept_string(matchers, input_strs)
+
+    bitmask_2d = xgr.allocate_token_bitmask(len(matchers), tokenizer_info.vocab_size)
+    xgr.GrammarMatcher.batched_fill_next_token_bitmask(matchers, bitmask_2d, max_threads=1)
+    for i in range(len(matchers)):
+        rejected_token_ids = _get_masked_tokens_from_bitmask(
+            bitmask_2d[i], tokenizer_info.vocab_size
+        )
+        assert len(rejected_token_ids) == rejected_token_size[i], (
+            i,
+            len(rejected_token_ids),
+            rejected_token_size[i],
+        )
+
+    bitmask_3d = xgr.allocate_token_bitmask(len(matchers) * 2, tokenizer_info.vocab_size)
+    bitmask_3d = bitmask_3d.view(len(matchers), 2, -1)
+    xgr.GrammarMatcher.batched_fill_next_token_bitmask(matchers, bitmask_3d, max_threads=2, index=1)
+    for i in range(len(matchers)):
+        rejected_token_ids = _get_masked_tokens_from_bitmask(
+            bitmask_3d[i][1], tokenizer_info.vocab_size
+        )
+        assert len(rejected_token_ids) == rejected_token_size[i], (
+            i,
+            len(rejected_token_ids),
+            rejected_token_size[i],
+        )
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -588,7 +588,7 @@ def test_batch_fill_next_token_bitmask_pressure_shuffled():
     input_strs = [input_str[:i] for i in range(len(input_str))] + [input_str]
     xgr.GrammarMatcher.batch_accept_string(matchers, input_strs)
 
-    shuffled_indices = [i for i in range(len(matchers))]
+    shuffled_indices = list(range(len(matchers)))
     random.shuffle(shuffled_indices)
     bitmask_2d = xgr.allocate_token_bitmask(len(matchers), tokenizer_info.vocab_size)
     xgr.GrammarMatcher.batch_fill_next_token_bitmask(matchers, bitmask_2d, shuffled_indices)

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -397,7 +397,7 @@ def test_fill_next_token_bitmask_errors():
 
 
 test_batch_accept_string_grammars_inputs_expecteds = [
-    (['root ::= "a"', "root ::= [0-9]+", 'root ::= "ab"'], ["a", "123", "ab"], [True, True, True]),
+    (['root ::= "a"', "root ::= [0-9]+", 'root ::= "ab"'], ["a", b"123", "ab"], [True, True, True]),
     (
         ['root ::= "a"', "root ::= [0-9]+", 'root ::= "ab"'],
         ["b", "123a", "d"],
@@ -405,18 +405,25 @@ test_batch_accept_string_grammars_inputs_expecteds = [
     ),
     (
         ['root ::= "a"', "root ::= [0-9]+", 'root ::= "ab"'],
-        ["a", "123a", "ab"],
+        ["a", b"123a", b"ab"],
         [True, False, True],
     ),
     (['root ::= "a"'], ["a"], [True]),
     (['root ::= "a"'], ["b"], [False]),
+    (
+        ['root ::= "你好"', 'root ::= "こんにちは"', 'root ::= "안녕하세요"'],
+        ["你好", "こんにちは", "안녕하세요"],
+        [True, True, True],
+    ),
 ]
 
 
 @pytest.mark.parametrize(
     "grammars, inputs, expecteds", test_batch_accept_string_grammars_inputs_expecteds
 )
-def test_batch_accept_string(grammars: List[str], inputs: List[str], expecteds: List[bool]):
+def test_batch_accept_string(
+    grammars: List[str], inputs: List[Union[str, bytes]], expecteds: List[bool]
+):
     matchers = [_get_matcher_from_grammar(grammar) for grammar in grammars]
     results = xgr.GrammarMatcher.batch_accept_string(matchers, inputs)
     assert results == expecteds

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -454,7 +454,7 @@ def test_batched_fill_next_token_bitmask():
     grammars = ['root ::= "a"', "root ::= [0-9]+", 'root ::= "ab"', "root ::= [a-z0-9]+"]
     vocab = [
         # fmt: off
-        "<s>", "</s>", "a", "b", "c", "1", "2", "3", "123a", "ab",
+        "ab", "</s>", "a", "b", "c", "1", "2", "3", "123a"
         # fmt: on
     ]
     tokenizer_info = xgr.TokenizerInfo(vocab)
@@ -470,9 +470,25 @@ def test_batched_fill_next_token_bitmask():
     input_str = ["a", "1", "a", "123a"]
 
     expected_accepted_tokens = [
-        [[2], [5, 6, 7], [2, 9], [2, 3, 4, 5, 6, 7, 8, 9]],
-        [[1], [1, 5, 6, 7], [3], [1, 2, 3, 4, 5, 6, 7, 8, 9]],
+        [[2], [5, 6, 7], [0, 2], [0, 2, 3, 4, 5, 6, 7, 8]],
+        [[1], [1, 5, 6, 7], [3], [0, 1, 2, 3, 4, 5, 6, 7, 8]],
     ]
+
+    result = xgr.GrammarMatcher.batched_fill_next_token_bitmask(
+        matchers, token_bitmask, max_threads=2
+    )
+
+    assert result == [True, True, True, True]
+
+    for i in range(batch_size):
+        rejected_token_ids = _get_masked_tokens_from_bitmask(
+            token_bitmask[i : i + 1], tokenizer_info.vocab_size
+        )
+        accepted = list(set(range(len(vocab))) - set(rejected_token_ids))
+        accepted.sort()
+        assert accepted == expected_accepted_tokens[0][i]
+
+    assert xgr.GrammarMatcher.batched_accept_string(matchers, input_str) == [True, True, True, True]
 
     result = xgr.GrammarMatcher.batched_fill_next_token_bitmask(
         matchers, token_bitmask, max_threads=2
@@ -484,16 +500,7 @@ def test_batched_fill_next_token_bitmask():
             token_bitmask[i : i + 1], tokenizer_info.vocab_size
         )
         accepted = list(set(range(len(vocab))) - set(rejected_token_ids))
-        assert accepted == expected_accepted_tokens[0][i]
-
-    assert xgr.GrammarMatcher.batched_accept_string(matchers, input_str) == [True, True, True, True]
-    assert result == [True, True, True, False]
-
-    for i in range(batch_size):
-        rejected_token_ids = _get_masked_tokens_from_bitmask(
-            token_bitmask[i : i + 1], tokenizer_info.vocab_size
-        )
-        accepted = list(set(range(len(vocab))) - set(rejected_token_ids))
+        accepted.sort()
         assert accepted == expected_accepted_tokens[1][i]
 
 


### PR DESCRIPTION
This PR provides a series of methods to batched fill next token mask and batched accept string/token for `GrammarMatcher`. In general, there are three new methods:
- `batch_fill_next_token_bitmask(matchers: List["GrammarMatcher"], bitmask: ArrayLike, index: int = 0, max_threads: int = 16, debug_print: bool = False)`
- `batch_accept_string(matchers: List["GrammarMatcher"], strings: List[str], debug_print: bool = False)`
- `batch_accept_token(matchers: List["GrammarMatcher"], tokens: List[int], debug_print: bool = False)`

These methods allow users to fill multiple `GrammarMatcher`s' token masks in a batch, and reduce the overhead of the transversion between cpp and python.