### PR TITLE
chore: disable the use of hf_token when `not hf_token_required` is explicitly passed.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,12 @@ def _hf_token_available() -> bool:
     return Path.home().joinpath(".cache", "huggingface", "token").is_file()
 
 
+def _hf_token_explicitly_disabled(config) -> bool:
+    """Return whether pytest mark expression explicitly excludes hf-token tests."""
+    markexpr = getattr(config.option, "markexpr", "") or config.getoption("markexpr", "")
+    return "not hf_token_required" in (markexpr or "")
+
+
 def pytest_configure(config):
     if not PARALLEL_RUN_AVAILABLE:
         config.addinivalue_line(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,8 @@ def _hf_token_available() -> bool:
 
 def _hf_token_explicitly_disabled(config) -> bool:
     """Return whether pytest mark expression explicitly excludes hf-token tests."""
-    markexpr = getattr(config.option, "markexpr", "") or config.getoption("markexpr", "")
-    return "not hf_token_required" in (markexpr or "")
+    markexpr = config.getoption("markexpr", "")
+    return "not hf_token_required" in markexpr
 
 
 def pytest_configure(config):

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -102,9 +102,9 @@ def disable_profiler(request):
     global PROFILER_ON
     global profiler
     # Import shared token check from conftest (handles env vars + cached login)
-    from conftest import _hf_token_available
+    from conftest import _hf_token_available, _hf_token_explicitly_disabled
 
-    if not _hf_token_available():
+    if not _hf_token_available() or _hf_token_explicitly_disabled(request.config):
         PROFILER_ON = False
     else:
         profiler = Profiler(tokenizer_id)

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -58,9 +58,9 @@ def disable_profiler(request):
     global PROFILER_ON
     global profiler
     # Import shared token check from conftest (handles env vars + cached login)
-    from conftest import _hf_token_available
+    from conftest import _hf_token_available, _hf_token_explicitly_disabled
 
-    if not _hf_token_available():
+    if not _hf_token_available() or _hf_token_explicitly_disabled(request.config):
         PROFILER_ON = False
     else:
         profiler = Profiler(tokenizer_id)


### PR DESCRIPTION
This PR disables the use of hf_token when `not hf_token_required` is explicitly passed.