### PR TITLE
feat: Allow any_text and triggered_tags format to terminate at any time when excludes are specified

### DIFF
--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -592,7 +592,6 @@ bool StructuralTagAnalyzer::IsExcluded(const Format& format) {
         } else if constexpr (std::is_same_v<T, TriggeredTagsFormat>) {
           const auto& triggered_tags_format = std::get<TriggeredTagsFormat>(format);
           return !triggered_tags_format.excludes.empty();
-          return true;
         } else {
           return false;
         }

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -84,7 +84,7 @@ struct RegexFormat {
 struct AnyTextFormat {
   static constexpr const char* type = "any_text";
   std::vector<std::string> excludes;
-  AnyTextFormat(std::vector<std::string> excluded_strs) : excludes(excluded_strs) {}
+  AnyTextFormat(std::vector<std::string> excluded_strs) : excludes(std::move(excluded_strs)) {}
 
  private:
   // Detected in StructuralTagAnalyzer - supports multiple end strings
@@ -146,7 +146,7 @@ struct TriggeredTagsFormat {
   )
       : triggers(std::move(triggers)),
         tags(std::move(tags)),
-        excludes(excludes),
+        excludes(std::move(excludes)),
         at_least_one(at_least_one),
         stop_after_first(stop_after_first) {}
 

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -2468,7 +2468,6 @@ test_strings_is_accepted_excluded_triggered_tags_without_end = [
     ("11ABC", True),
     ("1HelloWorld", False),
     ("1ABC123", False),
-    ("11ABC", True),
     ("2ABC", True),
 ]
 


### PR DESCRIPTION
Previously, the structural tag analyzer will find the terminating string for any_text and triggered_tags formats. The terminating string is determined by the "end" part of the tag format wrapping the any_text or triggered_tags format. The terminating string will determine when to exit the any_text tag. If it's not generated, the any_text tag will never exit. If the terminating string is not determined, this any_text or triggered_tags will be called "unlimited". Such tag can only exist at the end of the whole structural tag and indicates can terminate at any place.

There are currently increasing needs for exclude strings for the free part of any_text or triggered_tags. There is a common use pattern:
```
Sequence(AnyTextFormat(excludes="<next_trigger>"), TagFormat(begin="<next_trigger>", content=..., end=...)
```

This essentially uses the <next_trigger> to separate any_text and the next tag. 

To support this, this PR enhances the structural tag analyzer to allow any_text and triggered_tags which:
1. Cannot detect terminating string, and
2. Has exclude strings

To terminate at any time. 