### PR TITLE
refac: remove the restriction of `unlimited`.

### DIFF
--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -1581,51 +1581,27 @@ std::optional<ISTError> StructuralTagAnalyzer::VisitSub(RegexFormat* format) {
 }
 
 std::optional<ISTError> StructuralTagAnalyzer::VisitSub(SequenceFormat* format) {
-  for (size_t i = 0; i < format->elements.size() - 1; ++i) {
-    auto& element = format->elements[i];
-    auto err = Visit(&element);
-    if (err.has_value()) {
-      return err;
-    }
-    if (IsUnlimited(element)) {
-      if (!IsExcluded(element)) {
-        return ISTError(
-            "Only the last element in a sequence can be unlimited, but the " + std::to_string(i) +
-            "th element of sequence format is unlimited"
-        );
-      }
-    }
-  }
-
-  auto& element = format->elements.back();
-  auto err = Visit(&element);
-  if (err.has_value()) {
-    return err;
-  }
-  format->is_unlimited_ = IsUnlimited(element) && !IsExcluded(element);
-  return std::nullopt;
-}
-
-std::optional<ISTError> StructuralTagAnalyzer::VisitSub(OrFormat* format) {
   bool is_any_unlimited = false;
-  bool is_all_unlimited = true;
   for (auto& element : format->elements) {
     auto err = Visit(&element);
     if (err.has_value()) {
       return err;
     }
-    auto is_unlimited = IsUnlimited(element) && !IsExcluded(element);
-    is_any_unlimited |= is_unlimited;
-    is_all_unlimited &= is_unlimited;
+    is_any_unlimited |= IsUnlimited(element) && !IsExcluded(element);
   }
+  format->is_unlimited_ = is_any_unlimited;
+  return std::nullopt;
+}
 
-  if (is_any_unlimited && !is_all_unlimited) {
-    return ISTError(
-        "Now we only support all elements in an or format to be unlimited or all limited, but the "
-        "or format has both unlimited and limited elements"
-    );
+std::optional<ISTError> StructuralTagAnalyzer::VisitSub(OrFormat* format) {
+  bool is_any_unlimited = false;
+  for (auto& element : format->elements) {
+    auto err = Visit(&element);
+    if (err.has_value()) {
+      return err;
+    }
+    is_any_unlimited |= IsUnlimited(element) && !IsExcluded(element);
   }
-
   format->is_unlimited_ = is_any_unlimited;
   return std::nullopt;
 }

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -2627,23 +2627,6 @@ def test_structural_tag_json_format_errors(json_input: str, expected_error: str)
 
 
 structural_tag_error_test_data = [
-    # Analyzer Errors - Only last element in sequence can be unlimited
-    {
-        "type": "sequence",
-        "elements": [
-            {"type": "const_string", "value": "start"},
-            {"type": "any_text"},  # This unlimited element in middle will cause error
-            {"type": "const_string", "value": "end"},
-        ],
-    },
-    # Analyzer Errors - Or format with mixed unlimited and limited elements
-    {
-        "type": "or",
-        "elements": [
-            {"type": "const_string", "value": "limited"},  # Limited element
-            {"type": "any_text"},  # Unlimited element - mix not allowed
-        ],
-    },
     # Analyzer Errors - Tag format with unlimited content but empty end
     {
         "type": "tag",
@@ -2665,42 +2648,6 @@ structural_tag_error_test_data = [
         "triggers": ["X", "Y"],  # Neither matches "ABC" begin
         "tags": [
             {"begin": "ABC", "content": {"type": "const_string", "value": "hello"}, "end": "end"}
-        ],
-    },
-    # Cannot detect end string of tags_with_separator in sequence
-    {
-        "type": "sequence",
-        "elements": [
-            {
-                "type": "tags_with_separator",
-                "tags": [
-                    {
-                        "begin": "<start>",
-                        "content": {"type": "const_string", "value": "[TEXT]"},
-                        "end": "<end>",
-                    }
-                ],
-                "separator": "<sep>",
-            },
-            {"type": "const_string", "value": "[TEXT]"},
-        ],
-    },
-    # Cannot detect end string of tags_with_separator in or
-    {
-        "type": "or",
-        "elements": [
-            {
-                "type": "tags_with_separator",
-                "tags": [
-                    {
-                        "begin": "<start>",
-                        "content": {"type": "const_string", "value": "[TEXT]"},
-                        "end": "<end>",
-                    }
-                ],
-                "separator": "<sep>",
-            },
-            {"type": "const_string", "value": "[TEXT]"},
         ],
     },
     # Original test cases - Detected end string of tags_with_separator is empty


### PR DESCRIPTION
This PR removes the restriction of `unlimited` in `SequenceFormat` and `OrFormat`. This PR will enhance the flexibility of StructuralTag and enable more structures.