### PR TITLE
feat: add builtin structural tag support for Gemma 4 models

### DIFF
--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -26,6 +26,7 @@ BuiltinSupportedModels = Literal[
     "deepseek_v3_2",
     "minimax",
     "glm47",
+    "gemma4",
 ]
 
 
@@ -111,6 +112,7 @@ _structural_tag_registry: Dict[
 ] = {}
 _structural_tag_supported_models: Dict[BuiltinSupportedModels, List[str]] = {}
 _THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
+_GEMMA4_EXCLUDE_TOKENS = ["<|channel>", "<channel|>"]
 
 
 def _validate_tool_function(tools: Any) -> None:
@@ -202,6 +204,8 @@ def _get_builtin_structural_tag_function(
           Supported Models: Deepseek-V3.1, Deepseek-R1, Deepseek-V3.2-exp and other models that follow the same style.
         - "harmony": OpenAI Harmony Response Format (gpt-oss).
           Supported Models: GPT-oss and other models that follow the same style.
+        - "gemma4": Gemma 4 style structural tag format.
+          Supported Models: Gemma-4 and other models that follow the same style.
 
     Returns
     -------
@@ -742,5 +746,74 @@ def _get_glm47_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
         prefix_tag = ConstStringFormat(value="<think>\n\n</think>")
     else:
         prefix_tag = TagFormat(begin="<think>", content=AnyTextFormat(), end="</think>")
+
+    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+
+
+@_register_builtin_structural_tag(
+    "gemma4",
+    ["Gemma-4", "gemma-4-12b-it", "gemma-4-26b-a4b-it", "gemma-4-31b-it", "gemma-4-e2b-it"],
+)
+def _get_gemma4_structural_tag(input_dict: Dict[str, Any]) -> StructuralTag:
+    """Get Gemma 4 style structural tag format.
+
+    Gemma 4 uses channel markers for reasoning and tool calls instead of
+    ``<think>``/``</think>``:
+
+    - Thinking: ``<|channel>thought\\n...thinking...<channel|>``
+    - Tool calls: ``<|tool_call>call:func_name{...}<tool_call|>``
+    - Turn end: ``<turn|>``
+
+    Reference: https://ai.google.dev/gemma/docs/core/prompt-formatting-gemma4
+
+    The input_dict should be a dictionary with the following keys:
+
+    - "tools": a list of tools, each tool should have a "function" key,
+      which is a dictionary containing "name" and "parameters" fields.
+    - "reasoning": a boolean indicating whether to enable reasoning mode.
+    - "force_empty_reasoning": a boolean; when reasoning is on, if True
+      use empty-thinking (pre-closed channel), if False use thinking.
+
+    Returns
+    -------
+    StructuralTag
+        A structural tag for Gemma 4 function calling format.
+    """
+    tools = input_dict.get("tools", [])
+    reasoning = input_dict.get("reasoning", True)
+    force_empty_reasoning = input_dict.get("force_empty_reasoning", False)
+
+    tags = []
+    for tool in tools:
+        if "function" not in tool:
+            continue
+
+        function = tool["function"]
+        parameters = _get_function_parameters(function)
+        name = function["name"]
+        tags.append(
+            TagFormat(
+                begin=f"<|tool_call>call:{name}",
+                content=JSONSchemaFormat(json_schema=parameters),
+                end="<tool_call|>",
+            )
+        )
+
+    if len(tags) > 0:
+        suffix_tag = TriggeredTagsFormat(
+            triggers=["<|tool_call>"], tags=tags, excludes=_GEMMA4_EXCLUDE_TOKENS
+        )
+    else:
+        suffix_tag = AnyTextFormat(excludes=_GEMMA4_EXCLUDE_TOKENS)
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    if force_empty_reasoning:
+        prefix_tag = ConstStringFormat(value="<|channel>thought\n<channel|>")
+    else:
+        prefix_tag = TagFormat(
+            begin="<|channel>thought\n", content=AnyTextFormat(), end="<channel|>"
+        )
 
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))

--- a/tests/python/test_structural_tag_for_model.py
+++ b/tests/python/test_structural_tag_for_model.py
@@ -151,6 +151,7 @@ def test_get_builtin_structural_tag_supported_models_all():
         "deepseek_v3_2",
         "minimax",
         "glm47",
+        "gemma4",
     }
     assert set(result.keys()) == expected_styles
     for style, models in result.items():
@@ -170,6 +171,16 @@ def test_get_builtin_structural_tag_supported_models_all():
         ("deepseek_v3_2", ["DeepSeek-V3.2"]),
         ("minimax", ["MiniMax-M2.5"]),
         ("glm47", ["GLM-5", "GLM-4.7"]),
+        (
+            "gemma4",
+            [
+                "Gemma-4",
+                "gemma-4-12b-it",
+                "gemma-4-26b-a4b-it",
+                "gemma-4-31b-it",
+                "gemma-4-e2b-it",
+            ],
+        ),
     ],
 )
 def test_get_structural_tag_supported_models_by_style(style: str, expected_models: List[str]):
@@ -2196,6 +2207,14 @@ def test_get_gemma4_structural_tag_instance():
     # Wrong function name should be rejected
     check_stag_with_instance(
         stag, '<|tool_call>call:unknown_func{"q": "x"}<tool_call|>', False
+    )
+
+    # --- Multiple tool calls ---
+    check_stag_with_instance(
+        stag,
+        '<|tool_call>call:get_weather{"q": "Paris"}<tool_call|>'
+        '<|tool_call>call:get_weather{"q": "London"}<tool_call|>',
+        True,
     )
 
     # --- With tools, reasoning enabled ---

--- a/tests/python/test_structural_tag_for_model.py
+++ b/tests/python/test_structural_tag_for_model.py
@@ -120,6 +120,7 @@ _builtin_harmony = make_tools(["analysis_tool"])
 _tools_deepseek_v3_2 = make_tools(["search"])
 _tools_minimax = make_tools(["search"])
 _tools_glm47 = make_tools(["search"])
+_tools_gemma4 = make_tools(["get_weather"])
 
 
 # ---------- Test: unknown format type ----------
@@ -2128,6 +2129,7 @@ _TOOLS: List[Dict[str, Any]] = [
         ("qwen", {"tools": _TOOLS}),
         ("deepseek_v3_2", {"tools": _TOOLS}),
         ("minimax", {"tools": _TOOLS}),
+        ("gemma4", {"tools": _TOOLS}),
         (
             "harmony",
             {
@@ -2151,3 +2153,69 @@ def test_get_builtin_structural_tag_build_grammar_with_no_parameter_tools(
     structural_tag = get_builtin_structural_tag(format_type, **kwargs)
     grammar = xgr.Grammar.from_structural_tag(structural_tag)
     assert grammar is not None
+
+
+# ----- gemma4
+
+
+def test_get_gemma4_structural_tag_instance():
+    """get_builtin_structural_tag(gemma4) accepts/rejects instances as expected."""
+
+    # --- No tools, no reasoning: plain text only ---
+    stag = get_builtin_structural_tag("gemma4", reasoning=False)
+    check_stag_with_instance(stag, "Hello world", True)
+    check_stag_with_instance(stag, "", True)
+
+    # --- No tools, reasoning enabled ---
+    stag = get_builtin_structural_tag("gemma4", reasoning=True)
+    check_stag_with_instance(
+        stag, "<|channel>thought\nLet me think...<channel|>The answer is 42.", True
+    )
+    check_stag_with_instance(
+        stag, "<|channel>thought\n<channel|>Quick answer.", True
+    )
+    # Missing thinking prefix should be rejected
+    check_stag_with_instance(stag, "No thinking here.", False)
+
+    # --- No tools, reasoning with force_empty_reasoning ---
+    stag = get_builtin_structural_tag("gemma4", reasoning=True, force_empty_reasoning=True)
+    check_stag_with_instance(
+        stag, "<|channel>thought\n<channel|>Direct answer.", True
+    )
+    # Non-empty thinking should be rejected when force_empty
+    check_stag_with_instance(
+        stag, "<|channel>thought\nSome reasoning<channel|>Answer.", False
+    )
+
+    # --- With tools, no reasoning ---
+    stag = get_builtin_structural_tag("gemma4", tools=_tools_gemma4, reasoning=False)
+    check_stag_with_instance(
+        stag, '<|tool_call>call:get_weather{"q": "Paris"}<tool_call|>', True
+    )
+    check_stag_with_instance(stag, "Plain text without tool call.", True)
+    # Wrong function name should be rejected
+    check_stag_with_instance(
+        stag, '<|tool_call>call:unknown_func{"q": "x"}<tool_call|>', False
+    )
+
+    # --- With tools, reasoning enabled ---
+    stag = get_builtin_structural_tag("gemma4", tools=_tools_gemma4, reasoning=True)
+    check_stag_with_instance(
+        stag,
+        '<|channel>thought\nI should check the weather.<channel|>'
+        '<|tool_call>call:get_weather{"q": "Paris"}<tool_call|>',
+        True,
+    )
+    check_stag_with_instance(
+        stag,
+        "<|channel>thought\nThinking...<channel|>Just text, no tool call.",
+        True,
+    )
+
+
+def test_get_gemma4_structural_tag_supported_models():
+    """gemma4 is listed in supported models."""
+    all_models = get_builtin_structural_tag_supported_models()
+    assert "gemma4" in all_models
+    gemma4_models = get_builtin_structural_tag_supported_models("gemma4")
+    assert "Gemma-4" in gemma4_models

--- a/tests/python/test_structural_tag_for_model.py
+++ b/tests/python/test_structural_tag_for_model.py
@@ -1,5 +1,4 @@
-"""Tests for get_structural_tag_for_model and generated structural tags.
-"""
+"""Tests for get_structural_tag_for_model and generated structural tags."""
 
 import re
 import time
@@ -173,13 +172,7 @@ def test_get_builtin_structural_tag_supported_models_all():
         ("glm47", ["GLM-5", "GLM-4.7"]),
         (
             "gemma4",
-            [
-                "Gemma-4",
-                "gemma-4-12b-it",
-                "gemma-4-26b-a4b-it",
-                "gemma-4-31b-it",
-                "gemma-4-e2b-it",
-            ],
+            ["Gemma-4", "gemma-4-12b-it", "gemma-4-26b-a4b-it", "gemma-4-31b-it", "gemma-4-e2b-it"],
         ),
     ],
 )
@@ -2182,32 +2175,22 @@ def test_get_gemma4_structural_tag_instance():
     check_stag_with_instance(
         stag, "<|channel>thought\nLet me think...<channel|>The answer is 42.", True
     )
-    check_stag_with_instance(
-        stag, "<|channel>thought\n<channel|>Quick answer.", True
-    )
+    check_stag_with_instance(stag, "<|channel>thought\n<channel|>Quick answer.", True)
     # Missing thinking prefix should be rejected
     check_stag_with_instance(stag, "No thinking here.", False)
 
     # --- No tools, reasoning with force_empty_reasoning ---
     stag = get_builtin_structural_tag("gemma4", reasoning=True, force_empty_reasoning=True)
-    check_stag_with_instance(
-        stag, "<|channel>thought\n<channel|>Direct answer.", True
-    )
+    check_stag_with_instance(stag, "<|channel>thought\n<channel|>Direct answer.", True)
     # Non-empty thinking should be rejected when force_empty
-    check_stag_with_instance(
-        stag, "<|channel>thought\nSome reasoning<channel|>Answer.", False
-    )
+    check_stag_with_instance(stag, "<|channel>thought\nSome reasoning<channel|>Answer.", False)
 
     # --- With tools, no reasoning ---
     stag = get_builtin_structural_tag("gemma4", tools=_tools_gemma4, reasoning=False)
-    check_stag_with_instance(
-        stag, '<|tool_call>call:get_weather{"q": "Paris"}<tool_call|>', True
-    )
+    check_stag_with_instance(stag, '<|tool_call>call:get_weather{"q": "Paris"}<tool_call|>', True)
     check_stag_with_instance(stag, "Plain text without tool call.", True)
     # Wrong function name should be rejected
-    check_stag_with_instance(
-        stag, '<|tool_call>call:unknown_func{"q": "x"}<tool_call|>', False
-    )
+    check_stag_with_instance(stag, '<|tool_call>call:unknown_func{"q": "x"}<tool_call|>', False)
 
     # --- Multiple tool calls ---
     check_stag_with_instance(
@@ -2221,14 +2204,12 @@ def test_get_gemma4_structural_tag_instance():
     stag = get_builtin_structural_tag("gemma4", tools=_tools_gemma4, reasoning=True)
     check_stag_with_instance(
         stag,
-        '<|channel>thought\nI should check the weather.<channel|>'
+        "<|channel>thought\nI should check the weather.<channel|>"
         '<|tool_call>call:get_weather{"q": "Paris"}<tool_call|>',
         True,
     )
     check_stag_with_instance(
-        stag,
-        "<|channel>thought\nThinking...<channel|>Just text, no tool call.",
-        True,
+        stag, "<|channel>thought\nThinking...<channel|>Just text, no tool call.", True
     )
 
 


### PR DESCRIPTION
## Summary

Adds builtin structural tag support for Google Gemma 4 models, enabling grammar-constrained decoding to coexist with Gemma 4's thinking mode.

Gemma 4 uses channel markers instead of `<think>`/`</think>`:
- **Thinking:** `<|channel>thought\n...<channel|>`
- **Tool calls:** `<|tool_call>call:func_name{...}<tool_call|>`

This follows the same pattern as existing model registrations (Qwen, DeepSeek, Llama, etc.).

## Changes

- **`python/xgrammar/builtin_structural_tag.py`**: Register `"gemma4"` in `BuiltinSupportedModels` and add `_get_gemma4_structural_tag()` with support for reasoning, force_empty_reasoning, and tool calls
- **`tests/python/test_structural_tag_for_model.py`**: Add instance acceptance/rejection tests covering all modes (reasoning on/off, force_empty, tools, combined), supported models listing, and no-parameter tools smoke test

## Format details

From the Gemma 4 tokenizer's `response_schema`:

```
(<|channel>thought\n...thinking...<channel|>)?    # optional thinking
(content text)?                                    # optional content  
(<|tool_call>call:name{json}<tool_call|>)*         # optional tool calls
(<turn|>)?                                         # optional turn end
```

Reference: https://ai.google.dev/gemma/docs/core/prompt-formatting-gemma4

## Test plan

- [ ] `ruff check` passes
- [ ] Instance acceptance tests for all reasoning/tool combinations
- [ ] Smoke test with no-parameter tools
- [ ] Supported models listing includes gemma4

Closes #587