### PR TITLE
fix: fix a undefined behavior in DynamicBitset.

### DIFF
--- a/cpp/support/dynamic_bitset.h
+++ b/cpp/support/dynamic_bitset.h
@@ -97,7 +97,7 @@ class DynamicBitset {
     size_ = other.size_;
     buffer_size_ = other.buffer_size_;
     if (is_internal_) {
-      internal_buffer_.reserve(buffer_size_);
+      internal_buffer_.resize(buffer_size_);
       data_ = internal_buffer_.data();
     }
     if (data_ != other.data_) {


### PR DESCRIPTION
This PR fixes a UB in DynamicBitset by replacing `reserve` with `resize`.