### PR TITLE
fix: auto-skip HuggingFace tests when HF_TOKEN is not set

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 import pytest
 
 try:
@@ -8,11 +11,30 @@ except ModuleNotFoundError:
     PARALLEL_RUN_AVAILABLE = False
 
 
+def _hf_token_available() -> bool:
+    """Check whether a HuggingFace token is available via env vars or cached login."""
+    if os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN"):
+        return True
+    # huggingface-cli login stores token here
+    return Path.home().joinpath(".cache", "huggingface", "token").is_file()
+
+
 def pytest_configure(config):
     if not PARALLEL_RUN_AVAILABLE:
         config.addinivalue_line(
             "markers", "thread_unsafe: mark the test function as single-threaded"
         )
+
+
+def pytest_collection_modifyitems(config, items):
+    if _hf_token_available():
+        return
+    skip_no_token = pytest.mark.skip(
+        reason="HF_TOKEN not set (run `huggingface-cli login` or set HF_TOKEN env var)"
+    )
+    for item in items:
+        if "hf_token_required" in item.keywords:
+            item.add_marker(skip_no_token)
 
 
 if not PARALLEL_RUN_AVAILABLE:

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -57,11 +57,10 @@ tokenizer_id = "meta-llama/Llama-3.1-8B-Instruct"
 def disable_profiler(request):
     global PROFILER_ON
     global profiler
-    markexpr = getattr(request.config.option, "markexpr", "") or request.config.getoption(
-        "markexpr", ""
-    )
-    hf_token_not_provided = "not hf_token_required" in (markexpr or "")
-    if hf_token_not_provided:
+    # Import shared token check from conftest (handles env vars + cached login)
+    from conftest import _hf_token_available
+
+    if not _hf_token_available():
         PROFILER_ON = False
     else:
         profiler = Profiler(tokenizer_id)

--- a/tests/python/test_structural_tag_for_model.py
+++ b/tests/python/test_structural_tag_for_model.py
@@ -68,11 +68,10 @@ tokenizer_id = "meta-llama/Llama-3.1-8B-Instruct"
 def disable_profiler(request):
     global PROFILER_ON
     global profiler
-    markexpr = getattr(request.config.option, "markexpr", "") or request.config.getoption(
-        "markexpr", ""
-    )
-    hf_token_not_provided = "not hf_token_required" in (markexpr or "")
-    if hf_token_not_provided:
+    # Import shared token check from conftest (handles env vars + cached login)
+    from conftest import _hf_token_available
+
+    if not _hf_token_available():
         PROFILER_ON = False
     else:
         profiler = Profiler(tokenizer_id)


### PR DESCRIPTION
## What's broken?

Running `pytest` without a HuggingFace token produces ~50 test **failures** (HTTP 401 Unauthorized) instead of graceful **skips**. This makes it hard to tell real failures from auth-related noise.

## Who is affected?

Anyone running `pytest` locally or in a fork CI without `HF_TOKEN` set and without explicitly passing `-m "not hf_token_required"`. The main repo's CI already handles this with a conditional `-m` filter, but local developers and downstream packagers (like the issue reporter) hit the raw 401 failures.

## When does it trigger?

Every time `pytest` is invoked without:
1. `HF_TOKEN` env var set, **or**
2. A cached HF login (`huggingface-cli login`), **or**
3. The `-m "not hf_token_required"` filter

The ~50 tests marked `@pytest.mark.hf_token_required` all attempt to download gated Meta Llama tokenizers via `AutoTokenizer.from_pretrained()`, which returns HTTP 401 without valid credentials.

## Where is the bug?

`tests/conftest.py` — the `hf_token_required` marker is registered in `pyproject.toml` but has no runtime skip logic. It's purely a CLI filter label; without an explicit `-m "not hf_token_required"` flag, marked tests run and fail.

## Why does it happen?

The marker was introduced in PR #190 as part of a build modernization. CI was updated to conditionally exclude these tests, but no `pytest_collection_modifyitems` hook was added to auto-skip them at collection time. The marker is metadata-only — pytest doesn't auto-skip based on markers without explicit hook logic.

## How did we fix it?

Added a `pytest_collection_modifyitems` hook in `tests/conftest.py` that:
1. Checks if an HF token is available (via `HF_TOKEN` env var, legacy `HUGGING_FACE_HUB_TOKEN` env var, or cached `~/.cache/huggingface/token` file)
2. If no token found, auto-adds `pytest.mark.skip` to all items with the `hf_token_required` marker
3. Skip reason clearly tells the user how to fix it: `"HF_TOKEN not set (run 'huggingface-cli login' or set HF_TOKEN env var)"`

This is the standard pytest pattern used by similar projects (redis-vl-python, ai-dynamo/dynamo).

| Scenario | Before | After |
|----------|--------|-------|
| `pytest` without HF_TOKEN | ~50 FAIL (401) | ~50 SKIP |
| `pytest` with HF_TOKEN | PASS | PASS (no change) |
| `pytest -m "not hf_token_required"` | 0 HF tests run | 0 HF tests run (no change) |

## How do we know it works?

Verified locally with a minimal pytest run:

```
# Without HF_TOKEN — marked test SKIPPED:
$ pytest tests/_test_skip_verify.py -v
tests/_test_skip_verify.py::test_should_be_skipped SKIPPED
  (HF_TOKEN not set (run `huggingface-cli login` or set HF_TOKEN env var))
tests/_test_skip_verify.py::test_should_run PASSED

# With HF_TOKEN — marked test RUNS (no false skip):
$ HF_TOKEN=xxx pytest tests/_test_skip_verify.py -v
tests/_test_skip_verify.py::test_should_be_skipped FAILED  # runs, not skipped
tests/_test_skip_verify.py::test_should_run PASSED
```

Full test suite validation deferred to CI (requires xgrammar C++ build).
