### PR TITLE
chore: update cibuildwheel to build more wheels.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ else()
     )
   else()
     set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -Wno-pedantic -Wno-unused-parameter \
--Woverloaded-virtual -flto=auto ${CMAKE_CXX_FLAGS}"
+-Woverloaded-virtual ${CMAKE_CXX_FLAGS}"
     )
   endif()
 endif()

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -195,8 +195,7 @@ Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
     );
   }
   // here introduces a serialization/deserialization overhead; try to avoid it in the future.
-  auto result = json_schema_it->second.serialize(false);
-  return ResultOk<JSONSchemaFormat>(std::move(result));
+  return ResultOk<JSONSchemaFormat>(json_schema_it->second.serialize(false));
 }
 
 Result<QwenXmlParameterFormat, ISTError> StructuralTagParser::ParseQwenXmlParameterFormat(
@@ -211,8 +210,7 @@ Result<QwenXmlParameterFormat, ISTError> StructuralTagParser::ParseQwenXmlParame
     );
   }
   // here introduces a serialization/deserialization overhead; try to avoid it in the future.
-  auto result = json_schema_it->second.serialize(false);
-  return ResultOk<QwenXmlParameterFormat>(std::move(result));
+  return ResultOk<QwenXmlParameterFormat>(json_schema_it->second.serialize(false));
 }
 
 Result<AnyTextFormat, ISTError> StructuralTagParser::ParseAnyTextFormat(const picojson::object& obj


### PR DESCRIPTION
As reported in #488, this PR updates the version of cibuildwheel. Now we can build more wheels. Moreover, gcc-14 will report false positives, so the lto should be switched off.

```
  FAILED: [code=1] cpp/nanobind/xgrammar/xgrammar_bindings.cpython-39-aarch64-linux-gnu.so 
  : && /opt/rh/gcc-toolset-14/root/usr/bin/g++  -pthread -fPIC -Wall -Wextra -Werror -Wno-pedantic -Wno-unused-parameter -Woverloaded-virtual -flto=auto -O3  -O2 -g -DNDEBUG  -shared -Wl,--gc-sections -Wl,--dependency-file=cpp/nanobind/CMakeFiles/xgrammar_bindings.dir/link.d  -o cpp/nanobind/xgrammar/xgrammar_bindings.cpython-39-aarch64-linux-gnu.so cpp/nanobind/CMakeFiles/xgrammar_bindings.dir/nanobind.cc.o  cpp/nanobind/libnanobind-static.a  cpp/nanobind/libpython_methods.a  libxgrammar.a && :
  In member function ‘deallocate’,
      inlined from ‘deallocate’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/alloc_traits.h:550:23,
      inlined from ‘_M_destroy’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/basic_string.h:294:34,
      inlined from ‘_M_dispose’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/basic_string.h:288:14,
      inlined from ‘_M_dispose’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/basic_string.h:285:7,
      inlined from ‘__dt_base ’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/basic_string.h:809:19,
      inlined from ‘ParseJSONSchemaFormat’ at /project/cpp/structural_tag.cc:198:59:
  /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/new_allocator.h:172:33: error: ‘operator delete’ called on unallocated object ‘<anonymous>’ [-Werror=free-nonheap-object]
    172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
        |                                 ^
  /project/cpp/structural_tag.cc: In member function ‘ParseJSONSchemaFormat’:
  /project/cpp/structural_tag.cc:198:59: note: declared here
    198 |   JSONSchemaFormat result(json_schema_it->second.serialize(false));
        |                                                           ^
  In member function ‘deallocate’,
      inlined from ‘deallocate’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/alloc_traits.h:550:23,
      inlined from ‘_M_destroy’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/basic_string.h:294:34,
      inlined from ‘_M_dispose’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/basic_string.h:288:14,
      inlined from ‘_M_dispose’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/basic_string.h:285:7,
      inlined from ‘__dt_base ’ at /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/basic_string.h:809:19,
      inlined from ‘ParseQwenXmlParameterFormat’ at /project/cpp/structural_tag.cc:214:65:
  /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/new_allocator.h:172:33: error: ‘operator delete’ called on unallocated object ‘<anonymous>’ [-Werror=free-nonheap-object]
    172 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
        |                                 ^
  /project/cpp/structural_tag.cc: In member function ‘ParseQwenXmlParameterFormat’:
  /project/cpp/structural_tag.cc:214:65: note: declared here
    214 |   QwenXmlParameterFormat result(json_schema_it->second.serialize(false));
        |                                                                 ^
  lto1: all warnings being treated as errors
  make: *** [/tmp/cc6FWz5Q.mk:44: /tmp/ccMizhcM.ltrans14.ltrans.o] Error 1
  make: *** Waiting for unfinished jobs....
  lto-wrapper: fatal error: make returned 2 exit status
  compilation terminated.
  /opt/rh/gcc-toolset-14/root/usr/libexec/gcc/aarch64-redhat-linux/14/ld: error: lto-wrapper failed
  collect2: error: ld returned 1 exit status
  ninja: build stopped: subcommand failed.
```