### PR TITLE
feat: support `DispatchFormat` and `TokenDispatchFormat`.

### DIFF
--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -256,9 +256,9 @@ picojson::value RepeatFormat::ToJSON() const {
 picojson::value DispatchFormat::ToJSON() const {
   picojson::object obj;
   obj["type"] = picojson::value(type);
-  picojson::array cases_arr;
-  cases_arr.reserve(cases.size());
-  for (const auto& pair : cases) {
+  picojson::array rules_arr;
+  rules_arr.reserve(rules.size());
+  for (const auto& pair : rules) {
     picojson::array pair_arr;
     pair_arr.push_back(picojson::value(pair.first));
     if (pair.second) {
@@ -266,9 +266,9 @@ picojson::value DispatchFormat::ToJSON() const {
     } else {
       pair_arr.push_back(picojson::value());
     }
-    cases_arr.push_back(picojson::value(std::move(pair_arr)));
+    rules_arr.push_back(picojson::value(std::move(pair_arr)));
   }
-  obj["cases"] = picojson::value(std::move(cases_arr));
+  obj["rules"] = picojson::value(std::move(rules_arr));
   obj["loop"] = picojson::value(loop);
   obj["excludes"] = StringVectorToJSONArray(excludes);
   return picojson::value(std::move(obj));
@@ -277,9 +277,9 @@ picojson::value DispatchFormat::ToJSON() const {
 picojson::value TokenDispatchFormat::ToJSON() const {
   picojson::object obj;
   obj["type"] = picojson::value(type);
-  picojson::array cases_arr;
-  cases_arr.reserve(cases.size());
-  for (const auto& pair : cases) {
+  picojson::array rules_arr;
+  rules_arr.reserve(rules.size());
+  for (const auto& pair : rules) {
     picojson::array pair_arr;
     if (std::holds_alternative<int32_t>(pair.first)) {
       pair_arr.push_back(picojson::value(static_cast<double>(std::get<int32_t>(pair.first))));
@@ -291,9 +291,9 @@ picojson::value TokenDispatchFormat::ToJSON() const {
     } else {
       pair_arr.push_back(picojson::value());
     }
-    cases_arr.push_back(picojson::value(std::move(pair_arr)));
+    rules_arr.push_back(picojson::value(std::move(pair_arr)));
   }
-  obj["cases"] = picojson::value(std::move(cases_arr));
+  obj["rules"] = picojson::value(std::move(rules_arr));
   obj["loop"] = picojson::value(loop);
   obj["exclude_tokens"] = IntOrStringVectorToJSONArray(exclude_tokens);
   return picojson::value(std::move(obj));
@@ -1042,17 +1042,17 @@ Result<TokenTriggeredTagsFormat, ISTError> StructuralTagParser::ParseTokenTrigge
 Result<DispatchFormat, ISTError> StructuralTagParser::ParseDispatchFormat(
     const picojson::object& obj
 ) {
-  auto cases_it = obj.find("cases");
-  if (cases_it == obj.end() || !cases_it->second.is<picojson::array>()) {
-    return ResultErr<ISTError>("TagDispatch format must have a cases field with an array");
+  auto rules_it = obj.find("rules");
+  if (rules_it == obj.end() || !rules_it->second.is<picojson::array>()) {
+    return ResultErr<ISTError>("TagDispatch format must have a rules field with an array");
   }
-  const auto& cases_array = cases_it->second.get<picojson::array>();
-  if (cases_array.empty()) {
-    return ResultErr<ISTError>("TagDispatch format cases must be non-empty");
+  const auto& rules_array = rules_it->second.get<picojson::array>();
+  if (rules_array.empty()) {
+    return ResultErr<ISTError>("TagDispatch format rules must be non-empty");
   }
-  std::vector<std::pair<std::string, std::shared_ptr<Format>>> cases;
-  cases.reserve(cases_array.size());
-  for (const auto& item : cases_array) {
+  std::vector<std::pair<std::string, std::shared_ptr<Format>>> rules;
+  rules.reserve(rules_array.size());
+  for (const auto& item : rules_array) {
     if (!item.is<picojson::array>()) {
       return ResultErr<ISTError>("TagDispatch pair must be a 2-element array");
     }
@@ -1068,7 +1068,7 @@ Result<DispatchFormat, ISTError> StructuralTagParser::ParseDispatchFormat(
     if (content.IsErr()) {
       return ResultErr<ISTError>(std::move(content).UnwrapErr());
     }
-    cases.push_back({std::move(trigger), std::make_shared<Format>(std::move(content).Unwrap())});
+    rules.push_back({std::move(trigger), std::make_shared<Format>(std::move(content).Unwrap())});
   }
 
   bool loop = true;
@@ -1094,23 +1094,23 @@ Result<DispatchFormat, ISTError> StructuralTagParser::ParseDispatchFormat(
     }
   }
 
-  return ResultOk<DispatchFormat>(std::move(cases), loop, std::move(excludes));
+  return ResultOk<DispatchFormat>(std::move(rules), loop, std::move(excludes));
 }
 
 Result<TokenDispatchFormat, ISTError> StructuralTagParser::ParseTokenDispatchFormat(
     const picojson::object& obj
 ) {
-  auto cases_it = obj.find("cases");
-  if (cases_it == obj.end() || !cases_it->second.is<picojson::array>()) {
-    return ResultErr<ISTError>("TokenTagDispatch format must have a cases field with an array");
+  auto rules_it = obj.find("rules");
+  if (rules_it == obj.end() || !rules_it->second.is<picojson::array>()) {
+    return ResultErr<ISTError>("TokenTagDispatch format must have a rules field with an array");
   }
-  const auto& cases_array = cases_it->second.get<picojson::array>();
-  if (cases_array.empty()) {
-    return ResultErr<ISTError>("TokenTagDispatch format cases must be non-empty");
+  const auto& rules_array = rules_it->second.get<picojson::array>();
+  if (rules_array.empty()) {
+    return ResultErr<ISTError>("TokenTagDispatch format rules must be non-empty");
   }
-  std::vector<std::pair<std::variant<int32_t, std::string>, std::shared_ptr<Format>>> cases;
-  cases.reserve(cases_array.size());
-  for (const auto& item : cases_array) {
+  std::vector<std::pair<std::variant<int32_t, std::string>, std::shared_ptr<Format>>> rules;
+  rules.reserve(rules_array.size());
+  for (const auto& item : rules_array) {
     if (!item.is<picojson::array>()) {
       return ResultErr<ISTError>("TokenTagDispatch pair must be a 2-element array");
     }
@@ -1135,7 +1135,7 @@ Result<TokenDispatchFormat, ISTError> StructuralTagParser::ParseTokenDispatchFor
     if (content.IsErr()) {
       return ResultErr<ISTError>(std::move(content).UnwrapErr());
     }
-    cases.push_back({std::move(trigger), std::make_shared<Format>(std::move(content).Unwrap())});
+    rules.push_back({std::move(trigger), std::make_shared<Format>(std::move(content).Unwrap())});
   }
 
   bool loop = true;
@@ -1157,7 +1157,7 @@ Result<TokenDispatchFormat, ISTError> StructuralTagParser::ParseTokenDispatchFor
     exclude_tokens = std::move(parsed).Unwrap();
   }
 
-  return ResultOk<TokenDispatchFormat>(std::move(cases), loop, std::move(exclude_tokens));
+  return ResultOk<TokenDispatchFormat>(std::move(rules), loop, std::move(exclude_tokens));
 }
 
 /************** StructuralTagTokenResolver **************/
@@ -1269,15 +1269,15 @@ std::optional<ISTError> StructuralTagTokenResolver::ResolveFormat(Format* format
           return std::nullopt;
         } else if constexpr (std::is_same_v<T, TokenDispatchFormat>) {
           std::vector<std::variant<int32_t, std::string>> trigger_tokens;
-          trigger_tokens.reserve(arg.cases.size());
-          for (const auto& p : arg.cases) {
+          trigger_tokens.reserve(arg.rules.size());
+          for (const auto& p : arg.rules) {
             trigger_tokens.push_back(p.first);
           }
           auto err = ResolveIntOrStringVec(trigger_tokens, &arg.resolved_trigger_token_ids_);
           if (err) return err;
           err = ResolveIntOrStringVec(arg.exclude_tokens, &arg.resolved_exclude_token_ids_);
           if (err) return err;
-          for (auto& p : arg.cases) {
+          for (auto& p : arg.rules) {
             if (p.second) {
               auto e = ResolveFormat(p.second.get());
               if (e) return e;
@@ -1285,7 +1285,7 @@ std::optional<ISTError> StructuralTagTokenResolver::ResolveFormat(Format* format
           }
           return std::nullopt;
         } else if constexpr (std::is_same_v<T, DispatchFormat>) {
-          for (auto& p : arg.cases) {
+          for (auto& p : arg.rules) {
             if (p.second) {
               auto err = ResolveFormat(p.second.get());
               if (err) return err;
@@ -1712,7 +1712,7 @@ std::optional<ISTError> StructuralTagAnalyzer::VisitSub(TokenTriggeredTagsFormat
 }
 
 std::optional<ISTError> StructuralTagAnalyzer::VisitSub(DispatchFormat* format) {
-  for (auto& pair : format->cases) {
+  for (auto& pair : format->rules) {
     if (pair.second) {
       auto err = Visit(pair.second.get());
       if (err.has_value()) return err;
@@ -1722,7 +1722,7 @@ std::optional<ISTError> StructuralTagAnalyzer::VisitSub(DispatchFormat* format) 
 }
 
 std::optional<ISTError> StructuralTagAnalyzer::VisitSub(TokenDispatchFormat* format) {
-  for (auto& pair : format->cases) {
+  for (auto& pair : format->rules) {
     if (pair.second) {
       auto err = Visit(pair.second.get());
       if (err.has_value()) return err;
@@ -2370,8 +2370,8 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const RepeatFormat
 
 Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const DispatchFormat& format) {
   std::vector<std::pair<std::string, int32_t>> tag_rule_pairs;
-  tag_rule_pairs.reserve(format.cases.size());
-  for (const auto& pair : format.cases) {
+  tag_rule_pairs.reserve(format.rules.size());
+  for (const auto& pair : format.rules) {
     if (!pair.second) {
       return ResultErr<ISTError>("TagDispatch pair must have content");
     }
@@ -2388,12 +2388,12 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const DispatchForm
 }
 
 Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TokenDispatchFormat& format) {
-  XGRAMMAR_DCHECK(format.resolved_trigger_token_ids_.size() == format.cases.size())
+  XGRAMMAR_DCHECK(format.resolved_trigger_token_ids_.size() == format.rules.size())
       << "TokenDispatchFormat must be resolved before conversion";
   std::vector<std::pair<int32_t, int32_t>> trigger_rule_pairs;
-  trigger_rule_pairs.reserve(format.cases.size());
-  for (size_t i = 0; i < format.cases.size(); ++i) {
-    const auto& pair = format.cases[i];
+  trigger_rule_pairs.reserve(format.rules.size());
+  for (size_t i = 0; i < format.rules.size(); ++i) {
+    const auto& pair = format.rules[i];
     if (!pair.second) {
       return ResultErr<ISTError>("TokenTagDispatch pair must have content");
     }

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -323,16 +323,16 @@ struct RepeatFormat {
  */
 struct DispatchFormat {
   static constexpr const char* type = "dispatch";
-  std::vector<std::pair<std::string, std::shared_ptr<Format>>> cases;
+  std::vector<std::pair<std::string, std::shared_ptr<Format>>> rules;
   bool loop = true;
   std::vector<std::string> excludes;
 
   DispatchFormat(
-      std::vector<std::pair<std::string, std::shared_ptr<Format>>> cases,
+      std::vector<std::pair<std::string, std::shared_ptr<Format>>> rules,
       bool loop = true,
       std::vector<std::string> excludes = {}
   )
-      : cases(std::move(cases)), loop(loop), excludes(std::move(excludes)) {}
+      : rules(std::move(rules)), loop(loop), excludes(std::move(excludes)) {}
   picojson::value ToJSON() const;
 };
 
@@ -343,16 +343,16 @@ struct DispatchFormat {
  */
 struct TokenDispatchFormat {
   static constexpr const char* type = "token_dispatch";
-  std::vector<std::pair<std::variant<int32_t, std::string>, std::shared_ptr<Format>>> cases;
+  std::vector<std::pair<std::variant<int32_t, std::string>, std::shared_ptr<Format>>> rules;
   bool loop = true;
   std::vector<std::variant<int32_t, std::string>> exclude_tokens;
 
   TokenDispatchFormat(
-      std::vector<std::pair<std::variant<int32_t, std::string>, std::shared_ptr<Format>>> cases,
+      std::vector<std::pair<std::variant<int32_t, std::string>, std::shared_ptr<Format>>> rules,
       bool loop = true,
       std::vector<std::variant<int32_t, std::string>> exclude_tokens = {}
   )
-      : cases(std::move(cases)), loop(loop), exclude_tokens(std::move(exclude_tokens)) {}
+      : rules(std::move(rules)), loop(loop), exclude_tokens(std::move(exclude_tokens)) {}
   picojson::value ToJSON() const;
 
  private:

--- a/docs/tutorials/structural_tag.md
+++ b/docs/tutorials/structural_tag.md
@@ -598,7 +598,11 @@ The format field requires a format object. We provide several basic format objec
 
     Accepts any string except the excluded string. But when any of the case strings is generated, the following format must follow the corresponding format. When the loop is false, after generating the format, we reach the end of the format. Otherwise, it will continue to allow generating any string and match the next case.
 
-    **`cases`** (required): Non-empty array of 2-element JSON arrays. Each entry is ``[trigger_string, content_format]``: a string trigger prefix, then a nested format object for the text after that trigger.
+    **`rules`** (required): Non-empty array of 2-element JSON arrays. Each entry is ``[pattern, content_format]``: the pattern is a string, followed by a format object for the content after that pattern.
+
+    **`loop`** (optional, default `true`): If true, after handling one dispatched format, it will continue to allow free-form text and match the next pattern. Otherwise, the matching of this format ends after handling the first dispatched format.
+
+    **`exclude_tokens`** (optional, default `[]`): List of strings that must not appear in the free-form text.
 
     Corresponds to an [Aho-Corasick automaton](https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm) under the hood to allow efficient and accurate pattern matching in a free-formed string.
 
@@ -615,13 +619,13 @@ The format field requires a format object. We provide several basic format objec
 
 20. `token_dispatch`
 
-    Similar to `dispatch` type, while the triggers are token IDs or token strings.
+    Similar to `dispatch` type, while the patterns are token IDs or token strings.
 
-    **`cases`** (required): Non-empty array of 2-element JSON arrays. Each entry is ``[trigger_token, content_format]``: the trigger is a token ID (integer) or token string (resolved via `tokenizer_info`), followed by a format object for the content after that token.
+    **`rules`** (required): Non-empty array of 2-element JSON arrays. Each entry is ``[pattern_token, content_format]``: the pattern is a token ID (integer) or token string (resolved via `tokenizer_info`), followed by a format object for the content after that token.
 
-    **`loop`** (optional, default `true`): If true, after one dispatch the grammar allows more tokens until the next trigger.
+    **`loop`** (optional, default `true`): If true, after one dispatched format, it will continue to allow free-form text and match the next pattern. Otherwise, the matching of this format ends after handling the first dispatched format.
 
-    **`exclude_tokens`** (optional, default `[]`): Token IDs or strings to exclude before a trigger is seen.
+    **`exclude_tokens`** (optional, default `[]`): List of Tokens that must not appear in the free-form text.
 
     ```json
     {

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -354,43 +354,63 @@ class RepeatFormat(BaseModel):
 
 
 class DispatchFormat(BaseModel):
-    """A format that maps directly to a TagDispatch grammar.
+    """Matches certain patterns in free-form text.
+    When certain strings are generated, the following content must follow the corresponding format.
+    Certain strings can be excluded from being generated in the free-form part.
 
-    Accepts a list of (trigger string, content format) pairs. In JSON, each pair is a two-element
-    array ``[trigger, content]``. When the output matches a trigger string, generation continues
-    with the corresponding content format. This is a lower-level alternative to
-    ``TriggeredTagsFormat`` when you want to specify exact trigger→rule mapping without tag
-    begin/end structure.
+    The user specifies a list of (pattern, formats). The LLM can generate any free-form text, but
+    when a pattern is matched in the text, the following output must follow the corresponding format.
+    The ``loop`` field controls whether the matching of this structure ends after accepting the first
+    pattern and format. If False, it ends. If true, the matching continues, and this format will
+    continue to allow free-form text and detect the next pattern to be generated.
+    The ``excludes`` field controls the strings that cannot be generated in the free-form text.
+    It can also control the end of the format:
+    ``SequenceFormat(DispatchFormat(..., excludes=""), ConstStringFormat(""))``
+    or
+    ``TagFormat(begin=..., content=DispatchFormat(..., excludes=""), end="")``
+    ends the matching of the format when LLM generates <end>.
     """
 
     type: Literal["dispatch"] = "dispatch"
     """The type of the format."""
-    cases: List[Tuple[str, "Format"]]
-    """List of ``(trigger string, content format)`` pairs."""
+    rules: List[Tuple[str, "Format"]]
+    """List of ``(pattern, content format)`` pairs."""
     loop: bool = True
-    """If true, after handling one dispatch the grammar allows any text until the next trigger."""
+    """If true, after handling one dispatched format, it will continue to allow free-form text
+    and match the next pattern. Otherwise, the matching of this format ends after handling the
+    first dispatched format."""
     excludes: List[str] = []
-    """List of strings that must not appear before a trigger is seen."""
+    """List of strings that must not appear in the free-form text."""
 
 
 class TokenDispatchFormat(BaseModel):
-    """A format that maps directly to a TokenTagDispatch grammar.
+    """Matches certain patterns in free-form text.
+    When certain tokens are generated, the following content must follow the corresponding format.
+    Certain tokens can be excluded from being generated in the free-form part.
 
-    Accepts a list of (trigger token, content format) pairs. In JSON, each pair is a two-element
-    array ``[trigger, content]``. When the model generates the trigger token, generation continues
-    with the corresponding content format. This is a lower-level alternative to
-    ``TokenTriggeredTagsFormat`` when you want exact token→rule mapping without tag begin/end
-    structure.
+    The user specifies a list of (pattern token, formats). The LLM can generate any free-form text, but
+    when a pattern is matched in the text, the following output must follow the corresponding format.
+    The ``loop`` field controls whether the matching of this structure ends after accepting the first
+    pattern and format. If False, it ends. If true, the matching continues, and this format will
+    continue to allow free-form text and detect the next pattern to be generated.
+    The ``excludes`` field controls the strings that cannot be generated in the free-form text.
+    It can also control the end of the format:
+    ``SequenceFormat(DispatchFormat(..., excludes=""), ConstStringFormat(""))``
+    or
+    ``TagFormat(begin=..., content=DispatchFormat(..., excludes=""), end="")``
+    ends the matching of the format when LLM generates <end>.
     """
 
     type: Literal["token_dispatch"] = "token_dispatch"
     """The type of the format."""
-    cases: List[Tuple[Union[int, str], "Format"]]
-    """List of ``(trigger token, content format)`` pairs. Trigger is token ID or token string."""
+    rules: List[Tuple[Union[int, str], "Format"]]
+    """List of ``(pattern token, content format)`` pairs. Pattern is token ID or token string."""
     loop: bool = True
-    """If true, after one dispatch the grammar allows more tokens until the next trigger."""
+    """If true, after one dispatched format, it will continue to allow free-form text
+    and match the next pattern. Otherwise, the matching of this format ends after handling the
+    first dispatched format."""
     exclude_tokens: List[Union[int, str]] = []
-    """Token IDs or strings to exclude before a trigger is seen."""
+    """List of tokens that must not appear in the free-form text."""
 
 
 # ---------- Discriminated Union ----------

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -3895,7 +3895,7 @@ def test_token_triggered_tags_rejects_string_begin():
 
 tag_dispatch_format_stag = {
     "type": "dispatch",
-    "cases": [
+    "rules": [
         ["tag1", {"type": "const_string", "value": "abcd"}],
         ["tag2", {"type": "const_string", "value": "efg"}],
     ],
@@ -3929,7 +3929,7 @@ def test_tag_dispatch_format_simple(instance: str, is_accepted: bool):
 
 tag_dispatch_format_no_loop_stag = {
     "type": "dispatch",
-    "cases": [
+    "rules": [
         ["tag1", {"type": "const_string", "value": "abcd"}],
         ["tag2", {"type": "const_string", "value": "efg"}],
     ],
@@ -3968,7 +3968,7 @@ def test_tag_dispatch_format_no_loop(instance: str, is_accepted: bool):
 
 tag_dispatch_format_with_excludes_stag = {
     "type": "dispatch",
-    "cases": [
+    "rules": [
         ["tag1", {"type": "const_string", "value": "abcd"}],
         ["tag2", {"type": "const_string", "value": "efg"}],
     ],
@@ -4019,7 +4019,7 @@ def test_token_tag_dispatch_format_simple():
     """TokenDispatchFormat: two trigger tokens, each with const_string content."""
     stag_format = {
         "type": "token_dispatch",
-        "cases": [
+        "rules": [
             [10, {"type": "const_string", "value": "A"}],
             [20, {"type": "const_string", "value": "B"}],
         ],
@@ -4043,7 +4043,7 @@ def test_token_tag_dispatch_format_with_excludes():
     """TokenDispatchFormat with exclude_tokens."""
     stag_format = {
         "type": "token_dispatch",
-        "cases": [[10, {"type": "const_string", "value": "C"}]],
+        "rules": [[10, {"type": "const_string", "value": "C"}]],
         "loop": False,
         "exclude_tokens": [50],
     }
@@ -4063,7 +4063,7 @@ def test_token_tag_dispatch_format_looping():
     """TokenDispatchFormat with loop=true."""
     stag_format = {
         "type": "token_dispatch",
-        "cases": [[10, {"type": "const_string", "value": "D"}]],
+        "rules": [[10, {"type": "const_string", "value": "D"}]],
         "loop": True,
     }
     expected_grammar = r"""const_string ::= (("D"))
@@ -4089,7 +4089,7 @@ def test_token_tag_dispatch_need_tokenizer_info():
         "type": "structural_tag",
         "format": {
             "type": "token_dispatch",
-            "cases": [["<|tag|>", {"type": "const_string", "value": "abcd"}]],
+            "rules": [["<|tag|>", {"type": "const_string", "value": "abcd"}]],
         },
     }
     with pytest.raises(Exception, match="Invalid structural tag error"):


### PR DESCRIPTION
Similar to #558, this PR provides two `StructuralTag` to provide the semantics of `TagDispatchFormat` and `TokenTagDispatchFormat`.