### PR TITLE
[Web] Use the modern `emcc -lembind` rather than `emcc --bind`

### DIFF
--- a/web/build.sh
+++ b/web/build.sh
@@ -8,7 +8,7 @@ emcmake cmake ../.. -DXGRAMMAR_BUILD_PYTHON_BINDINGS=OFF\
 emmake make xgrammar -j8
 cd ..
 
-emcc --bind -o src/xgrammar_binding.js src/xgrammar_binding.cc\
-  build/libxgrammar.a\
+emcc -o src/xgrammar_binding.js src/xgrammar_binding.cc\
+  build/libxgrammar.a -lembind\
  -O3 -s EXPORT_ES6=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s NO_DYNAMIC_EXECUTION=1 -s MODULARIZE=1 -s SINGLE_FILE=1 -s EXPORTED_RUNTIME_METHODS=FS -s ALLOW_MEMORY_GROWTH=1\
  -I../include -I../3rdparty/picojson -I../3rdparty/dlpack/include


### PR DESCRIPTION
Replace the `--bind` option to `emmc` with `-lembind` in the build script.

According to `emcc --help`:
> "--bind"
> [link] Links against embind library.  Deprecated: Use "-lembind"
> instead.