### PR TITLE
refactor: remove AST fallback paths from Earley parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,3 +282,6 @@ _docs/
 
 # GDB history file
 .gdb_history
+
+# AI assistant files
+.cursor/

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -61,7 +61,10 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print) {
     if (ref_id != state.rule_id) {
       continue;
     }
-    if (parent_state.rule_id == -1 || !grammar_->per_rule_fsms[parent_state.rule_id].has_value()) {
+    XGRAMMAR_DCHECK(
+        parent_state.rule_id == -1 || grammar_->per_rule_fsms[parent_state.rule_id].has_value()
+    );
+    if (parent_state.rule_id == -1) {
       const auto& parent_expr = grammar_->GetGrammarExpr(parent_state.sequence_id);
       const auto& element_expr = grammar_->GetGrammarExpr(parent_expr[parent_state.element_id]);
       // The new rule is not referenced by a fsm.
@@ -148,7 +151,8 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
     const ParserState& state, bool debug_print
 ) {
   // Check if the rule has a corresponding FSM.
-  if (state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value()) {
+  if (state.rule_id != -1) {
+    XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
     // Try to expand the fsm.
     ExpandNextRuleRefElementOnFSM(state, debug_print);
     const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
@@ -204,7 +208,8 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
 }
 
 void EarleyParser::Scan(const ParserState& state, const uint8_t ch) {
-  if (state.rule_id == -1 || (!grammar_->per_rule_fsms[state.rule_id].has_value())) {
+  XGRAMMAR_DCHECK(state.rule_id == -1 || grammar_->per_rule_fsms[state.rule_id].has_value());
+  if (state.rule_id == -1) {
     const auto& cur_rule = grammar_->GetGrammarExpr(state.sequence_id);
     const auto& element_expr = grammar_->GetGrammarExpr(cur_rule[state.element_id]);
     // The element is a rule reference, we do not need to scan it.
@@ -359,27 +364,16 @@ bool EarleyParser::ExpandAndEnqueueUnexpandedState(const ParserState& state) {
   if (state.sequence_id != ParserState::kUnexpandedRuleStartSequenceId) {
     return false;
   }
-  // The rule is already expanded, and finished.
   auto cur_rule_id = state.rule_id;
   auto cur_rule_body_id = grammar_->GetRule(cur_rule_id).body_expr_id;
-  auto cur_rule_body = grammar_->GetGrammarExpr(cur_rule_body_id);
-  // There are two types of an unexpanded rule:
-  // 1. The rule is a tag dispatch rule.
-  // 2. The rule is a choice, consisting of multiple sequences.
-  if (state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value()) {
-    Enqueue(ParserState{
-        cur_rule_id,
-        cur_rule_body_id,
-        grammar_->per_rule_fsms[state.rule_id]->GetStart(),
-        ParserState::kNoPrevInputPos,
-        0
-    });
-    return true;
-  }
-  XGRAMMAR_DCHECK(cur_rule_body.type == GrammarExprType::kChoices);
-  for (const auto& sequence_id : cur_rule_body) {
-    Enqueue(ParserState{cur_rule_id, sequence_id, 0, ParserState::kNoPrevInputPos, 0});
-  }
+  XGRAMMAR_DCHECK(state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value());
+  Enqueue(ParserState{
+      cur_rule_id,
+      cur_rule_body_id,
+      grammar_->per_rule_fsms[state.rule_id]->GetStart(),
+      ParserState::kNoPrevInputPos,
+      0
+  });
   return true;
 }
 
@@ -452,47 +446,23 @@ void EarleyParser::ExpandNextRuleRefElement(
   const auto& ref_rule = grammar_->GetRule(ref_rule_id);
   const auto& ref_grammar_expr_id = ref_rule.body_expr_id;
 
-  if (grammar_->per_rule_fsms[ref_rule_id].has_value()) {
-    if (std::find(
-            grammar_->allow_empty_rule_ids.begin(),
-            grammar_->allow_empty_rule_ids.end(),
-            ref_rule_id
-        ) != grammar_->allow_empty_rule_ids.end()) {
-      Enqueue(ParserState{
-          state.rule_id, state.sequence_id, state.element_id + 1, state.rule_start_pos, 0
-      });
-    }
-    const auto& ref_fsm = grammar_->per_rule_fsms[ref_rule_id].value();
-    Enqueue(ParserState{
-        ref_rule_id,
-        ref_grammar_expr_id,
-        ref_fsm.GetStart(),
-        right_recursion_to_root ? ParserState::kNoPrevInputPos
-                                : int32_t(rule_id_to_completable_states_.size() - 1),
-        0
-    });
-    return;
+  XGRAMMAR_DCHECK(grammar_->per_rule_fsms[ref_rule_id].has_value());
+  if (std::find(
+          grammar_->allow_empty_rule_ids.begin(), grammar_->allow_empty_rule_ids.end(), ref_rule_id
+      ) != grammar_->allow_empty_rule_ids.end()) {
+    Enqueue(
+        ParserState{state.rule_id, state.sequence_id, state.element_id + 1, state.rule_start_pos, 0}
+    );
   }
-
-  const auto& ref_grammar_expr = grammar_->GetGrammarExpr(ref_grammar_expr_id);
-  XGRAMMAR_DCHECK(!grammar_->per_rule_fsms[ref_rule_id].has_value());
-  for (const auto& sequence_id : ref_grammar_expr) {
-    const auto& sequence = grammar_->GetGrammarExpr(sequence_id);
-    if (sequence.type == GrammarExprType::kEmptyStr) {
-      Enqueue(ParserState{
-          state.rule_id, state.sequence_id, state.element_id + 1, state.rule_start_pos, 0
-      });
-      continue;
-    }
-    Enqueue(ParserState{
-        ref_rule_id,
-        sequence_id,
-        0,
-        right_recursion_to_root ? ParserState::kNoPrevInputPos
-                                : int32_t(rule_id_to_completable_states_.size() - 1),
-        0
-    });
-  }
+  const auto& ref_fsm = grammar_->per_rule_fsms[ref_rule_id].value();
+  Enqueue(ParserState{
+      ref_rule_id,
+      ref_grammar_expr_id,
+      ref_fsm.GetStart(),
+      right_recursion_to_root ? ParserState::kNoPrevInputPos
+                              : int32_t(rule_id_to_completable_states_.size() - 1),
+      0
+  });
 }
 
 void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool debug_print) {
@@ -601,43 +571,23 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
     const auto& ref_rule = grammar_->GetRule(ref_rule_id);
     const auto& ref_grammar_expr_id = ref_rule.body_expr_id;
 
-    if (grammar_->per_rule_fsms[ref_rule_id].has_value()) {
-      if (!is_repeat && std::binary_search(
-                            grammar_->allow_empty_rule_ids.begin(),
-                            grammar_->allow_empty_rule_ids.end(),
-                            ref_rule_id
-                        )) {
-        Enqueue(ParserState{state.rule_id, state.sequence_id, target, state.rule_start_pos, 0});
-      }
-      const auto& ref_fsm = grammar_->per_rule_fsms[ref_rule_id].value();
-      Enqueue(ParserState{
-          ref_rule_id,
-          ref_grammar_expr_id,
-          ref_fsm.GetStart(),
-          right_recursion_to_root ? ParserState::kNoPrevInputPos
-                                  : int32_t(rule_id_to_completable_states_.size() - 1),
-          0
-      });
-    } else {
-      const auto& ref_grammar_expr = grammar_->GetGrammarExpr(ref_grammar_expr_id);
-      for (const auto& sequence_id : ref_grammar_expr) {
-        const auto& sequence = grammar_->GetGrammarExpr(sequence_id);
-        if (sequence.type == GrammarExprType::kEmptyStr) {
-          if (!is_repeat) {
-            Enqueue(ParserState{state.rule_id, state.sequence_id, target, state.rule_start_pos, 0});
-          }
-          continue;
-        }
-        Enqueue(ParserState{
-            ref_rule_id,
-            sequence_id,
-            0,
-            right_recursion_to_root ? ParserState::kNoPrevInputPos
-                                    : int32_t(rule_id_to_completable_states_.size() - 1),
-            0
-        });
-      }
+    XGRAMMAR_DCHECK(grammar_->per_rule_fsms[ref_rule_id].has_value());
+    if (!is_repeat && std::binary_search(
+                          grammar_->allow_empty_rule_ids.begin(),
+                          grammar_->allow_empty_rule_ids.end(),
+                          ref_rule_id
+                      )) {
+      Enqueue(ParserState{state.rule_id, state.sequence_id, target, state.rule_start_pos, 0});
     }
+    const auto& ref_fsm = grammar_->per_rule_fsms[ref_rule_id].value();
+    Enqueue(ParserState{
+        ref_rule_id,
+        ref_grammar_expr_id,
+        ref_fsm.GetStart(),
+        right_recursion_to_root ? ParserState::kNoPrevInputPos
+                                : int32_t(rule_id_to_completable_states_.size() - 1),
+        0
+    });
   }
 }
 

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -436,33 +436,8 @@ std::pair<bool, std::bitset<256>> GrammarMatcherForTokenMaskCache::GetSpeculativ
     return {true, speculative_mask};
   }
 
-  // Check if the initial state is self-recursive-like. If the state is self-recursive-like,
-  // and it covers a large part of the vocabulary, we will do speculative calculation in compiling.
-  if (!grammar_->per_rule_fsms[init_rule_id_].has_value()) {
-    if (initial_state_.sub_element_id == 0) {
-      const auto& sequence_expr = grammar_->GetGrammarExpr(initial_state_.sequence_id);
-      // A self-recursive-like rule must be a sequence.
-      if (sequence_expr.type == GrammarExprType::kSequence) {
-        const auto& current_element_expr =
-            grammar_->GetGrammarExpr(sequence_expr[initial_state_.element_id]);
-        // If the current element is a character class star, then it's self-recursive without doubt.
-        if (current_element_expr.type == GrammarExprType::kCharacterClassStar) {
-          return {true, {}};
-          // If the current element is a character class, and the next element is a rule ref to
-          // itself, and the rule only has 2 elements, then it's self-recursive-like.
-        } else if (current_element_expr.type == GrammarExprType::kCharacterClass &&
-                   sequence_expr.size() == 2 && initial_state_.element_id == 0) {
-          const auto& end_element_expr = grammar_->GetGrammarExpr(sequence_expr[1]);
-          if (end_element_expr.type == GrammarExprType::kRuleRef &&
-              end_element_expr[0] == initial_state_.rule_id) {
-            return {true, {}};
-          }
-        }
-      }
-    }
-    return {false, {}};
-  }
-  // If the initial state is a FSM, we will check if the FSM is self-recursive-like.
+  // Check if the initial state is self-recursive-like via FSM.
+  XGRAMMAR_DCHECK(grammar_->per_rule_fsms[init_rule_id_].has_value());
   bool can_be_applied = false;
   std::bitset<256> speculative_mask;
   const auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
@@ -522,16 +497,8 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
     }
   }
 
-  bool speculative_calculation = false;
-  std::bitset<256> speculative_mask;
-  if (init_rule_id_ == -1 || !grammar_->per_rule_fsms[init_rule_id_].has_value()) {
-    speculative_calculation =
-        GetSpeculativeCalculation().first &&
-        (possible_token_num >= static_cast<int>(sorted_decoded_vocab.size() / 4));
-    speculative_mask = first_char_mask;
-  } else {
-    std::tie(speculative_calculation, speculative_mask) = GetSpeculativeCalculation();
-  }
+  XGRAMMAR_DCHECK(init_rule_id_ != -1 && grammar_->per_rule_fsms[init_rule_id_].has_value());
+  auto [speculative_calculation, speculative_mask] = GetSpeculativeCalculation();
 
   int prev_matched_size = 0;
   int last_rejected_range = 0;
@@ -702,49 +669,13 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
 void GrammarMatcherForTokenMaskCache::GetFirstCharacterMask(std::bitset<256>& first_character_mask
 ) {
   first_character_mask.reset();
-  const auto& sequence = grammar_->GetGrammarExpr(initial_state_.sequence_id);
-  if (!grammar_->per_rule_fsms[init_rule_id_].has_value()) {
-    const auto& sub_sequence = grammar_->GetGrammarExpr(sequence[initial_state_.element_id]);
-    switch (sub_sequence.type) {
-      case Grammar::Impl::GrammarExprType::kByteString: {
-        first_character_mask[sub_sequence[initial_state_.sub_element_id]] = true;
-        break;
-      }
-      case xgrammar::Grammar::Impl::GrammarExprType::kCharacterClass:
-      case xgrammar::Grammar::Impl::GrammarExprType::kCharacterClassStar: {
-        if (initial_state_.sub_element_id == 0) {
-          bool is_negative = sub_sequence[0];
-          for (int i = 1; i < sub_sequence.size(); i += 2) {
-            int left_char = static_cast<uint8_t>(sub_sequence[i]);
-            int right_char = static_cast<uint8_t>(sub_sequence[i + 1]);
-            for (int c = left_char; c <= right_char; ++c) {
-              first_character_mask[c] = true;
-            }
-          }
-          if (is_negative) {
-            first_character_mask = ~first_character_mask;
-          }
-          break;
-        }
-        // Otherwise, it's matching a UTF-8 character. We can optimize the matching process
-        // here.
-        for (size_t i = 0x80; i < 0xC0; ++i) {
-          first_character_mask[i] = true;
-        }
-        break;
-      }
-      default: {
-        XGRAMMAR_LOG(FATAL) << "Unsupported grammar expr type: " << static_cast<int>(sequence.type);
-      }
-    }
-  } else {
-    const auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
-    const auto& edges = fsm.GetFsm().GetEdges(initial_state_.element_id);
-    for (const auto& edge : edges) {
-      if (edge.IsCharRange()) {
-        for (int c = edge.min; c <= edge.max; ++c) {
-          first_character_mask[c] = true;
-        }
+  XGRAMMAR_DCHECK(grammar_->per_rule_fsms[init_rule_id_].has_value());
+  const auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
+  const auto& edges = fsm.GetFsm().GetEdges(initial_state_.element_id);
+  for (const auto& edge : edges) {
+    if (edge.IsCharRange()) {
+      for (int c = edge.min; c <= edge.max; ++c) {
+        first_character_mask[c] = true;
       }
     }
   }
@@ -998,8 +929,6 @@ class GrammarCompilerSub {
 };
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
-  using GrammarExprType = Grammar::Impl::GrammarExprType;
-
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
 
   compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
@@ -1064,52 +993,18 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   for (int32_t rule_id = 0; rule_id < static_cast<int>(compiled_grammar_impl->grammar->NumRules());
        ++rule_id) {
     auto rule = compiled_grammar_impl->grammar->GetRule(rule_id);
-    auto rule_body = compiled_grammar_impl->grammar->GetGrammarExpr(rule.body_expr_id);
     const auto& rule_fsm = compiled_grammar_impl->grammar->per_rule_fsms[rule_id];
-    if (rule_fsm.has_value()) {
-      auto cur_stack_element =
-          ParserState(rule_id, rule.body_expr_id, 0, ParserState::kNoPrevInputPos, 0);
-      std::unordered_set<int> reachable_states;
-      rule_fsm->GetReachableStates(&reachable_states);
-      for (int i : reachable_states) {
-        cur_stack_element.element_id = i;
-        if (!rule_fsm->IsScanableState(i)) {
-          continue;
-        }
-        add_task_adaptive_token_mask(cur_stack_element, rule_id == root_rule_id);
-      }
-      continue;
-    }
-    XGRAMMAR_DCHECK(rule_body.type == GrammarExprType::kChoices);
-    for (auto sequence_id : rule_body) {
-      const auto& sequence = compiled_grammar_impl->grammar->GetGrammarExpr(sequence_id);
-      if (sequence.type == GrammarExprType::kEmptyStr) {
+    XGRAMMAR_DCHECK(rule_fsm.has_value());
+    auto cur_stack_element =
+        ParserState(rule_id, rule.body_expr_id, 0, ParserState::kNoPrevInputPos, 0);
+    std::unordered_set<int> reachable_states;
+    rule_fsm->GetReachableStates(&reachable_states);
+    for (int i : reachable_states) {
+      cur_stack_element.element_id = i;
+      if (!rule_fsm->IsScanableState(i)) {
         continue;
       }
-      XGRAMMAR_DCHECK(sequence.type == GrammarExprType::kSequence);
-      auto state = ParserState(rule_id, sequence_id, 0, ParserState::kNoPrevInputPos, 0);
-      for (int element_id = 0; element_id < sequence.size(); ++element_id) {
-        state.element_id = element_id;
-        auto element = compiled_grammar_impl->grammar->GetGrammarExpr(sequence[element_id]);
-        if (element.type == GrammarExprType::kRuleRef || element.type == GrammarExprType::kRepeat) {
-          continue;
-        }
-        if (element.type == GrammarExprType::kByteString) {
-          for (int idx = 0; idx < element.size(); ++idx) {
-            state.sub_element_id = idx;
-            add_task_adaptive_token_mask(state, rule_id == root_rule_id);
-          }
-        } else {
-          XGRAMMAR_DCHECK(
-              element.type == GrammarExprType::kCharacterClassStar ||
-              element.type == GrammarExprType::kCharacterClass
-          );
-          for (int left_utf8_bytes = 0; left_utf8_bytes <= 3; ++left_utf8_bytes) {
-            state.sub_element_id = left_utf8_bytes;
-            add_task_adaptive_token_mask(state, rule_id == root_rule_id);
-          }
-        }
-      }
+      add_task_adaptive_token_mask(cur_stack_element, rule_id == root_rule_id);
     }
   }
 

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1027,6 +1027,12 @@ class GrammarFSMBuilderImpl {
       }
     }
 
+    for (int i = 0; i < (*grammar)->NumRules(); ++i) {
+      XGRAMMAR_DCHECK(per_rule_fsms[i].has_value())
+          << "Rule " << i << " (" << (*grammar)->GetRule(i).name
+          << ") does not have an FSM after optimization";
+    }
+
     // Compress to compact fsm
     CompactFSM compact_complete_fsm = complete_fsm.ToCompact();
     std::vector<std::optional<CompactFSMWithStartEnd>> compact_per_rule_fsms((*grammar)->NumRules()

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -798,68 +798,23 @@ std::string GrammarMatcher::Impl::FindJumpForwardString() {
     // -1 means not found yet; 0~255 means the next char
     int next_char = -1;
     for (const auto& state : states) {
-      if (state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value()) {
-        const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
-        const auto& current_edges = fsm.GetFsm().GetEdges(state.element_id);
-        for (const auto& edge : current_edges) {
-          if (!edge.IsCharRange()) {
-            continue;
-          }
-          if (edge.min != edge.max) {
-            can_find_next_char = false;
-            break;
-          }
-          if (next_char == -1) {
-            next_char = edge.min;
-          } else if (next_char != edge.min) {
-            can_find_next_char = false;
-            break;
-          }
+      XGRAMMAR_DCHECK(state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value());
+      const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
+      const auto& current_edges = fsm.GetFsm().GetEdges(state.element_id);
+      for (const auto& edge : current_edges) {
+        if (!edge.IsCharRange()) {
+          continue;
         }
-        continue;
-      }
-
-      auto cur_sequence = grammar_->GetGrammarExpr(state.sequence_id);
-
-      // We cannot deduce the next char for tag dispatch
-      if (cur_sequence.type == GrammarExprType::kTagDispatch) {
-        can_find_next_char = false;
-        break;
-      }
-      // The ParserState comes to the end of the grammar
-      XGRAMMAR_DCHECK(state.element_id != cur_sequence.size());
-      XGRAMMAR_DCHECK(
-          cur_sequence.type != GrammarExprType::kChoices &&
-          cur_sequence.type != GrammarExprType::kEmptyStr
-      );
-      const auto& cur_element = grammar_->GetGrammarExpr(cur_sequence[state.element_id]);
-      if (cur_element.type == GrammarExprType::kByteString) {
-        XGRAMMAR_DCHECK(state.sub_element_id < cur_element.size());
-        if (next_char == -1) {
-          next_char = cur_element[state.sub_element_id];
-        } else if (next_char != cur_element[state.sub_element_id]) {
+        if (edge.min != edge.max) {
           can_find_next_char = false;
           break;
         }
-        continue;
-      }
-      if (cur_element.type == GrammarExprType::kRuleRef) {
-        continue;
-      }
-
-      XGRAMMAR_DCHECK(
-          cur_element.type == GrammarExprType::kCharacterClass ||
-          cur_element.type == GrammarExprType::kCharacterClassStar
-      );
-      if (state.sub_element_id > 0 || cur_element.size() != 3 || cur_element[0] != 0 ||
-          cur_element[1] != cur_element[2]) {
-        can_find_next_char = false;
-        break;
-      } else if (next_char == -1) {
-        next_char = cur_element[1];
-      } else if (next_char != cur_element[1]) {
-        can_find_next_char = false;
-        break;
+        if (next_char == -1) {
+          next_char = edge.min;
+        } else if (next_char != edge.min) {
+          can_find_next_char = false;
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Remove AST fallback branches from the Earley parser, grammar compiler, and grammar matcher for normal rules (rule_id != -1), replacing them with DCHECKs that assert all rules have FSMs after optimization.
- Add DCHECK in GrammarFSMBuilder to verify every rule has an FSM after optimization.
- Preserve AST paths only for lookahead assertions (rule_id == -1).