### PR TITLE
[Feature] support openGPT-x tokenizer.

### DIFF
--- a/python/xgrammar/tokenizer_info.py
+++ b/python/xgrammar/tokenizer_info.py
@@ -139,6 +139,7 @@ class TokenizerInfo(XGRObject):
             and hasattr(tokenizer.tokenizer, "sp_model")
             and isinstance(tokenizer.tokenizer.sp_model, sentencepiece.SentencePieceProcessor)
         ) or (
+            # Support Teuken-7B-instruct-v0.6
             hasattr(tokenizer, "tok")
             and isinstance(tokenizer.tok, sentencepiece.SentencePieceProcessor)
         )

--- a/python/xgrammar/tokenizer_info.py
+++ b/python/xgrammar/tokenizer_info.py
@@ -138,6 +138,9 @@ class TokenizerInfo(XGRObject):
             hasattr(tokenizer, "tokenizer")
             and hasattr(tokenizer.tokenizer, "sp_model")
             and isinstance(tokenizer.tokenizer.sp_model, sentencepiece.SentencePieceProcessor)
+        ) or (
+            hasattr(tokenizer, "tok")
+            and isinstance(tokenizer.tok, sentencepiece.SentencePieceProcessor)
         )
 
         return has_sp_model_attr or has_nested_sp_model_attr
@@ -273,6 +276,8 @@ class TokenizerInfo(XGRObject):
                 sp_model = tokenizer.sp_model
             elif hasattr(tokenizer, "tokenizer") and hasattr(tokenizer.tokenizer, "sp_model"):
                 sp_model = tokenizer.tokenizer.sp_model
+            elif hasattr(tokenizer, "tok"):
+                sp_model = tokenizer.tok
 
             if stop_token_ids is None:
                 if hasattr(tokenizer, "eos_token_id") and tokenizer.eos_token_id is not None:

--- a/tests/python/test_tokenizer_info.py
+++ b/tests/python/test_tokenizer_info.py
@@ -45,6 +45,7 @@ tokenizer_path__vocab_type__prepend_space = [
     ("deepseek-ai/DeepSeek-R1", xgr.VocabType.BYTE_LEVEL, False),
     ("deepseek-ai/DeepSeek-R1-Distill-Qwen-7B", xgr.VocabType.BYTE_LEVEL, False),
     ("deepseek-ai/DeepSeek-R1-Distill-Llama-8B", xgr.VocabType.BYTE_LEVEL, False),
+    ("openGPT-X/Teuken-7B-instruct-v0.6", xgr.VocabType.BYTE_FALLBACK, True),
 ]
 
 tokenizer_paths = [path for path, *_ in tokenizer_path__vocab_type__prepend_space]


### PR DESCRIPTION
As reported in #444, this PR supported openGPT-x's tokenizer.
openGPT-x's tokenizer is a sentence piece tokenizer, but it uses a unusual method to intialize its SentencePieceProcessor: `self.tok`. This PR supports this situation.