### PR TITLE
fix: argument in overload needs to be positional

### DIFF
--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -281,7 +281,7 @@ class GrammarCompiler(XGRObject):
 
     @overload
     def compile_grammar(
-        self, ebnf_string: str, *, root_rule_name: str = "root"
+        self, ebnf_string: str, /, *, root_rule_name: str = "root"
     ) -> CompiledGrammar: ...
 
     @overload


### PR DESCRIPTION
The first `overload` for `GrammarCompiler.compile_grammar` indicates that passing a keyword argument `ebnf_string` is allowed. This is not the case as the actual implementation only accepts the `grammar` keyword.  
Changed the first `overload` to only accept a positional first argument.