### PR TITLE
fix: AnyTokensFormat with exclude_tokens should be treated as self-terminating

### DIFF
--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -1527,6 +1527,8 @@ bool StructuralTagAnalyzer::IsExcluded(const Format& format) {
           return !arg.excludes.empty();
         } else if constexpr (std::is_same_v<T, TokenDispatchFormat>) {
           return !arg.exclude_tokens.empty();
+        } else if constexpr (std::is_same_v<T, AnyTokensFormat>) {
+          return !arg.exclude_tokens.empty();
         } else {
           return false;
         }

--- a/tests/python/test_token_edge.py
+++ b/tests/python/test_token_edge.py
@@ -1556,3 +1556,75 @@ def test_stag_repeated_token_triggered_tags_different_tags():
         _accept_tokens(m, [5, 7, 6])
     assert m.accept_token(STAG_STOP)
     assert m.is_terminated()
+
+
+def test_stag_any_tokens_excludes_allow_empty_end():
+    """Tags with any_tokens content + exclude_tokens should allow end: "".
+
+    Models a dispatch loop where channels have no explicit end delimiter —
+    the content stops when an excluded trigger token appears, and the
+    dispatch loop handles the transition.
+
+    Pattern:
+        <tool>  hello world  <tool>  x y  </s>
+        ^trigger  ^content    ^next trigger
+
+    Each tag is: begin=<tool>, content=any_tokens(exclude=[<tool>,<bad>]), end=""
+    The content stops naturally when the next <tool> appears. The dispatch
+    loop re-triggers.
+    """
+    stag = {
+        "type": "structural_tag",
+        "format": {
+            "type": "token_triggered_tags",
+            "trigger_tokens": ["<tool>"],
+            "tags": [
+                {
+                    "begin": {"type": "token", "token": "<tool>"},
+                    "content": {"type": "any_tokens", "exclude_tokens": ["<tool>", "<bad>"]},
+                    "end": "",
+                }
+            ],
+        },
+    }
+    m, b, ti = _stag_matcher(stag)
+
+    # First dispatch: <tool> hello world
+    _accept_tokens(m, [2, 7, 8])  # <tool> hello world
+
+    # Second dispatch: <tool> x y
+    _accept_tokens(m, [2, 13, 14])  # <tool> x y
+
+    # Stop
+    assert m.accept_token(STAG_STOP)
+    assert m.is_terminated()
+
+
+def test_stag_any_tokens_exclude_redispatch():
+    """any_tokens(exclude=[<tool>]) stops content when <tool> appears, allowing re-dispatch."""
+    stag = {
+        "type": "structural_tag",
+        "format": {
+            "type": "token_triggered_tags",
+            "trigger_tokens": ["<tool>"],
+            "tags": [
+                {
+                    "begin": {"type": "token", "token": "<tool>"},
+                    "content": {"type": "any_tokens", "exclude_tokens": ["<tool>"]},
+                    "end": "",
+                }
+            ],
+        },
+    }
+    m, b, ti = _stag_matcher(stag)
+
+    # First tag: <tool> hello
+    _accept_tokens(m, [2, 7])  # <tool> hello
+
+    # <tool> re-triggers (content excluded <tool>, so dispatch takes over)
+    _accept_tokens(m, [2, 8])  # <tool> world
+
+    # Third round then stop
+    _accept_tokens(m, [2, 13])  # <tool> x
+    assert m.accept_token(STAG_STOP)
+    assert m.is_terminated()


### PR DESCRIPTION
`AnyTokensFormat` with non-empty `exclude_tokens` is self-terminating — content stops when an excluded token appears — but `IsExcluded` was missing this case. As a result, `token_triggered_tags` tags using `content: any_tokens(exclude=[...])` with `end: ""` were incorrectly rejected with *"When the content is unlimited, at least one end string must be non-empty"*.

Adds the missing branch to `IsExcluded`, consistent with the existing handling of `AnyTextFormat` with string excludes.