### PR TITLE
fix the broken link of api/python/builtin_structural_tag.

### DIFF
--- a/docs/api/python/builtin_structural_tag.rst
+++ b/docs/api/python/builtin_structural_tag.rst
@@ -4,7 +4,7 @@ Builtin Structural Tag
 .. currentmodule:: xgrammar.builtin_structural_tag
 
 This page contains the API reference for the structural tag template function. For its usage, see
-:doc:`Builtin Structural Tag Usage <../../tutorials/advanced_builtin_structural_tag>`.
+:doc:`Builtin Structural Tag Usage <../../tutorials/advanced_structural_tag>`.
 
 .. autofunction::  get_builtin_structural_tag_supported_models
 


### PR DESCRIPTION
This PR fixes the broken link of [https://xgrammar.mlc.ai/docs/api/python/builtin_structural_tag.html](https://xgrammar.mlc.ai/docs/api/python/builtin_structural_tag.html).