### PR TITLE
[BugFix] Fix error `TypeError: apply_token_bitmask_inplace_cpu(): incompatible function arguments`

### DIFF
--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_cpu.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_cpu.py
@@ -41,6 +41,12 @@ def apply_token_bitmask_inplace_cpu(
 
     vocab_size = min(logits.shape[-1], bitmask.shape[-1] * 32) if vocab_size is None else vocab_size
 
+    indices_list = None
+    if indices is not None:
+        if isinstance(indices, torch.Tensor):
+            indices_list = indices.tolist()
+        elif isinstance(indices, list):
+            indices_list = indices
     if logits.dtype == torch.float32:
         _core.kernels.apply_token_bitmask_inplace_cpu(
             logits.data_ptr(),
@@ -50,7 +56,7 @@ def apply_token_bitmask_inplace_cpu(
             bitmask_shape,
             bitmask_stride,
             vocab_size,
-            indices,
+            indices_list,
             "float32",
         )
     elif logits.dtype == torch.bfloat16:
@@ -62,7 +68,7 @@ def apply_token_bitmask_inplace_cpu(
             bitmask_shape,
             bitmask_stride,
             vocab_size,
-            indices,
+            indices_list,
             "bfloat16",
         )
     elif logits.dtype == torch.float16:
@@ -74,7 +80,7 @@ def apply_token_bitmask_inplace_cpu(
             bitmask_shape,
             bitmask_stride,
             vocab_size,
-            indices,
+            indices_list,
             "float16",
         )
     else:


### PR DESCRIPTION
### Related Issue
https://github.com/mlc-ai/xgrammar/issues/506

### Bug Description
The `indices` parameter in `apply_token_bitmask_inplace_cpu` was passed incorrectly as a `torch.Tensor`, but it was expected to be a `List[int]`

```
(EngineCore_DP0 pid=79130) TypeError: apply_token_bitmask_inplace_cpu(): incompatible function arguments. The following argument types are supported:
(EngineCore_DP0 pid=79130)     1. apply_token_bitmask_inplace_cpu(logits_ptr: int, logits_shape: tuple[int, int], logits_strides: tuple[int, int], bitmask_ptr: int, bitmask_shape: tuple[int, int], bitmask_strides: tuple[int, int], vocab_size: int, indices: collections.abc.Sequence[int] | None, logit_type: str) -> None
(EngineCore_DP0 pid=79130)
(EngineCore_DP0 pid=79130) Invoked with types: int, tuple, tuple, int, tuple, tuple, int, torch.Tensor, str
```

### Cause Summary
Although the interface supports a union `List[int]` and `torch.Tensor` in `xgrammar`

![Image](https://github.com/user-attachments/assets/f32110cd-0463-4dc1-b3a3-fc714acd720c)

The actual implementation only supports `List[int]`

![Image](https://github.com/user-attachments/assets/c106dea5-acda-4378-bb79-3685d1438537)
