### PR TITLE
 refac: migrate the logic of built-in structural_tags to cpp.

### DIFF
--- a/cpp/builtin_structural_tag.cc
+++ b/cpp/builtin_structural_tag.cc
@@ -1,0 +1,453 @@
+/*!
+ *  Copyright (c) 2026 by Contributors
+ * \file xgrammar/builtin_structural_tag.cc
+ */
+
+#include <picojson.h>
+#include <xgrammar/builtin_structural_tag.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "structural_tag.h"
+#include "support/logging.h"
+
+namespace xgrammar {
+
+using FunctionDef = std::pair<std::string, std::string>;
+
+const std::vector<std::string> kThinkExcludeTokens = {"<think>", "</think>"};
+
+std::string StructuralTagToJSON(const StructuralTag& structural_tag) {
+  picojson::object obj;
+  obj["type"] = picojson::value(StructuralTag::type);
+  obj["format"] = FormatToJSONValue(structural_tag.format);
+  return picojson::value(std::move(obj)).serialize(false);
+}
+
+bool GetBoolWithDefault(const picojson::object& obj, const std::string& key, bool default_value) {
+  auto it = obj.find(key);
+  if (it == obj.end()) {
+    return default_value;
+  }
+  XGRAMMAR_CHECK(it->second.is<bool>())
+      << "The '" << key << "' key in the input_dict must be a boolean.";
+  return it->second.get<bool>();
+}
+
+std::vector<FunctionDef> ParseFunctionList(
+    const picojson::value& input_value, const std::string& key
+) {
+  std::vector<FunctionDef> functions;
+  if (!input_value.is<picojson::object>()) {
+    return functions;
+  }
+  const auto& obj = input_value.get<picojson::object>();
+  auto list_it = obj.find(key);
+  if (list_it == obj.end()) {
+    return functions;
+  }
+  XGRAMMAR_CHECK(list_it->second.is<picojson::array>())
+      << "The '" << key << "' key in the input_dict must be a list.";
+  for (const auto& tool : list_it->second.get<picojson::array>()) {
+    if (!tool.is<picojson::object>()) {
+      continue;
+    }
+    const auto& tool_obj = tool.get<picojson::object>();
+    auto function_it = tool_obj.find("function");
+    if (function_it == tool_obj.end() || !function_it->second.is<picojson::object>()) {
+      continue;
+    }
+    const auto& function_obj = function_it->second.get<picojson::object>();
+    auto name_it = function_obj.find("name");
+    XGRAMMAR_CHECK(name_it != function_obj.end() && name_it->second.is<std::string>())
+        << "Each function in the '" << key << "' list must have 'name' key.";
+
+    bool use_true_schema = false;
+    auto strict_it = function_obj.find("strict");
+    if (strict_it != function_obj.end() && strict_it->second.is<bool>() &&
+        strict_it->second.get<bool>() == false) {
+      use_true_schema = true;
+    }
+    auto parameters_it = function_obj.find("parameters");
+    if (parameters_it == function_obj.end()) {
+      use_true_schema = true;
+    }
+
+    std::string schema_json;
+    if (use_true_schema) {
+      schema_json = "true";
+    } else {
+      XGRAMMAR_CHECK(
+          parameters_it->second.is<picojson::object>() || parameters_it->second.is<bool>()
+      ) << "The 'parameters' key in each tool must be a dict or a boolean.";
+      schema_json = parameters_it->second.serialize(false);
+    }
+    functions.push_back({name_it->second.get<std::string>(), std::move(schema_json)});
+  }
+  return functions;
+}
+
+Format BuildSuffixTriggeredOrAnyText(
+    const std::vector<TagFormat>& tags, const std::vector<std::string>& triggers
+) {
+  if (!tags.empty()) {
+    return TriggeredTagsFormat(triggers, tags, kThinkExcludeTokens, false, false);
+  }
+  return AnyTextFormat(kThinkExcludeTokens);
+}
+
+StructuralTag BuildLlamaStructuralTag(
+    const std::vector<FunctionDef>& tools, bool reasoning, bool force_empty_reasoning
+) {
+  std::vector<TagFormat> tags;
+  tags.reserve(tools.size());
+  for (const auto& [name, schema] : tools) {
+    tags.emplace_back(
+        "{\"name\": \"" + name + "\", \"parameters\": ",
+        std::make_shared<Format>(JSONSchemaFormat(schema)),
+        std::vector<std::string>{"}"}
+    );
+  }
+  Format suffix_tag = BuildSuffixTriggeredOrAnyText(tags, {"{\"name\": "});
+  if (!reasoning) {
+    return StructuralTag(std::move(suffix_tag));
+  }
+  Format prefix_tag = force_empty_reasoning ? Format(ConstStringFormat("<think>\n\n</think>"))
+                                            : Format(TagFormat(
+                                                  "<think>",
+                                                  std::make_shared<Format>(AnyTextFormat({})),
+                                                  std::vector<std::string>{"</think>"}
+                                              ));
+  return StructuralTag(SequenceFormat({std::move(prefix_tag), std::move(suffix_tag)}));
+}
+
+StructuralTag BuildKimiStructuralTag(
+    const std::vector<FunctionDef>& tools, bool reasoning, bool force_empty_reasoning
+) {
+  std::vector<TagFormat> tags;
+  tags.reserve(tools.size());
+  for (const auto& [name, schema] : tools) {
+    tags.emplace_back(
+        "<|tool_call_begin|>functions." + name + ":",
+        std::make_shared<Format>(SequenceFormat(
+            {Format(RegexFormat("\\d+")),
+             Format(ConstStringFormat("<|tool_call_argument_begin|>")),
+             Format(JSONSchemaFormat(schema))}
+        )),
+        std::vector<std::string>{"<|tool_call_end|>"}
+    );
+  }
+  Format suffix_tag = BuildSuffixTriggeredOrAnyText(tags, {"<|tool_call_begin|>"});
+  if (!reasoning) {
+    return StructuralTag(std::move(suffix_tag));
+  }
+  Format prefix_tag = force_empty_reasoning ? Format(ConstStringFormat("<think></think>"))
+                                            : Format(TagFormat(
+                                                  "<think>",
+                                                  std::make_shared<Format>(AnyTextFormat({})),
+                                                  std::vector<std::string>{"</think>"}
+                                              ));
+  return StructuralTag(SequenceFormat({std::move(prefix_tag), std::move(suffix_tag)}));
+}
+
+StructuralTag BuildDeepSeekR1StructuralTag(
+    const std::vector<FunctionDef>& tools, bool reasoning, bool force_empty_reasoning
+) {
+  std::vector<TagFormat> tags;
+  tags.reserve(tools.size());
+  for (const auto& [name, schema] : tools) {
+    tags.emplace_back(
+        "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>" + name + "<｜tool▁sep｜>",
+        std::make_shared<Format>(JSONSchemaFormat(schema)),
+        std::vector<std::string>{"<｜tool▁call▁end｜>"}
+    );
+  }
+  Format suffix_tag =
+      BuildSuffixTriggeredOrAnyText(tags, {"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>"});
+  if (!reasoning) {
+    return StructuralTag(std::move(suffix_tag));
+  }
+  Format prefix_tag = force_empty_reasoning ? Format(ConstStringFormat("</think>"))
+                                            : Format(TagFormat(
+                                                  "",
+                                                  std::make_shared<Format>(AnyTextFormat({})),
+                                                  std::vector<std::string>{"</think>"}
+                                              ));
+  return StructuralTag(SequenceFormat({std::move(prefix_tag), std::move(suffix_tag)}));
+}
+
+StructuralTag BuildQwenCoderStructuralTag(
+    const std::vector<FunctionDef>& tools, bool reasoning, bool force_empty_reasoning
+) {
+  std::vector<TagFormat> tags;
+  tags.reserve(tools.size());
+  for (const auto& [name, schema] : tools) {
+    tags.emplace_back(
+        "<tool_call>\n<function=" + name + ">\n",
+        std::make_shared<Format>(JSONSchemaFormat(schema, "qwen_xml")),
+        std::vector<std::string>{"\n</function>\n</tool_call>"}
+    );
+  }
+  Format suffix_tag = BuildSuffixTriggeredOrAnyText(tags, {"<tool_call>\n<function="});
+  if (!reasoning) {
+    return StructuralTag(std::move(suffix_tag));
+  }
+  Format prefix_tag = force_empty_reasoning ? Format(ConstStringFormat("<think>\n\n</think>"))
+                                            : Format(TagFormat(
+                                                  "<think>",
+                                                  std::make_shared<Format>(AnyTextFormat({})),
+                                                  std::vector<std::string>{"</think>"}
+                                              ));
+  return StructuralTag(SequenceFormat({std::move(prefix_tag), std::move(suffix_tag)}));
+}
+
+StructuralTag BuildQwenStructuralTag(
+    const std::vector<FunctionDef>& tools, bool reasoning, bool force_empty_reasoning
+) {
+  std::vector<TagFormat> tags;
+  tags.reserve(tools.size());
+  for (const auto& [name, schema] : tools) {
+    tags.emplace_back(
+        "<tool_call>\n{\"name\": \"" + name + "\", \"arguments\": ",
+        std::make_shared<Format>(JSONSchemaFormat(schema)),
+        std::vector<std::string>{"}\n</tool_call>"}
+    );
+  }
+  Format suffix_tag = BuildSuffixTriggeredOrAnyText(tags, {"<tool_call>"});
+  if (!reasoning) {
+    return StructuralTag(std::move(suffix_tag));
+  }
+  Format prefix_tag = force_empty_reasoning ? Format(ConstStringFormat("<think>\n\n</think>"))
+                                            : Format(TagFormat(
+                                                  "<think>",
+                                                  std::make_shared<Format>(AnyTextFormat({})),
+                                                  std::vector<std::string>{"</think>"}
+                                              ));
+  return StructuralTag(SequenceFormat({std::move(prefix_tag), std::move(suffix_tag)}));
+}
+
+StructuralTag BuildHarmonyStructuralTag(
+    const std::vector<FunctionDef>& tools,
+    const std::vector<FunctionDef>& builtin_tools,
+    bool reasoning,
+    bool force_empty_reasoning
+) {
+  std::vector<TagFormat> tags;
+  if (reasoning) {
+    if (force_empty_reasoning) {
+      tags.emplace_back(
+          "<|channel|>analysis<|message|>",
+          std::make_shared<Format>(ConstStringFormat("<|end|>")),
+          std::vector<std::string>{""}
+      );
+    } else {
+      tags.emplace_back(
+          "<|channel|>analysis<|message|>",
+          std::make_shared<Format>(AnyTextFormat({})),
+          std::vector<std::string>{"<|end|>"}
+      );
+    }
+  }
+  for (const auto& [name, schema] : tools) {
+    tags.emplace_back(
+        "<|channel|>commentary to=" + name + "<|constrain|>json<|message|>",
+        std::make_shared<Format>(JSONSchemaFormat(schema)),
+        std::vector<std::string>{"<|call|>"}
+    );
+  }
+  for (const auto& [name, schema] : builtin_tools) {
+    tags.emplace_back(
+        "<|channel|>analysis to=" + name + "<|message|>",
+        std::make_shared<Format>(JSONSchemaFormat(schema)),
+        std::vector<std::string>{"<|call|>"}
+    );
+  }
+  tags.emplace_back(
+      "<|channel|>final<|message|>",
+      std::make_shared<Format>(AnyTextFormat({})),
+      std::vector<std::string>{"<|end|>"}
+  );
+  return StructuralTag(TagsWithSeparatorFormat(std::move(tags), "<|start|>assistant", false, false)
+  );
+}
+
+StructuralTag BuildDeepSeekV32StructuralTag(
+    const std::vector<FunctionDef>& tools, bool reasoning, bool force_empty_reasoning
+) {
+  std::vector<TagFormat> tags;
+  tags.reserve(tools.size());
+  for (const auto& [name, schema] : tools) {
+    tags.emplace_back(
+        "<｜DSML｜invoke name=\"" + name + "\">\n",
+        std::make_shared<Format>(JSONSchemaFormat(schema, "deepseek_xml")),
+        std::vector<std::string>{"</｜DSML｜invoke>\n"}
+    );
+  }
+  if (!tags.empty()) {
+    Format function_calling_tags = TagsWithSeparatorFormat(tags, "\n", true, false);
+    Format suffix_tag = TriggeredTagsFormat(
+        {"<｜DSML｜function_calls>"},
+        {TagFormat(
+            "<｜DSML｜function_calls>\n",
+            std::make_shared<Format>(std::move(function_calling_tags)),
+            std::vector<std::string>{"</｜DSML｜function_calls>\n"}
+        )},
+        kThinkExcludeTokens,
+        false,
+        false
+    );
+    if (!reasoning) {
+      return StructuralTag(std::move(suffix_tag));
+    }
+    Format prefix_tag = force_empty_reasoning ? Format(ConstStringFormat("<think>\n\n</think>"))
+                                              : Format(TagFormat(
+                                                    "<think>",
+                                                    std::make_shared<Format>(AnyTextFormat({})),
+                                                    std::vector<std::string>{"</think>"}
+                                                ));
+    return StructuralTag(SequenceFormat({std::move(prefix_tag), std::move(suffix_tag)}));
+  } else {
+    Format suffix_tag = AnyTextFormat(kThinkExcludeTokens);
+    if (!reasoning) {
+      return StructuralTag(std::move(suffix_tag));
+    }
+    Format prefix_tag = force_empty_reasoning ? Format(ConstStringFormat("<think>\n\n</think>"))
+                                              : Format(TagFormat(
+                                                    "<think>",
+                                                    std::make_shared<Format>(AnyTextFormat({})),
+                                                    std::vector<std::string>{"</think>"}
+                                                ));
+    return StructuralTag(SequenceFormat({std::move(prefix_tag), std::move(suffix_tag)}));
+  }
+}
+
+StructuralTag BuildMiniMaxStructuralTag(
+    const std::vector<FunctionDef>& tools, bool reasoning, bool force_empty_reasoning
+) {
+  std::vector<TagFormat> tags;
+  tags.reserve(tools.size());
+  for (const auto& [name, schema] : tools) {
+    tags.emplace_back(
+        "<invoke name=\"" + name + "\">\n",
+        std::make_shared<Format>(JSONSchemaFormat(schema, "minimax_xml")),
+        std::vector<std::string>{"</invoke>\n"}
+    );
+  }
+  if (!tags.empty()) {
+    Format function_calling_tags = TagsWithSeparatorFormat(tags, "\n", true, false);
+    Format suffix_tag = TriggeredTagsFormat(
+        {"<minimax:tool_call>"},
+        {TagFormat(
+            "<minimax:tool_call>\n",
+            std::make_shared<Format>(std::move(function_calling_tags)),
+            std::vector<std::string>{"</minimax:tool_call>\n"}
+        )},
+        kThinkExcludeTokens,
+        false,
+        false
+    );
+    if (!reasoning) {
+      return StructuralTag(std::move(suffix_tag));
+    }
+    Format prefix_tag = force_empty_reasoning ? Format(ConstStringFormat("<think>\n\n</think>"))
+                                              : Format(TagFormat(
+                                                    "<think>",
+                                                    std::make_shared<Format>(AnyTextFormat({})),
+                                                    std::vector<std::string>{"</think>"}
+                                                ));
+    return StructuralTag(SequenceFormat({std::move(prefix_tag), std::move(suffix_tag)}));
+  } else {
+    Format suffix_tag = AnyTextFormat(kThinkExcludeTokens);
+    if (!reasoning) {
+      return StructuralTag(std::move(suffix_tag));
+    }
+    Format prefix_tag = force_empty_reasoning ? Format(ConstStringFormat("<think>\n\n</think>"))
+                                              : Format(TagFormat(
+                                                    "<think>",
+                                                    std::make_shared<Format>(AnyTextFormat({})),
+                                                    std::vector<std::string>{"</think>"}
+                                                ));
+    return StructuralTag(SequenceFormat({std::move(prefix_tag), std::move(suffix_tag)}));
+  }
+}
+
+StructuralTag BuildGLM47StructuralTag(
+    const std::vector<FunctionDef>& tools, bool reasoning, bool force_empty_reasoning
+) {
+  std::vector<TagFormat> tags;
+  tags.reserve(tools.size());
+  for (const auto& [name, schema] : tools) {
+    tags.emplace_back(
+        "<tool_call>" + name,
+        std::make_shared<Format>(JSONSchemaFormat(schema, "glm_xml")),
+        std::vector<std::string>{"</tool_call>"}
+    );
+  }
+  Format suffix_tag = BuildSuffixTriggeredOrAnyText(tags, {"<tool_call>"});
+  if (!reasoning) {
+    return StructuralTag(std::move(suffix_tag));
+  }
+  Format prefix_tag = force_empty_reasoning ? Format(ConstStringFormat("<think>\n\n</think>"))
+                                            : Format(TagFormat(
+                                                  "<think>",
+                                                  std::make_shared<Format>(AnyTextFormat({})),
+                                                  std::vector<std::string>{"</think>"}
+                                              ));
+  return StructuralTag(SequenceFormat({std::move(prefix_tag), std::move(suffix_tag)}));
+}
+
+std::string GetBuiltinStructuralTagJSON(
+    const std::string& model, const std::string& input_dict_json
+) {
+  picojson::value input_value;
+  std::string err = picojson::parse(input_value, input_dict_json);
+  XGRAMMAR_CHECK(err.empty()) << "Failed to parse input_dict_json: " << err;
+  XGRAMMAR_CHECK(input_value.is<picojson::object>()) << "input_dict_json must be a JSON object.";
+
+  const auto& input_obj = input_value.get<picojson::object>();
+  const bool reasoning = GetBoolWithDefault(input_obj, "reasoning", true);
+  const bool force_empty_reasoning = GetBoolWithDefault(input_obj, "force_empty_reasoning", false);
+  const auto tools = ParseFunctionList(input_value, "tools");
+  const auto builtin_tools = ParseFunctionList(input_value, "builtin_tools");
+
+  StructuralTag structural_tag = [&]() -> StructuralTag {
+    if (model == "llama") {
+      return BuildLlamaStructuralTag(tools, reasoning, force_empty_reasoning);
+    }
+    if (model == "kimi") {
+      return BuildKimiStructuralTag(tools, reasoning, force_empty_reasoning);
+    }
+    if (model == "deepseek_r1") {
+      return BuildDeepSeekR1StructuralTag(tools, reasoning, force_empty_reasoning);
+    }
+    if (model == "qwen_coder") {
+      return BuildQwenCoderStructuralTag(tools, reasoning, force_empty_reasoning);
+    }
+    if (model == "qwen") {
+      return BuildQwenStructuralTag(tools, reasoning, force_empty_reasoning);
+    }
+    if (model == "harmony") {
+      return BuildHarmonyStructuralTag(tools, builtin_tools, reasoning, force_empty_reasoning);
+    }
+    if (model == "deepseek_v3_2") {
+      return BuildDeepSeekV32StructuralTag(tools, reasoning, force_empty_reasoning);
+    }
+    if (model == "minimax") {
+      return BuildMiniMaxStructuralTag(tools, reasoning, force_empty_reasoning);
+    }
+    if (model == "glm47") {
+      return BuildGLM47StructuralTag(tools, reasoning, force_empty_reasoning);
+    }
+    XGRAMMAR_LOG(FATAL) << "Unknown format type: " << model
+                        << ", support types: [llama, qwen, qwen_coder, kimi, deepseek_r1, "
+                           "harmony, deepseek_v3_2, minimax, glm47]";
+    XGRAMMAR_UNREACHABLE();
+  }();
+
+  return StructuralTagToJSON(structural_tag);
+}
+
+}  // namespace xgrammar

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -31,9 +31,6 @@ namespace xgrammar {
 // Short alias for the error type.
 using ISTError = InvalidStructuralTagError;
 
-// Forward declaration for helpers that convert Format to picojson::value.
-picojson::value FormatToJSONValue(const Format& format);
-
 picojson::value StringVectorToJSONArray(const std::vector<std::string>& vector) {
   picojson::array array;
   array.reserve(vector.size());
@@ -78,10 +75,6 @@ picojson::value IntOrStringVectorToJSONArray(
 
 /******************** Format To JSON ********************/
 std::string FormatToJSON(const Format& format) { return FormatToJSONValue(format).serialize(); }
-
-picojson::value FormatToJSONValue(const Format& format) {
-  return std::visit([&](auto&& arg) { return arg.ToJSON(); }, format);
-}
 
 picojson::value ConstStringFormat::ToJSON() const {
   picojson::object obj;

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -371,6 +371,10 @@ struct StructuralTag {
   StructuralTag(Format format) : format(std::move(format)) {}
 };
 
+inline picojson::value FormatToJSONValue(const Format& format) {
+  return std::visit([&](auto&& arg) { return arg.ToJSON(); }, format);
+}
+
 /******************** Conversion API ********************/
 
 /*!

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -24,6 +24,7 @@
 #include "../support/utils.h"
 #include "../testing.h"
 #include "python_methods.h"
+#include "xgrammar/builtin_structural_tag.h"
 #include "xgrammar/exception.h"
 #include "xgrammar/matcher.h"
 
@@ -680,6 +681,12 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 
   // ----- Global functions: testing, kernels, config, exceptions -----
   refl::GlobalDef()
+      .def(
+          "xgrammar.tvm_ffi_binding.get_builtin_structural_tag_json",
+          [](ffi::String model, ffi::String input_dict_json) {
+            return ffi::String(GetBuiltinStructuralTagJSON(model, input_dict_json));
+          }
+      )
       .def(
           "xgrammar.tvm_ffi_binding.testing._json_schema_to_ebnf",
           [](ffi::String schema,

--- a/include/xgrammar/builtin_structural_tag.h
+++ b/include/xgrammar/builtin_structural_tag.h
@@ -1,0 +1,26 @@
+/*!
+ *  Copyright (c) 2026 by Contributors
+ * \file xgrammar/builtin_structural_tag.h
+ */
+
+#ifndef XGRAMMAR_BUILTIN_STRUCTURAL_TAG_H_
+#define XGRAMMAR_BUILTIN_STRUCTURAL_TAG_H_
+
+#include <string>
+
+namespace xgrammar {
+
+/*!
+ * \brief Generate built-in structural tag json by model.
+ * \param model Built-in style name.
+ * \param input_dict_json JSON string that contains tools, builtin_tools, reasoning and
+ * force_empty_reasoning.
+ * \return StructuralTag JSON string.
+ */
+std::string GetBuiltinStructuralTagJSON(
+    const std::string& model, const std::string& input_dict_json
+);
+
+}  // namespace xgrammar
+
+#endif  // XGRAMMAR_BUILTIN_STRUCTURAL_TAG_H_

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -1,17 +1,8 @@
+import json
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
-from .structural_tag import (
-    AnyTextFormat,
-    ConstStringFormat,
-    JSONSchemaFormat,
-    QwenXMLParameterFormat,
-    RegexFormat,
-    SequenceFormat,
-    StructuralTag,
-    TagFormat,
-    TagsWithSeparatorFormat,
-    TriggeredTagsFormat,
-)
+from .base import _core
+from .structural_tag import StructuralTag
 
 # ---------- API Functions ----------
 
@@ -229,53 +220,19 @@ def _get_llama_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
     """Get Llama style structural tag format.
     Reference: https://www.llama.com/docs/model-cards-and-prompt-formats/llama3_1/
     The input_dict should be a dictionary with the following keys:
-    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary containing "name" and "parameters" fields.
+    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary
+      containing "name" and "parameters" fields.
     - "reasoning": a boolean indicating whether to enable reasoning mode.
-    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking, if False use thinking.
+    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking,
+      if False use thinking.
 
     Returns
     -------
     StructuralTag
         A structural tag for function calling format.
         This format is used by Llama 3 and other models that follow the same style.
-
     """
-    tools = input_dict.get("tools", [])
-    reasoning = input_dict.get("reasoning", True)
-    force_empty_reasoning = input_dict.get("force_empty_reasoning", False)
-
-    tags = []
-    for tool in tools:
-        if "function" not in tool:
-            continue
-
-        function = tool["function"]
-        parameters = _get_function_parameters(function)
-        name = function["name"]
-        tags.append(
-            TagFormat(
-                begin=('{"name": "' + name + '", "parameters": '),
-                content=JSONSchemaFormat(json_schema=parameters),
-                end="}",
-            )
-        )
-
-    if len(tags) > 0:
-        suffix_tag = TriggeredTagsFormat(
-            triggers=['{"name": '], tags=tags, excludes=_THINK_EXCLUDE_TOKENS
-        )
-    else:
-        suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
-
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value="<think>\n\n</think>")
-    else:
-        prefix_tag = TagFormat(begin="<think>", content=AnyTextFormat(), end="</think>")
-
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    return _get_builtin_structural_tag_from_cpp("llama", input_dict)
 
 
 @_register_builtin_structural_tag("kimi", ["Kimi-K2", "Kimi-K2.5"])
@@ -283,9 +240,11 @@ def _get_kimi_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
     """Get Kimi-K2 style structural tag format.
     Reference: https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/tool_call_guidance.md
     The input_dict should be a dictionary with the following keys:
-    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary containing "name" and "parameters" fields.
+    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary
+      containing "name" and "parameters" fields.
     - "reasoning": a boolean indicating whether to enable reasoning mode.
-    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking, if False use thinking.
+    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking,
+      if False use thinking.
 
     Returns
     -------
@@ -293,48 +252,7 @@ def _get_kimi_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
         A structural tag template.
         This format is used by Kimi-K2 and other models that follow the same style.
     """
-    tools = input_dict.get("tools", [])
-    reasoning = input_dict.get("reasoning", True)
-    force_empty_reasoning = input_dict.get("force_empty_reasoning", False)
-
-    tags = []
-    for tool in tools:
-        if "function" not in tool:
-            continue
-
-        function = tool["function"]
-        parameters = _get_function_parameters(function)
-        name = function["name"]
-        tags.append(
-            TagFormat(
-                begin=f"<|tool_call_begin|>functions.{name}:",
-                content=SequenceFormat(
-                    elements=[
-                        RegexFormat(pattern=r"\d+"),
-                        ConstStringFormat(value="<|tool_call_argument_begin|>"),
-                        JSONSchemaFormat(json_schema=parameters),
-                    ]
-                ),
-                end="<|tool_call_end|>",
-            )
-        )
-
-    if len(tags) > 0:
-        suffix_tag = TriggeredTagsFormat(
-            triggers=["<|tool_call_begin|>"], tags=tags, excludes=_THINK_EXCLUDE_TOKENS
-        )
-    else:
-        suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
-
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value="<think></think>")
-    else:
-        prefix_tag = TagFormat(begin="<think>", content=AnyTextFormat(), end="</think>")
-
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    return _get_builtin_structural_tag_from_cpp("kimi", input_dict)
 
 
 @_register_builtin_structural_tag(
@@ -344,55 +262,19 @@ def _get_deepseek_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
     """Get DeepSeek-R1 style structural tag format.
     Reference: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/tokenizer_config.json
     The input_dict should be a dictionary with the following keys:
-    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary containing "name" and "parameters" fields.
+    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary
+      containing "name" and "parameters" fields.
     - "reasoning": a boolean indicating whether to enable reasoning mode.
-    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking, if False use thinking.
+    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking,
+      if False use thinking.
 
     Returns
     -------
     StructuralTag
         A structural tag for function calling format.
         This format is used by DeepSeek-R1 and other models that follow the same style.
-
     """
-    tools = input_dict.get("tools", [])
-    reasoning = input_dict.get("reasoning", True)
-    force_empty_reasoning = input_dict.get("force_empty_reasoning", False)
-
-    tags = []
-    for tool in tools:
-        if "function" not in tool:
-            continue
-
-        function = tool["function"]
-        parameters = _get_function_parameters(function)
-        name = function["name"]
-        tags.append(
-            TagFormat(
-                begin=f"<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>{name}<｜tool▁sep｜>",
-                content=JSONSchemaFormat(json_schema=parameters),
-                end="<｜tool▁call▁end｜>",
-            )
-        )
-
-    if len(tags) > 0:
-        suffix_tag = TriggeredTagsFormat(
-            triggers=["<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>"],
-            tags=tags,
-            excludes=_THINK_EXCLUDE_TOKENS,
-        )
-    else:
-        suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
-
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value="</think>")
-    else:
-        prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end="</think>")
-
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    return _get_builtin_structural_tag_from_cpp("deepseek_r1", input_dict)
 
 
 @_register_builtin_structural_tag("qwen_coder", ["Qwen3-Coder", "Qwen3-Coder-Next"])
@@ -400,9 +282,11 @@ def _get_qwen_coder_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
     """Get Qwen3-Coder style structural tag format.
     Reference: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8/blob/main/chat_template.jinja
     The input_dict should be a dictionary with the following keys:
-    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary containing "name" and "parameters" fields.
+    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary
+      containing "name" and "parameters" fields.
     - "reasoning": a boolean indicating whether to enable reasoning mode.
-    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking, if False use thinking.
+    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking,
+      if False use thinking.
 
     Returns
     -------
@@ -410,42 +294,7 @@ def _get_qwen_coder_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
         A structural tag for function calling format.
         This format is used by Qwen3-Coder and other models that follow the same style.
     """
-    tools = input_dict.get("tools", [])
-    reasoning = input_dict.get("reasoning", True)
-    force_empty_reasoning = input_dict.get("force_empty_reasoning", False)
-
-    tags = []
-    for tool in tools:
-        if "function" not in tool:
-            continue
-
-        function = tool["function"]
-        parameters = _get_function_parameters(function)
-        name = function["name"]
-        tags.append(
-            TagFormat(
-                begin=f"<tool_call>\n<function={name}>\n",
-                content=QwenXMLParameterFormat(json_schema=parameters),
-                end="\n</function>\n</tool_call>",
-            )
-        )
-
-    if len(tags) > 0:
-        suffix_tag = TriggeredTagsFormat(
-            triggers=["<tool_call>\n<function="], tags=tags, excludes=_THINK_EXCLUDE_TOKENS
-        )
-    else:
-        suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
-
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value="<think>\n\n</think>")
-    else:
-        prefix_tag = TagFormat(begin="<think>", content=AnyTextFormat(), end="</think>")
-
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    return _get_builtin_structural_tag_from_cpp("qwen_coder", input_dict)
 
 
 @_register_builtin_structural_tag("qwen", ["Qwen3"])
@@ -453,64 +302,37 @@ def _get_qwen_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
     """Get Qwen3 style structural tag format.
     Reference: https://qwen.readthedocs.io/en/latest/framework/function_call.html
     The input_dict should be a dictionary with the following keys:
-    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary containing "name" and "parameters" fields.
+    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary
+      containing "name" and "parameters" fields.
     - "reasoning": a boolean indicating whether to enable reasoning mode.
+    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking,
+      if False use thinking.
 
     Returns
     -------
     StructuralTag
         A structural tag template.
         This format is used by Qwen3 and other models that follow the same style.
-
     """
-    tools = input_dict.get("tools", [])
-    reasoning = input_dict.get("reasoning", True)
-    force_empty_reasoning = input_dict.get("force_empty_reasoning", False)
-
-    tags = []
-    for tool in tools:
-        if "function" not in tool:
-            continue
-
-        function = tool["function"]
-        parameters = _get_function_parameters(function)
-        name = function["name"]
-        tags.append(
-            TagFormat(
-                begin=('<tool_call>\n{"name": "' + name + '", "arguments": '),
-                content=JSONSchemaFormat(json_schema=parameters),
-                end="}\n</tool_call>",
-            )
-        )
-    if len(tags) > 0:
-        suffix_tag = TriggeredTagsFormat(
-            triggers=["<tool_call>"], tags=tags, excludes=_THINK_EXCLUDE_TOKENS
-        )
-    else:
-        suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
-
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value="<think>\n\n</think>")
-    else:
-        prefix_tag = TagFormat(begin="<think>", content=AnyTextFormat(), end="</think>")
-
-    sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
-    return StructuralTag(format=sequence_format)
+    return _get_builtin_structural_tag_from_cpp("qwen", input_dict)
 
 
 @_register_builtin_structural_tag("harmony", ["gpt-oss"])
 def _get_harmony_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
-    """Get harmony(gpt-oss) style structural tag format.
-    Reference: https://developers.openai.com/cookbook/articles/openai-harmony
-    Reference: https://huggingface.co/openai/gpt-oss-120b/blob/main/chat_template.jinja
+    """Get OpenAI Harmony (gpt-oss) style structural tag format.
+
+    References:
+    - https://developers.openai.com/cookbook/articles/openai-harmony
+    - https://huggingface.co/openai/gpt-oss-120b/blob/main/chat_template.jinja
+
     The input_dict should be a dictionary with the following keys:
-    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary containing "name" and "parameters" fields.
-    - "builtin_tools": a list of builtin tools, each builtin tool should have a "function" key, which is a dictionary containing "name" and "parameters" fields.
+    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary
+      containing "name" and "parameters" fields.
+    - "builtin_tools": a list of builtin tools, each builtin tool should have a "function" key,
+      which is a dictionary containing "name" and "parameters" fields.
     - "reasoning": a boolean indicating whether to enable reasoning mode.
-    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking, if False use thinking.
+    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking,
+      if False use thinking.
 
     Returns
     -------
@@ -518,173 +340,36 @@ def _get_harmony_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
         A structural tag template.
         This format is in OpenAI Harmony Response Format, which is used by GPT-oss
         and other models that follow the same style.
-
     """
-    tools = input_dict.get("tools", [])
-    reasoning = input_dict.get("reasoning", True)
-    force_empty_reasoning = input_dict.get("force_empty_reasoning", False)
-    builtin_tools = input_dict.get("builtin_tools", [])
-
-    tags = []
-
-    if reasoning:
-        if force_empty_reasoning:
-            analysis_tag = TagFormat(
-                begin="<|channel|>analysis<|message|>",
-                content=ConstStringFormat(value="<|end|>"),
-                end="",
-            )
-        else:
-            analysis_tag = TagFormat(
-                begin="<|channel|>analysis<|message|>", content=AnyTextFormat(), end="<|end|>"
-            )
-        tags.append(analysis_tag)
-
-    for tool in tools:
-        if "function" not in tool:
-            continue
-
-        function = tool["function"]
-        parameters = _get_function_parameters(function)
-        name = function["name"]
-        tags.append(
-            TagFormat(
-                begin=f"<|channel|>commentary to={name}<|constrain|>json<|message|>",
-                content=JSONSchemaFormat(json_schema=parameters),
-                end="<|call|>",
-            )
-        )
-
-    for tool in builtin_tools:
-        if "function" not in tool:
-            continue
-
-        function = tool["function"]
-        parameters = _get_function_parameters(function)
-        name = function["name"]
-        tags.append(
-            TagFormat(
-                begin=f"<|channel|>analysis to={name}<|message|>",
-                content=JSONSchemaFormat(json_schema=parameters),
-                end="<|call|>",
-            )
-        )
-
-    final_tag = TagFormat(
-        begin="<|channel|>final<|message|>", content=AnyTextFormat(), end="<|end|>"
-    )
-
-    tags.append(final_tag)
-    tags_with_separator = TagsWithSeparatorFormat(tags=tags, separator="<|start|>assistant")
-    return StructuralTag(format=tags_with_separator)
+    return _get_builtin_structural_tag_from_cpp("harmony", input_dict)
 
 
 @_register_builtin_structural_tag("deepseek_v3_2", ["DeepSeek-V3.2"])
 def _get_deepseek_v3_2_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
-    tools = input_dict.get("tools", [])
-    reasoning = input_dict.get("reasoning", True)
-    force_empty_reasoning = input_dict.get("force_empty_reasoning", False)
+    """Get DeepSeek-V3.2 style structural tag format.
 
-    tags = []
-    for tool in tools:
-        if "function" not in tool:
-            continue
-
-        function = tool["function"]
-        parameters = _get_function_parameters(function)
-        name = function["name"]
-        tags.append(
-            TagFormat(
-                begin='<｜DSML｜invoke name="' + name + '">\n',
-                content=JSONSchemaFormat(json_schema=parameters, style="deepseek_xml"),
-                end="</｜DSML｜invoke>\n",
-            )
-        )
-
-    # generate function calling triggered tag
-    if len(tags) > 0:
-        function_calling_tags = TagsWithSeparatorFormat(
-            tags=tags, separator="\n", at_least_one=True
-        )
-
-        suffix_tag = TriggeredTagsFormat(
-            triggers=["<｜DSML｜function_calls>"],
-            tags=[
-                TagFormat(
-                    begin="<｜DSML｜function_calls>\n",
-                    content=function_calling_tags,
-                    end="</｜DSML｜function_calls>\n",
-                )
-            ],
-            excludes=_THINK_EXCLUDE_TOKENS,
-        )
-    else:
-        suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
-
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value="<think>\n\n</think>")
-    else:
-        prefix_tag = TagFormat(begin="<think>", content=AnyTextFormat(), end="</think>")
-
-    sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
-    return StructuralTag(format=sequence_format)
+    The input_dict should be a dictionary with the following keys:
+    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary
+      containing "name" and "parameters" fields.
+    - "reasoning": a boolean indicating whether to enable reasoning mode.
+    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking,
+      if False use thinking.
+    """
+    return _get_builtin_structural_tag_from_cpp("deepseek_v3_2", input_dict)
 
 
 @_register_builtin_structural_tag("minimax", ["MiniMax-M2.5"])
 def _get_minimax_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
-    tools = input_dict.get("tools", [])
-    reasoning = input_dict.get("reasoning", True)
-    force_empty_reasoning = input_dict.get("force_empty_reasoning", False)
+    """Get MiniMax-M2.5 style structural tag format.
 
-    tags = []
-    for tool in tools:
-        if "function" not in tool:
-            continue
-
-        function = tool["function"]
-        parameters = _get_function_parameters(function)
-        name = function["name"]
-        tags.append(
-            TagFormat(
-                begin='<invoke name="' + name + '">\n',
-                content=JSONSchemaFormat(json_schema=parameters, style="minimax_xml"),
-                end="</invoke>\n",
-            )
-        )
-
-    # generate function calling triggered tag
-    if len(tags) > 0:
-        function_calling_tags = TagsWithSeparatorFormat(
-            tags=tags, separator="\n", at_least_one=True
-        )
-
-        suffix_tag = TriggeredTagsFormat(
-            triggers=["<minimax:tool_call>"],
-            tags=[
-                TagFormat(
-                    begin="<minimax:tool_call>\n",
-                    content=function_calling_tags,
-                    end="</minimax:tool_call>\n",
-                )
-            ],
-            excludes=_THINK_EXCLUDE_TOKENS,
-        )
-    else:
-        suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
-
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value="<think>\n\n</think>")
-    else:
-        prefix_tag = TagFormat(begin="<think>", content=AnyTextFormat(), end="</think>")
-
-    sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
-    return StructuralTag(format=sequence_format)
+    The input_dict should be a dictionary with the following keys:
+    - "tools": a list of tools, each tool should have a "function" key, which is a dictionary
+      containing "name" and "parameters" fields.
+    - "reasoning": a boolean indicating whether to enable reasoning mode.
+    - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking,
+      if False use thinking.
+    """
+    return _get_builtin_structural_tag_from_cpp("minimax", input_dict)
 
 
 @_register_builtin_structural_tag("glm47", ["GLM-5", "GLM-4.7"])
@@ -708,39 +393,11 @@ def _get_glm47_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
     StructuralTag
         A structural tag for GLM function calling format.
     """
-    tools = input_dict.get("tools", [])
-    reasoning = input_dict.get("reasoning", True)
-    force_empty_reasoning = input_dict.get("force_empty_reasoning", False)
+    return _get_builtin_structural_tag_from_cpp("glm47", input_dict)
 
-    tags = []
-    for tool in tools:
-        if "function" not in tool:
-            continue
 
-        function = tool["function"]
-        parameters = function["parameters"]
-        name = function["name"]
-        tags.append(
-            TagFormat(
-                begin=f"<tool_call>{name}",
-                content=JSONSchemaFormat(json_schema=parameters, style="glm_xml"),
-                end="</tool_call>",
-            )
-        )
-
-    if len(tags) > 0:
-        suffix_tag = TriggeredTagsFormat(
-            triggers=["<tool_call>"], tags=tags, excludes=_THINK_EXCLUDE_TOKENS
-        )
-    else:
-        suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
-
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value="<think>\n\n</think>")
-    else:
-        prefix_tag = TagFormat(begin="<think>", content=AnyTextFormat(), end="</think>")
-
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+def _get_builtin_structural_tag_from_cpp(
+    model: BuiltinSupportedModels, input_dict: Dict[str, Any]
+) -> StructuralTag:
+    structural_tag_json = _core.get_builtin_structural_tag_json(model, json.dumps(input_dict))
+    return StructuralTag.from_json(structural_tag_json)

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -401,3 +401,84 @@ def _get_builtin_structural_tag_from_cpp(
 ) -> StructuralTag:
     structural_tag_json = _core.get_builtin_structural_tag_json(model, json.dumps(input_dict))
     return StructuralTag.from_json(structural_tag_json)
+
+
+# It's also welcomed to contribute new builtin structural tags in Python. Here is
+# an example:
+# @_register_builtin_structural_tag("harmony", ["gpt-oss"])
+# def _get_harmony_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
+#     """Get harmony(gpt-oss) style structural tag format.
+#     Reference: https://developers.openai.com/cookbook/articles/openai-harmony
+#     Reference: https://huggingface.co/openai/gpt-oss-120b/blob/main/chat_template.jinja
+#     The input_dict should be a dictionary with the following keys:
+#     - "tools": a list of tools, each tool should have a "function" key, which is a dictionary containing "name" and "parameters" fields.
+#     - "builtin_tools": a list of builtin tools, each builtin tool should have a "function" key, which is a dictionary containing "name" and "parameters" fields.
+#     - "reasoning": a boolean indicating whether to enable reasoning mode.
+#     - "force_empty_reasoning": a boolean; when reasoning is on, if True use empty-thinking, if False use thinking.
+
+#     Returns
+#     -------
+#     StructuralTag
+#         A structural tag template.
+#         This format is in OpenAI Harmony Response Format, which is used by GPT-oss
+#         and other models that follow the same style.
+
+#     """
+#     from .structural_tag import StructuralTag, TagFormat, AnyTextFormat, JSONSchemaFormat, TagsWithSeparatorFormat, ConstStringFormat
+#     tools = input_dict.get("tools", [])
+#     reasoning = input_dict.get("reasoning", True)
+#     force_empty_reasoning = input_dict.get("force_empty_reasoning", False)
+#     builtin_tools = input_dict.get("builtin_tools", [])
+
+#     tags = []
+
+#     if reasoning:
+#         if force_empty_reasoning:
+#             analysis_tag = TagFormat(
+#                 begin="<|channel|>analysis<|message|>",
+#                 content=ConstStringFormat(value="<|end|>"),
+#                 end="",
+#             )
+#         else:
+#             analysis_tag = TagFormat(
+#                 begin="<|channel|>analysis<|message|>", content=AnyTextFormat(), end="<|end|>"
+#             )
+#         tags.append(analysis_tag)
+
+#     for tool in tools:
+#         if "function" not in tool:
+#             continue
+
+#         function = tool["function"]
+#         parameters = _get_function_parameters(function)
+#         name = function["name"]
+#         tags.append(
+#             TagFormat(
+#                 begin=f"<|channel|>commentary to={name}<|constrain|>json<|message|>",
+#                 content=JSONSchemaFormat(json_schema=parameters),
+#                 end="<|call|>",
+#             )
+#         )
+
+#     for tool in builtin_tools:
+#         if "function" not in tool:
+#             continue
+
+#         function = tool["function"]
+#         parameters = _get_function_parameters(function)
+#         name = function["name"]
+#         tags.append(
+#             TagFormat(
+#                 begin=f"<|channel|>analysis to={name}<|message|>",
+#                 content=JSONSchemaFormat(json_schema=parameters),
+#                 end="<|call|>",
+#             )
+#         )
+
+#     final_tag = TagFormat(
+#         begin="<|channel|>final<|message|>", content=AnyTextFormat(), end="<|end|>"
+#     )
+
+#     tags.append(final_tag)
+#     tags_with_separator = TagsWithSeparatorFormat(tags=tags, separator="<|start|>assistant")
+#     return StructuralTag(format=tags_with_separator)


### PR DESCRIPTION
This PR refactors the logic of the generation of built-in `structural_tags`. This PR migrates the logic from Python to cpp.