### PR TITLE
feat: token-level grammar support with Token/ExcludeToken/TokenTagDispatch edges

### DIFF
--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -199,6 +199,10 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
     case GrammarExprType::kCharacterClass: {
       return std::make_pair(true, false);  // The element is scanable, but not completable.
     }
+    case GrammarExprType::kToken:
+    case GrammarExprType::kExcludeToken: {
+      return std::make_pair(false, false);
+    }
     default: {
       XGRAMMAR_LOG(FATAL) << "The element type is not supported! The type is: "
                           << int(element_expr.type);
@@ -889,6 +893,61 @@ void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
       Enqueue(std::move(new_state));
     }
   }
+}
+
+void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
+  if (state.rule_id == -1) return;
+  XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
+  const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
+  for (const auto& edge : current_fsm.GetFsm().GetEdges(state.element_id)) {
+    bool matched = false;
+    if (edge.IsToken()) {
+      auto info = current_fsm.GetFsm().GetTokenEdgeInfo(edge.GetAuxIndex());
+      matched = info.Contains(token_id);
+    } else if (edge.IsExcludeToken()) {
+      auto info = current_fsm.GetFsm().GetExcludeTokenEdgeInfo(edge.GetAuxIndex());
+      matched = info.Accepts(token_id);
+    }
+    if (!matched) continue;
+    auto new_state = state;
+    new_state.element_id = edge.target;
+    if ((!current_fsm.IsNonTerminalState(edge.target)) &&
+        (!current_fsm.IsEndState(edge.target) && current_fsm.IsScanableState(edge.target))) {
+      EnqueueWithoutProcessing(std::move(new_state));
+    } else {
+      Enqueue(std::move(new_state));
+    }
+  }
+}
+
+bool EarleyParser::AdvanceAtomicToken(int32_t token_id, bool debug_print) {
+  XGRAMMAR_DCHECK(tmp_process_state_queue_.empty())
+      << "The tmp_process_state_queue_ should be empty before AdvanceAtomicToken.";
+  tmp_states_visited_in_queue_.Clear();
+  tmp_states_to_be_added_.clear();
+  tmp_accept_stop_token_ = false;
+  const auto& latest_states = scanable_state_history_[scanable_state_history_.size() - 1];
+  for (const auto& state : latest_states) {
+    ScanAtomicToken(state, token_id);
+  }
+  if (tmp_process_state_queue_.empty() && tmp_states_to_be_added_.empty()) {
+    return false;
+  }
+  rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
+  while (!tmp_process_state_queue_.empty()) {
+    const auto state = std::move(tmp_process_state_queue_.front());
+    tmp_process_state_queue_.pop();
+    auto [scanable, completable] = Predict(state, debug_print);
+    if (completable) {
+      Complete(state, debug_print);
+    }
+    if (scanable) {
+      tmp_states_to_be_added_.push_back(state);
+    }
+  }
+  is_completed_.push_back(tmp_accept_stop_token_);
+  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  return true;
 }
 
 bool RepeatDetector::IsVisited(const ParserState& state) const {

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -121,11 +121,19 @@ struct ParserState {
   }
 
   std::string ToString() const {
-    return "ParserState(rule_id=" + std::to_string(rule_id) +
-           ", sequence_id=" + std::to_string(sequence_id) +
-           ", element_id=" + std::to_string(element_id) +
-           ", rule_start_pos=" + std::to_string(rule_start_pos) +
-           ", sub_element_id=" + std::to_string(sub_element_id) + ")";
+    std::string result = "ParserState(rule_id=" + std::to_string(rule_id) +
+                         ", sequence_id=" + std::to_string(sequence_id) +
+                         ", element_id=" + std::to_string(element_id) +
+                         ", rule_start_pos=" + std::to_string(rule_start_pos) +
+                         ", sub_element_id=" + std::to_string(sub_element_id);
+    if (repeat_count != 0) {
+      result += ", repeat_count=" + std::to_string(repeat_count);
+    }
+    if (partial_codepoint != 0) {
+      result += ", partial_codepoint=" + std::to_string(partial_codepoint);
+    }
+    result += ")";
+    return result;
   }
 };
 
@@ -376,6 +384,20 @@ class EarleyParser {
    * \return The next state, Invalid state if the character is not accepted.
    */
   void AdvanceFsm(const ParserState& state, const uint8_t ch);
+
+  /*!
+   * \brief Scan a token edge: check if token_id matches any kToken or kExcludeToken edge from
+   * state.
+   */
+  void ScanAtomicToken(const ParserState& state, int32_t token_id);
+
+  /*!
+   * \brief Advance the parser by accepting a whole token via kToken/kExcludeToken edges.
+   * \param token_id The token ID to accept.
+   * \param debug_print Whether to print debug info.
+   * \return True if any state advanced, false otherwise.
+   */
+  bool AdvanceAtomicToken(int32_t token_id, bool debug_print = false);
 
   /*!
    * \brief Enqueue the state into the queue.

--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -78,6 +78,12 @@ class FSMImplBase {
 
   RepeatEdgeRef GetRepeatEdgeInfo(int16_t idx) const { return {edge_aux_data_.data() + idx}; }
 
+  TokenEdgeRef GetTokenEdgeInfo(int16_t idx) const { return {edge_aux_data_.data() + idx}; }
+
+  ExcludeTokenEdgeRef GetExcludeTokenEdgeInfo(int16_t idx) const {
+    return {edge_aux_data_.data() + idx};
+  }
+
  protected:
   ContainerType edges_;
   std::vector<int32_t> edge_aux_data_;
@@ -111,6 +117,22 @@ std::string FSMImplBase<ContainerType>::EdgesToString(std::optional<std::vector<
         result += "Repeat(rule=" + std::to_string(info.RuleId()) +
                   ", min=" + std::to_string(info.Lower()) +
                   ", max=" + std::to_string(info.Upper()) + ")->" + std::to_string(edge.target);
+      } else if (edge.min == FSMEdge::EdgeType::kToken) {
+        auto info = GetTokenEdgeInfo(edge.max);
+        result += "Token(";
+        for (int32_t k = 0; k < info.Count(); ++k) {
+          if (k > 0) result += ", ";
+          result += std::to_string(info.TokenIds()[k]);
+        }
+        result += ")->" + std::to_string(edge.target);
+      } else if (edge.min == FSMEdge::EdgeType::kExcludeToken) {
+        auto info = GetExcludeTokenEdgeInfo(edge.max);
+        result += "ExcludeToken(";
+        for (int32_t k = 0; k < info.Count(); ++k) {
+          if (k > 0) result += ", ";
+          result += std::to_string(info.TokenIds()[k]);
+        }
+        result += ")->" + std::to_string(edge.target);
       }
       if (j < static_cast<int>(edges.size()) - 1) {
         result += ", ";
@@ -235,12 +257,37 @@ class FSM::Impl : public FSMImplBase<std::vector<std::vector<FSMEdge>>> {
   void AddRepeatEdge(int from, int to, int32_t rule_id, int32_t lower, int32_t upper) {
     XGRAMMAR_DCHECK(edges_[from].empty())
         << "A state with a kRepeatRef edge must have no other outgoing edges.";
+    XGRAMMAR_DCHECK(edge_aux_data_.size() <= INT16_MAX);
     int16_t aux_index = static_cast<int16_t>(edge_aux_data_.size());
     edge_aux_data_.reserve(edge_aux_data_.size() + 3);
     edge_aux_data_.emplace_back(rule_id);
     edge_aux_data_.emplace_back(lower);
     edge_aux_data_.emplace_back(upper);
     AddEdge(from, to, FSMEdge::EdgeType::kRepeatRef, aux_index);
+  }
+
+  void AddTokenEdge(int from, int to, const std::vector<int32_t>& token_ids) {
+    XGRAMMAR_DCHECK(!token_ids.empty()) << "Token set must not be empty";
+    XGRAMMAR_CHECK(edge_aux_data_.size() <= INT16_MAX)
+        << "edge_aux_data_ overflow: too many auxiliary data entries";
+    int16_t aux_index = static_cast<int16_t>(edge_aux_data_.size());
+    edge_aux_data_.push_back(static_cast<int32_t>(token_ids.size()));
+    for (int32_t id : token_ids) {
+      edge_aux_data_.push_back(id);
+    }
+    edges_[from].push_back(FSMEdge(FSMEdge::EdgeType::kToken, aux_index, to));
+  }
+
+  void AddExcludeTokenEdge(int from, int to, const std::vector<int32_t>& token_ids) {
+    XGRAMMAR_DCHECK(!token_ids.empty()) << "Token exclude set must not be empty";
+    XGRAMMAR_CHECK(edge_aux_data_.size() <= INT16_MAX)
+        << "edge_aux_data_ overflow: too many auxiliary data entries";
+    int16_t aux_index = static_cast<int16_t>(edge_aux_data_.size());
+    edge_aux_data_.push_back(static_cast<int32_t>(token_ids.size()));
+    for (int32_t id : token_ids) {
+      edge_aux_data_.push_back(id);
+    }
+    edges_[from].push_back(FSMEdge(FSMEdge::EdgeType::kExcludeToken, aux_index, to));
   }
 
   void AddFSM(const FSM& fsm, std::vector<int>* state_mapping);
@@ -444,11 +491,25 @@ void FSM::AddRepeatEdge(int from, int to, int32_t rule_id, int32_t lower, int32_
   pimpl_->AddRepeatEdge(from, to, rule_id, lower, upper);
 }
 
+void FSM::AddTokenEdge(int from, int to, const std::vector<int32_t>& token_ids) {
+  pimpl_->AddTokenEdge(from, to, token_ids);
+}
+
+void FSM::AddExcludeTokenEdge(int from, int to, const std::vector<int32_t>& token_ids) {
+  pimpl_->AddExcludeTokenEdge(from, to, token_ids);
+}
+
 const std::vector<int32_t>& FSM::GetEdgeAuxData() const { return pimpl_->GetEdgeAuxData(); }
 
 void FSM::SetEdgeAuxData(std::vector<int32_t> data) { pimpl_->SetEdgeAuxData(std::move(data)); }
 
 RepeatEdgeRef FSM::GetRepeatEdgeInfo(int16_t idx) const { return pimpl_->GetRepeatEdgeInfo(idx); }
+
+TokenEdgeRef FSM::GetTokenEdgeInfo(int16_t idx) const { return pimpl_->GetTokenEdgeInfo(idx); }
+
+ExcludeTokenEdgeRef FSM::GetExcludeTokenEdgeInfo(int16_t idx) const {
+  return pimpl_->GetExcludeTokenEdgeInfo(idx);
+}
 
 void FSM::AddFSM(const FSM& fsm, std::vector<int>* state_mapping) {
   pimpl_->AddFSM(fsm, state_mapping);
@@ -726,6 +787,14 @@ void CompactFSM::SetEdgeAuxData(std::vector<int32_t> data) {
 
 RepeatEdgeRef CompactFSM::GetRepeatEdgeInfo(int16_t idx) const {
   return pimpl_->GetRepeatEdgeInfo(idx);
+}
+
+TokenEdgeRef CompactFSM::GetTokenEdgeInfo(int16_t idx) const {
+  return pimpl_->GetTokenEdgeInfo(idx);
+}
+
+ExcludeTokenEdgeRef CompactFSM::GetExcludeTokenEdgeInfo(int16_t idx) const {
+  return pimpl_->GetExcludeTokenEdgeInfo(idx);
 }
 
 picojson::value SerializeJSONValue(const CompactFSM& value) {
@@ -1130,12 +1199,23 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
   UnionFindSet<int> union_find_set;
   std::vector<int> in_degree(NumStates(), 0);
   std::vector<std::pair<int32_t, int32_t>> epsilon_edges;
+
+  std::vector<bool> has_exclude_token(NumStates(), false);
+  for (int i = 0; i < NumStates(); i++) {
+    for (const auto& edge : fsm_->GetEdges(i)) {
+      if (edge.IsExcludeToken()) {
+        has_exclude_token[i] = true;
+        break;
+      }
+    }
+  }
+
   for (int i = 0; i < NumStates(); i++) {
     const auto& edges = fsm_->GetEdges(i);
     for (const auto& edge : edges) {
       in_degree[edge.target]++;
       if (edge.IsEpsilon()) {
-        if (edges.size() == 1) {
+        if (edges.size() == 1 && !has_exclude_token[i] && !has_exclude_token[edge.target]) {
           // a -- epsilon --> b, and a doesn't have other outward edges.
           union_find_set.Add(i);
           union_find_set.Add(edge.target);
@@ -1167,7 +1247,8 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
   for (const auto& [from_raw, to_raw] : epsilon_edges) {
     const int& from = equiv_node[from_raw];
     const int& to = equiv_node[to_raw];
-    if (in_degree[to] == 1 && equiv_node[GetStart()] != to) {
+    if (in_degree[to] == 1 && equiv_node[GetStart()] != to && !has_exclude_token[from_raw] &&
+        !has_exclude_token[to_raw]) {
       union_find_set.Add(from);
       union_find_set.Add(to);
       union_find_set.Union(from, to);
@@ -1492,6 +1573,8 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
   while (now_process < static_cast<int>(closures.size())) {
     rules.clear();
     repeat_aux_indices.clear();
+    std::unordered_set<int16_t> token_aux_indices;
+    std::unordered_set<int16_t> exclude_token_aux_indices;
     std::set<int> interval_ends;
     std::bitset<256> allowed_characters;
     dfa.AddState();
@@ -1513,6 +1596,10 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
           rules.insert(edge.GetRefRuleId());
         } else if (edge.IsRepeatRef()) {
           repeat_aux_indices.insert(edge.GetAuxIndex());
+        } else if (edge.IsToken()) {
+          token_aux_indices.insert(edge.GetAuxIndex());
+        } else if (edge.IsExcludeToken()) {
+          exclude_token_aux_indices.insert(edge.GetAuxIndex());
         }
       }
     }
@@ -1628,6 +1715,67 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
         closures.push_back(next_closure);
       }
     }
+
+    for (auto aux_idx : token_aux_indices) {
+      std::unordered_set<int> next_closure;
+      for (const auto& state : closures[now_process]) {
+        const auto& edges = fsm_.GetEdges(state);
+        for (const auto& edge : edges) {
+          if (edge.IsToken() && edge.GetAuxIndex() == aux_idx) {
+            if (next_closure.find(edge.target) == next_closure.end()) {
+              std::unordered_set<int> epsilon_closure;
+              epsilon_closure.insert(edge.target);
+              fsm_.GetEpsilonClosure(&epsilon_closure);
+              next_closure.insert(epsilon_closure.begin(), epsilon_closure.end());
+            }
+          }
+        }
+      }
+      bool flag = false;
+      for (int j = 0; j < static_cast<int>(closures.size()); j++) {
+        if (closures[j] == next_closure) {
+          dfa.GetFsm().AddEdge(now_process, j, FSMEdge::EdgeType::kToken, aux_idx);
+          flag = true;
+          break;
+        }
+      }
+      if (!flag) {
+        dfa.GetFsm().AddEdge(now_process, closures.size(), FSMEdge::EdgeType::kToken, aux_idx);
+        closures.push_back(next_closure);
+      }
+    }
+
+    for (auto aux_idx : exclude_token_aux_indices) {
+      std::unordered_set<int> next_closure;
+      for (const auto& state : closures[now_process]) {
+        const auto& edges = fsm_.GetEdges(state);
+        for (const auto& edge : edges) {
+          if (edge.IsExcludeToken() && edge.GetAuxIndex() == aux_idx) {
+            if (next_closure.find(edge.target) == next_closure.end()) {
+              std::unordered_set<int> epsilon_closure;
+              epsilon_closure.insert(edge.target);
+              fsm_.GetEpsilonClosure(&epsilon_closure);
+              next_closure.insert(epsilon_closure.begin(), epsilon_closure.end());
+            }
+          }
+        }
+      }
+      bool flag = false;
+      for (int j = 0; j < static_cast<int>(closures.size()); j++) {
+        if (closures[j] == next_closure) {
+          dfa.GetFsm().AddEdge(now_process, j, FSMEdge::EdgeType::kExcludeToken, aux_idx);
+          flag = true;
+          break;
+        }
+      }
+      if (!flag) {
+        dfa.GetFsm().AddEdge(
+            now_process, closures.size(), FSMEdge::EdgeType::kExcludeToken, aux_idx
+        );
+        closures.push_back(next_closure);
+      }
+    }
+
     now_process++;
   }
   dfa.GetFsm().SetEdgeAuxData(std::vector<int32_t>(fsm_.GetEdgeAuxData()));

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -32,29 +32,34 @@ namespace xgrammar {
  */
 struct alignas(8) FSMEdge {
   /*!
-   * \brief The min field of the edge stores the type of the edge. When min >= 0, it represents a
-   * range of characters [min, max]. When min < 0, it represents a special edge type.
+   * \brief Edge type is encoded in the `min` field. When min >= 0, the edge is a character range
+   * [min, max]. When min < 0, it is a special edge type identified by the enum values below.
+   *
+   * For each type, `max` has a type-specific meaning (see comments on each enumerator).
    */
   enum EdgeType : int16_t {
-    kCharRange = 0,  // When min >= kCharRange, it represents a range of characters.
+    //! Character range [min, max]. min >= 0.
+    kCharRange = 0,
+    //! Epsilon transition. max is unused.
     kEpsilon = -1,
+    //! Rule reference. max = rule_id.
     kRuleRef = -2,
+    //! Accepts the EOS token. max is unused.
     kEOS = -3,
+    //! Repeated rule reference. max = aux index into edge_aux_data
+    //! (layout: [rule_id, lower, upper]).
+    //! Invariant: a state with a kRepeatRef edge has exactly one outgoing edge.
     kRepeatRef = -4,
+    //! Accepts a set of token IDs. max = aux index into edge_aux_data
+    //! (layout: [count, token_id_0, token_id_1, ...]).
+    kToken = -5,
+    //! Accepts any token NOT in the given set. max = aux index into edge_aux_data
+    //! (layout: [count, token_id_0, token_id_1, ...]).
+    kExcludeToken = -6,
   };
 
   inline static constexpr int kMaxChar = 255;
 
-  /*!
-   * \brief The information of the edge.
-   * \details When min >= 0, then it represents a range of characters [min, max].
-   * When min == EdgeType::kRuleRef, it represents a reference to a rule. max is the rule id.
-   * When min == EdgeType::kEpsilon, it means the edge is an epsilon transition.
-   * When min == EdgeType::kEOS, it means the edge accepts an EOS token.
-   * When min == EdgeType::kRepeatRef, it represents a repeated rule reference.
-   *   max is the index into the owning FSM's edge_aux_data (layout: [rule_id, lower, upper]).
-   *   Invariant: a state with a kRepeatRef edge has exactly one outgoing edge.
-   */
   int16_t min, max;
 
   /*!
@@ -112,6 +117,10 @@ struct alignas(8) FSMEdge {
    */
   bool IsRepeatRef() const { return min == EdgeType::kRepeatRef; }
 
+  bool IsToken() const { return min == EdgeType::kToken; }
+
+  bool IsExcludeToken() const { return min == EdgeType::kExcludeToken; }
+
   /*!
    * \brief Get the rule id of the edge.
    * \return The rule id of the edge. -1 if the edge is not a rule reference.
@@ -122,10 +131,12 @@ struct alignas(8) FSMEdge {
    * \brief Get the auxiliary data index for repeat reference edges.
    * \return The index into the owning FSM's edge_aux_data. -1 if not a repeat reference.
    */
-  int16_t GetAuxIndex() const { return IsRepeatRef() ? max : -1; }
+  int16_t GetAuxIndex() const {
+    return (IsRepeatRef() || IsToken() || IsExcludeToken()) ? max : -1;
+  }
 
-  /*! \brief Check if the edge uses auxiliary data (currently only kRepeatRef). */
-  bool IsAuxEdge() const { return IsRepeatRef(); }
+  /*! \brief Check if the edge uses auxiliary data. */
+  bool IsAuxEdge() const { return IsRepeatRef() || IsToken() || IsExcludeToken(); }
 
   friend struct member_trait<FSMEdge>;
 };
@@ -136,6 +147,33 @@ struct RepeatEdgeRef {
   int16_t RuleId() const { return static_cast<int16_t>(data[0]); }
   int32_t Lower() const { return data[1]; }
   int32_t Upper() const { return data[2]; }
+};
+
+/*! \brief View into edge_aux_data for a token edge (layout: [count, token_id_0, ...]). */
+struct TokenEdgeRef {
+  const int32_t* data;
+  int32_t Count() const { return data[0]; }
+  const int32_t* TokenIds() const { return data + 1; }
+  bool Contains(int32_t token_id) const {
+    for (int32_t i = 0; i < Count(); ++i) {
+      if (TokenIds()[i] == token_id) return true;
+    }
+    return false;
+  }
+};
+
+/*! \brief View into edge_aux_data for an exclude-token edge (layout: [count, token_id_0, ...]). */
+struct ExcludeTokenEdgeRef {
+  const int32_t* data;
+  int32_t Count() const { return data[0]; }
+  const int32_t* TokenIds() const { return data + 1; }
+  bool Contains(int32_t token_id) const {
+    for (int32_t i = 0; i < Count(); ++i) {
+      if (TokenIds()[i] == token_id) return true;
+    }
+    return false;
+  }
+  bool Accepts(int32_t token_id) const { return !Contains(token_id); }
 };
 
 /*!
@@ -325,6 +363,10 @@ class FSM {
    */
   void AddRepeatEdge(int from, int to, int32_t rule_id, int32_t lower, int32_t upper);
 
+  void AddTokenEdge(int from, int to, const std::vector<int32_t>& token_ids);
+
+  void AddExcludeTokenEdge(int from, int to, const std::vector<int32_t>& token_ids);
+
   /*! \brief Get the edge auxiliary data. */
   const std::vector<int32_t>& GetEdgeAuxData() const;
 
@@ -333,6 +375,12 @@ class FSM {
 
   /*! \brief Get repeat edge info by aux index. */
   RepeatEdgeRef GetRepeatEdgeInfo(int16_t idx) const;
+
+  /*! \brief Get token edge info by aux index. */
+  TokenEdgeRef GetTokenEdgeInfo(int16_t idx) const;
+
+  /*! \brief Get exclude-token edge info by aux index. */
+  ExcludeTokenEdgeRef GetExcludeTokenEdgeInfo(int16_t idx) const;
 
   /*!
    * \brief Add a whole FSM to the current FSM.
@@ -496,6 +544,12 @@ class CompactFSM {
   /*! \brief Get repeat edge info by aux index. */
   RepeatEdgeRef GetRepeatEdgeInfo(int16_t idx) const;
 
+  /*! \brief Get token edge info by aux index. */
+  TokenEdgeRef GetTokenEdgeInfo(int16_t idx) const;
+
+  /*! \brief Get exclude-token edge info by aux index. */
+  ExcludeTokenEdgeRef GetExcludeTokenEdgeInfo(int16_t idx) const;
+
   /****************** CompactFSM Construction Methods ******************/
 
   /*!
@@ -562,7 +616,7 @@ class FSMWithStartEndBase {
    */
   bool IsScanableState(int state) const {
     for (const auto& edge : fsm_.GetEdges(state)) {
-      if (edge.IsCharRange()) {
+      if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken()) {
         return true;
       }
     }

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -158,6 +158,20 @@ class GrammarBuilder {
   /*! \brief Add a GrammarExpr for empty string.*/
   int32_t AddEmptyStr() { return AddGrammarExpr({GrammarExprType::kEmptyStr, nullptr, 0}); }
 
+  /*! \brief Add a GrammarExpr for kToken (token-level matching). */
+  int32_t AddTokenSet(const std::vector<int32_t>& token_ids) {
+    return AddGrammarExpr(
+        {GrammarExprType::kToken, token_ids.data(), static_cast<int32_t>(token_ids.size())}
+    );
+  }
+
+  /*! \brief Add a GrammarExpr for kExcludeToken (excluded token-level matching). */
+  int32_t AddExcludeTokenSet(const std::vector<int32_t>& token_ids) {
+    return AddGrammarExpr(
+        {GrammarExprType::kExcludeToken, token_ids.data(), static_cast<int32_t>(token_ids.size())}
+    );
+  }
+
   /*! \brief Add a GrammarExpr for rule reference.*/
   int32_t AddRuleRef(int32_t rule_id) {
     std::vector<int32_t> data;
@@ -181,28 +195,40 @@ class GrammarBuilder {
     );
   }
 
-  /*!
-   * \brief Add a GrammarExpr for tag dispatch.
-   * \param tag_dispatch_list A list of pairs of tag_expr_id and rule_id.
-   */
+  /*! \brief Encode a TagDispatch struct into a kTagDispatch expr. */
   int32_t AddTagDispatch(const Grammar::Impl::TagDispatch& tag_dispatch) {
     std::vector<int32_t> data;
-    data.reserve(
-        tag_dispatch.tag_rule_pairs.size() * 2 +
-        Grammar::Impl::TagDispatch::kTagDispatchExtraParameter
-    );
+    data.reserve(tag_dispatch.tag_rule_pairs.size() * 2 + 2);
     for (const auto& [tag, rule_id] : tag_dispatch.tag_rule_pairs) {
       data.push_back(AddByteString(tag));
       data.push_back(rule_id);
     }
     data.push_back(static_cast<int32_t>(tag_dispatch.loop_after_dispatch));
     std::vector<int32_t> exclude_str_expr_ids;
-    for (const auto& exclude_str : tag_dispatch.excluded_str) {
+    for (const auto& exclude_str : tag_dispatch.excludes) {
       exclude_str_expr_ids.push_back(AddByteString(exclude_str));
     }
     data.push_back(AddChoices(exclude_str_expr_ids));
     return AddGrammarExpr(
         {GrammarExprType::kTagDispatch, data.data(), static_cast<int32_t>(data.size())}
+    );
+  }
+
+  /*! \brief Encode a TokenTagDispatch struct into a kTokenTagDispatch expr. */
+  int32_t AddTokenTagDispatch(const Grammar::Impl::TokenTagDispatch& ttd) {
+    std::vector<int32_t> data;
+    data.push_back(static_cast<int32_t>(ttd.trigger_rule_pairs.size()));
+    for (const auto& [token_id, rule_id] : ttd.trigger_rule_pairs) {
+      data.push_back(token_id);
+      data.push_back(rule_id);
+    }
+    data.push_back(static_cast<int32_t>(ttd.loop_after_dispatch));
+    data.push_back(static_cast<int32_t>(ttd.excludes.size()));
+    for (auto token_id : ttd.excludes) {
+      data.push_back(token_id);
+    }
+    return AddGrammarExpr(
+        {GrammarExprType::kTokenTagDispatch, data.data(), static_cast<int32_t>(data.size())}
     );
   }
 

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -27,6 +27,7 @@
 #include "support/thread_pool.h"
 #include "support/thread_safe_cache.h"
 #include "support/utils.h"
+#include "tokenizer_info_impl.h"
 #include "xgrammar/grammar.h"
 #include "xgrammar/tokenizer_info.h"
 
@@ -69,7 +70,9 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
    * It's used to determine which construction function will be used.
    */
   bool GetTokenMaskWithFirstCharacterCheck(
-      const std::bitset<256>& first_char_mask, bool is_root_rule
+      const std::bitset<256>& first_char_mask,
+      bool is_root_rule,
+      const std::vector<int32_t>& token_edge_accepted
   );
 
   /*!
@@ -98,6 +101,14 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
    * \param first_character_mask the bitset to store the first character mask.
    */
   void GetFirstCharacterMask(std::bitset<256>& first_character_mask);
+
+  /*!
+   * \brief Compute sorted vocab indices accepted by token edges at the current FSM state.
+   * Token(ids) edges accept listed token IDs.
+   * ExcludeToken(ids) edges accept all tokens except listed IDs.
+   * \return Sorted, deduplicated vector of accepted sorted vocab indices.
+   */
+  const std::vector<int32_t>& GetTokenEdgeAcceptedIndices();
 
   // The id of the initial rule.
   int32_t init_rule_id_;
@@ -128,6 +139,9 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   std::vector<int32_t> tmp_accepted_by_lookahead_indices_;
   std::vector<bool> tmp_can_reach_end_stack_;
   std::vector<bool> tmp_can_reach_end_prefix_or_stack_;
+  // Temporary data for GetTokenEdgeAcceptedIndices.
+  std::vector<int32_t> tmp_token_edge_accepted_;
+  std::vector<int32_t> tmp_token_edge_excluded_;
 };
 
 void GrammarMatcherForTokenMaskCache::AdaptCacheWithLookahead(
@@ -474,7 +488,9 @@ std::pair<bool, std::bitset<256>> GrammarMatcherForTokenMaskCache::GetSpeculativ
 }
 
 bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
-    const std::bitset<256>& first_char_mask, bool is_root_rule
+    const std::bitset<256>& first_char_mask,
+    bool is_root_rule,
+    const std::vector<int32_t>& token_edge_accepted
 ) {
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
   const auto& subtree_nodes_range = tokenizer_info_.GetTrieSubtreeNodesRange();
@@ -513,9 +529,15 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
   }
 
   const std::string* prev_token = nullptr;
+  int32_t skip_ptr = 0;
+  const int32_t skip_size = static_cast<int32_t>(token_edge_accepted.size());
   for (size_t interval_idx = 0; interval_idx < possible_intervals.size(); ++interval_idx) {
     const auto& interval = possible_intervals[interval_idx];
     for (int i = interval.first; i < interval.second; ++i) {
+      // Skip tokens already accepted by token edges (avoid expensive Earley simulation).
+      while (skip_ptr < skip_size && token_edge_accepted[skip_ptr] < i) ++skip_ptr;
+      if (skip_ptr < skip_size && token_edge_accepted[skip_ptr] == i) continue;
+
       // Check if the current token is in the rejected range. i.e. check if the current token
       // is on the subtree of the rejected token.
       if (i < last_rejected_range) {
@@ -681,6 +703,77 @@ void GrammarMatcherForTokenMaskCache::GetFirstCharacterMask(std::bitset<256>& fi
   }
 }
 
+const std::vector<int32_t>& GrammarMatcherForTokenMaskCache::GetTokenEdgeAcceptedIndices() {
+  // Compute sorted vocab indices accepted by Token(ids) and ExcludeToken(ids) edges.
+  // Result is stored in tmp_token_edge_accepted_.
+
+  tmp_token_edge_accepted_.clear();
+  tmp_token_edge_excluded_.clear();
+
+  XGRAMMAR_DCHECK(grammar_->per_rule_fsms[init_rule_id_].has_value());
+  const auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
+  const auto& edges = fsm.GetFsm().GetEdges(initial_state_.element_id);
+
+  const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
+  int32_t sorted_size = static_cast<int32_t>(sorted_decoded_vocab.size());
+  const auto& tid_to_sorted = tokenizer_info_.ImplPtr()->GetTokenIdToSortedVocabIndex();
+
+  bool has_exclude_token = false;
+
+  for (const auto& edge : edges) {
+    if (edge.IsToken()) {
+      auto info = fsm.GetFsm().GetTokenEdgeInfo(edge.GetAuxIndex());
+      for (int32_t i = 0; i < info.Count(); ++i) {
+        int32_t tid = info.TokenIds()[i];
+        XGRAMMAR_DCHECK(tid >= 0 && tid < static_cast<int32_t>(tid_to_sorted.size()));
+        if (tid_to_sorted[tid] >= 0) {
+          tmp_token_edge_accepted_.push_back(tid_to_sorted[tid]);
+        }
+      }
+    } else if (edge.IsExcludeToken()) {
+      has_exclude_token = true;
+      auto info = fsm.GetFsm().GetExcludeTokenEdgeInfo(edge.GetAuxIndex());
+      for (int32_t i = 0; i < info.Count(); ++i) {
+        int32_t tid = info.TokenIds()[i];
+        XGRAMMAR_DCHECK(tid >= 0 && tid < static_cast<int32_t>(tid_to_sorted.size()));
+        if (tid_to_sorted[tid] >= 0) {
+          tmp_token_edge_excluded_.push_back(tid_to_sorted[tid]);
+        }
+      }
+    }
+  }
+
+  // Token-only: result = token_accepted
+  if (!has_exclude_token) {
+    if (!tmp_token_edge_accepted_.empty()) {
+      std::sort(tmp_token_edge_accepted_.begin(), tmp_token_edge_accepted_.end());
+      tmp_token_edge_accepted_.erase(
+          std::unique(tmp_token_edge_accepted_.begin(), tmp_token_edge_accepted_.end()),
+          tmp_token_edge_accepted_.end()
+      );
+    }
+    return tmp_token_edge_accepted_;
+  }
+
+  // ExcludeToken: result = [0, sorted_size) - (excluded - token_accepted)
+  // Token(ids) overrides ExcludeToken(ids) when both present.
+  if (!tmp_token_edge_accepted_.empty()) {
+    std::sort(tmp_token_edge_accepted_.begin(), tmp_token_edge_accepted_.end());
+    tmp_token_edge_accepted_.erase(
+        std::unique(tmp_token_edge_accepted_.begin(), tmp_token_edge_accepted_.end()),
+        tmp_token_edge_accepted_.end()
+    );
+  }
+  std::sort(tmp_token_edge_excluded_.begin(), tmp_token_edge_excluded_.end());
+  tmp_token_edge_excluded_.erase(
+      std::unique(tmp_token_edge_excluded_.begin(), tmp_token_edge_excluded_.end()),
+      tmp_token_edge_excluded_.end()
+  );
+  IntsetDifference(&tmp_token_edge_excluded_, tmp_token_edge_accepted_);
+  IntsetComplement(&tmp_token_edge_accepted_, sorted_size, tmp_token_edge_excluded_);
+  return tmp_token_edge_accepted_;
+}
+
 AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_root_rule) {
   tmp_accepted_indices_.clear();
   tmp_rejected_indices_.clear();
@@ -740,7 +833,28 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   std::bitset<256> first_character_mask;
   GetFirstCharacterMask(first_character_mask);
 
-  bool rejected_filled = GetTokenMaskWithFirstCharacterCheck(first_character_mask, is_root_rule);
+  // Token edge accepted indices (for byte path skip + merge).
+  const auto& token_edge_accepted = GetTokenEdgeAcceptedIndices();
+
+  // Byte path: skip tokens already accepted by token edges.
+  bool rejected_filled;
+  if (first_character_mask.none()) {
+    rejected_filled = false;
+  } else {
+    rejected_filled = GetTokenMaskWithFirstCharacterCheck(
+        first_character_mask, is_root_rule, token_edge_accepted
+    );
+  }
+
+  // Merge: token edge accepted overrides byte path classification.
+  // accepted  = accepted + token_edge_accepted
+  // rejected  = rejected - token_edge_accepted
+  // uncertain = uncertain - token_edge_accepted
+  if (!token_edge_accepted.empty()) {
+    IntsetUnion(&tmp_accepted_indices_, token_edge_accepted);
+    IntsetDifference(&tmp_rejected_indices_, token_edge_accepted);
+    IntsetDifference(&tmp_uncertain_indices_, token_edge_accepted);
+  }
   if (rejected_filled) {
     auto return_value = AdaptiveTokenMask(
         tokenizer_info_.GetVocabSize(),
@@ -1072,31 +1186,32 @@ void GrammarCompilerSub::TagDispatchOptimization(
         compiled_grammar_impl->GetGrammar()->GetTagDispatch(rule.body_expr_id);
     const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
     DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
-    for (int i = 0; i < static_cast<int32_t>(sorted_decoded_vocab.size()); i++) {
+    for (int j = 0; j < static_cast<int32_t>(sorted_decoded_vocab.size()); j++) {
       bool definite_accept_since_second_char = true;
-      const auto& token = sorted_decoded_vocab[i].second;
+      const auto& token = sorted_decoded_vocab[j].second;
       if (token.empty()) {
-        definite_accepted_tokens_since_second_char.Set(i);
+        definite_accepted_tokens_since_second_char.Set(j);
         continue;
       }
 
-      // Check if the token contains any tag or stop string after the first character.
-      for (const auto& tag : tag_dispatch.tag_rule_pairs) {
-        if (token.find(tag.first, 1) != std::string::npos) {
+      // Check if the token contains any string trigger or exclude string after first char.
+      for (const auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
+        if (token.find(trigger, 1) != std::string::npos) {
           definite_accept_since_second_char = false;
           break;
         }
       }
-      for (const auto& exclude_str : tag_dispatch.excluded_str) {
-        if (token.find(exclude_str, 1) != std::string::npos) {
-          definite_accept_since_second_char = false;
-          break;
+      if (definite_accept_since_second_char) {
+        for (const auto& excl : tag_dispatch.excludes) {
+          if (token.find(excl, 1) != std::string::npos) {
+            definite_accept_since_second_char = false;
+            break;
+          }
         }
       }
 
-      // If the token can be definitely accepted since the second character, set the bit.
       if (definite_accept_since_second_char) {
-        definite_accepted_tokens_since_second_char.Set(i);
+        definite_accepted_tokens_since_second_char.Set(j);
       }
     }
     (*tag_dispatch_rule_id_to_second_slicing_bitset)[i] =

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -16,6 +16,7 @@
 #include <set>
 #include <stack>
 #include <tuple>
+#include <variant>
 #include <vector>
 
 #include "compiled_grammar_impl.h"
@@ -83,12 +84,23 @@ class SubGrammarAdderImpl : public GrammarMutator {
   int32_t VisitTagDispatch(const GrammarExpr& grammar_expr) final {
     Grammar::Impl::TagDispatch old_tag_dispatch = base_grammar_->GetTagDispatch(grammar_expr);
     Grammar::Impl::TagDispatch new_tag_dispatch;
-    for (const auto& [tag, rule_id] : old_tag_dispatch.tag_rule_pairs) {
-      new_tag_dispatch.tag_rule_pairs.emplace_back(tag, new_rule_ids_names[rule_id].first);
+    for (const auto& [trigger, rule_id] : old_tag_dispatch.tag_rule_pairs) {
+      new_tag_dispatch.tag_rule_pairs.emplace_back(trigger, new_rule_ids_names[rule_id].first);
     }
     new_tag_dispatch.loop_after_dispatch = old_tag_dispatch.loop_after_dispatch;
-    new_tag_dispatch.excluded_str = old_tag_dispatch.excluded_str;
+    new_tag_dispatch.excludes = old_tag_dispatch.excludes;
     return builder_->AddTagDispatch(new_tag_dispatch);
+  }
+
+  int32_t VisitTokenTagDispatch(const GrammarExpr& grammar_expr) final {
+    Grammar::Impl::TokenTagDispatch old_ttd = base_grammar_->GetTokenTagDispatch(grammar_expr);
+    Grammar::Impl::TokenTagDispatch new_ttd;
+    for (const auto& [token_id, rule_id] : old_ttd.trigger_rule_pairs) {
+      new_ttd.trigger_rule_pairs.emplace_back(token_id, new_rule_ids_names[rule_id].first);
+    }
+    new_ttd.loop_after_dispatch = old_ttd.loop_after_dispatch;
+    new_ttd.excludes = old_ttd.excludes;
+    return builder_->AddTokenTagDispatch(new_ttd);
   }
 
   std::vector<std::pair<int32_t, std::string>> new_rule_ids_names;
@@ -286,6 +298,9 @@ class StructureNormalizerImpl : public GrammarMutator {
       case GrammarExprType::kCharacterClassStar:
       case GrammarExprType::kRuleRef:
       case GrammarExprType::kRepeat:
+      case GrammarExprType::kToken:
+      case GrammarExprType::kExcludeToken:
+      case GrammarExprType::kTokenTagDispatch:
         return builder_->AddSequence({builder_->AddGrammarExpr(assertion_expr)});
       default:
         XGRAMMAR_LOG(FATAL) << "Unexpected lookahead assertion type: "
@@ -308,10 +323,17 @@ class StructureNormalizerImpl : public GrammarMutator {
       case GrammarExprType::kCharacterClassStar:
       case GrammarExprType::kRuleRef:
       case GrammarExprType::kRepeat:
+      case GrammarExprType::kToken:
+      case GrammarExprType::kExcludeToken:
         return builder_->AddChoices({builder_->AddSequence({builder_->AddGrammarExpr(grammar_expr)})
         });
       case GrammarExprType::kTagDispatch:
         return VisitTagDispatch(grammar_expr);
+      case GrammarExprType::kTokenTagDispatch: {
+        auto ttd_expr_id = VisitTokenTagDispatch(grammar_expr);
+        auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, ttd_expr_id);
+        return builder_->AddChoices({builder_->AddSequence({builder_->AddRuleRef(new_rule_id)})});
+      }
       default:
         XGRAMMAR_LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(grammar_expr.type);
         XGRAMMAR_UNREACHABLE();
@@ -342,11 +364,20 @@ class StructureNormalizerImpl : public GrammarMutator {
         case GrammarExprType::kCharacterClassStar:
         case GrammarExprType::kRuleRef:
         case GrammarExprType::kRepeat:
+        case GrammarExprType::kToken:
+        case GrammarExprType::kExcludeToken:
           VisitElementInChoices(choice_expr, &new_choice_ids);
           break;
         case GrammarExprType::kTagDispatch: {
           auto tag_dispatch_expr_id = VisitTagDispatch(choice_expr);
           auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, tag_dispatch_expr_id);
+          auto new_sequence_id = builder_->AddSequence({builder_->AddRuleRef(new_rule_id)});
+          new_choice_ids.push_back(new_sequence_id);
+          break;
+        }
+        case GrammarExprType::kTokenTagDispatch: {
+          auto ttd_expr_id = VisitTokenTagDispatch(choice_expr);
+          auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, ttd_expr_id);
           auto new_sequence_id = builder_->AddSequence({builder_->AddRuleRef(new_rule_id)});
           new_choice_ids.push_back(new_sequence_id);
           break;
@@ -421,11 +452,19 @@ class StructureNormalizerImpl : public GrammarMutator {
         case GrammarExprType::kCharacterClassStar:
         case GrammarExprType::kRuleRef:
         case GrammarExprType::kRepeat:
+        case GrammarExprType::kToken:
+        case GrammarExprType::kExcludeToken:
           VisitElementInSequence(element_expr, &new_sequence_ids);
           break;
         case GrammarExprType::kTagDispatch: {
           auto tag_dispatch_expr_id = VisitTagDispatch(element_expr);
           auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, tag_dispatch_expr_id);
+          new_sequence_ids.push_back(builder_->AddRuleRef(new_rule_id));
+          break;
+        }
+        case GrammarExprType::kTokenTagDispatch: {
+          auto ttd_expr_id = VisitTokenTagDispatch(element_expr);
+          auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, ttd_expr_id);
           new_sequence_ids.push_back(builder_->AddRuleRef(new_rule_id));
           break;
         }
@@ -617,10 +656,16 @@ class UsedRulesAnalyzer : public GrammarVisitor<std::vector<int32_t>> {
   }
 
   void VisitTagDispatch(const GrammarExpr& grammar_expr) {
-    for (int i = 0;
-         i < grammar_expr.size() - Grammar::Impl::TagDispatch::kTagDispatchExtraParameter;
-         i += 2) {
-      visit_queue_.push(grammar_expr[i + 1]);
+    auto tag_dispatch = base_grammar_->GetTagDispatch(grammar_expr);
+    for (const auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
+      visit_queue_.push(rule_id);
+    }
+  }
+
+  void VisitTokenTagDispatch(const GrammarExpr& grammar_expr) {
+    auto ttd = base_grammar_->GetTokenTagDispatch(grammar_expr);
+    for (const auto& [token_id, rule_id] : ttd.trigger_rule_pairs) {
+      visit_queue_.push(rule_id);
     }
   }
 
@@ -659,12 +704,20 @@ class DeadCodeEliminatorImpl : public GrammarMutator {
 
   int32_t VisitTagDispatch(const GrammarExpr& grammar_expr) final {
     Grammar::Impl::TagDispatch tag_dispatch = base_grammar_->GetTagDispatch(grammar_expr);
-    for (auto& [tag, rule_id] : tag_dispatch.tag_rule_pairs) {
+    for (auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
       XGRAMMAR_DCHECK(rule_id_map_.count(rule_id) > 0);
       rule_id = rule_id_map_[rule_id];
     }
-
     return builder_->AddTagDispatch(tag_dispatch);
+  }
+
+  int32_t VisitTokenTagDispatch(const GrammarExpr& grammar_expr) final {
+    Grammar::Impl::TokenTagDispatch ttd = base_grammar_->GetTokenTagDispatch(grammar_expr);
+    for (auto& [token_id, rule_id] : ttd.trigger_rule_pairs) {
+      XGRAMMAR_DCHECK(rule_id_map_.count(rule_id) > 0);
+      rule_id = rule_id_map_[rule_id];
+    }
+    return builder_->AddTokenTagDispatch(ttd);
   }
 
   int32_t VisitRuleRef(const GrammarExpr& grammar_expr) final {
@@ -692,7 +745,8 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
     InitBuilder(grammar);
     auto root_rule = grammar->GetRootRule();
     auto root_grammar_expr = base_grammar_->GetGrammarExpr(root_rule.body_expr_id);
-    if (root_grammar_expr.type == GrammarExprType::kTagDispatch) {
+    if (root_grammar_expr.type == GrammarExprType::kTagDispatch ||
+        root_grammar_expr.type == GrammarExprType::kTokenTagDispatch) {
       return grammar;
     }
     for (int i = 0; i < static_cast<int>(grammar->NumRules()); ++i) {
@@ -720,10 +774,18 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
       auto rule = base_grammar_->GetRule(i);
       auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
       if (grammar_expr.type == GrammarExprType::kTagDispatch) {
-        for (int j = 1;
-             j < grammar_expr.size() - Grammar::Impl::TagDispatch::kTagDispatchExtraParameter;
-             j += 2) {
-          if (grammar_expr[j] == rule_id) {
+        auto tag_dispatch = base_grammar_->GetTagDispatch(grammar_expr);
+        for (const auto& [trigger, rid] : tag_dispatch.tag_rule_pairs) {
+          if (rid == rule_id) {
+            return false;
+          }
+        }
+        continue;
+      }
+      if (grammar_expr.type == GrammarExprType::kTokenTagDispatch) {
+        auto ttd = base_grammar_->GetTokenTagDispatch(grammar_expr);
+        for (const auto& [token_id, rid] : ttd.trigger_rule_pairs) {
+          if (rid == rule_id) {
             return false;
           }
         }
@@ -763,10 +825,18 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
       auto rule = base_grammar_->GetRule(i);
       auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
       if (grammar_expr.type == GrammarExprType::kTagDispatch) {
-        for (int j = 1;
-             j < grammar_expr.size() - Grammar::Impl::TagDispatch::kTagDispatchExtraParameter;
-             j += 2) {
-          if (grammar_expr[j] == rule_id) {
+        auto tag_dispatch = base_grammar_->GetTagDispatch(grammar_expr);
+        for (const auto& [trigger, rid] : tag_dispatch.tag_rule_pairs) {
+          if (rid == rule_id) {
+            return -1;
+          }
+        }
+        continue;
+      }
+      if (grammar_expr.type == GrammarExprType::kTokenTagDispatch) {
+        auto ttd = base_grammar_->GetTokenTagDispatch(grammar_expr);
+        for (const auto& [token_id, rid] : ttd.trigger_rule_pairs) {
+          if (rid == rule_id) {
             return -1;
           }
         }
@@ -844,10 +914,16 @@ class RuleRefGraphFinder : public GrammarVisitor<std::vector<std::vector<int32_t
   }
 
   void VisitTagDispatch(const GrammarExpr& grammar_expr) {
-    for (int i = 1;
-         i < grammar_expr.size() - Grammar::Impl::TagDispatch::kTagDispatchExtraParameter;
-         i += 2) {
-      rule_visit_graph_[grammar_expr[i]].push_back(cur_rule_id_);
+    auto tag_dispatch = base_grammar_->GetTagDispatch(grammar_expr);
+    for (const auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
+      rule_visit_graph_[rule_id].push_back(cur_rule_id_);
+    }
+  }
+
+  void VisitTokenTagDispatch(const GrammarExpr& grammar_expr) {
+    auto ttd = base_grammar_->GetTokenTagDispatch(grammar_expr);
+    for (const auto& [token_id, rule_id] : ttd.trigger_rule_pairs) {
+      rule_visit_graph_[rule_id].push_back(cur_rule_id_);
     }
   }
 
@@ -884,7 +960,8 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
     for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
       auto rule = base_grammar_->GetRule(i);
       auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
-      if (grammar_expr.type == GrammarExprType::kTagDispatch) {
+      if (grammar_expr.type == GrammarExprType::kTagDispatch ||
+          grammar_expr.type == GrammarExprType::kTokenTagDispatch) {
         empty_rule_id_set->insert(i);
         continue;
       }
@@ -945,8 +1022,10 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
         auto rule = base_grammar_->GetRule(referer_rule_id);
         auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
 
-        XGRAMMAR_DCHECK(grammar_expr.type != GrammarExprType::kTagDispatch)
-            << "TagDispatch rules should already exist in empty_rule_id_set";
+        XGRAMMAR_DCHECK(
+            grammar_expr.type != GrammarExprType::kTagDispatch &&
+            grammar_expr.type != GrammarExprType::kTokenTagDispatch
+        ) << "TagDispatch rules should already exist in empty_rule_id_set";
 
         bool is_epsilon = std::any_of(grammar_expr.begin(), grammar_expr.end(), [&](int32_t i) {
           auto seq_expr = base_grammar_->GetGrammarExpr(i);
@@ -1013,6 +1092,11 @@ class GrammarFSMBuilderImpl {
         auto rule_fsm = TagDispatch((*grammar)->GetTagDispatch(grammar_expr));
         XGRAMMAR_CHECK(rule_fsm.has_value()) << "Failed to build tag dispatch fsm for rule " << i;
         per_rule_fsms[i] = rule_fsm->AddToCompleteFSM(&complete_fsm, &state_mapping);
+      } else if (grammar_expr.type == Grammar::Impl::GrammarExprType::kTokenTagDispatch) {
+        auto rule_fsm = TokenTagDispatch((*grammar)->GetTokenTagDispatch(grammar_expr));
+        XGRAMMAR_CHECK(rule_fsm.has_value())
+            << "Failed to build token tag dispatch fsm for rule " << i;
+        per_rule_fsms[i] = rule_fsm->AddToCompleteFSM(&complete_fsm, &state_mapping);
       } else {
         XGRAMMAR_DCHECK(grammar_expr.type == Grammar::Impl::GrammarExprType::kChoices);
         auto rule_fsm = Choices(grammar_expr, *grammar);
@@ -1049,13 +1133,17 @@ class GrammarFSMBuilderImpl {
   static FSMWithStartEnd CharacterClass(const GrammarExpr& expr);
   static FSMWithStartEnd ByteString(const GrammarExpr& expr);
   static FSMWithStartEnd Repeat(const GrammarExpr& expr);
+  static FSMWithStartEnd Token(const GrammarExpr& expr);
+  static FSMWithStartEnd ExcludeToken(const GrammarExpr& expr);
+  static std::optional<FSMWithStartEnd> TokenTagDispatch(const Grammar::Impl::TokenTagDispatch& ttd
+  );
   static std::optional<FSMWithStartEnd> Sequence(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> Choices(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> TagDispatch(const Grammar::Impl::TagDispatch& tag_dispatch);
   static void AddCharacterRange(FSMWithStartEnd& fsm, int from, int to, uint32_t min, uint32_t max);
-  /* Building tool funtions.*/
-  static std::optional<FSMWithStartEnd> BuildTagDispatchFSM(
-      const std::vector<std::pair<std::string, int>>& tag_dispatch_rules,
+  /* Building tool functions.*/
+  static std::optional<FSMWithStartEnd> BuildTagDispatch(
+      const std::vector<std::pair<std::string, int>>& string_trigger_rules,
       bool loop_after_dispatch,
       const std::vector<std::string>& excluded_strings
   );
@@ -1368,6 +1456,59 @@ FSMWithStartEnd GrammarFSMBuilderImpl::Repeat(const GrammarExpr& expr) {
   return repeat_fsm;
 }
 
+FSMWithStartEnd GrammarFSMBuilderImpl::Token(const GrammarExpr& expr) {
+  XGRAMMAR_DCHECK(expr.type == ExprType::kToken);
+  std::vector<int32_t> token_ids(expr.begin(), expr.end());
+  FSM fsm(2);
+  fsm.AddTokenEdge(0, 1, token_ids);
+  return FSMWithStartEnd(fsm, 0, {false, true});
+}
+
+FSMWithStartEnd GrammarFSMBuilderImpl::ExcludeToken(const GrammarExpr& expr) {
+  XGRAMMAR_DCHECK(expr.type == ExprType::kExcludeToken);
+  std::vector<int32_t> token_ids(expr.begin(), expr.end());
+  FSM fsm(2);
+  fsm.AddExcludeTokenEdge(0, 1, token_ids);
+  return FSMWithStartEnd(fsm, 0, {false, true});
+}
+
+std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::TokenTagDispatch(
+    const Grammar::Impl::TokenTagDispatch& ttd
+) {
+  int num_triggers = static_cast<int>(ttd.trigger_rule_pairs.size());
+  bool loop = ttd.loop_after_dispatch;
+  int num_states = 1 + num_triggers + (loop ? 0 : 1);
+  FSM fsm(num_states);
+  std::vector<bool> ends(num_states, false);
+  int start = 0;
+  ends[start] = true;
+  int end_state = -1;
+  if (!loop) {
+    end_state = num_states - 1;
+    ends[end_state] = true;
+  }
+  std::vector<int32_t> self_loop_exclude;
+  for (const auto& [token_id, rule_id] : ttd.trigger_rule_pairs) {
+    self_loop_exclude.push_back(token_id);
+  }
+  for (auto excl_id : ttd.excludes) {
+    self_loop_exclude.push_back(excl_id);
+  }
+  std::sort(self_loop_exclude.begin(), self_loop_exclude.end());
+  self_loop_exclude.erase(
+      std::unique(self_loop_exclude.begin(), self_loop_exclude.end()), self_loop_exclude.end()
+  );
+  for (int i = 0; i < num_triggers; ++i) {
+    int dispatch_state = 1 + i;
+    auto [token_id, rule_id] = ttd.trigger_rule_pairs[i];
+    fsm.AddTokenEdge(start, dispatch_state, {token_id});
+    int target = loop ? start : end_state;
+    fsm.AddRuleEdge(dispatch_state, target, static_cast<int16_t>(rule_id));
+  }
+  fsm.AddExcludeTokenEdge(start, start, self_loop_exclude);
+  return FSMWithStartEnd(fsm, start, ends);
+}
+
 std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Sequence(
     const GrammarExpr& expr, const Grammar& grammar
 ) {
@@ -1392,6 +1533,14 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Sequence(
       }
       case (ExprType::kRepeat): {
         fsm_lists.push_back(Repeat(sequence_expr));
+        break;
+      }
+      case (ExprType::kToken): {
+        fsm_lists.push_back(Token(sequence_expr));
+        break;
+      }
+      case (ExprType::kExcludeToken): {
+        fsm_lists.push_back(ExcludeToken(sequence_expr));
         break;
       }
       default: {
@@ -1484,14 +1633,14 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Choices(
   return result;
 }
 
-std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildTagDispatchFSM(
-    const std::vector<std::pair<std::string, int>>& tag_dispatch_rules,
+std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildTagDispatch(
+    const std::vector<std::pair<std::string, int>>& string_trigger_rules,
     bool loop_after_dispatch,
     const std::vector<std::string>& excluded_strings
 ) {
   std::vector<std::string> tag_names;
-  tag_names.reserve(tag_dispatch_rules.size());
-  for (const auto& [tag_name, tag_id] : tag_dispatch_rules) {
+  tag_names.reserve(string_trigger_rules.size());
+  for (const auto& [tag_name, tag_id] : string_trigger_rules) {
     tag_names.push_back(tag_name);
   }
   std::vector<int> end_states;
@@ -1516,8 +1665,8 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildTagDispatchFSM(
     }
   }
 
-  // Add rule ref edges
-  for (int i = 0; i < static_cast<int>(tag_dispatch_rules.size()); i++) {
+  // Add rule ref edges for string triggers
+  for (int i = 0; i < static_cast<int>(string_trigger_rules.size()); i++) {
     int next_state;
     if (loop_after_dispatch) {
       next_state = start;
@@ -1525,7 +1674,7 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildTagDispatchFSM(
       next_state = trie_fsm.AddState();
       ends.push_back(true);
     }
-    trie_fsm.AddRuleEdge(end_states[i], next_state, tag_dispatch_rules[i].second);
+    trie_fsm.AddRuleEdge(end_states[i], next_state, string_trigger_rules[i].second);
   }
 
   return FSMWithStartEnd(trie_fsm, start, ends);
@@ -1534,8 +1683,12 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildTagDispatchFSM(
 std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::TagDispatch(
     const Grammar::Impl::TagDispatch& tag_dispatch
 ) {
-  return BuildTagDispatchFSM(
-      tag_dispatch.tag_rule_pairs, tag_dispatch.loop_after_dispatch, tag_dispatch.excluded_str
+  std::vector<std::pair<std::string, int>> string_trigger_rules(
+      tag_dispatch.tag_rule_pairs.begin(), tag_dispatch.tag_rule_pairs.end()
+  );
+
+  return BuildTagDispatch(
+      string_trigger_rules, tag_dispatch.loop_after_dispatch, tag_dispatch.excludes
   );
 }
 
@@ -2144,8 +2297,16 @@ std::optional<uint64_t> GrammarFSMHasherImpl::HashSequence(
       case (GrammarExprType::kChoices): {
         return std::nullopt;
       }
-      case (GrammarExprType::kTagDispatch): {
+      case (GrammarExprType::kTagDispatch):
+      case (GrammarExprType::kTokenTagDispatch): {
         return std::nullopt;
+      }
+      case (GrammarExprType::kToken):
+      case (GrammarExprType::kExcludeToken): {
+        for (const auto& element : expr) {
+          hash_result = HashCombine(hash_result, element);
+        }
+        break;
       }
     }
   }
@@ -2366,6 +2527,20 @@ FSMWithStartEnd GrammarFSMBuilder::CharacterClass(const GrammarExpr& expr) {
 
 FSMWithStartEnd GrammarFSMBuilder::ByteString(const GrammarExpr& expr) {
   return GrammarFSMBuilderImpl::ByteString(expr);
+}
+
+FSMWithStartEnd GrammarFSMBuilder::Token(const GrammarExpr& expr) {
+  return GrammarFSMBuilderImpl::Token(expr);
+}
+
+FSMWithStartEnd GrammarFSMBuilder::ExcludeToken(const GrammarExpr& expr) {
+  return GrammarFSMBuilderImpl::ExcludeToken(expr);
+}
+
+std::optional<FSMWithStartEnd> GrammarFSMBuilder::TokenTagDispatch(
+    const Grammar::Impl::TokenTagDispatch& ttd
+) {
+  return GrammarFSMBuilderImpl::TokenTagDispatch(ttd);
 }
 
 std::optional<FSMWithStartEnd> GrammarFSMBuilder::Sequence(

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -137,6 +137,12 @@ class GrammarFunctor {
         return VisitTagDispatch(grammar_expr);
       case GrammarExprType::kRepeat:
         return VisitRepeat(grammar_expr);
+      case GrammarExprType::kToken:
+        return VisitToken(grammar_expr);
+      case GrammarExprType::kExcludeToken:
+        return VisitExcludeToken(grammar_expr);
+      case GrammarExprType::kTokenTagDispatch:
+        return VisitTokenTagDispatch(grammar_expr);
       default:
         XGRAMMAR_LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(grammar_expr.type);
         XGRAMMAR_UNREACHABLE();
@@ -220,6 +226,16 @@ class GrammarFunctor {
 
   /*! \brief Visit a repeat GrammarExpr. */
   virtual T VisitRepeat(const GrammarExpr& grammar_expr) { return VisitElement(grammar_expr); }
+
+  virtual T VisitToken(const GrammarExpr& grammar_expr) { return VisitElement(grammar_expr); }
+
+  virtual T VisitExcludeToken(const GrammarExpr& grammar_expr) {
+    return VisitElement(grammar_expr);
+  }
+
+  virtual T VisitTokenTagDispatch(const GrammarExpr& grammar_expr) {
+    return VisitElement(grammar_expr);
+  }
 
   /*! \brief The grammar to visit or mutate. */
   Grammar base_grammar_{NullObj{}};
@@ -349,6 +365,11 @@ class GrammarFSMBuilder {
   static FSMWithStartEnd RuleRef(const GrammarExpr& expr);
   static FSMWithStartEnd CharacterClass(const GrammarExpr& expr);
   static FSMWithStartEnd ByteString(const GrammarExpr& expr);
+  static FSMWithStartEnd Token(const GrammarExpr& expr);
+  static FSMWithStartEnd ExcludeToken(const GrammarExpr& expr);
+  static std::optional<FSMWithStartEnd> TokenTagDispatch(
+      const Grammar::Impl::TokenTagDispatch& token_tag_dispatch
+  );
   static std::optional<FSMWithStartEnd> Sequence(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> Choices(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> TagDispatch(const Grammar::Impl::TagDispatch& tag_dispatch);

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -121,11 +121,17 @@ class Grammar::Impl {
     kChoices,
     // data format: [tag_expr0, rule_id0, tag_expr1, rule_id1, ..., loop_after_dispatch,
     // excluded_str_expr_id]
-    // tag_expr should be a byte string, and rule_id should be a rule id.
-    // loop_after_dispatch is a bool. excluded_str_expr_id is a choices GrammarExpr id.
     kTagDispatch,
     // data format: [rule_id, min_repeat_count, max_repeat_count]
     kRepeat,
+    // data format: [token_id_0, token_id_1, ...]
+    kToken,
+    // data format: [token_id_0, token_id_1, ...]
+    kExcludeToken,
+    // data format: [trigger_cnt, (token_id, rule_id) × N,
+    //               loop_after_dispatch,
+    //               exclude_cnt, token_id × M]
+    kTokenTagDispatch,
   };
 
   /*! \brief The object representing a grammar expr. */
@@ -190,7 +196,7 @@ class Grammar::Impl {
     /*! \brief If true, the tag dispatch will loop after dispatching. */
     bool loop_after_dispatch;
     /*! \brief The strings that are excluded by the tag dispatch. */
-    std::vector<std::string> excluded_str;
+    std::vector<std::string> excludes;
     static const int kTagDispatchExtraParameter = 2;
   };
 
@@ -219,9 +225,9 @@ class Grammar::Impl {
         grammar_expr[grammar_expr.size() - TagDispatch::kTagDispatchExtraParameter + 1]
     );
     XGRAMMAR_DCHECK(exclude_str_expr.type == GrammarExprType::kChoices);
-    result.excluded_str.reserve(exclude_str_expr.size());
+    result.excludes.reserve(exclude_str_expr.size());
     for (int j = 0; j < exclude_str_expr.size(); j++) {
-      result.excluded_str.push_back(GetByteString(exclude_str_expr[j]));
+      result.excludes.push_back(GetByteString(exclude_str_expr[j]));
     }
     return result;
   }
@@ -229,6 +235,38 @@ class Grammar::Impl {
   /*! \brief Get the tag dispatch from the grammar expr with the given id. */
   TagDispatch GetTagDispatch(int32_t grammar_expr_id) {
     return GetTagDispatch(GetGrammarExpr(grammar_expr_id));
+  }
+
+  /*! \brief The object representing a token tag dispatch. */
+  struct TokenTagDispatch {
+    std::vector<std::pair<int32_t, int32_t>> trigger_rule_pairs;  // token_id → rule_id
+    bool loop_after_dispatch;
+    std::vector<int32_t> excludes;
+  };
+
+  /*! \brief Decode a kTokenTagDispatch expr into the TokenTagDispatch struct. */
+  TokenTagDispatch GetTokenTagDispatch(const GrammarExpr& grammar_expr) {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kTokenTagDispatch);
+    TokenTagDispatch result;
+    int pos = 0;
+    int32_t trigger_count = grammar_expr[pos++];
+    for (int i = 0; i < trigger_count; ++i) {
+      auto token_id = grammar_expr[pos++];
+      auto rule_id = grammar_expr[pos++];
+      result.trigger_rule_pairs.push_back({token_id, rule_id});
+    }
+    result.loop_after_dispatch = static_cast<bool>(grammar_expr[pos++]);
+    int32_t exclude_count = grammar_expr[pos++];
+    for (int i = 0; i < exclude_count; ++i) {
+      result.excludes.push_back(grammar_expr[pos++]);
+    }
+    XGRAMMAR_DCHECK(pos == grammar_expr.size());
+    return result;
+  }
+
+  /*! \brief Get the token tag dispatch from the grammar expr with the given id. */
+  TokenTagDispatch GetTokenTagDispatch(int32_t grammar_expr_id) {
+    return GetTokenTagDispatch(GetGrammarExpr(grammar_expr_id));
   }
 
  private:

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -531,25 +531,91 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   }
 
   const auto& token = tokenizer_info_.GetDecodedVocab()[token_id];
+
+  // Phase 1: Try atomic token path (from current state, before byte path)
+  std::vector<ParserState> atomic_states;
+  std::vector<std::pair<int32_t, ParserState>> atomic_completable;
+  bool atomic_completed = false;
+  bool atomic_success = AdvanceAtomicToken(token_id, debug_print);
+  if (atomic_success) {
+    atomic_states = GetLatestScanableStates();
+    auto row = rule_id_to_completable_states_.Back();
+    atomic_completable.assign(row.data, row.data + row.data_len);
+    atomic_completed = is_completed_.back();
+    PopLastStates(1);
+  }
+
+  // Phase 2: Try byte-by-byte path (from the same original state)
   int pos = 0;
+  bool byte_path_success = true;
   for (auto char_value : token) {
     if (!Advance(char_value, debug_print)) {
-      if (debug_print) {
-        XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<" << EscapeString(token)
-                           << "> rejected at position " << pos << ", char "
-                           << EscapeString(char_value);
-      }
-      PopLastStates(pos);
-      return false;
+      byte_path_success = false;
+      break;
     }
     ++pos;
   }
-  token_length_history.push_back(token.size());
+
+  // Phase 3: Combine results (no priority — merge with deduplication)
+  if (!byte_path_success && !atomic_success) {
+    if (debug_print) {
+      XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<" << EscapeString(token)
+                         << "> rejected at position " << pos;
+    }
+    PopLastStates(pos);
+    return false;
+  }
+
+  if (atomic_success && !byte_path_success) {
+    PopLastStates(pos);
+    AdvanceAtomicToken(token_id, debug_print);
+    token_length_history.push_back(1);
+  } else if (byte_path_success && !atomic_success) {
+    token_length_history.push_back(token.size());
+  } else {
+    // Both paths succeeded — merge atomic token states into byte path
+    if (token.empty()) {
+      // Zero-length token: byte path created 0 timepoints, just push atomic states
+      scanable_state_history_.PushBack(atomic_states);
+      rule_id_to_completable_states_.PushBack(atomic_completable);
+      is_completed_.push_back(atomic_completed);
+      token_length_history.push_back(1);
+    } else {
+      auto byte_states = GetLatestScanableStates();
+      std::vector<ParserState> merged = byte_states;
+      StateEqualForParsing state_eq;
+      for (const auto& s : atomic_states) {
+        if (std::find_if(merged.begin(), merged.end(), [&](const auto& m) {
+              return state_eq(m, s);
+            }) == merged.end()) {
+          merged.push_back(s);
+        }
+      }
+
+      auto byte_row = rule_id_to_completable_states_.Back();
+      std::vector<std::pair<int32_t, ParserState>> merged_completable(
+          byte_row.data, byte_row.data + byte_row.data_len
+      );
+      bool byte_completed = is_completed_.back();
+      PopLastStates(1);
+
+      for (const auto& cs : atomic_completable) {
+        if (std::find_if(merged_completable.begin(), merged_completable.end(), [&](const auto& m) {
+              return m.first == cs.first && state_eq(m.second, cs.second);
+            }) == merged_completable.end()) {
+          merged_completable.push_back(cs);
+        }
+      }
+
+      scanable_state_history_.PushBack(merged);
+      rule_id_to_completable_states_.PushBack(merged_completable);
+      is_completed_.push_back(byte_completed || atomic_completed);
+      token_length_history.push_back(token.size());
+    }
+  }
 
   if (debug_print) {
-    XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<"
-                       << EscapeString(tokenizer_info_.GetDecodedVocab()[token_id])
-                       << "> accepted.";
+    XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<" << EscapeString(token) << "> accepted.";
   }
   return true;
 }

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -7,6 +7,7 @@
 
 #include <picojson.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -490,6 +491,9 @@ class EBNFParser {
   MacroIR::NodePtr ParseMacroValue();
 
   int32_t ParseTagDispatch();
+  int32_t ParseTokenSet();
+  int32_t ParseExcludeToken();
+  int32_t ParseTokenTagDispatch();
 
   // Helper functions
 
@@ -540,6 +544,9 @@ class EBNFParser {
 const std::unordered_map<std::string, std::function<int32_t(EBNFParser*)>>
     EBNFParser::kMacroFunctions = {
         {"TagDispatch", [](EBNFParser* parser) { return parser->ParseTagDispatch(); }},
+        {"Token", [](EBNFParser* parser) { return parser->ParseTokenSet(); }},
+        {"ExcludeToken", [](EBNFParser* parser) { return parser->ParseExcludeToken(); }},
+        {"TokenTagDispatch", [](EBNFParser* parser) { return parser->ParseTokenTagDispatch(); }},
 };
 
 const EBNFParser::Token& EBNFParser::Peek(int delta) const { return *(current_token_ + delta); }
@@ -1021,13 +1028,16 @@ EBNFParser::MacroIR::NodePtr EBNFParser::ParseMacroValue() {
 
     MacroIR::TupleNode tuple;
 
-    // Parse tuple elements
+    // Parse tuple elements (supports trailing comma)
     if (Peek().type != TokenType::RParen) {
       while (true) {
         tuple.elements.push_back(ParseMacroValue());
 
         if (Peek().type == TokenType::Comma) {
           Consume();
+          if (Peek().type == TokenType::RParen) {
+            break;
+          }
         } else if (Peek().type == TokenType::RParen) {
           break;
         } else {
@@ -1051,7 +1061,16 @@ int32_t EBNFParser::ParseTagDispatch() {
 
   Grammar::Impl::TagDispatch tag_dispatch;
 
-  // Position parameters: ("tag", rule_name)
+  static const std::unordered_set<std::string> kValidNamedArgs = {
+      "loop_after_dispatch", "excludes"
+  };
+  for (const auto& [name, _] : args.named_arguments) {
+    if (kValidNamedArgs.count(name) == 0) {
+      ReportParseError("Unknown named argument for TagDispatch: " + name, delta_element);
+    }
+  }
+
+  // Positional parameters: ("tag_string", rule_name) — string triggers only
   for (const auto& arg : args.arguments) {
     auto tuple_node = std::get_if<MacroIR::TupleNode>(arg.get());
     if (tuple_node == nullptr) {
@@ -1062,12 +1081,11 @@ int32_t EBNFParser::ParseTagDispatch() {
       ReportParseError("Each tag dispatch element must be a pair (tag, rule)", delta_element);
     }
 
-    // First element should be a string (tag)
     auto tag_str_node = std::get_if<MacroIR::StringNode>(tuple_node->elements[0].get());
     if (tag_str_node == nullptr || tag_str_node->value.empty()) {
       ReportParseError("Tag must be a non-empty string literal", delta_element);
     }
-    // Second element should be an identifier (rule name)
+
     auto rule_name_node = std::get_if<MacroIR::IdentifierNode>(tuple_node->elements[1].get());
     if (rule_name_node == nullptr) {
       ReportParseError("Rule reference must be an identifier", delta_element);
@@ -1077,7 +1095,6 @@ int32_t EBNFParser::ParseTagDispatch() {
     if (rule_id == -1) {
       ReportParseError("Rule \"" + rule_name_node->name + "\" is not defined", delta_element);
     }
-
     tag_dispatch.tag_rule_pairs.push_back({tag_str_node->value, rule_id});
   }
 
@@ -1092,47 +1109,166 @@ int32_t EBNFParser::ParseTagDispatch() {
     tag_dispatch.loop_after_dispatch = bool_node->value;
   }
 
-  // exclude_str
+  // excludes — string only
   if (auto it = args.named_arguments.find("excludes"); it != args.named_arguments.end()) {
     auto tuple_node = std::get_if<MacroIR::TupleNode>(it->second.get());
     if (tuple_node == nullptr) {
-      ReportParseError("excluded strings must be a tuple", delta_element);
+      ReportParseError("excludes must be a tuple", delta_element);
     }
-
     for (const auto& element : tuple_node->elements) {
-      auto exclude_str_node = std::get_if<MacroIR::StringNode>(element.get());
-      if (exclude_str_node == nullptr || exclude_str_node->value.empty()) {
-        ReportParseError("Stop string must be a non-empty string literal", delta_element);
+      auto str_node = std::get_if<MacroIR::StringNode>(element.get());
+      if (str_node == nullptr || str_node->value.empty()) {
+        ReportParseError("Exclude must be a non-empty string literal", delta_element);
       }
-      tag_dispatch.excluded_str.push_back(exclude_str_node->value);
+      tag_dispatch.excludes.push_back(str_node->value);
     }
   }
 
-  // Check for deprecated and unknown named arguments
-  static const std::unordered_set<std::string> kKnownArgs = {"loop_after_dispatch", "excludes"};
-  static const std::unordered_set<std::string> kDeprecatedArgs = {"stop_eos", "stop_str"};
-  for (const auto& [name, _] : args.named_arguments) {
-    if (kDeprecatedArgs.count(name)) {
-      XGRAMMAR_LOG(WARNING) << "TagDispatch parameter \"" << name
-                            << "\" is deprecated and will be ignored";
-    } else if (!kKnownArgs.count(name)) {
-      ReportParseError("Unknown TagDispatch parameter: " + name, delta_element);
-    }
-  }
-
-  // Check no exclude is a prefix of any trigger
-  for (const auto& excl : tag_dispatch.excluded_str) {
-    for (const auto& [tag, rule_id] : tag_dispatch.tag_rule_pairs) {
-      if (excl.size() <= tag.size() && tag.substr(0, excl.size()) == excl) {
+  // Well-formedness checks: string excludes vs string triggers
+  for (const auto& excl_str : tag_dispatch.excludes) {
+    for (const auto& [trigger_str, _] : tag_dispatch.tag_rule_pairs) {
+      if (trigger_str.rfind(excl_str, 0) == 0) {
         ReportParseError(
-            "TagDispatch exclude \"" + excl + "\" is a prefix of trigger \"" + tag + "\"",
-            delta_element
+            "Exclude string must not be a prefix of trigger string: " + excl_str, delta_element
         );
       }
     }
   }
 
   return builder_.AddTagDispatch(tag_dispatch);
+}
+
+int32_t EBNFParser::ParseTokenSet() {
+  Consume();  // Consume Token identifier
+  auto start = current_token_;
+  auto args = ParseMacroArguments();
+  auto delta_element = start - current_token_;
+
+  if (!args.named_arguments.empty()) {
+    ReportParseError("Token() does not accept named arguments", delta_element);
+  }
+
+  if (args.arguments.empty()) {
+    ReportParseError("Token() requires at least one integer argument", delta_element);
+  }
+
+  std::vector<int32_t> token_ids;
+  for (const auto& arg : args.arguments) {
+    auto int_node = std::get_if<MacroIR::IntegerNode>(arg.get());
+    if (int_node == nullptr || int_node->value < 0) {
+      ReportParseError("Token() arguments must be non-negative integers", delta_element);
+    }
+    token_ids.push_back(static_cast<int32_t>(int_node->value));
+  }
+
+  std::sort(token_ids.begin(), token_ids.end());
+  token_ids.erase(std::unique(token_ids.begin(), token_ids.end()), token_ids.end());
+
+  return builder_.AddTokenSet(token_ids);
+}
+
+int32_t EBNFParser::ParseExcludeToken() {
+  Consume();
+  auto start = current_token_;
+  auto args = ParseMacroArguments();
+  auto delta_element = start - current_token_;
+
+  if (!args.named_arguments.empty()) {
+    ReportParseError("ExcludeToken() does not accept named arguments", delta_element);
+  }
+  if (args.arguments.empty()) {
+    ReportParseError("ExcludeToken() requires at least one integer argument", delta_element);
+  }
+
+  std::vector<int32_t> token_ids;
+  for (const auto& arg : args.arguments) {
+    auto int_node = std::get_if<MacroIR::IntegerNode>(arg.get());
+    if (int_node == nullptr || int_node->value < 0) {
+      ReportParseError("ExcludeToken() arguments must be non-negative integers", delta_element);
+    }
+    token_ids.push_back(static_cast<int32_t>(int_node->value));
+  }
+  std::sort(token_ids.begin(), token_ids.end());
+  token_ids.erase(std::unique(token_ids.begin(), token_ids.end()), token_ids.end());
+
+  return builder_.AddExcludeTokenSet(token_ids);
+}
+
+int32_t EBNFParser::ParseTokenTagDispatch() {
+  Consume();
+  auto start = current_token_;
+  auto args = ParseMacroArguments();
+  auto delta_element = start - current_token_;
+
+  Grammar::Impl::TokenTagDispatch ttd;
+
+  static const std::unordered_set<std::string> kValidNamedArgs = {
+      "loop_after_dispatch", "excludes"
+  };
+  for (const auto& [name, _] : args.named_arguments) {
+    if (kValidNamedArgs.count(name) == 0) {
+      ReportParseError("Unknown named argument for TokenTagDispatch: " + name, delta_element);
+    }
+  }
+
+  for (const auto& arg : args.arguments) {
+    auto tuple_node = std::get_if<MacroIR::TupleNode>(arg.get());
+    if (tuple_node == nullptr || tuple_node->elements.size() != 2) {
+      ReportParseError(
+          "Each TokenTagDispatch element must be a pair (token_id, rule)", delta_element
+      );
+    }
+    auto id_node = std::get_if<MacroIR::IntegerNode>(tuple_node->elements[0].get());
+    if (id_node == nullptr || id_node->value < 0) {
+      ReportParseError("Token trigger ID must be a non-negative integer", delta_element);
+    }
+    auto rule_node = std::get_if<MacroIR::IdentifierNode>(tuple_node->elements[1].get());
+    if (rule_node == nullptr) {
+      ReportParseError("Rule reference must be an identifier", delta_element);
+    }
+    auto rule_id = builder_.GetRuleId(rule_node->name);
+    if (rule_id == -1) {
+      ReportParseError("Rule \"" + rule_node->name + "\" is not defined", delta_element);
+    }
+    ttd.trigger_rule_pairs.push_back({static_cast<int32_t>(id_node->value), rule_id});
+  }
+
+  ttd.loop_after_dispatch = true;
+  if (auto it = args.named_arguments.find("loop_after_dispatch");
+      it != args.named_arguments.end()) {
+    auto bool_node = std::get_if<MacroIR::BooleanNode>(it->second.get());
+    if (bool_node == nullptr) {
+      ReportParseError("loop_after_dispatch must be a boolean", delta_element);
+    }
+    ttd.loop_after_dispatch = bool_node->value;
+  }
+
+  if (auto it = args.named_arguments.find("excludes"); it != args.named_arguments.end()) {
+    auto tuple_node = std::get_if<MacroIR::TupleNode>(it->second.get());
+    if (tuple_node == nullptr) {
+      ReportParseError("excludes must be a tuple", delta_element);
+    }
+    for (const auto& element : tuple_node->elements) {
+      auto int_node = std::get_if<MacroIR::IntegerNode>(element.get());
+      if (int_node == nullptr || int_node->value < 0) {
+        ReportParseError("Exclude token ID must be a non-negative integer", delta_element);
+      }
+      ttd.excludes.push_back(static_cast<int32_t>(int_node->value));
+    }
+  }
+
+  for (auto excl_id : ttd.excludes) {
+    for (const auto& [tid, _] : ttd.trigger_rule_pairs) {
+      if (tid == excl_id) {
+        ReportParseError(
+            "Token trigger ID " + std::to_string(tid) + " must not overlap with exclude token ID",
+            delta_element
+        );
+      }
+    }
+  }
+
+  return builder_.AddTokenTagDispatch(ttd);
 }
 
 int32_t EBNFParser::ParseLookaheadAssertion() {

--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -44,6 +44,12 @@ std::string GrammarPrinter::PrintGrammarExpr(const GrammarExpr& grammar_expr) {
       return PrintTagDispatch(grammar_expr);
     case GrammarExprType::kRepeat:
       return PrintRepeat(grammar_expr);
+    case GrammarExprType::kToken:
+      return PrintToken(grammar_expr);
+    case GrammarExprType::kExcludeToken:
+      return PrintExcludeToken(grammar_expr);
+    case GrammarExprType::kTokenTagDispatch:
+      return PrintTokenTagDispatch(grammar_expr);
     default:
       XGRAMMAR_LOG(FATAL) << "Unexpected GrammarExpr type: " << static_cast<int>(grammar_expr.type);
       XGRAMMAR_UNREACHABLE();
@@ -131,17 +137,15 @@ std::string GrammarPrinter::PrintTagDispatch(const GrammarExpr& grammar_expr) {
   auto tag_dispatch = grammar_->GetTagDispatch(grammar_expr);
   std::string result = "TagDispatch(\n";
   std::string indent = "  ";
-  for (const auto& [tag, rule_id] : tag_dispatch.tag_rule_pairs) {
-    result += indent + "(" + PrintString(tag) + ", " + grammar_->GetRule(rule_id).name + "),\n";
+  for (const auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
+    result += indent + "(" + PrintString(trigger) + ", " + grammar_->GetRule(rule_id).name + "),\n";
   }
   result +=
       indent + "loop_after_dispatch=" + PrintBoolean(tag_dispatch.loop_after_dispatch) + ",\n";
   result += indent + "excludes=(";
-  for (int i = 0; i < static_cast<int>(tag_dispatch.excluded_str.size()); ++i) {
-    result += PrintString(tag_dispatch.excluded_str[i]);
-    if (i + 1 != static_cast<int>(tag_dispatch.excluded_str.size())) {
-      result += ", ";
-    }
+  for (int i = 0; i < static_cast<int>(tag_dispatch.excludes.size()); ++i) {
+    if (i > 0) result += ", ";
+    result += PrintString(tag_dispatch.excludes[i]);
   }
   result += ")\n)";
   return result;
@@ -155,6 +159,44 @@ std::string GrammarPrinter::PrintRepeat(const GrammarExpr& grammar_expr) {
   result += ", ";
   result += std::to_string(upper_bound);
   result += "}";
+  return result;
+}
+
+std::string GrammarPrinter::PrintToken(const GrammarExpr& grammar_expr) {
+  std::string result = "Token(";
+  for (int i = 0; i < grammar_expr.data_len; ++i) {
+    if (i > 0) result += ", ";
+    result += std::to_string(grammar_expr[i]);
+  }
+  result += ")";
+  return result;
+}
+
+std::string GrammarPrinter::PrintExcludeToken(const GrammarExpr& grammar_expr) {
+  std::string result = "ExcludeToken(";
+  for (int i = 0; i < grammar_expr.data_len; ++i) {
+    if (i > 0) result += ", ";
+    result += std::to_string(grammar_expr[i]);
+  }
+  result += ")";
+  return result;
+}
+
+std::string GrammarPrinter::PrintTokenTagDispatch(const GrammarExpr& grammar_expr) {
+  auto ttd = grammar_->GetTokenTagDispatch(grammar_expr);
+  std::string result = "TokenTagDispatch(\n";
+  std::string indent = "  ";
+  for (const auto& [token_id, rule_id] : ttd.trigger_rule_pairs) {
+    result +=
+        indent + "(" + std::to_string(token_id) + ", " + grammar_->GetRule(rule_id).name + "),\n";
+  }
+  result += indent + "loop_after_dispatch=" + PrintBoolean(ttd.loop_after_dispatch) + ",\n";
+  result += indent + "excludes=(";
+  for (int i = 0; i < static_cast<int>(ttd.excludes.size()); ++i) {
+    if (i > 0) result += ", ";
+    result += std::to_string(ttd.excludes[i]);
+  }
+  result += ")\n)";
   return result;
 }
 

--- a/cpp/grammar_printer.h
+++ b/cpp/grammar_printer.h
@@ -62,6 +62,12 @@ class GrammarPrinter {
   std::string PrintTagDispatch(const GrammarExpr& grammar_expr);
   /*! \brief Print a GrammarExpr for repeat. */
   std::string PrintRepeat(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for token. */
+  std::string PrintToken(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for exclude token. */
+  std::string PrintExcludeToken(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for token tag dispatch. */
+  std::string PrintTokenTagDispatch(const GrammarExpr& grammar_expr);
   /*! \brief Print a string. */
   std::string PrintString(const std::string& str);
   /*! \brief Print a boolean. */

--- a/cpp/support/int_set.h
+++ b/cpp/support/int_set.h
@@ -83,6 +83,50 @@ inline void IntsetIntersection(std::vector<int32_t>* lhs, const std::vector<int3
   lhs->erase(it_result, lhs->end());
 }
 
+/*!
+ * \brief Let lhs = lhs - rhs. Both sets must be sorted.
+ * \note In-place, no additional vector allocated, O(n) time.
+ */
+inline void IntsetDifference(std::vector<int32_t>* lhs, const std::vector<int32_t>& rhs) {
+  auto it_lhs = lhs->begin();
+  auto it_rhs = rhs.begin();
+  auto it_result = lhs->begin();
+
+  while (it_lhs != lhs->end() && it_rhs != rhs.end()) {
+    if (*it_lhs < *it_rhs) {
+      *it_result++ = *it_lhs++;
+    } else if (*it_lhs > *it_rhs) {
+      ++it_rhs;
+    } else {
+      ++it_lhs;
+      ++it_rhs;
+    }
+  }
+  while (it_lhs != lhs->end()) {
+    *it_result++ = *it_lhs++;
+  }
+  lhs->erase(it_result, lhs->end());
+}
+
+/*!
+ * \brief Compute result = [0, n) - excluded. excluded must be sorted with values in [0, n).
+ * \note O(n) time.
+ */
+inline void IntsetComplement(
+    std::vector<int32_t>* result, int32_t n, const std::vector<int32_t>& excluded
+) {
+  result->clear();
+  result->reserve(n - static_cast<int32_t>(excluded.size()));
+  auto it = excluded.begin();
+  for (int32_t i = 0; i < n; ++i) {
+    if (it != excluded.end() && *it == i) {
+      ++it;
+    } else {
+      result->push_back(i);
+    }
+  }
+}
+
 }  // namespace xgrammar
 
 #endif  // XGRAMMAR_SUPPORT_INT_SET_H_

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v9";
+  static constexpr const char kXGrammarSerializeVersion[] = "v11";
 };
 
 /*!

--- a/cpp/tokenizer_info.cc
+++ b/cpp/tokenizer_info.cc
@@ -298,6 +298,11 @@ TokenizerInfo::Impl::Impl(
   };
   std::sort(sorted_decoded_vocab_.begin(), sorted_decoded_vocab_.end(), f_compare_token);
 
+  token_id_to_sorted_vocab_index_.assign(vocab_size_, -1);
+  for (int32_t i = 0; i < static_cast<int32_t>(sorted_decoded_vocab_.size()); ++i) {
+    token_id_to_sorted_vocab_index_[sorted_decoded_vocab_[i].first] = i;
+  }
+
   // The value means: the subtree is [i, trie_subtree_nodes_range[i]).
   trie_subtree_nodes_range_.resize(sorted_decoded_vocab_.size(), 0);
   std::stack<std::pair<std::string, int32_t>> prefix_stack;

--- a/cpp/tokenizer_info_impl.h
+++ b/cpp/tokenizer_info_impl.h
@@ -36,6 +36,9 @@ class TokenizerInfo::Impl {
     return sorted_decoded_vocab_;
   }
   const std::vector<int32_t>& GetTrieSubtreeNodesRange() const { return trie_subtree_nodes_range_; }
+  const std::vector<int32_t>& GetTokenIdToSortedVocabIndex() const {
+    return token_id_to_sorted_vocab_index_;
+  }
 
   std::string DumpMetadata() const;
   picojson::value DumpMetadataValue() const;
@@ -74,6 +77,8 @@ class TokenizerInfo::Impl {
   /*! \brief The special tokens. These tokens are ignored (masked out) during the grammar-guided
    * generation. */
   std::vector<int32_t> special_token_ids_;
+  /*! \brief Reverse mapping: token_id -> index in sorted_decoded_vocab_. -1 if not present. */
+  std::vector<int32_t> token_id_to_sorted_vocab_index_;
 
   /*!
    * \brief The tokens used to detect stop tokens from the vocabulary.

--- a/tests/cpp/test_fsm_builder.cc
+++ b/tests/cpp/test_fsm_builder.cc
@@ -59,7 +59,7 @@ TEST(XGrammarFSMBuilderTest, TestTagDispatchFSMBuilder1) {
   Grammar::Impl::TagDispatch tag_dispatch = {
       /* tag_rule_pairs = */ {{"hel", 1}, {"hi", 2}, {"哈", 3}},
       /* loop_after_dispatch = */ true,
-      /* excluded_str = */ {}
+      /* excludes = */ {}
   };
   auto fsm_result = GrammarFSMBuilder::TagDispatch(tag_dispatch);
   EXPECT_TRUE(fsm_result.has_value());
@@ -84,7 +84,7 @@ TEST(XGrammarFSMBuilderTest, TestTagDispatchFSMBuilder2) {
   Grammar::Impl::TagDispatch tag_dispatch = {
       /* tag_rule_pairs = */ {{"hel", 1}, {"hi", 2}, {"哈", 3}},
       /* loop_after_dispatch = */ false,
-      /* excluded_str = */ {}
+      /* excludes = */ {}
   };
   auto fsm_result = GrammarFSMBuilder::TagDispatch(tag_dispatch);
   EXPECT_TRUE(fsm_result.has_value());
@@ -108,6 +108,35 @@ TEST(XGrammarFSMBuilderTest, TestTagDispatchFSMBuilder2) {
   EXPECT_EQ(fsm_printed, expected_fsm_printed);
 }
 
+TEST(XGrammarFSMBuilderTest, TestTagDispatchFSMBuilder3) {
+  // Case 3. string excludes are compiled into the trie
+  Grammar::Impl::TagDispatch tag_dispatch = {
+      /* tag_rule_pairs = */ {{"hel", 1}, {"hi", 2}, {"哈", 3}},
+      /* loop_after_dispatch = */ true,
+      /* excludes = */ {"hos", "eos"}
+  };
+  auto fsm_result = GrammarFSMBuilder::TagDispatch(tag_dispatch);
+  EXPECT_TRUE(fsm_result.has_value());
+  auto fsm = std::move(fsm_result).value();
+  auto fsm_printed = fsm.ToString();
+  EXPECT_NE(fsm_printed.find("Rule(1)->0"), std::string::npos);
+  EXPECT_NE(fsm_printed.find("Rule(2)->0"), std::string::npos);
+  EXPECT_NE(fsm_printed.find("Rule(3)->0"), std::string::npos);
+}
+
+TEST(XGrammarFSMBuilderTest, TestTokenTagDispatchFSMBuilder) {
+  Grammar::Impl::TokenTagDispatch ttd = {
+      /* trigger_rule_pairs = */ {{3, 1}, {5, 2}},
+      /* loop_after_dispatch = */ false,
+      /* excludes = */ {7}
+  };
+  auto fsm_result = GrammarFSMBuilder::TokenTagDispatch(ttd);
+  EXPECT_TRUE(fsm_result.has_value());
+  auto fsm = std::move(fsm_result).value();
+  auto fsm_printed = fsm.ToString();
+  EXPECT_NE(fsm_printed.find("Token"), std::string::npos);
+  EXPECT_NE(fsm_printed.find("ExcludeToken"), std::string::npos);
+}
 using GrammarExpr = Grammar::Impl::GrammarExpr;
 using GrammarExprType = Grammar::Impl::GrammarExprType;
 

--- a/tests/python/test_grammar_matcher_macro.py
+++ b/tests/python/test_grammar_matcher_macro.py
@@ -47,22 +47,53 @@ rule2 ::= "efg" [t]*
     assert not _is_grammar_accept_string(grammar, "tag2efgtag1")
 
 
-def test_excludes():
-    grammar_str = """root ::= TagDispatch(
+def test_stop_str():
+    grammar_str = """root ::= root1 stop "w"
+root1 ::= TagDispatch(
   ("tag1", rule1),
   ("tag2", rule2),
-  excludes=("bad", "xx")
+  excludes=("tag3", "ll")
 )
+stop ::= "tag3" | "ll"
 rule1 ::= "abcd" [p]*
 rule2 ::= "efg" [t]*
 """
 
     grammar = xgr.Grammar.from_ebnf(grammar_str)
-    assert _is_grammar_accept_string(grammar, "tag1abcd")
-    assert _is_grammar_accept_string(grammar, "tag1abcdqqtag2efg")
-    assert not _is_grammar_accept_string(grammar, "tag1abcdbadtag2efg")
-    assert not _is_grammar_accept_string(grammar, "tag1abcdxxqqtag2efg")
+    assert _is_grammar_accept_string(grammar, "tag1abcdllw", debug_print=True)
+    assert _is_grammar_accept_string(grammar, "tag1abcdtag3w")
+    assert _is_grammar_accept_string(grammar, "tag1abcdqqqtag2efgtag3w")
+    assert _is_grammar_accept_string(grammar, "tag1abcd", require_termination=False)
+    assert _is_grammar_accept_string(grammar, "tag2efgttt", require_termination=False)
+    assert not _is_grammar_accept_string(grammar, "tag1abcd")
+    assert not _is_grammar_accept_string(grammar, "tag2efgttt")
     assert not _is_grammar_accept_string(grammar, "tag1abce")
+    assert not _is_grammar_accept_string(grammar, "tag1abcdlltag3w", require_termination=False)
+
+
+def test_stop_str_no_loop():
+    grammar_str = """root ::= root1 stop "w"
+root1 ::= TagDispatch(
+  ("tag1", rule1),
+  ("tag2", rule2),
+  excludes=("tag3", "ll"),
+  loop_after_dispatch=false
+)
+stop ::= "tag3" | "ll"
+rule1 ::= "abcd" [p]*
+rule2 ::= "efg" [t]*
+"""
+
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    assert _is_grammar_accept_string(grammar, "tag1abcdllw")
+    assert _is_grammar_accept_string(grammar, "tag1abcdtag3w")
+    assert _is_grammar_accept_string(grammar, "tag1abcd", require_termination=False)
+    assert _is_grammar_accept_string(grammar, "tag2efgttt", require_termination=False)
+    assert not _is_grammar_accept_string(grammar, "tag1abcdqqqtag2efgtag3w")
+    assert not _is_grammar_accept_string(grammar, "tag1abcd")
+    assert not _is_grammar_accept_string(grammar, "tag2efgttt")
+    assert not _is_grammar_accept_string(grammar, "tag1abce")
+    assert not _is_grammar_accept_string(grammar, "tag1abcdlltag3w", require_termination=False)
 
 
 def test_tag_dispatch_mask_generation_correctness():
@@ -124,71 +155,43 @@ root1 ::= TagDispatch(
   ("tag2", rule2),
   loop_after_dispatch=false
 )
-rule1 ::= TagDispatch(
+rule1 ::= rule1_dispatch rule1_stop
+rule1_dispatch ::= TagDispatch(
   ("tag1", rule2),
   ("tag2", rule3),
-  loop_after_dispatch=true,
-  excludes=("tag3", "ll")
+  excludes=("tag3", "ll"),
+  loop_after_dispatch=true
 )
+rule1_stop ::= "tag3" | "ll"
 rule2 ::= "efg" [t]*
 rule3 ::= "abcd" [p]*
 """
-    assert _is_grammar_accept_string(grammar_str, "tag1tag1efgw")
-    assert _is_grammar_accept_string(grammar_str, "tag1tag2abcdw")
-    assert not _is_grammar_accept_string(grammar_str, "tag1tag1efglltag2abcdw")
-    assert not _is_grammar_accept_string(grammar_str, "tag1tag2abcdtag3tag1efgw")
+    assert _is_grammar_accept_string(grammar_str, "tag1tag1efgllw")
+    assert _is_grammar_accept_string(grammar_str, "tag1tag2abcdtag3w")
+    assert not _is_grammar_accept_string(grammar_str, "tag1Ktag2abcdtag3tag1")
+    assert _is_grammar_accept_string(grammar_str, "tag1tag3w")
+    assert not _is_grammar_accept_string(grammar_str, "tag1tag3tag2abcdll")
 
 
 def test_excluded_str():
-    grammar_str = """root ::= TagDispatch(
+    grammar_str = """root ::= root_dispatch end_tag
+root_dispatch ::= TagDispatch(
   ("start", rule1),
-  excludes=("</conclude>"),
+  excludes=("</think>", "</conclude>"),
   loop_after_dispatch=true
 )
 rule1 ::= "12345"
-"""
-
-    expected = """root ::= TagDispatch(
-  ("start", rule1),
-  loop_after_dispatch=true,
-  excludes=("</conclude>")
-)
-rule1 ::= (("12345"))
+end_tag ::= "</think>"
 """
 
     grammar = xgr.Grammar.from_ebnf(grammar_str)
-    assert str(grammar) == expected
+    printed = str(grammar)
+    assert 'excludes=("</think>", "</conclude>")' in printed
 
-    assert _is_grammar_accept_string(grammar, "start12345")
+    assert _is_grammar_accept_string(grammar, "start12345</think>")
     assert not _is_grammar_accept_string(grammar, "start12345</conclude>")
-    assert _is_grammar_accept_string(grammar, "start12345abc")
+    assert _is_grammar_accept_string(grammar, "start12345abc</think>")
     assert not _is_grammar_accept_string(grammar, "start12345</conclude>abc")
-
-
-def test_duplicate_triggers():
-    grammar_str = """root ::= TagDispatch(("tag", rule1), ("tag", rule2))
-rule1 ::= "abc"
-rule2 ::= "def"
-"""
-    grammar = xgr.Grammar.from_ebnf(grammar_str)
-    assert _is_grammar_accept_string(grammar, "tagabc")
-    assert _is_grammar_accept_string(grammar, "tagdef")
-    assert _is_grammar_accept_string(grammar, "tagabctagdef")
-    assert not _is_grammar_accept_string(grammar, "tagxyz")
-
-
-def test_duplicate_excludes():
-    grammar_str = """root ::= TagDispatch(
-  ("tag1", rule1),
-  excludes=("stop", "stop")
-)
-rule1 ::= "abc"
-"""
-    grammar = xgr.Grammar.from_ebnf(grammar_str)
-    assert _is_grammar_accept_string(grammar, "tag1abc")
-    assert _is_grammar_accept_string(grammar, "tag1abcqqtag1abc")
-    assert not _is_grammar_accept_string(grammar, "tag1abcstop")
-    assert not _is_grammar_accept_string(grammar, "stop")
 
 
 if __name__ == "__main__":

--- a/tests/python/test_grammar_parser_macro.py
+++ b/tests/python/test_grammar_parser_macro.py
@@ -14,8 +14,8 @@ def test_tag_dispatch():
     before = """root ::= TagDispatch(
     ("tag1", rule1),
     ("tag2", rule2),
-    loop_after_dispatch = false,
-    excludes = ("abc", "def")
+    excludes = ("abc", "def"),
+    loop_after_dispatch = false
 )
 rule1 ::= "a"
 rule2 ::= "b"
@@ -189,16 +189,16 @@ ebnf_str__expected_error_regex__test_tag_dispatch_parser_errors = [
         "EBNF parser error at line 1, column 30: Expect , or \\) in tuple",
     ),
     (
-        'root ::= TagDispatch(("tag1", rule1), excludes=(""))\nrule1 ::= "a"',
-        "Stop string must be a non-empty string literal",
+        'root ::= TagDispatch(("tag1", rule1), stop_str=true)\nrule1 ::= "a"',
+        "EBNF parser error at line 1, column 21: Unknown named argument for TagDispatch: stop_str",
     ),
     (
-        'root ::= TagDispatch(("<tool_calc>", rule1), excludes=("<tool"))\nrule1 ::= "a"',
-        'exclude "<tool" is a prefix of trigger "<tool_calc>"',
+        'root ::= TagDispatch(("tag1", rule1), stop_eos=false)\nrule1 ::= "a"',
+        "EBNF parser error at line 1, column 21: Unknown named argument for TagDispatch: stop_eos",
     ),
     (
-        'root ::= TagDispatch(("stop", rule1), excludes=("stop"))\nrule1 ::= "a"',
-        'exclude "stop" is a prefix of trigger "stop"',
+        'root ::= TagDispatch(("tag1", rule1), excludes=("tag1"))\nrule1 ::= "a"',
+        "EBNF parser error at line 1, column 21: Exclude string must not be a prefix of trigger string: tag1",
     ),
 ]
 

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -42,7 +42,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v9"
+    assert xgr.get_serialization_version() == "v11"
 
 
 def test_serialize_grammar():
@@ -62,7 +62,7 @@ def test_serialize_grammar():
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v9",
+        "__VERSION__": "v11",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -82,14 +82,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v9",
+        "__VERSION__": "v11",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v9"
+    expected_json["__VERSION__"] = "v11"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -141,7 +141,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v9"}'
+        '"__VERSION__":"v11"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -255,7 +255,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v9",
+        "__VERSION__": "v11",
     }
 
     class AdaptiveTokenMask(BaseModel):

--- a/tests/python/test_token_edge.py
+++ b/tests/python/test_token_edge.py
@@ -1,0 +1,758 @@
+"""Tests for Token() edge support in grammar parsing, matching, and bitmask generation."""
+
+import pytest
+
+import xgrammar as xgr
+from xgrammar.testing import (
+    _ebnf_to_grammar_no_normalization,
+    _get_masked_tokens_from_bitmask,
+    _get_matcher_from_grammar_and_tokenizer_info,
+)
+
+# --- Parser / Printer roundtrip tests ---
+
+
+def test_parse_token_basic():
+    before = "root ::= Token(1, 2, 3)\n"
+    expected = "root ::= ((Token(1, 2, 3)))\n"
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+def test_parse_token_single():
+    before = "root ::= Token(42)\n"
+    expected = "root ::= ((Token(42)))\n"
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+def test_parse_token_sorted_deduped():
+    before = "root ::= Token(3, 1, 2, 1, 3)\n"
+    expected = "root ::= ((Token(1, 2, 3)))\n"
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+def test_parse_token_in_sequence():
+    before = 'root ::= Token(1, 2) "hello"\n'
+    expected = 'root ::= ((Token(1, 2) "hello"))\n'
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+def test_parse_token_in_alternation():
+    before = 'root ::= Token(1) | "hello"\n'
+    expected = 'root ::= ((Token(1)) | ("hello"))\n'
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+def test_parse_exclude_token_basic():
+    before = "root ::= ExcludeToken(1, 2, 3)\n"
+    expected = "root ::= ((ExcludeToken(1, 2, 3)))\n"
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+def test_parse_exclude_token_sorted_deduped():
+    before = "root ::= ExcludeToken(3, 1, 2, 1)\n"
+    expected = "root ::= ((ExcludeToken(1, 2, 3)))\n"
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+# --- Matcher accept_token tests ---
+
+
+STOP_TOKEN_ID = 1  # "</s>" in our test vocab
+
+
+def _make_matcher(vocab, grammar_str):
+    """Create a matcher with a custom vocab and grammar."""
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    return _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+
+def test_accept_token_basic():
+    """Token(2, 4) should accept token IDs 2 and 4 but reject others."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc", "dd"]
+    #         0      1       2     3     4     5
+    matcher = _make_matcher(vocab, "root ::= Token(2, 4)\n")
+
+    assert matcher.accept_token(2)
+    assert matcher.accept_token(STOP_TOKEN_ID)
+    assert matcher.is_terminated()
+
+
+def test_accept_token_reject():
+    """Tokens not in the Token() set should be rejected."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc", "dd"]
+    matcher = _make_matcher(vocab, "root ::= Token(2, 4)\n")
+
+    assert not matcher.accept_token(3)
+    assert not matcher.accept_token(5)
+    assert matcher.accept_token(4)
+    assert matcher.accept_token(STOP_TOKEN_ID)
+    assert matcher.is_terminated()
+
+
+def test_token_then_string():
+    """Token followed by string literal: Token(2) "bb" ."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc"]
+    matcher = _make_matcher(vocab, 'root ::= Token(2) "bb"\n')
+
+    assert matcher.accept_token(2)  # Token(2) = "aa"
+    assert matcher.accept_token(3)  # "bb"
+    assert matcher.accept_token(STOP_TOKEN_ID)
+    assert matcher.is_terminated()
+
+
+def test_token_or_string():
+    """Alternation: Token(2) | "bb" ."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc"]
+
+    # Accept via token path
+    matcher = _make_matcher(vocab, 'root ::= Token(2) | "bb"\n')
+    assert matcher.accept_token(2)
+    assert matcher.accept_token(STOP_TOKEN_ID)
+    assert matcher.is_terminated()
+
+    # Accept via string path
+    matcher2 = _make_matcher(vocab, 'root ::= Token(2) | "bb"\n')
+    assert matcher2.accept_token(3)  # "bb"
+    assert matcher2.accept_token(STOP_TOKEN_ID)
+    assert matcher2.is_terminated()
+
+
+# --- Bitmask tests ---
+
+
+def test_bitmask_token_only():
+    """FillNextTokenBitmask should allow only tokens in Token() set (and stop token)."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc", "dd"]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf("root ::= Token(2, 4)\n")
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected = set(_get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size))
+
+    assert rejected == {0, 1, 3, 5}
+
+
+def test_bitmask_token_and_string():
+    """Bitmask for Token(2) | "bb" should allow token 2 and token whose text is "bb"."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc"]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf('root ::= Token(2) | "bb"\n')
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected = set(_get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size))
+
+    assert rejected == {0, 1, 4}
+
+
+def test_bitmask_after_token():
+    """After accepting a Token, the bitmask should reflect the next expected tokens."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc"]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf('root ::= Token(2) "bb"\n')
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected = set(_get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size))
+    assert rejected == {0, 1, 3, 4}
+
+    assert matcher.accept_token(2)
+
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected2 = set(_get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size))
+    assert rejected2 == {0, 1, 2, 4}
+
+
+def test_token_multiple_choices():
+    """Token set with multiple IDs in alternation with other rules."""
+    vocab = ["<s>", "</s>", "x", "y", "z", "w"]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf('root ::= Token(2, 3, 4) | "w"\n')
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected = set(_get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size))
+
+    assert rejected == {0, 1}
+
+
+# --- 4.3 char-then-token sequence tests ---
+
+
+def test_char_then_token_sequence():
+    """String literal followed by Token: "A" Token(4, 5)."""
+    vocab = ["<s>", "</s>", "A", "B", "hello", "world"]
+    matcher = _make_matcher(vocab, 'root ::= "A" Token(4, 5)\n')
+    assert matcher.accept_token(2)  # "A"
+    assert matcher.accept_token(4)  # Token(4) = "hello"
+    assert matcher.accept_token(STOP_TOKEN_ID)
+    assert matcher.is_terminated()
+
+
+# --- TokenTagDispatch + excludes tests ---
+
+
+def _make_bitmask_helper(vocab, grammar_str):
+    """Create matcher, tokenizer_info, and bitmask for a grammar."""
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    return matcher, tokenizer_info, token_bitmask
+
+
+def _get_accepted(matcher, token_bitmask, vocab_size):
+    """Fill bitmask and return accepted token IDs."""
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected = _get_masked_tokens_from_bitmask(token_bitmask, vocab_size)
+    return set(range(vocab_size)) - set(rejected)
+
+
+def test_token_tag_dispatch_exclude_no_triggers():
+    """ExcludeToken self-loop accepts all tokens except excluded ones."""
+    vocab = ["<s>", "</s>", "hello", "world", "blocked_1", "blocked_2"]
+    grammar_str = """root ::= TokenTagDispatch(
+      excludes=(4, 5)
+    )"""
+    matcher, ti, bitmask = _make_bitmask_helper(vocab, grammar_str)
+
+    for _ in range(3):
+        assert _get_accepted(matcher, bitmask, ti.vocab_size) == {0, 1, 2, 3}
+        matcher.accept_token(2)
+
+
+def test_token_tag_dispatch_exclude_basic():
+    """ExcludeToken edge blocks excluded tokens."""
+    vocab = ["<s>", "</s>", "hello", "world", "bad"]
+    grammar_str = """root ::= TokenTagDispatch(
+      excludes=(4,)
+    )"""
+    matcher, ti, bitmask = _make_bitmask_helper(vocab, grammar_str)
+    assert _get_accepted(matcher, bitmask, ti.vocab_size) == {0, 1, 2, 3}
+
+
+def test_token_tag_dispatch_reject_enforced_by_parser():
+    """accept_token must reject tokens excluded by kExcludeToken edge."""
+    vocab = ["<s>", "</s>", "hello", "world", "blocked"]
+    grammar_str = """root ::= TokenTagDispatch(
+      excludes=(4,)
+    )"""
+    ti = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, ti)
+    assert not matcher.accept_token(4), "parser must reject excluded token"
+    assert matcher.accept_token(2)  # "hello" still accepted
+
+
+def test_token_tag_dispatch_trigger_and_exclude():
+    """TokenTagDispatch with trigger and exclude."""
+    vocab = ["<s>", "</s>", "A", "AB", "blocked"]
+    grammar_str = """
+    rule1 ::= "done"
+    root ::= TokenTagDispatch(
+      (3, rule1),
+      excludes=(4,)
+    )"""
+    matcher, ti, bitmask = _make_bitmask_helper(vocab, grammar_str)
+    assert _get_accepted(matcher, bitmask, ti.vocab_size) == {0, 1, 2, 3}
+
+
+# --- TokenTagDispatch + trigger tests ---
+
+
+def test_token_tag_dispatch_trigger():
+    """Token trigger dispatches to a rule."""
+    vocab = ["<s>", "</s>", "hello", "trigger_tok", "content"]
+    grammar_str = """
+    triggered_rule ::= Token(4)
+    root ::= TokenTagDispatch(
+      (3, triggered_rule)
+    )"""
+    matcher, ti, bitmask = _make_bitmask_helper(vocab, grammar_str)
+    assert _get_accepted(matcher, bitmask, ti.vocab_size) == {0, 1, 2, 3, 4}
+
+    assert matcher.accept_token(3)  # dispatch trigger
+    assert _get_accepted(matcher, bitmask, ti.vocab_size) == {4}
+
+
+def test_token_tag_dispatch_multiple_triggers():
+    """Multiple token triggers in TokenTagDispatch."""
+    vocab = ["<s>", "</s>", "A", "B", "<tool>", "content"]
+    grammar_str = """
+    tool_body ::= Token(5)
+    other_body ::= Token(5)
+    root ::= TokenTagDispatch(
+      (3, tool_body),
+      (4, other_body)
+    )"""
+    matcher, ti, bitmask = _make_bitmask_helper(vocab, grammar_str)
+    assert _get_accepted(matcher, bitmask, ti.vocab_size) == {0, 1, 2, 3, 4, 5}
+
+    assert matcher.accept_token(3)  # dispatch to tool_body
+    assert _get_accepted(matcher, bitmask, ti.vocab_size) == {5}
+
+
+def test_token_tag_dispatch_trigger_loop():
+    """Token trigger with loop_after_dispatch returns to start after body completes."""
+    vocab = ["<s>", "</s>", "hello", "trigger", "content"]
+    grammar_str = """
+    body ::= Token(4)
+    root ::= TokenTagDispatch(
+      (3, body),
+      loop_after_dispatch=true
+    )"""
+    matcher, ti, bitmask = _make_bitmask_helper(vocab, grammar_str)
+
+    assert matcher.accept_token(3)  # trigger dispatches to body
+    assert matcher.accept_token(4)  # Token(4) completes body
+    assert _get_accepted(matcher, bitmask, ti.vocab_size) == {0, 1, 2, 3, 4}
+
+
+def test_token_tag_dispatch_trigger_and_exclude_no_overlap():
+    """Token trigger IDs and excludes must not overlap."""
+    grammar_str = """
+    body ::= Token(2)
+    root ::= TokenTagDispatch(
+      (3, body),
+      excludes=(3,)
+    )"""
+    with pytest.raises(Exception):
+        xgr.Grammar.from_ebnf(grammar_str)
+
+
+def test_token_tag_dispatch_trigger_in_bitmask():
+    """Trigger tokens accepted via kToken edge, others via ExcludeToken self-loop."""
+    vocab = ["<s>", "</s>", "hello", "trigger", "content"]
+    grammar_str = """
+    body ::= Token(4)
+    root ::= TokenTagDispatch(
+      (3, body)
+    )"""
+    matcher, ti, bitmask = _make_bitmask_helper(vocab, grammar_str)
+    assert _get_accepted(matcher, bitmask, ti.vocab_size) == {0, 1, 2, 3, 4}
+
+    assert matcher.accept_token(3)  # dispatch trigger
+    assert _get_accepted(matcher, bitmask, ti.vocab_size) == {4}
+
+
+def test_token_tag_dispatch_full_combo():
+    """Token triggers + excludes all working together."""
+    vocab = ["<s>", "</s>", "hello", "B", "<tool>", "content", "blocked"]
+    grammar_str = """
+    tool_body ::= Token(5)
+    other_body ::= Token(5)
+    root ::= TokenTagDispatch(
+      (3, tool_body),
+      (4, other_body),
+      excludes=(6,)
+    )"""
+    matcher, ti, bitmask = _make_bitmask_helper(vocab, grammar_str)
+    assert _get_accepted(matcher, bitmask, ti.vocab_size) == {0, 1, 2, 3, 4, 5}
+
+
+# --- Lookahead Assertion + kToken tests ---
+
+
+def test_lookahead_exact_with_token_set():
+    """Exact lookahead containing kToken: tokens matching the rule are accepted."""
+    vocab = ["<s>", "</s>", "abc", "abcd", "X"]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(
+        """
+    rule_a ::= [a-z]+
+    root ::= rule_a Token(4)
+    """
+    )
+    matcher = xgr.GrammarMatcher(compiled)
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected = set(_get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size))
+    assert rejected == {0, 1, 4}
+
+
+def test_lookahead_token_set_suffix_nonempty_rejected():
+    """Token that partially matches rule but has bytes left at kToken boundary → rejected."""
+    vocab = ["<s>", "</s>", "ab", "a", "X"]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(
+        """
+    rule_a ::= "a"
+    root ::= rule_a Token(4)
+    """
+    )
+    matcher = xgr.GrammarMatcher(compiled)
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected = set(_get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size))
+    assert rejected == {0, 1, 2, 4}
+
+
+def test_lookahead_mixed_char_and_token():
+    """Lookahead with char elements before kToken."""
+    vocab = ["<s>", "</s>", "abc", "abc!", "X"]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(
+        """
+    rule_a ::= [a-z]+
+    root ::= rule_a "!" Token(4)
+    """
+    )
+    matcher = xgr.GrammarMatcher(compiled)
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected = set(_get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size))
+    assert rejected == {0, 1, 4}
+
+
+# --- End-to-end tests ---
+
+
+def test_e2e_complex():
+    """TokenTagDispatch with two trigger paths: tool (char grammar) and code (Token grammar)."""
+    # fmt: off
+    vocab = [
+        "<s>",       # 0
+        "</s>",      # 1
+        "<tool>",    # 2   (trigger -> tool_body)
+        "<code>",    # 3   (trigger -> code_body)
+        "<blocked>", # 4   (excluded)
+        "hello",     # 5
+        "he",        # 6   (prefix of "hello")
+        "name",      # 7
+        "val",       # 8
+        "x",         # 9
+        "y",         # 10
+        "{",         # 11
+        "}",         # 12
+        ":",         # 13
+        ",",         # 14
+        "[",         # 15
+        "]",         # 16
+        ";",         # 17
+        "42",        # 18
+        "a:",        # 19  (crosses [a-z]+ / ":" boundary)
+        "{a",        # 20  (crosses "{" / [a-z]+ boundary)
+        "a}",        # 21  (crosses [a-z]+ / "}" boundary)
+        "a;",        # 22  (crosses [a-z]+ / ";" boundary)
+        "fn(",       # 23  (matches "fn(" exactly)
+        ")",         # 24
+    ]
+    # fmt: on
+    grammar_str = """
+value ::= [a-z]+ | [0-9]+
+entry ::= [a-z]+ ":" value
+inner ::= entry (";" entry)*
+body ::= "{" inner "}" | "[" inner "]"
+tool_body ::= body ("," body)*
+arg ::= [a-z]+
+call ::= "fn(" Token(9, 10) "," arg ")"
+code_body ::= call (";" call)*
+root ::= TokenTagDispatch(
+    (2, tool_body),
+    (3, code_body),
+    excludes=(4,)
+)
+"""
+    ti = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    A = set(range(len(vocab))) - {4}
+    AZ = {5, 6, 7, 8, 9, 10}
+
+    # fmt: off
+    paths = [
+        [   # tool path: trigger -> nested char grammar with uncertainty tokens
+            (None, A),                      # initial
+            (2,    {11, 15, 20}),            # <tool> -> body: need "{" or "["
+            (20,   AZ | {13, 19}),           # {a -> entry key continues
+            (19,   AZ | {18, 21, 22}),       # a: -> cross-boundary: key done + ":"
+            (18,   {12, 17, 18}),            # 42 -> [0-9]+ value; then "}" or ";"
+            (17,   AZ | {19}),              # ; -> second entry
+            (7,    AZ | {13, 19}),           # name -> entry key
+            (13,   AZ | {18, 21, 22}),       # : -> value
+            (8,    AZ | {12, 17, 21, 22}),   # val -> [a-z]+ value; then "}" or ";"
+            (12,   A),                       # } -> tool_body complete, back to self-loop
+        ],
+        [   # code path: trigger -> text-nested-Token grammar fn(Token,arg)
+            (None, A),            # initial
+            (3,    {23}),          # <code> -> call: need "fn("
+            (23,   {9, 10}),       # fn( -> Token(9, 10) position
+            (9,    {14}),          # x (Token 9) -> need ","
+            (14,   AZ),           # , -> arg: [a-z]+
+            (7,    AZ | {24}),    # name -> arg continues or ")"
+            (24,   A),            # ) -> call complete, back to self-loop
+        ],
+    ]
+    # fmt: on
+
+    for steps in paths:
+        matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, ti)
+        bitmask = xgr.allocate_token_bitmask(1, ti.vocab_size)
+        for token_id, expected in steps:
+            if token_id is not None:
+                assert matcher.accept_token(token_id)
+            assert _get_accepted(matcher, bitmask, ti.vocab_size) == expected
+        assert matcher.accept_token(1)  # </s>
+        assert matcher.is_terminated()
+
+
+def test_e2e_nested_dispatch():
+    """Nested TokenTagDispatch: outer excludes 4, inner excludes 5.
+
+    Token 4 (o_block): rejected at outer, but accepted inside inner dispatch.
+    Token 5 (i_block): rejected at inner, but accepted at outer dispatch.
+    """
+    vocab = [
+        "<s>",  # 0
+        "</s>",  # 1
+        "<outer>",  # 2
+        "<inner>",  # 3
+        "<o_block>",  # 4
+        "<i_block>",  # 5
+        "hello",  # 6
+        "world",  # 7
+        "fn(",  # 8
+        ")",  # 9
+        "x",  # 10
+        "y",  # 11
+    ]
+    grammar_str = """
+    leaf ::= Token(10, 11)
+    inner ::= TokenTagDispatch((3, leaf), excludes=(5,))
+    tool_fn ::= "fn(" inner ")"
+    root ::= TokenTagDispatch((2, tool_fn), excludes=(4,))
+    """
+    ALL = set(range(len(vocab)))
+    OUTER = ALL - {4}
+    INNER = ALL - {1, 5}
+
+    ti = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+
+    def fresh():
+        m = _get_matcher_from_grammar_and_tokenizer_info(grammar, ti)
+        b = xgr.allocate_token_bitmask(1, ti.vocab_size)
+        return m, b
+
+    # fmt: off
+    paths = [
+        [   # Path A: outer trigger -> fn( -> inner -> leaf -> )
+            (None, OUTER), (2, {8}), (8, INNER), (6, INNER),
+            (3, {10, 11}), (10, INNER), (9, ALL), (1, None),
+        ],
+        [   # Path B: outer loop only, <o_block>(4) rejected
+            (None, OUTER), (6, OUTER), (5, OUTER), (4, False), (1, None),
+        ],
+        [   # Path C1: <o_block>(4) rejected at outer
+            (None, OUTER), (4, False),
+        ],
+        [   # Path C2: <o_block>(4) accepted inside inner
+            (2, {8}), (8, INNER), (4, INNER), (9, ALL), (1, None),
+        ],
+    ]
+    # fmt: on
+
+    for steps in paths:
+        m, b = fresh()
+        for token_id, expected in steps:
+            if token_id is None:
+                assert _get_accepted(m, b, ti.vocab_size) == expected
+            elif expected is False:
+                assert not m.accept_token(token_id)
+            elif expected is None:
+                assert m.accept_token(token_id)
+                assert m.is_terminated()
+            else:
+                assert m.accept_token(token_id)
+                assert _get_accepted(m, b, ti.vocab_size) == expected
+
+
+def test_e2e_nested_exclude_loop():
+    """Nested ExcludeToken-only loop: [a-z]+ loop Token(5) [a-z]+.
+
+    Token 4 ("###") is excluded from loop AND not [a-z]+ -> always rejected.
+    Token 5 ("<END>") is excluded from loop but accepted via Token(5) after loop.
+    Token 0 ("<s>") is consumed by loop (non-[a-z], non-excluded).
+    """
+    vocab = ["<s>", "</s>", "hello", "world", "###", "<END>", "foo", "done"]
+    #         0      1       2        3        4      5        6      7
+    grammar_str = """
+    loop ::= TokenTagDispatch(excludes=(4, 5))
+    root ::= [a-z]+ loop Token(5) [a-z]+
+    """
+    ti = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    AZ = {2, 3, 6, 7}
+    LOOP = {0, 2, 3, 5, 6, 7}
+
+    # fmt: off
+    paths = [
+        [   # Main path: [a-z]+ -> loop -> Token(5) -> [a-z]+ -> end
+            (None, AZ), (4, False), (2, LOOP), (0, LOOP), (3, LOOP),
+            (5, AZ), (7, {1} | AZ), (1, None),
+        ],
+    ]
+    # fmt: on
+
+    for steps in paths:
+        matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, ti)
+        bitmask = xgr.allocate_token_bitmask(1, ti.vocab_size)
+        for token_id, expected in steps:
+            if token_id is None:
+                assert _get_accepted(matcher, bitmask, ti.vocab_size) == expected
+            elif expected is False:
+                assert not matcher.accept_token(token_id)
+            elif expected is None:
+                assert matcher.accept_token(token_id)
+                assert matcher.is_terminated()
+            else:
+                assert matcher.accept_token(token_id)
+                assert _get_accepted(matcher, bitmask, ti.vocab_size) == expected
+
+
+def test_e2e_mixed_tag_and_token_dispatch():
+    """Three-layer nesting: TagDispatch -> TokenTagDispatch -> TagDispatch.
+
+    Outer (TagDispatch): trigger "<call>", excludes string "<bad>"
+    Mid   (TokenTagDispatch): trigger token 3, excludes token 4
+    Inner (TagDispatch): trigger "<end>", excludes string "<bad>"
+
+    Key: token 6 ("<bad>") rejected by string-based excludes (outer+inner),
+    but temporarily accepted inside mid (token-based, doesn't exclude 6).
+    """
+    vocab = [
+        "<s>",  # 0
+        "</s>",  # 1
+        "<call>",  # 2
+        "<mid>",  # 3
+        "<skip>",  # 4
+        "<end>",  # 5
+        "<bad>",  # 6
+        "hello",  # 7
+        "world",  # 8
+        "x",  # 9
+        "y",  # 10
+        "done",  # 11
+    ]
+    grammar_str = """
+    leaf ::= [a-z]+
+    inner ::= TagDispatch(("<end>", leaf), excludes=("<bad>"))
+    mid_body ::= Token(9, 10) inner
+    mid ::= TokenTagDispatch((3, mid_body), excludes=(4,))
+    root ::= TagDispatch(("<call>", mid), excludes=("<bad>"))
+    """
+    ALL = set(range(len(vocab)))
+    OUTER = ALL - {6}
+
+    ti = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+
+    def fresh():
+        m = _get_matcher_from_grammar_and_tokenizer_info(grammar, ti)
+        b = xgr.allocate_token_bitmask(1, ti.vocab_size)
+        return m, b
+
+    # expected=False means reject; expected=None means accept+terminated
+    # fmt: off
+    paths = [
+        [   # Path A: full traversal through all 3 layers
+            (None, OUTER), (7, OUTER), (2, ALL), (3, OUTER), (9, OUTER),
+            (8, OUTER), (5, OUTER), (11, OUTER), (1, None),
+        ],
+        [   # Path B: outer loop only, <bad>(6) rejected
+            (None, OUTER), (7, OUTER), (8, OUTER), (6, False), (1, None),
+        ],
+        [   # Path C1: <bad>(6) rejected at outer
+            (None, OUTER), (6, False),
+        ],
+        [   # Path C2: <bad>(6) accepted inside mid
+            (2, ALL), (6, ALL),
+        ],
+        [   # Path C3: <bad>(6) rejected by inner excludes
+            (2, ALL), (3, OUTER), (9, OUTER), (6, False),
+        ],
+        [   # Path D1: <skip>(4) accepted at outer
+            (4, OUTER),
+        ],
+        [   # Path D2: <skip>(4) accepted at inner
+            (2, ALL), (3, OUTER), (9, OUTER), (4, OUTER),
+        ],
+    ]
+    # fmt: on
+
+    for steps in paths:
+        m, b = fresh()
+        for token_id, expected in steps:
+            if token_id is None:
+                assert _get_accepted(m, b, ti.vocab_size) == expected
+            elif expected is False:
+                assert not m.accept_token(token_id)
+            elif expected is None:
+                assert m.accept_token(token_id)
+                assert m.is_terminated()
+            else:
+                assert m.accept_token(token_id)
+                assert _get_accepted(m, b, ti.vocab_size) == expected
+
+
+def test_rollback():
+    """Rollback restores mask and accept_token behavior for token edges."""
+    vocab = ["<s>", "</s>", "<tool>", "<code>", "hello", "world", "fn(", ")", "x", "y"]
+    #          0      1       2         3        4        5       6      7    8    9
+    grammar_str = """
+    arg ::= [a-z]+
+    call ::= "fn(" Token(8, 9) "," arg ")"
+    root ::= TokenTagDispatch(
+      (2, call),
+      excludes=(3,)
+    )
+    """
+    ti = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    m = _get_matcher_from_grammar_and_tokenizer_info(grammar, ti)
+    b = xgr.allocate_token_bitmask(1, ti.vocab_size)
+
+    mask_0 = _get_accepted(m, b, ti.vocab_size)
+    assert m.accept_token(2)  # <tool> trigger
+    mask_1 = _get_accepted(m, b, ti.vocab_size)
+    assert m.accept_token(6)  # fn(
+    mask_2 = _get_accepted(m, b, ti.vocab_size)
+    assert m.accept_token(8)  # x (Token edge)
+    mask_3 = _get_accepted(m, b, ti.vocab_size)
+
+    # Rollback all 3 tokens
+    m.rollback(3)
+    assert _get_accepted(m, b, ti.vocab_size) == mask_0
+
+    # Re-accept and verify masks match
+    assert m.accept_token(2)
+    assert _get_accepted(m, b, ti.vocab_size) == mask_1
+    assert m.accept_token(6)
+    assert _get_accepted(m, b, ti.vocab_size) == mask_2
+    assert m.accept_token(8)
+    assert _get_accepted(m, b, ti.vocab_size) == mask_3
+
+    # Rollback 2, then continue on a different path
+    m.rollback(2)
+    assert _get_accepted(m, b, ti.vocab_size) == mask_1
+    assert m.accept_token(6)
+    assert m.accept_token(9)  # y instead of x
+    assert _get_accepted(m, b, ti.vocab_size) == mask_3  # same: need ","
+
+    # Rollback 1 past the token edge, re-accept
+    m.rollback(1)
+    assert _get_accepted(m, b, ti.vocab_size) == mask_2
+    assert m.accept_token(8)
+    assert _get_accepted(m, b, ti.vocab_size) == mask_3


### PR DESCRIPTION
## Summary

- Add three new grammar constructs: `Token(ids)`, `ExcludeToken(ids)`, `TokenTagDispatch((id, rule), ..., excludes=(ids))` for token-level matching alongside character-based matching
- Two new FSM edge types (`kToken`, `kExcludeToken`) enable atomic token matching in the Earley parser
- Dual-path `AcceptToken`: token path (`AdvanceAtomicToken`) + byte path, with state merging and deduplication
- Token edge contributions pre-computed into `AdaptiveTokenMask` for zero-overhead bitmask generation

Depends on #546 (remove AST fallback).

## Architecture

### New Grammar Constructs

| Construct | EBNF Syntax | Semantics |
|-----------|------------|-----------|
| `kToken` | `Token(1, 2, 3)` | Accept any token whose ID is in the set |
| `kExcludeToken` | `ExcludeToken(1, 2)` | Accept any token whose ID is NOT in the set |
| `kTokenTagDispatch` | `TokenTagDispatch((id, rule), ..., excludes=(ids))` | Token-level TagDispatch: trigger by token ID, exclude by token ID |

### Dual-Path AcceptToken

```
AcceptToken(token_id):
  1. Atomic path:  AdvanceAtomicToken(token_id)  — token edges
  2. Byte path:    Advance(byte) × len(token)    — char range edges
  3. Merge: deduplicate states from both paths
```

Both paths run from the same state independently, then merge. This allows token edges and byte-level matching to coexist in the same grammar.

### Bitmask Optimization

Token edge accepted tokens are pre-computed and merged into the adaptive token mask:
1. `GetTokenEdgeAcceptedIndices()` collects all token-edge-accepted sorted vocab indices
2. Byte path skips already-accepted tokens (skip pointer)
3. Final merge: `accepted = accepted ∪ token_edge_accepted`

### Key Implementation Details

- `ExcludeToken` edges block epsilon simplification to preserve "accept all except" semantics
- `TokenTagDispatch` FSM: trigger token edges + rule refs + self-loop with exclude-token edge (trigger IDs ∪ exclude IDs)
- `TokenEdgeRef` / `ExcludeTokenEdgeRef` view structs for efficient aux data access
- `token_id_to_sorted_vocab_index_` reverse mapping in `TokenizerInfo` for fast lookup
- New `IntsetDifference` and `IntsetComplement` set operations for efficient sorted-index computation