### PR TITLE
feat: support use RegexFormat as the TagFormat.begin field (#544)

### DIFF
--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -53,6 +53,9 @@ class StructuralTagParser {
   /*! \brief ParseTagFormat with extra check for object and the type field. */
   Result<TagFormat, ISTError> ParseTagFormat(const picojson::value& value);
   Result<TagFormat, ISTError> ParseTagFormat(const picojson::object& value);
+  Result<std::variant<std::string, RegexBegin>, ISTError> ParseTagBeginField(
+      const picojson::value& value
+  );
   Result<TriggeredTagsFormat, ISTError> ParseTriggeredTagsFormat(const picojson::object& value);
   Result<TagsWithSeparatorFormat, ISTError> ParseTagsWithSeparatorFormat(
       const picojson::object& value
@@ -314,12 +317,101 @@ Result<TagFormat, ISTError> StructuralTagParser::ParseTagFormat(const picojson::
   return ParseTagFormat(obj);
 }
 
-Result<TagFormat, ISTError> StructuralTagParser::ParseTagFormat(const picojson::object& obj) {
-  // begin is required.
-  auto begin_it = obj.find("begin");
-  if (begin_it == obj.end() || !begin_it->second.is<std::string>()) {
-    return ResultErr<ISTError>("Tag format's begin field must be a string");
+Result<std::variant<std::string, RegexBegin>, ISTError> StructuralTagParser::ParseTagBeginField(
+    const picojson::value& value
+) {
+  if (value.is<std::string>()) {
+    // String case
+    return ResultOk<std::variant<std::string, RegexBegin>>(value.get<std::string>());
+  } else if (value.is<picojson::object>()) {
+    // Object case - can be either:
+    // 1. Simple regex format: {"type": "regex", "pattern": "..."}
+    // 2. Full RegexBegin format: {"type": "regex_begin", "trigger": "...", "regex": {...}}
+    const auto& begin_obj = value.get<picojson::object>();
+
+    // Check type field
+    auto type_it = begin_obj.find("type");
+    if (type_it == begin_obj.end() || !type_it->second.is<std::string>()) {
+      return ResultErr<ISTError>(
+          "Tag format's begin field, when it is an object, must have a 'type' field."
+      );
+    }
+    const std::string& type_value = type_it->second.get<std::string>();
+
+    if (type_value == "regex") {
+      // Simple regex format: {"type": "regex", "pattern": "..."}
+      auto pattern_it = begin_obj.find("pattern");
+      if (pattern_it == begin_obj.end() || !pattern_it->second.is<std::string>()) {
+        return ResultErr<ISTError>(
+            "Tag format's begin field with type='regex' must have a 'pattern' field with a string "
+            "value."
+        );
+      }
+      // Create RegexBegin with no trigger
+      return ResultOk<std::variant<std::string, RegexBegin>>(
+          RegexBegin(std::nullopt, RegexFormat(pattern_it->second.get<std::string>()))
+      );
+    } else if (type_value == "regex_begin") {
+      // Full RegexBegin format: {"type": "regex_begin", "trigger": "...", "regex": {...}}
+      std::optional<std::string> trigger = std::nullopt;
+      auto trigger_it = begin_obj.find("trigger");
+      if (trigger_it != begin_obj.end() && trigger_it->second.is<std::string>()) {
+        trigger = trigger_it->second.get<std::string>();
+      }
+
+      const auto& regex_obj_it = begin_obj.find("regex");
+      if (regex_obj_it == begin_obj.end() || !regex_obj_it->second.is<picojson::object>()) {
+        return ResultErr<ISTError>(
+            "Tag format's begin field with type='regex_begin' must have a 'regex' object field."
+        );
+      }
+      const auto& regex_obj = regex_obj_it->second.get<picojson::object>();
+
+      // Check regex type field is "regex"
+      auto regex_type_it = regex_obj.find("type");
+      if (regex_type_it == regex_obj.end() || !regex_type_it->second.is<std::string>() ||
+          regex_type_it->second.get<std::string>() != "regex") {
+        return ResultErr<ISTError>(
+            "Tag format's begin.regex field must be an object with type='regex'."
+        );
+      }
+      // Parse pattern field
+      auto pattern_it = regex_obj.find("pattern");
+      if (pattern_it == regex_obj.end() || !pattern_it->second.is<std::string>()) {
+        return ResultErr<ISTError>(
+            "Tag format's begin.regex field must have a 'pattern' field with a string value."
+        );
+      }
+      return ResultOk<std::variant<std::string, RegexBegin>>(
+          RegexBegin(trigger, RegexFormat(pattern_it->second.get<std::string>()))
+      );
+    } else {
+      return ResultErr<ISTError>(
+          "Tag format's begin field type must be 'regex' or 'regex_begin', got '" + type_value +
+          "'."
+      );
+    }
+  } else {
+    return ResultErr<ISTError>(
+        "Tag format's begin field must be a string, a regex object, or a regex_begin object."
+    );
   }
+}
+
+Result<TagFormat, ISTError> StructuralTagParser::ParseTagFormat(const picojson::object& obj) {
+  // begin is required - can be string or regex format object
+  auto begin_it = obj.find("begin");
+  if (begin_it == obj.end()) {
+    return ResultErr<ISTError>(
+        "Tag format's begin field must be a string, a regex object, or a regex_begin object."
+    );
+  }
+
+  auto begin_result = ParseTagBeginField(begin_it->second);
+  if (begin_result.IsErr()) {
+    return ResultErr<ISTError>(std::move(begin_result).UnwrapErr());
+  }
+
   // content is required.
   auto content_it = obj.find("content");
   if (content_it == obj.end()) {
@@ -356,7 +448,7 @@ Result<TagFormat, ISTError> StructuralTagParser::ParseTagFormat(const picojson::
   }
 
   return ResultOk<TagFormat>(
-      begin_it->second.get<std::string>(),
+      std::move(begin_result).Unwrap(),
       std::make_shared<Format>(std::move(content).Unwrap()),
       std::move(end_strings)
   );
@@ -766,6 +858,11 @@ class StructuralTagGrammarConverter {
 
   bool IsPrefix(const std::string& prefix, const std::string& full_str);
 
+  /*! \brief Create an expression for the begin field of a TagFormat. */
+  Result<int, ISTError> CreateBeginExpr(
+      const TagFormat& tag, const std::optional<std::string>& trigger = std::nullopt
+  );
+
   GrammarBuilder grammar_builder_;
 };
 
@@ -774,6 +871,48 @@ bool StructuralTagGrammarConverter::IsPrefix(
 ) {
   return prefix.size() <= full_str.size() &&
          std::string_view(full_str).substr(0, prefix.size()) == prefix;
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::CreateBeginExpr(
+    const TagFormat& tag, const std::optional<std::string>& trigger
+) {
+  return std::visit(
+      [&](auto&& arg) -> Result<int, ISTError> {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, std::string>) {
+          // String case: use substring after trigger (if trigger is provided and non-empty)
+          std::string remaining =
+              (!trigger.has_value() || trigger->empty()) ? arg : arg.substr(trigger->size());
+          // Always call AddByteString, even with an empty remaining string, to ensure the
+          // regression unit test passes.
+          return ResultOk(grammar_builder_.AddByteString(remaining));
+        } else if constexpr (std::is_same_v<T, RegexBegin>) {
+          auto arg_has_trigger = arg.trigger.has_value() && (!arg.trigger->empty());
+          // Regex case: convert regex to grammar and add as sub-grammar after trigger (if trigger
+          // is provided and non-empty)
+          if (trigger.has_value() && (!trigger->empty()) && (trigger != arg.trigger)) {
+            return ResultErr<ISTError>("One tag's regex begin does not match trigger");
+          } else if ((trigger.has_value() && (!trigger->empty()) && (trigger == arg.trigger)) ||
+                     (!arg_has_trigger)) {
+            auto sub_grammar = Grammar::FromRegex(arg.regex.pattern);
+            auto regex_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
+            return ResultOk(grammar_builder_.AddRuleRef(regex_rule_id));
+          } else if (arg_has_trigger) {
+            // The normal case, add trigger string before regex grammar
+            auto trigger_expr_id = grammar_builder_.AddByteString(arg.trigger.value());
+            auto sub_grammar = Grammar::FromRegex(arg.regex.pattern);
+            auto regex_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
+            auto begin_expr_id = grammar_builder_.AddSequence(
+                {trigger_expr_id, grammar_builder_.AddRuleRef(regex_rule_id)}
+            );
+            return ResultOk(begin_expr_id);
+          }
+        }
+        // Unreachable
+        return ResultErr<ISTError>("Unknown begin field type");
+      },
+      tag.begin
+  );
 }
 
 Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(const StructuralTag& structural_tag
@@ -913,7 +1052,14 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TagFormat& f
     return result;
   }
   auto sub_rule_id = std::move(result).Unwrap();
-  auto begin_expr = grammar_builder_.AddByteString(format.begin);
+
+  // Handle begin field - can be string or RegexBegin
+  auto begin_result = CreateBeginExpr(format);
+  if (begin_result.IsErr()) {
+    return begin_result;
+  }
+  int begin_expr = std::move(begin_result).Unwrap();
+
   auto rule_ref_expr = grammar_builder_.AddRuleRef(sub_rule_id);
 
   if (format.end.size() > 1) {
@@ -956,16 +1102,34 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTag
 
   for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
     const auto& tag = format.tags[it_tag];
+
+    // Check if begin is a regex, checking format.trigger matched tage.begin.trigger
+    bool is_regex_begin = std::holds_alternative<RegexBegin>(tag.begin);
+
     // Find matched triggers
     int matched_trigger_id = -1;
-    for (int it_trigger = 0; it_trigger < static_cast<int>(format.triggers.size()); ++it_trigger) {
-      const auto& trigger = format.triggers[it_trigger];
-      if (IsPrefix(trigger, tag.begin)) {
-        if (matched_trigger_id != -1) {
-          return ResultErr<ISTError>("One tag matches multiple triggers in a triggered tags format"
-          );
+    if (is_regex_begin) {
+      // For regex begin, check trigger == tag.begin.trigger
+      for (int it_trigger = 0; it_trigger < static_cast<int>(format.triggers.size());
+           ++it_trigger) {
+        const auto& trigger = format.triggers[it_trigger];
+        if (trigger == std::get<RegexBegin>(tag.begin).trigger) {
+          matched_trigger_id = it_trigger;
         }
-        matched_trigger_id = it_trigger;
+      }
+    } else {
+      // For string begin, use IsPrefix matching
+      for (int it_trigger = 0; it_trigger < static_cast<int>(format.triggers.size());
+           ++it_trigger) {
+        const auto& trigger = format.triggers[it_trigger];
+        if (IsPrefix(trigger, std::get<std::string>(tag.begin))) {
+          if (matched_trigger_id != -1) {
+            return ResultErr<ISTError>(
+                "One tag matches multiple triggers in a triggered tags format"
+            );
+          }
+          matched_trigger_id = it_trigger;
+        }
       }
     }
     if (matched_trigger_id == -1) {
@@ -990,7 +1154,14 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTag
     std::vector<int> choice_elements;
     for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
       const auto& tag = format.tags[it_tag];
-      auto begin_expr_id = grammar_builder_.AddByteString(tag.begin);
+
+      // Handle begin field - can be string or RegexBegin
+      auto begin_result = CreateBeginExpr(tag);
+      if (begin_result.IsErr()) {
+        return ResultErr(std::move(begin_result).UnwrapErr());
+      }
+      int begin_expr_id = std::move(begin_result).Unwrap();
+
       auto rule_ref_expr_id = grammar_builder_.AddRuleRef(tag_content_rule_ids[it_tag]);
       if (tag.end.empty()) {
         // Unlimited content case - skip adding end string
@@ -1067,7 +1238,12 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTag
     std::vector<int> choice_elements;
     for (const auto& tag_id : trigger_to_tag_ids[it_trigger]) {
       const auto& tag = format.tags[tag_id];
-      int begin_expr_id = grammar_builder_.AddByteString(tag.begin.substr(trigger.size()));
+      // Handle begin field - can be string or RegexBegin
+      auto begin_result = CreateBeginExpr(tag, trigger);
+      if (begin_result.IsErr()) {
+        return ResultErr(std::move(begin_result).UnwrapErr());
+      }
+      int begin_expr_id = std::move(begin_result).Unwrap();
       int rule_ref_expr_id = grammar_builder_.AddRuleRef(tag_content_rule_ids[tag_id]);
       if (tag.end.empty()) {
         // Unlimited content case - skip adding end string
@@ -1125,7 +1301,12 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTag
     std::vector<int> first_choice_elements;
     for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
       const auto& tag = format.tags[it_tag];
-      auto begin_expr_id = grammar_builder_.AddByteString(tag.begin);
+      // Handle begin field - can be string or RegexBegin
+      auto begin_result = CreateBeginExpr(tag);
+      if (begin_result.IsErr()) {
+        return ResultErr(std::move(begin_result).UnwrapErr());
+      }
+      int begin_expr_id = std::move(begin_result).Unwrap();
       auto rule_ref_expr_id = grammar_builder_.AddRuleRef(tag_content_rule_ids[it_tag]);
       if (tag.end.empty()) {
         // Unlimited content case - skip adding end string

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -112,13 +112,26 @@ struct OrFormat {
   friend class StructuralTagGrammarConverter;
 };
 
+struct RegexBegin {
+  static constexpr const char* type = "regex_begin";
+  std::optional<std::string> trigger;
+  RegexFormat regex;
+  RegexBegin(std::optional<std::string> trigger, RegexFormat regex)
+      : trigger(std::move(trigger)), regex(std::move(regex)) {}
+};
+
 struct TagFormat {
   static constexpr const char* type = "tag";
-  std::string begin;
+  // begin can be a constant string or a regex pattern
+  std::variant<std::string, RegexBegin> begin;
   std::shared_ptr<Format> content;
   std::vector<std::string> end;  // Supports multiple end tokens
 
-  TagFormat(std::string begin, std::shared_ptr<Format> content, std::vector<std::string> end)
+  TagFormat(
+      std::variant<std::string, RegexBegin> begin,
+      std::shared_ptr<Format> content,
+      std::vector<std::string> end
+  )
       : begin(std::move(begin)), content(std::move(content)), end(std::move(end)) {}
 };
 

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -99,6 +99,38 @@ class RegexFormat(BaseModel):
     """The regex pattern."""
 
 
+class RegexBegin(BaseModel):
+    """A regex begin format for tags with optional trigger support.
+
+    This is used in TagFormat.begin when you need regex pattern matching
+    with optional trigger support for TriggeredTagsFormat.
+
+    Examples
+    --------
+    Simple regex begin (no trigger):
+
+    .. code-block:: python
+
+        RegexBegin(regex=RegexFormat(pattern="<think\\d+>"))
+
+    Regex begin with trigger (for TriggeredTagsFormat):
+
+    .. code-block:: python
+
+        RegexBegin(trigger="<think", regex=RegexFormat(pattern="<think\\d+>"))
+
+    """
+
+    type: Literal["regex_begin"] = "regex_begin"
+    """The type of the format."""
+
+    trigger: str = ""
+    """Optional trigger string. Used in TriggeredTagsFormat to match the trigger prefix."""
+
+    regex: RegexFormat
+    """The regex pattern for matching the begin tag."""
+
+
 # ---------- Combinatorial Formats ----------
 
 
@@ -123,6 +155,11 @@ class OrFormat(BaseModel):
 class TagFormat(BaseModel):
     """A format that matches a tag: ``begin content end``.
 
+    The ``begin`` field can be:
+    - A string for exact matching
+    - A RegexFormat for simple regex pattern matching
+    - A RegexBegin for regex with optional trigger support (used in TriggeredTagsFormat)
+
     The ``end`` field can be a single string or a list of possible end strings.
     When multiple end strings are provided, any of them will be accepted as a valid
     ending for the tag.
@@ -130,7 +167,7 @@ class TagFormat(BaseModel):
     Examples
     --------
 
-    Single end string:
+    String begin:
 
     .. code-block:: python
 
@@ -142,12 +179,28 @@ class TagFormat(BaseModel):
 
         TagFormat(begin="<response>", content=..., end=["</response>", "</answer>"])
 
+    Simple regex begin:
+
+    .. code-block:: python
+
+        TagFormat(begin=RegexFormat(pattern="<\\w+>"), content=..., end="</tag>")
+
+    Regex begin with trigger (for TriggeredTagsFormat):
+
+    .. code-block:: python
+
+        TagFormat(
+            begin=RegexBegin(trigger="<think", regex=RegexFormat(pattern="<think\\d+>")),
+            content=...,
+            end="</think>"
+        )
+
     """
 
     type: Literal["tag"] = "tag"
     """The type of the format."""
-    begin: str
-    """The begin tag."""
+    begin: Union[str, RegexFormat, "RegexBegin"]
+    """The begin tag. Can be a string, RegexFormat for simple regex, or RegexBegin for regex with trigger."""
     content: "Format"
     """The content of the tag. It can be any of the formats."""
     end: Union[str, List[str]]
@@ -269,12 +322,14 @@ Format = Annotated[
 
 # Solve forward references
 if hasattr(BaseModel, "model_rebuild"):
+    RegexBegin.model_rebuild()
     SequenceFormat.model_rebuild()
     TagFormat.model_rebuild()
     TriggeredTagsFormat.model_rebuild()
     TagsWithSeparatorFormat.model_rebuild()
 elif hasattr(BaseModel, "update_forward_refs"):
     # This is for backward compatibility with pydantic v1
+    RegexBegin.update_forward_refs()
     SequenceFormat.update_forward_refs()
     TagFormat.update_forward_refs()
     TriggeredTagsFormat.update_forward_refs()
@@ -361,6 +416,7 @@ __all__ = [
     "AnyTextFormat",
     "GrammarFormat",
     "RegexFormat",
+    "RegexBegin",
     "SequenceFormat",
     "OrFormat",
     "TagFormat",

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -699,6 +699,94 @@ def test_tag_format(
     check_stag_with_instance(stag_format, instance, is_accepted)
 
 
+tag_with_regex_begin_stag_grammar = [
+    (
+        {
+            "type": "tag",
+            "begin": {"type": "regex_begin", "regex": {"type": "regex", "pattern": r"BEG[a-z]*"}},
+            "content": {"type": "json_schema", "json_schema": {"type": "number"}},
+            "end": "END",
+        },
+        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
+basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
+root_0 ::= ((basic_number))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
+basic_number_3 ::= ("" | ("." basic_number_2))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
+basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
+basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
+basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
+basic_number_7 ::= (("0") | ([1-9] [0-9]*))
+root_1 ::= (("B" "E" "G" [a-z]*))
+tag ::= ((root_1 root_0 "END"))
+root ::= ((tag))
+""",
+    ),
+    (
+        {
+            "type": "tag",
+            # "For Normal TagsFormat, 'begin.trigger' is not necessary; using a RegexFormat object as 'begin' directly is acceptable."
+            "begin": {"type": "regex", "pattern": r"BEG[a-z]*"},
+            "content": {"type": "grammar", "grammar": "root ::= [+\\-]?[1-9][0-9]*"},
+            "end": "END",
+        },
+        r"""root_0 ::= ((root_1 [1-9] [0-9]*))
+root_1 ::= ("" | ([+\-]))
+root_2 ::= (("B" "E" "G" [a-z]*))
+tag ::= ((root_2 root_0 "END"))
+root ::= ((tag))
+""",
+    ),
+    (
+        {
+            "type": "tag",
+            # "For Normal TagsFormat, 'begin.trigger' is not necessary; using a RegexFormat object as 'begin' directly is acceptable."
+            "begin": {"type": "regex", "pattern": r"BEG[a-z]*"},
+            "content": {"type": "regex", "pattern": "[+\\-]?[1-9][0-9]*"},
+            "end": "END",
+        },
+        r"""root_0 ::= ((root_1 [1-9] [0-9]*))
+root_1 ::= ("" | ([+\-]))
+root_2 ::= (("B" "E" "G" [a-z]*))
+tag ::= ((root_2 root_0 "END"))
+root ::= ((tag))
+""",
+    ),
+]
+
+
+tag_with_regex_begin_instance_is_accepted = [
+    ("BEG12345END", True),
+    ("BEG123456END", True),
+    ("BEG1234567END", True),
+    ("BEG???END", False),
+    ("BEG12345ENDEND", False),
+    ("BEGa12345END", True),
+    ("BEGaa12345END", True),
+    ("BEG1a12345END", False),
+]
+
+
+@pytest.mark.parametrize("stag_format, expected_grammar", tag_with_regex_begin_stag_grammar)
+@pytest.mark.parametrize("instance, is_accepted", tag_with_regex_begin_instance_is_accepted)
+def test_tag_with_regex_begin(
+    stag_format: Dict[str, Any], expected_grammar: str, instance: str, is_accepted: bool
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, is_accepted)
+
+
 any_text_stag_grammar = [
     (
         {"type": "tag", "begin": "BEG", "content": {"type": "any_text"}, "end": "END"},
@@ -876,6 +964,7 @@ root ::= ((triggered_tags))
 triggered_tag_instance_accepted_results = [
     ("textA1L1AtextA2L2AText", [True, False, False, False]),
     ("textA1L1AtextA2L2A", [True, False, False, False]),
+    ("A1L1AA2L2Atext", [True, True, False, False]),
     ("A1L1Atext", [True, True, False, False]),
     ("A1L1AtextA2L2A", [True, True, False, False]),
     ("A1L1A", [True, True, True, True]),
@@ -890,6 +979,130 @@ triggered_tag_instance_accepted_results = [
 @pytest.mark.parametrize("stag_id, stag_format, expected_grammar", triggered_tag_stag_grammar)
 @pytest.mark.parametrize("instance, accepted_results", triggered_tag_instance_accepted_results)
 def test_triggered_tag_format(
+    stag_id: int,
+    stag_format: Dict[str, Any],
+    expected_grammar: str,
+    instance: str,
+    accepted_results: List[bool],
+):
+    check_stag_with_grammar(stag_format, expected_grammar)
+    check_stag_with_instance(stag_format, instance, accepted_results[stag_id])
+
+
+def _get_triggered_tag_format_with_regex_begin(at_least_one: bool, stop_after_first: bool):
+    regex_begin = {
+        "type": "regex_begin",
+        "trigger": "A",
+        "regex": {"type": "regex", "pattern": r"[13-9]"},
+    }
+    return {
+        "type": "triggered_tags",
+        "triggers": ["A"],
+        "tags": [
+            {"begin": regex_begin, "content": {"type": "const_string", "value": "L1"}, "end": "A"},
+            {"begin": "A2", "content": {"type": "const_string", "value": "L2"}, "end": "A"},
+        ],
+        "at_least_one": at_least_one,
+        "stop_after_first": stop_after_first,
+    }
+
+
+triggered_tag_with_regex_begin_stag_grammar = [
+    (
+        0,
+        _get_triggered_tag_format_with_regex_begin(at_least_one=False, stop_after_first=False),
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+root_0 ::= (([13-9]))
+triggered_tags_group ::= ((root_0 const_string "A") | ("2" const_string_1 "A"))
+triggered_tags ::= TagDispatch(
+  ("A", triggered_tags_group),
+  stop_eos=true,
+  stop_str=(),
+  loop_after_dispatch=true,
+  excludes=()
+)
+root ::= ((triggered_tags))
+""",
+    ),
+    (
+        1,
+        _get_triggered_tag_format_with_regex_begin(at_least_one=True, stop_after_first=False),
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+root_0 ::= (([13-9]))
+triggered_tags_group ::= ((root_0 const_string "A") | ("2" const_string_1 "A"))
+root_1 ::= (([13-9]))
+triggered_tags_first ::= (("A" root_1 const_string "A") | ("A2" const_string_1 "A"))
+triggered_tags_sub ::= TagDispatch(
+  ("A", triggered_tags_group),
+  stop_eos=true,
+  stop_str=(),
+  loop_after_dispatch=true,
+  excludes=()
+)
+triggered_tags ::= ((triggered_tags_first triggered_tags_sub))
+root ::= ((triggered_tags))
+""",
+    ),
+    (
+        2,
+        _get_triggered_tag_format_with_regex_begin(at_least_one=False, stop_after_first=True),
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+root_0 ::= (([13-9]))
+triggered_tags_group ::= ((root_0 const_string "A") | ("2" const_string_1 "A"))
+triggered_tags ::= TagDispatch(
+  ("A", triggered_tags_group),
+  stop_eos=true,
+  stop_str=(),
+  loop_after_dispatch=false,
+  excludes=()
+)
+root ::= ((triggered_tags))
+""",
+    ),
+    (
+        3,
+        _get_triggered_tag_format_with_regex_begin(at_least_one=True, stop_after_first=True),
+        r"""const_string ::= (("L1"))
+const_string_1 ::= (("L2"))
+root_0 ::= (([13-9]))
+triggered_tags ::= (("A" root_0 const_string "A") | ("A2" const_string_1 "A"))
+root ::= ((triggered_tags))
+""",
+    ),
+]
+
+
+triggered_tag_with_regex_begin_instance_accepted_results = [
+    ("textA1L1AtextA2L2AText", [True, False, False, False]),
+    ("textA1L1AtextA2L2A", [True, False, False, False]),
+    ("A1L1AA2L2Atext", [True, True, False, False]),
+    ("A1L1Atext", [True, True, False, False]),
+    ("A1L1AtextA2L2A", [True, True, False, False]),
+    ("A1L1A", [True, True, True, True]),
+    ("textA3L1AtextA2L2AText", [True, False, False, False]),
+    ("textA3L1AtextA2L2A", [True, False, False, False]),
+    ("A3L1AA2L2Atext", [True, True, False, False]),
+    ("A3L1Atext", [True, True, False, False]),
+    ("A3L1AtextA2L2A", [True, True, False, False]),
+    ("A3L1A", [True, True, True, True]),
+    ("text", [True, False, True, False]),
+    ("", [True, False, True, False]),
+    ("AA", [False, False, False, False]),
+    ("A1L2A", [False, False, False, False]),
+    ("A1L1A2L2A", [False, False, False, False]),
+]
+
+
+@pytest.mark.parametrize(
+    "stag_id, stag_format, expected_grammar", triggered_tag_with_regex_begin_stag_grammar
+)
+@pytest.mark.parametrize(
+    "instance, accepted_results", triggered_tag_with_regex_begin_instance_accepted_results
+)
+def test_triggered_tag_with_regex_begin(
     stag_id: int,
     stag_format: Dict[str, Any],
     expected_grammar: str,
@@ -1879,11 +2092,11 @@ json_format_error_test_data = [
     # TagFormat Errors
     (
         '{"type": "structural_tag", "format": {"type": "tag", "content": {"type": "const_string", "value": "hello"}, "end": "end"}}',
-        "Tag format's begin field must be a string",
+        "Tag format's begin field must be a string, a regex object, or a regex_begin object.",
     ),
     (
         '{"type": "structural_tag", "format": {"type": "tag", "begin": 123, "content": {"type": "const_string", "value": "hello"}, "end": "end"}}',
-        "Tag format's begin field must be a string",
+        "Tag format's begin field must be a string, a regex object, or a regex_begin object.",
     ),
     (
         '{"type": "structural_tag", "format": {"type": "tag", "begin": "start", "end": "end"}}',
@@ -1937,6 +2150,18 @@ json_format_error_test_data = [
     (
         '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"], "tags": [{"begin": "start", "content": {"type": "const_string", "value": "hello"}, "end": "end"}], "stop_after_first": "not_boolean"}}',
         "stop_after_first must be a boolean",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"], "tags": [{"begin": {"type": "regex_begin", "regex": {"type": "regex", "pattern": "A+"}}, "content": {"type": "const_string", "value": "hello"}, "end": "end"}]}}',
+        "One tag does not match any trigger in a triggered tags format",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"], "tags": [{"begin": {"type": "regex_begin", "trigger": "triggers", "regex": {"type": "regex", "pattern": "A+"}}, "content": {"type": "const_string", "value": "hello"}, "end": "end"}]}}',
+        "One tag does not match any trigger in a triggered tags format",
+    ),
+    (
+        '{"type": "structural_tag", "format": {"type": "triggered_tags", "triggers": ["trigger"], "tags": [{"begin": {"type": "regex", "pattern": "A+"}, "content": {"type": "const_string", "value": "hello"}, "end": "end"}]}}',
+        "One tag does not match any trigger in a triggered tags format",
     ),
     # TagsWithSeparatorFormat Errors
     (
@@ -2332,6 +2557,88 @@ basic_structural_tags_instance_is_accepted = [
         ),
         "<b>text</b",
         False,
+    ),
+    (
+        xgr.structural_tag.TagFormat(
+            begin=xgr.structural_tag.RegexFormat(pattern='<b id="\\d+">'),
+            content=xgr.structural_tag.AnyTextFormat(),
+            end="</b>",
+        ),
+        '<b id="1">text</b>',
+        True,
+    ),
+    (
+        xgr.structural_tag.TagFormat(
+            begin=xgr.structural_tag.RegexFormat(pattern='<b id="\\d+">'),
+            content=xgr.structural_tag.AnyTextFormat(),
+            end="</b>",
+        ),
+        "<b>text</b>",
+        False,
+    ),
+    (
+        xgr.structural_tag.TagFormat(
+            begin=xgr.structural_tag.RegexBegin(
+                # The trigger arg of RegexBegin is optional
+                regex=xgr.structural_tag.RegexFormat(pattern='<b id="\\d+">')
+            ),
+            content=xgr.structural_tag.AnyTextFormat(),
+            end="</b>",
+        ),
+        '<b id="1">text</b>',
+        True,
+    ),
+    # TriggeredTagsFormat
+    (
+        xgr.structural_tag.TriggeredTagsFormat(
+            triggers=["<"],
+            tags=[
+                xgr.structural_tag.TagFormat(
+                    begin=xgr.structural_tag.RegexBegin(
+                        trigger="<",
+                        # The trigger text itself should not be part of the regex pattern
+                        regex=xgr.structural_tag.RegexFormat(pattern='b id="\\d+">'),
+                    ),
+                    content=xgr.structural_tag.AnyTextFormat(),
+                    end="</b>",
+                )
+            ],
+            at_least_one=False,
+            stop_after_first=False,
+        ),
+        '<b id="1">"1"</b>,<b id="2">"2"</b>',
+        True,
+    ),
+    (
+        xgr.structural_tag.TriggeredTagsFormat(
+            triggers=["<"],
+            tags=[
+                xgr.structural_tag.TagFormat(
+                    begin='<b id="1">', content=xgr.structural_tag.AnyTextFormat(), end="</b>"
+                )
+            ],
+            at_least_one=False,
+            stop_after_first=False,
+        ),
+        '<b id="1">"1"</b>,<b id="2">"2"</b>',
+        False,
+    ),
+    (
+        xgr.structural_tag.TriggeredTagsFormat(
+            triggers=["<"],
+            tags=[
+                xgr.structural_tag.TagFormat(
+                    begin='<b id="1">', content=xgr.structural_tag.AnyTextFormat(), end="</b>"
+                ),
+                xgr.structural_tag.TagFormat(
+                    begin='<b id="2">', content=xgr.structural_tag.AnyTextFormat(), end="</b>"
+                ),
+            ],
+            at_least_one=False,
+            stop_after_first=False,
+        ),
+        '<b id="1">"1"</b>,<b id="2">"2"</b>',
+        True,
     ),
     # TagsWithSeparatorFormat
     (


### PR DESCRIPTION
Allow using a `RegexFormat` like object for the `TagFormat.begin` field.  #544 

Here is a use case describing this feature:
```
(
    xgammar.structural_tag.TagFormat(
        begin=xgammar.structural_tag.RegexFormat(pattern='<b id="\\d+">'),
        content=xgammar.structural_tag.AnyTextFormat(),
        end="</b>",
    ),
    # The grammar should match the content below:
    '<b id="1">text</b>',
    # Matching result
    True,
)
```

For the `TriggeredTagsFormat`, use a `RegexBegin` object to pack the trigger and the regex.
```
(
    xgammar.structural_tag.TriggeredTagsFormat(
        triggers=["<"],
        tags=[
            xgammar.structural_tag.TagFormat(
                begin=xgammar.structural_tag.RegexBegin(
                    trigger="<",
                    # The trigger text itself should not be part of the regex pattern
                    regex=xgammar.structural_tag.RegexFormat(pattern='b id="\\d+">'),
                ),
                content=xgammar.structural_tag.AnyTextFormat(),
                end="</b>",
            )
        ],
        at_least_one=False,
        stop_after_first=False,
    ),
    '<b id="1">"1"</b>,<b id="2">"2"</b>',
    True,
)
```

Better support for Kimi-k2 and Kimi-k2.5 series LLMs by correctly constraining the tool_calls ID format, thereby improving the tool call success rate.

Update `TagFormat` and `TriggeredTagsFormat` related unit test in `test_structural_tag_converter.py`. All regression test is passed in out local run.