### PR TITLE
chore: disable the unit test with python3.14t and macOS-14.

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -34,6 +34,8 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-14, macos-15-intel]
         python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
         exclude:
+          - os: macos-14
+            python: '3.14t'
           - os: macos-15-intel
             python: '3.13'
           - os: macos-15-intel


### PR DESCRIPTION
This PR disables the unit test with python3.14t and macOS-14 because of the installation issue about `transformers`.