### PR TITLE
[Feature] Provide more detailed debug print information in AcceptString and AcceptToken.

### DIFF
--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -276,20 +276,24 @@ class EarleyParser {
 
   /*!
    * \brief The completion operation of the Earley parser.
+   * \param state The state to be completed.
+   * \param debug_print Whether to print the debug information.
    * \details The reason is that if the state can't be scanned, then
    * add it into the next states is useless. Moreover, the end
    * of the grammar is used to check if the grammar is completed,
    * so it should be added into the next states.
    */
-  void Complete(const ParserState& state);
+  void Complete(const ParserState& state, bool debug_print = false);
 
   /*!
    * \brief The prediction operation of the Earley parser.
+   * \param state The state to be predicted.
+   * \param debug_print Whether to print the debug information.
    * \return First: If the state scanable, or the state is the end of the grammar,
    * then return true, otherwise return false.
    * \return Second: If the state is completable, then return true, otherwise return false.
    */
-  std::pair<bool, bool> Predict(const ParserState& state);
+  std::pair<bool, bool> Predict(const ParserState& state, bool debug_print = false);
 
   /*!
    * \brief Handle the unexpanded rule, used for pushing initial state.
@@ -307,16 +311,21 @@ class EarleyParser {
    * \param grammar_expr The grammar expression to be expanded.
    * \param sub_grammar_expr The sub grammar expression to be expanded, especially
    * when the rule is a kSequence, and the sub rule is a kRuleRef.
+   * \param debug_print Whether to print the debug information.
    */
   void ExpandNextRuleRefElement(
-      const ParserState& state, const GrammarExpr& grammar_expr, const GrammarExpr* sub_grammar_expr
+      const ParserState& state,
+      const GrammarExpr& grammar_expr,
+      const GrammarExpr* sub_grammar_expr,
+      bool debug_print = false
   );
 
   /*!
    * \brief Expand the rule, used for RuleRef and kTagDispatch.
    * \param state The state to be expanded, and it's should be on the FSM.
+   * \param debug_print Whether to print the debug information.
    */
-  void ExpandNextRuleRefElementOnFSM(const ParserState& state);
+  void ExpandNextRuleRefElementOnFSM(const ParserState& state, bool debug_print = false);
 
   /*!
    * \brief Advance the parser to the next state, with the sub sequence is kCharacterClass.
@@ -396,10 +405,11 @@ class EarleyParser {
   /*!
    * \brief From the current states, advance to the next state.
    * \param ch The character to be advanced.
+   * \param debug_print Whether to print the debug information.
    * \return True if the character is accepted, false otherwise.
    * \note If the character isn't accepted, then the states won't be changed.
    */
-  bool Advance(const uint8_t ch);
+  bool Advance(const uint8_t ch, bool debug_print = false);
 
   /*!
    * \brief Remove the newly added states.

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -411,7 +411,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   const auto& token = tokenizer_info_.GetDecodedVocab()[token_id];
   int pos = 0;
   for (auto char_value : token) {
-    if (!Advance(char_value)) {
+    if (!Advance(char_value, debug_print)) {
       if (debug_print) {
         XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<" << EscapeString(token)
                            << "> rejected at position " << pos << ", char "
@@ -447,7 +447,7 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
 
   int accepted_cnt = 0;
   for (auto char_value : input_str) {
-    if (!Advance(char_value)) {
+    if (!Advance(char_value, debug_print)) {
       if (debug_print) {
         XGRAMMAR_LOG(INFO) << "String \"" << EscapeString(input_str) << "\" is rejected at "
                            << "position " << accepted_cnt << ", char " << EscapeString(char_value);


### PR DESCRIPTION
As reported in #443, it may be hard to understand the prediction and completion relationship in the Earley parser. This PR provides more detailed informations for developers and users to check the states in the Earley parser. 

This is the comparison between the main branch and this PR(left: this PR, right: main branch).
<img width="2880" height="1620" alt="3979b53add5743a69d8337218aa6ca87" src="https://github.com/user-attachments/assets/2d59e29e-eeee-4576-b1fc-883422b5b993" />
