### PR TITLE
[CI] Add a ci to run unit tests every day.

### DIFF
--- a/.github/workflows/routine_unit_test.yaml
+++ b/.github/workflows/routine_unit_test.yaml
@@ -1,0 +1,65 @@
+name: Routine Unit Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  run_unit_test:
+    if: github.ref == 'refs/heads/main'
+    name: Run unit tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-14, macos-15-intel]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        exclude:
+          - os: macos-15-intel
+            python: '3.13'
+            # The reason for the exclusion is that pytorch distribution
+            # can't be found by pip on macos-15-intel with python 3.13.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Cache huggingface
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/huggingface
+          key: huggingface-${{ matrix.os }}-python-${{ matrix.python }}
+
+      - name: Build xgrammar from source
+        run: |
+          echo "set(XGRAMMAR_BUILD_CXX_TESTS ON)" >> cmake/config.cmake
+          echo "set(XGRAMMAR_ENABLE_INTERNAL_CHECK ON)" >> cmake/config.cmake
+          python -m pip install --upgrade pip
+          pip install -v ".[test]"
+
+      - name: Run C++ tests
+        run: |
+          ctest --test-dir build -V --timeout 30 --stop-on-failure
+
+      - name: Run Python tests
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_HUB_DOWNLOAD_TIMEOUT: 60
+        if: env.HF_TOKEN != ''
+        run: |
+          pytest
+
+      - name: Run Python tests without HF_TOKEN
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        if: env.HF_TOKEN == ''
+        run: |
+          pytest -m "not hf_token_required"


### PR DESCRIPTION
CI will fail caused to the request limits of HuggingFace. Although we have cached the data we need, GitHub's cache will expire after 7 days. This PR adds a CI to run the unit tests every day. With the CI, we can:
- Flush the expiration date of the cache.
- Find the potential dependency problem as soon as possible.