### PR TITLE
[test] Add a build test for Web-XGrammar.

### DIFF
--- a/.github/workflows/build_web_xgrammar.yaml
+++ b/.github/workflows/build_web_xgrammar.yaml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-  # branches:
-  #   - main
+  branches:
+    - main
 
 jobs:
   build:
@@ -31,6 +31,7 @@ jobs:
           npm install
           npm run build
 
+    # TODO(Linzhang): Tests will fail currently. Need further maintenance.
     # - name: Run tests
     #   run: |
     #     cd web


### PR DESCRIPTION
As mentioned in #456, this PR adds a new workflow to test the build of Web-XGrammar. This PR should be merged after #456. At current, tests for Web-XGrammar will fail, and it may need further maintenance in the future.