### PR TITLE
fix: fix the doc building.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,7 +14,7 @@ pandoc
 pillow
 pydantic
 sentencepiece
-setuptools == 81.0.0
+setuptools==81.0.0
 sphinx==5.2.3
 sphinx-autobuild
 sphinx-book-theme


### PR DESCRIPTION
This PR fixes the doc building by adding the requirements for `setuptools==81.0.0`.