### PR TITLE
fix: fix the DeepSeek_R1's built-in tool-calling format.

### DIFF
--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -652,6 +652,8 @@ def get_deepseek_structural_tag(
     TOOL_CALL_BEGIN = "<｜tool▁call▁begin｜>"
     TOOL_CALL_END = "<｜tool▁call▁end｜>"
     TOOL_SEP = "<｜tool▁sep｜>"
+    JSON_RENDER_BEGIN = "\n```json\n"
+    JSON_RENDER_END = "\n```\n"
     THINK_TAG_END = "</think>"
     EMPTY_THINK_CONTENT = "</think>"
 
@@ -665,9 +667,9 @@ def get_deepseek_structural_tag(
             name = function.name
             tags.append(
                 TagFormat(
-                    begin=f"{TOOL_CALL_BEGIN}{tool.type}{TOOL_SEP}{name}\n",
+                    begin=f"{TOOL_CALL_BEGIN}{tool.type}{TOOL_SEP}{name}{JSON_RENDER_BEGIN}",
                     content=JSONSchemaFormat(json_schema=parameters),
-                    end=TOOL_CALL_END,
+                    end=f"{JSON_RENDER_END}{TOOL_CALL_END}",
                 )
             )
 
@@ -686,10 +688,11 @@ def get_deepseek_structural_tag(
         if not tools:
             raise ValueError("Forced tool choice must resolve to exactly one tool.")
         function = tools[0].function
+        parameters = _get_function_parameters(function)
         suffix_tag = TagFormat(
-            begin=f"{TOOL_CALLS_BEGIN}{TOOL_CALL_BEGIN}{tools[0].type}{TOOL_SEP}{function.name}\n",
+            begin=f"{TOOL_CALLS_BEGIN}{TOOL_CALL_BEGIN}{tools[0].type}{TOOL_SEP}{function.name}{JSON_RENDER_BEGIN}",
             content=JSONSchemaFormat(json_schema=parameters),
-            end=f"{TOOL_CALL_END}{TOOL_CALLS_END}",
+            end=f"{JSON_RENDER_END}{TOOL_CALL_END}{TOOL_CALLS_END}",
         )
 
     elif tool_choice == "required":
@@ -700,9 +703,9 @@ def get_deepseek_structural_tag(
             name = function.name
             tags.append(
                 TagFormat(
-                    begin=f"{TOOL_CALL_BEGIN}{tool.type}{TOOL_SEP}{name}\n",
+                    begin=f"{TOOL_CALL_BEGIN}{tool.type}{TOOL_SEP}{name}{JSON_RENDER_BEGIN}",
                     content=JSONSchemaFormat(json_schema=parameters),
-                    end=TOOL_CALL_END,
+                    end=f"{JSON_RENDER_END}{TOOL_CALL_END}",
                 )
             )
 

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -647,10 +647,11 @@ def get_deepseek_structural_tag(
         This format is used by DeepSeek-R1 and other models that follow the same style.
 
     """
-    TOOL_CALLS_PREFIX = "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>"
-    TOOL_SEP = "<｜tool▁sep｜>"
+    TOOL_CALLS_BEGIN = "<｜tool▁calls▁begin｜>"
+    TOOL_CALLS_END = "<｜tool▁calls▁end｜>"
+    TOOL_CALL_BEGIN = "<｜tool▁call▁begin｜>"
     TOOL_CALL_END = "<｜tool▁call▁end｜>"
-    TOOL_CALL_TRIGGER = "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>"
+    TOOL_SEP = "<｜tool▁sep｜>"
     THINK_TAG_END = "</think>"
     EMPTY_THINK_CONTENT = "</think>"
 
@@ -664,15 +665,19 @@ def get_deepseek_structural_tag(
             name = function.name
             tags.append(
                 TagFormat(
-                    begin=f"{TOOL_CALLS_PREFIX}{name}{TOOL_SEP}",
+                    begin=f"{TOOL_CALL_BEGIN}{tool.type}{TOOL_SEP}{name}\n",
                     content=JSONSchemaFormat(json_schema=parameters),
                     end=TOOL_CALL_END,
                 )
             )
 
         if len(tags) > 0:
+            inner_tool_calls = TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True)
+            tool_calls = TagFormat(
+                begin=TOOL_CALLS_BEGIN, content=inner_tool_calls, end=TOOL_CALLS_END
+            )
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=_THINK_EXCLUDE_TOKENS
+                triggers=[TOOL_CALLS_BEGIN], tags=[tool_calls], excludes=_THINK_EXCLUDE_TOKENS
             )
         else:
             suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
@@ -682,9 +687,9 @@ def get_deepseek_structural_tag(
             raise ValueError("Forced tool choice must resolve to exactly one tool.")
         function = tools[0].function
         suffix_tag = TagFormat(
-            begin=f"{TOOL_CALLS_PREFIX}{function.name}{TOOL_SEP}",
-            content=JSONSchemaFormat(json_schema=_get_function_parameters(function)),
-            end=TOOL_CALL_END,
+            begin=f"{TOOL_CALLS_BEGIN}{TOOL_CALL_BEGIN}{tools[0].type}{TOOL_SEP}{function.name}\n",
+            content=JSONSchemaFormat(json_schema=parameters),
+            end=f"{TOOL_CALL_END}{TOOL_CALLS_END}",
         )
 
     elif tool_choice == "required":
@@ -695,14 +700,17 @@ def get_deepseek_structural_tag(
             name = function.name
             tags.append(
                 TagFormat(
-                    begin=f"{TOOL_CALLS_PREFIX}{name}{TOOL_SEP}",
+                    begin=f"{TOOL_CALL_BEGIN}{tool.type}{TOOL_SEP}{name}\n",
                     content=JSONSchemaFormat(json_schema=parameters),
                     end=TOOL_CALL_END,
                 )
             )
 
         if len(tags) > 0:
-            suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
+            inner_tool_calls = TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True)
+            suffix_tag = TagFormat(
+                begin=TOOL_CALLS_BEGIN, content=inner_tool_calls, end=TOOL_CALLS_END
+            )
         else:
             raise ValueError(_REQUIRED_TOOLS_ERROR)
 

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -552,7 +552,7 @@ def test_specific_functions_cases(structural_tag_fn, case: Dict[str, Any]):
         ),
         (
             "deepseek_r1",
-            'text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>t1<｜tool▁sep｜>{"q": "v"}<｜tool▁call▁end｜>',
+            'text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>t1\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
             True,
         ),
         (
@@ -1104,11 +1104,11 @@ def test_kimi_instances(case: InstanceCase):
 # ----- deepseek_r1
 
 _deepseek_r1_instances_with_tools = [
-    'text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>search<｜tool▁sep｜>{"q": "v"}<｜tool▁call▁end｜>',
-    '123</think><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>search<｜tool▁sep｜>{"q": "v"}<｜tool▁call▁end｜>',
-    'thinking</think>text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>search<｜tool▁sep｜>{"q": "v"}<｜tool▁call▁end｜>',
+    'text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+    '123</think><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+    'thinking</think>text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
     "</think>text<think>123</think>",
-    '</think>text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>search<｜tool▁sep｜>{"q": "v"}<｜tool▁call▁end｜>',
+    '</think>text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
 ]
 _deepseek_r1_instances_no_tools = ["", "text", "123</think>123", "</think></think>", "</think>text"]
 
@@ -1140,9 +1140,13 @@ basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
 basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
 basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
 basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-triggered_tags_group ::= (("search<\uff5ctool\u2581sep\uff5c>" root_0 "<\uff5ctool\u2581call\u2581end\uff5c>"))
+tag ::= (("<\uff5ctool\u2581call\u2581begin\uff5c>function<\uff5ctool\u2581sep\uff5c>search\n```json\n" root_0 "\n```\n<\uff5ctool\u2581call\u2581end\uff5c>"))
+tags_with_separator_tags ::= ((tag))
+tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
+tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
+triggered_tags_group ::= (("" tags_with_separator "<\uff5ctool\u2581calls\u2581end\uff5c>"))
 triggered_tags ::= TagDispatch(
-  ("<\uff5ctool\u2581calls\u2581begin\uff5c><\uff5ctool\u2581call\u2581begin\uff5c>", triggered_tags_group),
+  ("<\uff5ctool\u2581calls\u2581begin\uff5c>", triggered_tags_group),
   loop_after_dispatch=true,
   excludes=("<think>", "</think>")
 )
@@ -1182,9 +1186,13 @@ basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
 basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
 basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
 basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-triggered_tags_group ::= (("search<\uff5ctool\u2581sep\uff5c>" root_0 "<\uff5ctool\u2581call\u2581end\uff5c>"))
+tag_1 ::= (("<\uff5ctool\u2581call\u2581begin\uff5c>function<\uff5ctool\u2581sep\uff5c>search\n```json\n" root_0 "\n```\n<\uff5ctool\u2581call\u2581end\uff5c>"))
+tags_with_separator_tags ::= ((tag_1))
+tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
+tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
+triggered_tags_group ::= (("" tags_with_separator "<\uff5ctool\u2581calls\u2581end\uff5c>"))
 triggered_tags ::= TagDispatch(
-  ("<\uff5ctool\u2581calls\u2581begin\uff5c><\uff5ctool\u2581call\u2581begin\uff5c>", triggered_tags_group),
+  ("<\uff5ctool\u2581calls\u2581begin\uff5c>", triggered_tags_group),
   loop_after_dispatch=true,
   excludes=("<think>", "</think>")
 )
@@ -1221,9 +1229,13 @@ basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
 basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
 basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
 basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-triggered_tags_group ::= (("search<\uff5ctool\u2581sep\uff5c>" root_0 "<\uff5ctool\u2581call\u2581end\uff5c>"))
+tag ::= (("<\uff5ctool\u2581call\u2581begin\uff5c>function<\uff5ctool\u2581sep\uff5c>search\n```json\n" root_0 "\n```\n<\uff5ctool\u2581call\u2581end\uff5c>"))
+tags_with_separator_tags ::= ((tag))
+tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
+tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
+triggered_tags_group ::= (("" tags_with_separator "<\uff5ctool\u2581calls\u2581end\uff5c>"))
 triggered_tags ::= TagDispatch(
-  ("<\uff5ctool\u2581calls\u2581begin\uff5c><\uff5ctool\u2581call\u2581begin\uff5c>", triggered_tags_group),
+  ("<\uff5ctool\u2581calls\u2581begin\uff5c>", triggered_tags_group),
   loop_after_dispatch=true,
   excludes=("<think>", "</think>")
 )
@@ -2580,7 +2592,7 @@ root ::= ((tag))
             {"tools": _tools_deepseek_pair, "tool_choice": "required"},
             [
                 "",
-                '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>search<｜tool▁sep｜>{"q": "v"}<｜tool▁call▁end｜>',
+                '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
             ],
             False,
             False,
@@ -2605,12 +2617,13 @@ basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
 basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
 basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
 basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<\uff5ctool\u2581calls\u2581begin\uff5c><\uff5ctool\u2581call\u2581begin\uff5c>search<\uff5ctool\u2581sep\uff5c>" root_0 "<\uff5ctool\u2581call\u2581end\uff5c>"))
-tag_1 ::= (("<\uff5ctool\u2581calls\u2581begin\uff5c><\uff5ctool\u2581call\u2581begin\uff5c>alt<\uff5ctool\u2581sep\uff5c>" root_0 "<\uff5ctool\u2581call\u2581end\uff5c>"))
+tag ::= (("<\uff5ctool\u2581call\u2581begin\uff5c>function<\uff5ctool\u2581sep\uff5c>search\n```json\n" root_0 "\n```\n<\uff5ctool\u2581call\u2581end\uff5c>"))
+tag_1 ::= (("<\uff5ctool\u2581call\u2581begin\uff5c>function<\uff5ctool\u2581sep\uff5c>alt\n```json\n" root_0 "\n```\n<\uff5ctool\u2581call\u2581end\uff5c>"))
 tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
+tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
 tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
+tag_2 ::= (("<\uff5ctool\u2581calls\u2581begin\uff5c>" tags_with_separator "<\uff5ctool\u2581calls\u2581end\uff5c>"))
+root ::= ((tag_2))
 """,
             [False, True],
         ),
@@ -2625,8 +2638,8 @@ root ::= ((tags_with_separator))
                 "forced_function_name": "search",
             },
             [
-                '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>search<｜tool▁sep｜>{"q": "v"}<｜tool▁call▁end｜>',
-                '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>alt<｜tool▁sep｜>{"q": "v"}<｜tool▁call▁end｜>',
+                '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+                '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>alt\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
             ],
             False,
             False,
@@ -2651,7 +2664,7 @@ basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
 basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
 basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
 basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<\uff5ctool\u2581calls\u2581begin\uff5c><\uff5ctool\u2581call\u2581begin\uff5c>search<\uff5ctool\u2581sep\uff5c>" root_0 "<\uff5ctool\u2581call\u2581end\uff5c>"))
+tag ::= (("<\uff5ctool\u2581calls\u2581begin\uff5c><\uff5ctool\u2581call\u2581begin\uff5c>function<\uff5ctool\u2581sep\uff5c>search\n```json\n" root_0 "\n```\n<\uff5ctool\u2581call\u2581end\uff5c><\uff5ctool\u2581calls\u2581end\uff5c>"))
 root ::= ((tag))
 """,
             [True, False],


### PR DESCRIPTION
This PR fixes the built-in structural tag for [DeepSeek_R1's tool-calling format](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B/blob/main/tokenizer_config.json). The PR is based on #586  and should be merged after it.