### PR TITLE
refactor: unify reasoning parameter and rename model keys

### DIFF
--- a/docs/api/python/builtin_structural_tag.rst
+++ b/docs/api/python/builtin_structural_tag.rst
@@ -26,9 +26,11 @@ The following model-specific APIs are registered via
 
 .. autofunction:: get_deepseek_structural_tag
 
-.. autofunction:: get_qwen_coder_structural_tag
+.. autofunction:: get_qwen_3_coder_structural_tag
 
-.. autofunction:: get_qwen_structural_tag
+.. autofunction:: get_qwen_3_5_structural_tag
+
+.. autofunction:: get_qwen_3_structural_tag
 
 .. autofunction:: get_harmony_structural_tag
 
@@ -36,6 +38,6 @@ The following model-specific APIs are registered via
 
 .. autofunction:: get_minimax_structural_tag
 
-.. autofunction:: get_glm47_structural_tag
+.. autofunction:: get_glm_4_7_structural_tag
 
-.. autofunction:: get_gemma4_structural_tag
+.. autofunction:: get_gemma_4_structural_tag

--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -13,7 +13,7 @@ The `tool_choice` parameter controls how tool calls and text are mixed:
 - **Forced** (named choice): exactly one specified tool must be called.
 - **None** (`"none"`): tool calls are disabled; only text and reasoning are allowed.
 
-The `reasoning` parameter independently controls whether the reasoning section is present, and `force_empty_reasoning` can force it to be empty.
+The `reasoning` parameter controls whether the model-specific reasoning section is enabled.
 
 ## Basic API: `get_model_structural_tag`
 
@@ -23,7 +23,7 @@ Use it when you need to constrain the model to output in a fixed pattern such as
 
 ### Parameters
 
-- **model** (`str`): The structural-tag style. Valid values are `"llama"`, `"qwen"`, `"qwen_coder"`, `"kimi"`, `"deepseek_r1"`, `"harmony"`, `"deepseek_v3_2"`, `"minimax"`, `"glm47"`, `"gemma4"`, `"deepseek_v4"`, `"qwen3_6"`.
+- **model** (`str`): The structural-tag style. Valid values are `"llama"`, `"qwen_3"`, `"qwen_3_5"`, `"qwen_3_coder"`, `"kimi"`, `"deepseek_r1"`, `"harmony"`, `"deepseek_v3_2"`, `"minimax"`, `"glm_4_7"`, `"gemma_4"`, `"deepseek_v4"`.
 - **tools** (`List[ToolParam | dict]`, optional): Function and builtin tools available to the model. The list can contain two kinds of tools:
   - **Function tools** use the OpenAI Chat Completions shape:
     ```json
@@ -48,7 +48,6 @@ Use it when you need to constrain the model to output in a fixed pattern such as
   - `{"type": <builtin_type>}`: forces one builtin tool (matched by `type`).
   - `{"type": "allowed_tools", "allowed_tools": {"mode": ..., "tools": [...]}}`: limits available tools before applying its `mode`. The `tools` list may contain both function refs and builtin refs (matched by `type`).
 - **reasoning** (`bool`, optional): Whether to enable reasoning mode (`<think>`/`</think>` tags or model-specific equivalents). Default `True`.
-- **force_empty_reasoning** (`bool`, optional): When reasoning is on, whether to force empty thinking content at the beginning. Default `False`.
 
 Passing an unsupported `model` or an invalid `tool_choice` will raise `ValueError`.
 
@@ -121,11 +120,11 @@ grammar = Grammar.from_structural_tag(structural_tag)
 For formats that support reasoning (like Qwen3, DeepSeek-R1, Kimi-K2), pass `reasoning` to enable/disable:
 
 ```python
-structural_tag = get_model_structural_tag("qwen", tools=tools, reasoning=True)
+structural_tag = get_model_structural_tag("qwen_3", tools=tools, reasoning=True)
 grammar = Grammar.from_structural_tag(structural_tag)
 ```
 
-If `reasoning` is not passed, reasoning mode is enabled by default. When `reasoning` is `True`, you can also set `force_empty_reasoning` to constrain the reasoning content.
+If `reasoning` is not passed, reasoning mode is enabled by default.
 
 ### Tool choice
 
@@ -177,17 +176,17 @@ The `model` argument of `get_model_structural_tag` accepts the style names below
 | `model` (style) | Supported models |
 |-----------------|-------------------|
 | `"llama"` | Meta-Llama-3, Llama-3.1, Llama-3.2, Llama-4 |
-| `"qwen"` | Qwen3 |
-| `"qwen_coder"` | Qwen3-Coder, Qwen3-Coder-Next |
+| `"qwen_3"` | Qwen3, Qwen3-Next |
+| `"qwen_3_5"` | Qwen3.5, Qwen3.6 |
+| `"qwen_3_coder"` | Qwen3-Coder, Qwen3-Coder-Next |
 | `"kimi"` | Kimi-K2, Kimi-K2.5 |
 | `"deepseek_r1"` | DeepSeek-V3.1, DeepSeek-R1, DeepSeek-V3.2-exp |
 | `"harmony"` | gpt-oss |
 | `"deepseek_v3_2"` | DeepSeek-V3.2 |
 | `"minimax"` | MiniMax-M2.5 |
-| `"glm47"` | GLM-5, GLM-4.7 |
-| `"gemma4"` | Gemma-4, gemma-4-12b-it, gemma-4-26b-a4b-it, gemma-4-31b-it, gemma-4-e2b-it |
+| `"glm_4_7"` | GLM-5, GLM-4.7 |
+| `"gemma_4"` | Gemma-4, gemma-4-12b-it, gemma-4-26b-a4b-it, gemma-4-31b-it, gemma-4-e2b-it |
 | `"deepseek_v4"` | DeepSeek-V4 |
-| `"qwen3_6"` | Qwen3.6 |
 
 ## Extending with custom models
 

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -178,8 +178,7 @@ def get_model_structural_tag(
         and DeepSeek V4, support both reasoning and non-reasoning modes. If
         ``False``, use the non-reasoning mode. For models that do not support
         reasoning, this has no effect. For models that only support reasoning,
-        ``False`` removes the reasoning part and constrains only the following
-        part.
+        ``False`` means reasoning with empty content.
 
     Notes
     -----
@@ -480,8 +479,8 @@ def get_kimi_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a ``function``
       object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode. If ``False``, constrain
-      the empty reasoning part.
+    - ``reasoning``: whether to enable reasoning mode. If ``False``, remove
+      the reasoning part and constrain only the following part.
 
     Supported models:
 
@@ -499,9 +498,7 @@ def get_kimi_structural_tag(
     TOOL_CALL_ARGUMENT_BEGIN = "<|tool_call_argument_begin|>"
     TOOL_CALL_END = "<|tool_call_end|>"
     TOOL_CALL_TRIGGER = "<|tool_call_begin|>"
-    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
-    EMPTY_THINK_CONTENT = "<think></think>"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
 
     tools = tools or []
@@ -570,11 +567,10 @@ def get_kimi_structural_tag(
         assert len(tags) > 0
         suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
 
-    if reasoning:
-        prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
-    else:
-        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
 
+    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
 
@@ -1224,6 +1220,12 @@ def get_minimax_structural_tag(
     Supported models:
 
     - MiniMax-M2.5
+    - MiniMax-M2.7
+
+    Returns
+    -------
+    StructuralTag
+        A structural tag for MiniMax function calling format.
     """
     INVOKE_BEGIN_PREFIX = '<invoke name="'
     INVOKE_BEGIN_SUFFIX = '">\n'
@@ -1231,8 +1233,9 @@ def get_minimax_structural_tag(
     TOOL_CALL_BEGIN = "<minimax:tool_call>\n"
     TOOL_CALL_END = "</minimax:tool_call>\n"
     TOOL_CALL_TRIGGER = "<minimax:tool_call>"
-    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
+    THINK_SUFFIX = "\n\n"
+    EMPTY_THINK_CONTENT = "\n</think>\n\n"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
     XML_STYLE = "minimax_xml"
 
@@ -1309,13 +1312,15 @@ def get_minimax_structural_tag(
             ]
         )
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
-
-    sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
-    return StructuralTag(format=sequence_format)
+    if reasoning:
+        think_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
+    else:
+        think_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
+    return StructuralTag(
+        format=SequenceFormat(
+            elements=[think_tag, ConstStringFormat(value=THINK_SUFFIX), suffix_tag]
+        )
+    )
 
 
 @register_model_structural_tag("glm_4_7")

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -33,7 +33,6 @@ def get_model_structural_tag(
     tools: Optional[List[Union[ToolParam, dict]]] = None,
     tool_choice: Union[ToolChoiceOptionParam, dict, None] = "auto",
     reasoning: bool = True,
-    force_empty_reasoning: bool = False,
 ) -> StructuralTag:
     r"""Get a structural tag for a model's reasoning and tool-call output format.
 
@@ -175,11 +174,12 @@ def get_model_structural_tag(
           contain both function refs and builtin refs. Builtin refs are matched
           by ``type``.
     reasoning : bool
-        Whether to enable the model-specific reasoning prefix/suffix. Defaults
-        to ``True``.
-    force_empty_reasoning : bool
-        Whether to emit an empty reasoning section when reasoning is enabled.
-        Defaults to ``False``.
+        Whether to enable the reasoning part. Some models, such as Qwen 3.6
+        and DeepSeek V4, support both reasoning and non-reasoning modes. If
+        ``False``, use the non-reasoning mode. For models that do not support
+        reasoning, this has no effect. For models that only support reasoning,
+        ``False`` removes the reasoning part and constrains only the following
+        part.
 
     Notes
     -----
@@ -252,7 +252,9 @@ def get_model_structural_tag(
         simplified_tool_choice = normalized_tool_choice
 
     if simplified_tool_choice == "required" and not function_tools and not builtin_tools:
-        raise ValueError(_REQUIRED_TOOLS_ERROR)
+        raise ValueError(
+            "The 'tools' list is empty, which is not allowed when " "'tool_choice' is 'required'."
+        )
     if simplified_tool_choice == "forced" and len(function_tools) + len(builtin_tools) != 1:
         raise ValueError("Forced tool choice must resolve to exactly one tool.")
 
@@ -260,9 +262,7 @@ def get_model_structural_tag(
     if func is None:
         supported = list(_structural_tag_registry.keys())
         raise ValueError(f"Unknown format type: {model}, supported types: {supported}")
-    return func(
-        function_tools, builtin_tools, simplified_tool_choice, reasoning, force_empty_reasoning
-    )
+    return func(function_tools, builtin_tools, simplified_tool_choice, reasoning)
 
 
 # ---------- Helper Functions And Constants ----------
@@ -274,11 +274,6 @@ _TOOL_ADAPTER = TypeAdapter(ToolParam)
 _TOOL_CHOICE_ADAPTER = TypeAdapter(ToolChoiceOptionParam)
 
 _structural_tag_registry: Dict[str, BuiltinStructuralTagFn] = {}
-_THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
-_GEMMA4_EXCLUDE_TOKENS = ["<|channel>", "<channel|>"]
-_REQUIRED_TOOLS_ERROR = (
-    "The 'tools' list is empty, which is not allowed when 'tool_choice' is 'required'."
-)
 
 
 def _get_function_parameters(
@@ -336,12 +331,6 @@ def _filter_allowed_tools(
         )
 
     filtered_tools = [tool for tool in tools if tool.function.name in allowed_function_names]
-    if (
-        tool_choice.allowed_tools.mode == "required"
-        and not filtered_tools
-        and not filtered_builtin_tools
-    ):
-        raise ValueError(_REQUIRED_TOOLS_ERROR)
     return filtered_tools, filtered_builtin_tools
 
 
@@ -364,7 +353,7 @@ def register_model_structural_tag(name: str):
         @register_model_structural_tag("my_model")
         def get_my_model_structural_tag(
             tools=None, builtin_tools=None, tool_choice="auto",
-            reasoning=True, force_empty_reasoning=False, **kwargs,
+            reasoning=True, **kwargs,
         ):
             ...
     """
@@ -385,7 +374,6 @@ def get_llama_structural_tag(
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
-    force_empty_reasoning: bool = False,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Llama style structural tag format.
@@ -399,9 +387,7 @@ def get_llama_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a ``function``
       object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode.
-    - ``force_empty_reasoning``: when reasoning is enabled, use empty thinking
-      if ``True`` and regular thinking if ``False``.
+    - ``reasoning``: ignored because this format has no reasoning part.
 
     Supported models:
 
@@ -421,9 +407,7 @@ def get_llama_structural_tag(
     TOOL_OBJECT_BEGIN_PREFIX = '{"name": "'
     TOOL_OBJECT_PARAMETERS_PREFIX = '", "parameters": '
     TOOLS_TRIGGER = '{"name": '
-    THINK_TAG_BEGIN = "<think>"
-    THINK_TAG_END = "</think>"
-    EMPTY_THINK_CONTENT = "<think>\n\n</think>"
+    THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
 
     tools = tools or []
     builtin_tools = builtin_tools or []
@@ -443,10 +427,10 @@ def get_llama_structural_tag(
 
         if len(tags) > 0:
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOLS_TRIGGER], tags=tags, excludes=_THINK_EXCLUDE_TOKENS
+                triggers=[TOOLS_TRIGGER], tags=tags, excludes=THINK_EXCLUDE_TOKENS
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
 
     elif tool_choice == "forced":
         if not tools:
@@ -471,20 +455,10 @@ def get_llama_structural_tag(
                     end="}",
                 )
             )
-        if len(tags) > 0:
-            suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
-        else:
-            raise ValueError(_REQUIRED_TOOLS_ERROR)
+        assert len(tags) > 0
+        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
-    else:
-        prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
-
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    return StructuralTag(format=suffix_tag)
 
 
 @register_model_structural_tag("kimi")
@@ -493,7 +467,6 @@ def get_kimi_structural_tag(
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
-    force_empty_reasoning: bool = False,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Kimi-K2 style structural tag format.
@@ -507,9 +480,8 @@ def get_kimi_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a ``function``
       object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode.
-    - ``force_empty_reasoning``: when reasoning is enabled, use empty thinking
-      if ``True`` and regular thinking if ``False``.
+    - ``reasoning``: whether to enable reasoning mode. If ``False``, constrain
+      the empty reasoning part.
 
     Supported models:
 
@@ -530,6 +502,7 @@ def get_kimi_structural_tag(
     THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
     EMPTY_THINK_CONTENT = "<think></think>"
+    THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
 
     tools = tools or []
     builtin_tools = builtin_tools or []
@@ -555,10 +528,10 @@ def get_kimi_structural_tag(
 
         if len(tags) > 0:
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=_THINK_EXCLUDE_TOKENS
+                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=THINK_EXCLUDE_TOKENS
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
 
     elif tool_choice == "forced":
         if not tools:
@@ -594,18 +567,13 @@ def get_kimi_structural_tag(
                     end=TOOL_CALL_END,
                 )
             )
-        if len(tags) > 0:
-            suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
-        else:
-            raise ValueError(_REQUIRED_TOOLS_ERROR)
+        assert len(tags) > 0
+        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
-    else:
+    if reasoning:
         prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
+    else:
+        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
 
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
@@ -616,7 +584,6 @@ def get_deepseek_structural_tag(
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
-    force_empty_reasoning: bool = False,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-R1 style structural tag format.
@@ -630,9 +597,8 @@ def get_deepseek_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a ``function``
       object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode.
-    - ``force_empty_reasoning``: when reasoning is enabled, use empty thinking
-      if ``True`` and regular thinking if ``False``.
+    - ``reasoning``: whether to enable reasoning mode. If ``False``, remove
+      the reasoning part and constrain only the following part.
 
     Supported models:
 
@@ -655,7 +621,7 @@ def get_deepseek_structural_tag(
     JSON_RENDER_BEGIN = "\n```json\n"
     JSON_RENDER_END = "\n```\n"
     THINK_TAG_END = "</think>"
-    EMPTY_THINK_CONTENT = "</think>"
+    THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
 
     tools = tools or []
     builtin_tools = builtin_tools or []
@@ -679,10 +645,10 @@ def get_deepseek_structural_tag(
                 begin=TOOL_CALLS_BEGIN, content=inner_tool_calls, end=TOOL_CALLS_END
             )
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALLS_BEGIN], tags=[tool_calls], excludes=_THINK_EXCLUDE_TOKENS
+                triggers=[TOOL_CALLS_BEGIN], tags=[tool_calls], excludes=THINK_EXCLUDE_TOKENS
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
 
     elif tool_choice == "forced":
         if not tools:
@@ -709,37 +675,29 @@ def get_deepseek_structural_tag(
                 )
             )
 
-        if len(tags) > 0:
-            inner_tool_calls = TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True)
-            suffix_tag = TagFormat(
-                begin=TOOL_CALLS_BEGIN, content=inner_tool_calls, end=TOOL_CALLS_END
-            )
-        else:
-            raise ValueError(_REQUIRED_TOOLS_ERROR)
+        assert len(tags) > 0
+        inner_tool_calls = TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True)
+        suffix_tag = TagFormat(begin=TOOL_CALLS_BEGIN, content=inner_tool_calls, end=TOOL_CALLS_END)
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
-    else:
-        prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
+    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
 
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
 
-@register_model_structural_tag("qwen_coder")
-def get_qwen_coder_structural_tag(
+@register_model_structural_tag("qwen_3_coder")
+def get_qwen_3_coder_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
-    force_empty_reasoning: bool = False,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Qwen3-Coder style structural tag format.
 
-    Corresponding model key: ``"qwen_coder"``.
+    Corresponding model key: ``"qwen_3_coder"``.
 
     Reference: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8/blob/main/chat_template.jinja
 
@@ -748,9 +706,7 @@ def get_qwen_coder_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a ``function``
       object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode.
-    - ``force_empty_reasoning``: when reasoning is enabled, use empty thinking
-      if ``True`` and regular thinking if ``False``.
+    - ``reasoning``: ignored because this format has no reasoning part.
 
     Supported models:
 
@@ -767,10 +723,7 @@ def get_qwen_coder_structural_tag(
     TOOL_CALL_BEGIN_SUFFIX = ">\n"
     TOOL_CALL_END = "\n</function>\n</tool_call>"
     TOOL_CALL_TRIGGER = "<tool_call>\n<function="
-    THINK_TAG_BEGIN = "<think>"
-    THINK_TAG_END = "</think>"
-    EMPTY_THINK_CONTENT = "<think>\n\n</think>"
-
+    THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
     tools = tools or []
     builtin_tools = builtin_tools or []
     if tool_choice == "auto":
@@ -789,10 +742,10 @@ def get_qwen_coder_structural_tag(
 
         if len(tags) > 0:
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=_THINK_EXCLUDE_TOKENS
+                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=THINK_EXCLUDE_TOKENS
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
 
     elif tool_choice == "forced":
         if not tools:
@@ -818,34 +771,119 @@ def get_qwen_coder_structural_tag(
                 )
             )
 
-        if len(tags) > 0:
-            suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
-        else:
-            raise ValueError(_REQUIRED_TOOLS_ERROR)
+        assert len(tags) > 0
+        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
-    else:
-        prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
-
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    return StructuralTag(format=suffix_tag)
 
 
-@register_model_structural_tag("qwen")
-def get_qwen_structural_tag(
+@register_model_structural_tag("qwen_3_5")
+def get_qwen_3_5_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
-    force_empty_reasoning: bool = False,
+    **kwargs: Any,
+) -> StructuralTag:
+    """Get Qwen XML tool-call structural tag format with reasoning.
+
+    Corresponding model key: ``"qwen_3_5"``.
+
+    Parameters are normalized by :func:`get_model_structural_tag` before this
+    function is called:
+
+    - ``tools``: a list of function tools. Each tool should have a ``function``
+      object containing ``name`` and ``parameters`` fields.
+    - ``reasoning``: whether to enable reasoning mode. If ``False``, constrain
+      the empty reasoning part.
+
+    Supported models:
+
+    - Qwen3.5
+    - Qwen3.6
+
+    Returns
+    -------
+    StructuralTag
+        A structural tag for Qwen XML function calling format with thinking.
+    """
+    TOOL_CALL_BEGIN_PREFIX = "<tool_call>\n<function="
+    TOOL_CALL_BEGIN_SUFFIX = ">\n"
+    TOOL_CALL_END = "\n</function>\n</tool_call>"
+    TOOL_CALL_TRIGGER = "<tool_call>\n<function="
+    THINK_TAG_BEGIN = "<think>"
+    THINK_TAG_END = "</think>"
+    EMPTY_THINK_CONTENT = "<think>\n\n</think>"
+    THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
+    tools = tools or []
+    builtin_tools = builtin_tools or []
+    if tool_choice == "auto":
+        tags = []
+        for tool in tools:
+            function = tool.function
+            parameters = _get_function_parameters(function)
+            name = function.name
+            tags.append(
+                TagFormat(
+                    begin=f"{TOOL_CALL_BEGIN_PREFIX}{name}{TOOL_CALL_BEGIN_SUFFIX}",
+                    content=QwenXMLParameterFormat(json_schema=parameters),
+                    end=TOOL_CALL_END,
+                )
+            )
+
+        if len(tags) > 0:
+            suffix_tag = TriggeredTagsFormat(
+                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=THINK_EXCLUDE_TOKENS
+            )
+        else:
+            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
+
+    elif tool_choice == "forced":
+        if not tools:
+            raise ValueError("Forced tool choice must resolve to exactly one tool.")
+        function = tools[0].function
+        suffix_tag = TagFormat(
+            begin=f"{TOOL_CALL_BEGIN_PREFIX}{function.name}{TOOL_CALL_BEGIN_SUFFIX}",
+            content=QwenXMLParameterFormat(json_schema=_get_function_parameters(function)),
+            end=TOOL_CALL_END,
+        )
+
+    elif tool_choice == "required":
+        tags = []
+        for tool in tools:
+            function = tool.function
+            parameters = _get_function_parameters(function)
+            name = function.name
+            tags.append(
+                TagFormat(
+                    begin=f"{TOOL_CALL_BEGIN_PREFIX}{name}{TOOL_CALL_BEGIN_SUFFIX}",
+                    content=QwenXMLParameterFormat(json_schema=parameters),
+                    end=TOOL_CALL_END,
+                )
+            )
+
+        assert len(tags) > 0
+        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
+
+    if reasoning:
+        prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
+    else:
+        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
+
+    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+
+
+@register_model_structural_tag("qwen_3")
+def get_qwen_3_structural_tag(
+    tools: Optional[List[FunctionToolParam]] = None,
+    builtin_tools: Optional[List[BuiltinToolParam]] = None,
+    tool_choice: Literal["auto", "required", "forced"] = "auto",
+    reasoning: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Qwen3 style structural tag format.
 
-    Corresponding model key: ``"qwen"``.
+    Corresponding model key: ``"qwen_3"``.
 
     Reference: https://qwen.readthedocs.io/en/latest/framework/function_call.html
 
@@ -854,13 +892,13 @@ def get_qwen_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a ``function``
       object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode.
-    - ``force_empty_reasoning``: when reasoning is enabled, use empty thinking
-      if ``True`` and regular thinking if ``False``.
+    - ``reasoning``: whether to enable reasoning mode. If ``False``, remove
+      the reasoning part.
 
     Supported models:
 
     - Qwen3
+    - Qwen3-Next
 
     Returns
     -------
@@ -874,7 +912,7 @@ def get_qwen_structural_tag(
     TOOL_CALL_TRIGGER = "<tool_call>"
     THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
-    EMPTY_THINK_CONTENT = "<think>\n\n</think>"
+    THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
 
     tools = tools or []
     builtin_tools = builtin_tools or []
@@ -893,10 +931,10 @@ def get_qwen_structural_tag(
             )
         if len(tags) > 0:
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=_THINK_EXCLUDE_TOKENS
+                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=THINK_EXCLUDE_TOKENS
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
 
     elif tool_choice == "forced":
         if not tools:
@@ -922,19 +960,13 @@ def get_qwen_structural_tag(
                 )
             )
 
-        if len(tags) > 0:
-            suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
-        else:
-            raise ValueError(_REQUIRED_TOOLS_ERROR)
+        assert len(tags) > 0
+        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
-    else:
-        prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
-
+    prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
     sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
     return StructuralTag(format=sequence_format)
 
@@ -945,7 +977,6 @@ def get_harmony_structural_tag(
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
-    force_empty_reasoning: bool = False,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get harmony(gpt-oss) style structural tag format.
@@ -962,9 +993,7 @@ def get_harmony_structural_tag(
       object containing ``name`` and ``parameters`` fields.
     - ``builtin_tools``: a list of builtin tools. Each builtin tool should
       provide ``type``, optional ``name``, and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode.
-    - ``force_empty_reasoning``: when reasoning is enabled, use empty thinking
-      if ``True`` and regular thinking if ``False``.
+    - ``reasoning``: whether to enable the analysis channel.
 
     Supported models:
 
@@ -1060,16 +1089,10 @@ def get_harmony_structural_tag(
                     end=CALL_END,
                 )
             )
-        if len(tags) <= 0:
-            raise ValueError(_REQUIRED_TOOLS_ERROR)
+        assert len(tags) > 0
 
     if reasoning:
-        if force_empty_reasoning:
-            analysis_tag = TagFormat(
-                begin=ANALYSIS_BEGIN, content=ConstStringFormat(value=FINAL_END), end=""
-            )
-        else:
-            analysis_tag = TagFormat(begin=ANALYSIS_BEGIN, content=AnyTextFormat(), end=FINAL_END)
+        analysis_tag = TagFormat(begin=ANALYSIS_BEGIN, content=AnyTextFormat(), end=FINAL_END)
         tags.append(analysis_tag)
 
     tags_with_separator = TagsWithSeparatorFormat(tags=tags, separator=TAG_SEPARATOR)
@@ -1082,7 +1105,6 @@ def get_deepseek_v3_2_structural_tag(
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
-    force_empty_reasoning: bool = False,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V3.2 style structural tag format.
@@ -1099,9 +1121,8 @@ def get_deepseek_v3_2_structural_tag(
     FUNCTION_CALLS_BEGIN = "<｜DSML｜function_calls>\n"
     FUNCTION_CALLS_END = "</｜DSML｜function_calls>\n"
     FUNCTION_CALLS_TRIGGER = "<｜DSML｜function_calls>"
-    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
-    EMPTY_THINK_CONTENT = "<think>\n\n</think>"
+    THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
     XML_STYLE = "deepseek_xml"
 
     tools = tools or []
@@ -1135,10 +1156,10 @@ def get_deepseek_v3_2_structural_tag(
                         end=FUNCTION_CALLS_END,
                     )
                 ],
-                excludes=_THINK_EXCLUDE_TOKENS,
+                excludes=THINK_EXCLUDE_TOKENS,
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
 
     elif tool_choice == "forced":
         if not tools:
@@ -1170,24 +1191,19 @@ def get_deepseek_v3_2_structural_tag(
                     end=INVOKE_END,
                 )
             )
-        if len(tags) > 0:
-            suffix_tag = SequenceFormat(
-                elements=[
-                    ConstStringFormat(value=FUNCTION_CALLS_BEGIN),
-                    TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True),
-                    ConstStringFormat(value=FUNCTION_CALLS_END),
-                ]
-            )
-        else:
-            raise ValueError(_REQUIRED_TOOLS_ERROR)
+        assert len(tags) > 0
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value=FUNCTION_CALLS_BEGIN),
+                TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True),
+                ConstStringFormat(value=FUNCTION_CALLS_END),
+            ]
+        )
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
-    else:
-        prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
+    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
 
     sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
     return StructuralTag(format=sequence_format)
@@ -1199,7 +1215,6 @@ def get_minimax_structural_tag(
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
-    force_empty_reasoning: bool = False,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get MiniMax-M2.5 style structural tag format.
@@ -1218,7 +1233,7 @@ def get_minimax_structural_tag(
     TOOL_CALL_TRIGGER = "<minimax:tool_call>"
     THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
-    EMPTY_THINK_CONTENT = "<think>\n\n</think>"
+    THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
     XML_STYLE = "minimax_xml"
 
     tools = tools or []
@@ -1250,10 +1265,10 @@ def get_minimax_structural_tag(
                         begin=TOOL_CALL_BEGIN, content=function_calling_tags, end=TOOL_CALL_END
                     )
                 ],
-                excludes=_THINK_EXCLUDE_TOKENS,
+                excludes=THINK_EXCLUDE_TOKENS,
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
 
     elif tool_choice == "forced":
         if not tools:
@@ -1285,36 +1300,30 @@ def get_minimax_structural_tag(
                     end=INVOKE_END,
                 )
             )
-        if len(tags) > 0:
-            suffix_tag = SequenceFormat(
-                elements=[
-                    ConstStringFormat(value=TOOL_CALL_BEGIN),
-                    TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True),
-                    ConstStringFormat(value=TOOL_CALL_END),
-                ]
-            )
-        else:
-            raise ValueError(_REQUIRED_TOOLS_ERROR)
+        assert len(tags) > 0
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value=TOOL_CALL_BEGIN),
+                TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True),
+                ConstStringFormat(value=TOOL_CALL_END),
+            ]
+        )
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
-    else:
-        prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
+    prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
 
     sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
     return StructuralTag(format=sequence_format)
 
 
-@register_model_structural_tag("glm47")
-def get_glm47_structural_tag(
+@register_model_structural_tag("glm_4_7")
+def get_glm_4_7_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
-    force_empty_reasoning: bool = False,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get GLM-4.7/GLM-5 style structural tag format.
@@ -1324,16 +1333,15 @@ def get_glm47_structural_tag(
     ``<arg_key>key</arg_key><arg_value>value</arg_value>``
     ``</tool_call>``
 
-    Corresponding model key: ``"glm47"``.
+    Corresponding model key: ``"glm_4_7"``.
 
     Parameters are normalized by :func:`get_model_structural_tag` before this
     function is called:
 
     - ``tools``: a list of function tools. Each tool should have a ``function``
       object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode.
-    - ``force_empty_reasoning``: when reasoning is enabled, use empty thinking
-      if ``True`` and regular thinking if ``False``.
+    - ``reasoning``: whether to enable reasoning mode. If ``False``, use the
+      non-reasoning mode.
 
     Supported models:
 
@@ -1348,9 +1356,8 @@ def get_glm47_structural_tag(
     TOOL_CALL_BEGIN_PREFIX = "<tool_call>"
     TOOL_CALL_END = "</tool_call>"
     TOOL_CALL_TRIGGER = "<tool_call>"
-    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
-    EMPTY_THINK_CONTENT = "<think>\n\n</think>"
+    THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
     XML_STYLE = "glm_xml"
 
     tools = tools or []
@@ -1371,10 +1378,10 @@ def get_glm47_structural_tag(
 
         if len(tags) > 0:
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=_THINK_EXCLUDE_TOKENS
+                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=THINK_EXCLUDE_TOKENS
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
 
     elif tool_choice == "forced":
         if not tools:
@@ -1400,29 +1407,23 @@ def get_glm47_structural_tag(
                     end=TOOL_CALL_END,
                 )
             )
-        if len(tags) > 0:
-            suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
-        else:
-            raise ValueError(_REQUIRED_TOOLS_ERROR)
+        assert len(tags) > 0
+        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
-    else:
-        prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
+    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
 
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
 
-@register_model_structural_tag("gemma4")
-def get_gemma4_structural_tag(
+@register_model_structural_tag("gemma_4")
+def get_gemma_4_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
-    force_empty_reasoning: bool = False,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Gemma 4 style structural tag format.
@@ -1434,7 +1435,7 @@ def get_gemma4_structural_tag(
     - Tool calls: ``<|tool_call>call:func_name{...}<tool_call|>``
     - Turn end: ``<turn|>``
 
-    Corresponding model key: ``"gemma4"``.
+    Corresponding model key: ``"gemma_4"``.
 
     Reference: https://ai.google.dev/gemma/docs/core/prompt-formatting-gemma4
 
@@ -1443,9 +1444,8 @@ def get_gemma4_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a
       ``function`` object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode.
-    - ``force_empty_reasoning``: when reasoning is enabled, use empty thinking
-      (pre-closed channel) if ``True`` and regular thinking if ``False``.
+    - ``reasoning``: whether to enable reasoning mode. If ``False``, the
+      reasoning channel is omitted.
     - ``tool_choice``: ``"auto"`` or ``"required"``. ``"required"`` forces at
       least one tool call.
 
@@ -1467,7 +1467,7 @@ def get_gemma4_structural_tag(
     TOOL_CALL_TRIGGER = "<|tool_call>"
     THINK_TAG_BEGIN = "<|channel>thought\n"
     THINK_TAG_END = "<channel|>"
-    EMPTY_THINK_CONTENT = THINK_TAG_BEGIN + THINK_TAG_END
+    GEMMA4_EXCLUDE_TOKENS = ["<|channel>", "<channel|>"]
 
     tools = tools or []
     builtin_tools = builtin_tools or []
@@ -1487,10 +1487,10 @@ def get_gemma4_structural_tag(
 
         if len(tags) > 0:
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=_GEMMA4_EXCLUDE_TOKENS
+                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=GEMMA4_EXCLUDE_TOKENS
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=_GEMMA4_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(excludes=GEMMA4_EXCLUDE_TOKENS)
 
     elif tool_choice == "forced":
         if not tools:
@@ -1515,19 +1515,13 @@ def get_gemma4_structural_tag(
                     end=TOOL_CALL_END,
                 )
             )
-        if len(tags) > 0:
-            suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
-        else:
-            raise ValueError(_REQUIRED_TOOLS_ERROR)
+        assert len(tags) > 0
+        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
-    else:
-        prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
-
+    prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
 
@@ -1537,7 +1531,6 @@ def get_deepseek_v4_structural_tag(
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
-    force_empty_reasoning: bool = False,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V4 style structural tag format.
@@ -1554,9 +1547,8 @@ def get_deepseek_v4_structural_tag(
     FUNCTION_CALLS_BEGIN = "<｜DSML｜tool_calls>\n"
     FUNCTION_CALLS_END = "</｜DSML｜tool_calls>\n"
     FUNCTION_CALLS_TRIGGER = "<｜DSML｜tool_calls>"
-    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
-    EMPTY_THINK_CONTENT = "<think>\n\n</think>"
+    THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
     XML_STYLE = "deepseek_xml"
 
     tools = tools or []
@@ -1590,10 +1582,10 @@ def get_deepseek_v4_structural_tag(
                         end=FUNCTION_CALLS_END,
                     )
                 ],
-                excludes=_THINK_EXCLUDE_TOKENS,
+                excludes=THINK_EXCLUDE_TOKENS,
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=_THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
 
     elif tool_choice == "forced":
         if not tools:
@@ -1625,73 +1617,22 @@ def get_deepseek_v4_structural_tag(
                     end=INVOKE_END,
                 )
             )
-        if len(tags) > 0:
-            suffix_tag = SequenceFormat(
-                elements=[
-                    ConstStringFormat(value=FUNCTION_CALLS_BEGIN),
-                    TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True),
-                    ConstStringFormat(value=FUNCTION_CALLS_END),
-                ]
-            )
-        else:
-            raise ValueError(_REQUIRED_TOOLS_ERROR)
+        assert len(tags) > 0
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value=FUNCTION_CALLS_BEGIN),
+                TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True),
+                ConstStringFormat(value=FUNCTION_CALLS_END),
+            ]
+        )
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    if force_empty_reasoning:
-        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
-    else:
-        prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
+    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
 
     sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
     return StructuralTag(format=sequence_format)
-
-
-@register_model_structural_tag("qwen3_6")
-def get_qwen3_6_structural_tag(
-    tools: Optional[List[FunctionToolParam]] = None,
-    builtin_tools: Optional[List[BuiltinToolParam]] = None,
-    tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
-    force_empty_reasoning: bool = False,
-    **kwargs: Any,
-) -> StructuralTag:
-    """Get Qwen 3.6 style structural tag format.
-
-    Corresponding model key: ``"qwen3_6"``.
-
-    Reference: https://huggingface.co/Qwen/Qwen3.6-27B/blob/main/chat_template.jinja
-
-    Parameters are normalized by :func:`get_model_structural_tag` before this
-    function is called:
-
-    - ``tools``: a list of function tools. Each tool should have a ``function``
-      object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode.
-    - ``force_empty_reasoning``: when reasoning is enabled, use empty thinking
-      if ``True`` and regular thinking if ``False``.
-
-    Supported models:
-
-    - Qwen3.6
-
-    Returns
-    -------
-    StructuralTag
-        A structural tag for function calling format.
-        This format is used by Qwen3.6 and other models that follow the same style.
-    """
-
-    # Qwen3.6 is the same as Qwen3-Coder, so we can use the same structural tag format.
-    return get_qwen_coder_structural_tag(
-        tools=tools,
-        builtin_tools=builtin_tools,
-        tool_choice=tool_choice,
-        reasoning=reasoning,
-        force_empty_reasoning=force_empty_reasoning,
-        **kwargs,
-    )
 
 
 # Backward-compatible alias

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -1,7 +1,6 @@
 """Tests for get_structural_tag_for_model and generated structural tags."""
 
 import re
-import sys
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -13,15 +12,16 @@ from xgrammar.builtin_structural_tag import (
     get_deepseek_structural_tag,
     get_deepseek_v3_2_structural_tag,
     get_deepseek_v4_structural_tag,
-    get_gemma4_structural_tag,
-    get_glm47_structural_tag,
+    get_gemma_4_structural_tag,
+    get_glm_4_7_structural_tag,
     get_harmony_structural_tag,
     get_kimi_structural_tag,
     get_llama_structural_tag,
     get_minimax_structural_tag,
     get_model_structural_tag,
-    get_qwen_coder_structural_tag,
-    get_qwen_structural_tag,
+    get_qwen_3_5_structural_tag,
+    get_qwen_3_coder_structural_tag,
+    get_qwen_3_structural_tag,
 )
 from xgrammar.openai_tool_call_schema import BuiltinToolParam, FunctionToolParam
 from xgrammar.structural_tag import JSONSchemaFormat, StructuralTag, TagFormat
@@ -56,7 +56,6 @@ def _input_dict_to_get_stag_kwargs(format_type: str, input_dict: Dict[str, Any])
         "model": format_type,
         "tools": tools,
         "reasoning": input_dict.get("reasoning", input_dict.get("reasoning", True)),
-        "force_empty_reasoning": input_dict.get("force_empty_reasoning", False),
         "tool_choice": tool_choice,
     }
 
@@ -109,19 +108,6 @@ def disable_profiler(request):
         PROFILER_ON = False
     else:
         profiler = Profiler(tokenizer_id)
-
-
-def check_stag_with_grammar(structural_tag: StructuralTag, expected_grammar_ebnf: str):
-    """Assert structural tag compiles to expected EBNF.
-
-    If ``expected_grammar_ebnf`` is empty or whitespace-only, skip the comparison
-    (useful while expected EBNF is not yet filled in).
-    """
-
-    stag_ebnf = xgr.Grammar.from_structural_tag(structural_tag)
-    assert (
-        str(stag_ebnf) == expected_grammar_ebnf
-    ), f"Expected:\n{expected_grammar_ebnf}\nGot:\n{str(stag_ebnf)}"
 
 
 def check_stag_with_instance(
@@ -183,15 +169,16 @@ def make_tools(names: List[str], schema: Dict[str, Any] = SIMPLE_SCHEMA) -> List
 _tools_llama = make_tools(["t1"])
 _tools_kimi = make_tools(["get_weather"])
 _tools_deepseek = make_tools(["search"])
-_tools_qwen_coder = make_tools(["run_sql"])
-_tools_qwen = make_tools(["t1"])
+_tools_qwen_3_coder = make_tools(["run_sql"])
+_tools_qwen_3 = make_tools(["t1"])
+_tools_qwen_3_5 = make_tools(["run_sql"])
 _tools_harmony = make_tools(["comment_tool"])
 _builtin_harmony = make_tools(["analysis_tool"])
 _tools_deepseek_v3_2 = make_tools(["search"])
 _tools_deepseek_v4 = make_tools(["search"])
 _tools_minimax = make_tools(["search"])
-_tools_glm47 = make_tools(["search"])
-_tools_gemma4 = make_tools(["get_weather"])
+_tools_glm_4_7 = make_tools(["search"])
+_tools_gemma_4 = make_tools(["get_weather"])
 
 # Two distinct tools for tool_choice=required / forced instance tests.
 _tools_llama_pair = make_tools(["t1", "t2"])
@@ -200,11 +187,12 @@ _tools_deepseek_pair = make_tools(["search", "alt"])
 _tools_deepseek_v3_2_pair = make_tools(["search", "alt"])
 _tools_deepseek_v4_pair = make_tools(["search", "alt"])
 _tools_minimax_pair = make_tools(["search", "alt"])
-_tools_qwen_coder_pair = make_tools(["run_sql", "run_py"])
-_tools_qwen_pair = make_tools(["t1", "t2"])
+_tools_qwen_3_coder_pair = make_tools(["run_sql", "run_py"])
+_tools_qwen_3_pair = make_tools(["t1", "t2"])
+_tools_qwen_3_5_pair = make_tools(["run_sql", "run_py"])
 _tools_harmony_pair = make_tools(["comment_tool", "other_tool"])
-_tools_glm47_pair = make_tools(["search", "alt"])
-_tools_gemma4_pair = make_tools(["search", "alt"])
+_tools_glm_4_7_pair = make_tools(["search", "alt"])
+_tools_gemma_4_pair = make_tools(["search", "alt"])
 
 
 # ---------- Test: unknown format type ----------
@@ -457,14 +445,15 @@ def test_none_parameters_unconstrained():
         get_llama_structural_tag,
         get_kimi_structural_tag,
         get_deepseek_structural_tag,
-        get_qwen_coder_structural_tag,
-        get_qwen_structural_tag,
+        get_qwen_3_5_structural_tag,
+        get_qwen_3_coder_structural_tag,
+        get_qwen_3_structural_tag,
         get_harmony_structural_tag,
         get_deepseek_v3_2_structural_tag,
         get_deepseek_v4_structural_tag,
         get_minimax_structural_tag,
-        get_glm47_structural_tag,
-        get_gemma4_structural_tag,
+        get_glm_4_7_structural_tag,
+        get_gemma_4_structural_tag,
     ],
 )
 @pytest.mark.parametrize(
@@ -533,7 +522,6 @@ def test_specific_functions_cases(structural_tag_fn, case: Dict[str, Any]):
         builtin_tools=case["builtin_tools"],
         tool_choice=case["tool_choice"],
         reasoning=True,
-        force_empty_reasoning=False,
     )
     assert isinstance(structural_tag, StructuralTag)
     xgr.Grammar.from_structural_tag(structural_tag)
@@ -595,14 +583,19 @@ def test_specific_functions_cases(structural_tag_fn, case: Dict[str, Any]):
             False,
         ),
         (
-            "qwen_coder",
+            "qwen_3_coder",
             '<tool_call>\n<function=t1>\n<q>{"type": "string"}</q>\n</function>\n</tool_call>',
             True,
         ),
-        ("qwen", 'text<tool_call>\n{"name": "t1", "arguments": {"q": "v"}}\n</tool_call>', True),
-        ("qwen", 'text<tool_call>\n{"name": "t2", "arguments": {"q": "v"}}\n</tool_call>', False),
-        ("qwen", 'text<tool_call>\n{"name": "t1", "arguments": {"q": "v"}}\n</tool_call>', True),
-        ("qwen", 'text<tool_call>\n{"name": "t2", "arguments": {"q": "v"}}\n</tool_call>', False),
+        (
+            "qwen_3_5",
+            '<tool_call>\n<function=t1>\n<q>{"type": "string"}</q>\n</function>\n</tool_call>',
+            True,
+        ),
+        ("qwen_3", 'text<tool_call>\n{"name": "t1", "arguments": {"q": "v"}}\n</tool_call>', True),
+        ("qwen_3", 'text<tool_call>\n{"name": "t2", "arguments": {"q": "v"}}\n</tool_call>', False),
+        ("qwen_3", 'text<tool_call>\n{"name": "t1", "arguments": {"q": "v"}}\n</tool_call>', True),
+        ("qwen_3", 'text<tool_call>\n{"name": "t2", "arguments": {"q": "v"}}\n</tool_call>', False),
         (
             "harmony",
             '<|channel|>commentary to=t1<|constrain|>json<|message|>{"q": "v"}<|call|>',
@@ -635,6 +628,11 @@ def test_strict_or_missing_parameters(
     format_type: str, instance: str, is_accepted: bool, tool: Dict[str, Any]
 ):
     """strict=False or missing 'parameters' should still accept/reject instances correctly."""
+    if is_accepted and format_type == "kimi":
+        instance = "<think></think>" + instance
+    elif is_accepted and format_type == "qwen_3_5":
+        instance = "<think>\n\n</think>" + instance
+
     if format_type == "harmony":
         tools = [tool]
         stag = get_model_structural_tag(format_type, tools=tools, reasoning=False)
@@ -647,61 +645,20 @@ def test_strict_or_missing_parameters(
 
 # ---------- Test: instance positive / negative ----------
 
-# Case: (input_dict, instances, reasoning, force_empty_reasoning, expected_grammar_ebnf, expected_accept_per_instance)
+# Case: (input_dict, instances, reasoning, expected_grammar_ebnf, expected_accept_per_instance)
 # input_dict may include tool_choice ("auto" | "forced" | "required") and forced_function_name (str | None).
 # When expected_grammar_ebnf is empty or whitespace-only, grammar equality is skipped (fill in EBNF when ready).
-InstanceCase = Tuple[Dict[str, Any], List[str], bool, bool, str, List[bool]]
+InstanceCase = Tuple[Dict[str, Any], List[str], bool, List[bool]]
 
 
 def run_instance_case(format_type: str, case: InstanceCase):
-    """Run one instance test case (grammar + accept/reject per instance string)."""
-    (
-        input_dict,
-        instances,
-        reasoning,
-        force_empty_reasoning,
-        expected_grammar_ebnf,
-        expected_accept_per_instance,
-    ) = case
+    """Run one instance test case (accept/reject per instance string)."""
+    (input_dict, instances, reasoning, expected_accept_per_instance) = case
     kwargs = _input_dict_to_get_stag_kwargs(format_type, input_dict)
     kwargs["reasoning"] = reasoning
-    kwargs["force_empty_reasoning"] = force_empty_reasoning
     stag = get_model_structural_tag(**kwargs)
-    check_stag_with_grammar(stag, expected_grammar_ebnf)
     for j, instance in enumerate(instances):
         check_stag_with_instance(stag, instance, expected_accept_per_instance[j])
-
-
-def _run_instance_cases_for_style(
-    format_type: str, cases: List[Tuple[Dict[str, Any], List[str], List[Tuple[str, List[bool]]]]]
-):
-    """Run instance accept/reject tests for a style. Each case is (input_dict, instances, expected_grammar_and_results)."""
-    for input_dict, instances, expected_grammar_and_results in cases:
-        assert (
-            len(expected_grammar_and_results) == 3
-        ), "3 modes: not reasoning, reasoning, empty reasoning"
-        for i in range(3):
-            current_grammar = expected_grammar_and_results[i][0]
-            current_results = expected_grammar_and_results[i][1]
-            if i == 0:
-                reasoning = False
-            else:
-                reasoning = True
-
-            if i == 2:
-                force_empty_reasoning = True
-            else:
-                force_empty_reasoning = False
-
-            kwargs = _input_dict_to_get_stag_kwargs(format_type, input_dict)
-            kwargs["reasoning"] = reasoning
-            kwargs["force_empty_reasoning"] = force_empty_reasoning
-            stag = get_model_structural_tag(**kwargs)
-            check_stag_with_grammar(stag, current_grammar)
-            for j in range(len(instances)):
-                instance = instances[j]
-                is_accepted = current_results[j]
-                check_stag_with_instance(stag, instance, is_accepted)
 
 
 # ----- llama
@@ -722,175 +679,19 @@ _llama_instances_no_tools = [
 ]
 
 llama_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False, force_empty_reasoning=False
+    # with tools, reasoning=False
     (
         {"tools": _tools_llama},
         _llama_instances_with_tools,
         False,
-        False,
-        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-triggered_tags_group ::= (("\"t1\", \"parameters\": " root_0 "}"))
-triggered_tags ::= TagDispatch(
-  ("{\"name\": ", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-root ::= ((triggered_tags))
-""",
         [True, True, False, False, False],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=False
-    (
-        {"tools": _tools_llama},
-        _llama_instances_with_tools,
-        True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-triggered_tags_group ::= (("\"t1\", \"parameters\": " root_0 "}"))
-triggered_tags ::= TagDispatch(
-  ("{\"name\": ", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag triggered_tags))
-root ::= ((sequence))
-""",
-        [False, False, True, False, True],
-    ),
-    # with tools, reasoning=True, force_empty_reasoning=True
-    (
-        {"tools": _tools_llama},
-        _llama_instances_with_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think>\n\n</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-triggered_tags_group ::= (("\"t1\", \"parameters\": " root_0 "}"))
-triggered_tags ::= TagDispatch(
-  ("{\"name\": ", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string triggered_tags))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
-    # no tools, reasoning=False, force_empty_reasoning=False
-    (
-        {},
-        _llama_instances_no_tools,
-        False,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-root ::= ((any_text))
-""",
-        [True, True, False, False, False],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=False
-    (
-        {},
-        _llama_instances_no_tools,
-        True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-any_text_1 ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag any_text_1))
-root ::= ((sequence))
-""",
-        [False, False, True, False, True],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=True
-    (
-        {},
-        _llama_instances_no_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think>\n\n</think>"))
-any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string any_text))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
+    # with tools, reasoning=True
+    ({"tools": _tools_llama}, _llama_instances_with_tools, True, [True, True, False, False, False]),
+    # no tools, reasoning=False
+    ({}, _llama_instances_no_tools, False, [True, True, False, False, False]),
+    # no tools, reasoning=True
+    ({}, _llama_instances_no_tools, True, [True, True, False, False, False]),
 ]
 
 
@@ -925,187 +726,24 @@ _kimi_instances_no_tools = [
 ]
 
 kimi_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False, force_empty_reasoning=False
+    # with tools, reasoning=False
     (
         {"tools": _tools_kimi},
         _kimi_instances_with_tools,
         False,
-        False,
-        r"""root_0 ::= ((root_1))
-root_1 ::= (([0-9] root_1) | ([0-9]))
-const_string ::= (("<|tool_call_argument_begin|>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_2 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-sequence ::= ((root_0 const_string root_2))
-triggered_tags_group ::= (("functions.get_weather:" sequence "<|tool_call_end|>"))
-triggered_tags ::= TagDispatch(
-  ("<|tool_call_begin|>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-root ::= ((triggered_tags))
-""",
-        [True, False, False, False, False, False],
-    ),
-    # with tools, reasoning=True, force_empty_reasoning=False
-    (
-        {"tools": _tools_kimi},
-        _kimi_instances_with_tools,
-        True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-root_0 ::= ((root_1))
-root_1 ::= (([0-9] root_1) | ([0-9]))
-const_string ::= (("<|tool_call_argument_begin|>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_2 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-sequence ::= ((root_0 const_string root_2))
-triggered_tags_group ::= (("functions.get_weather:" sequence "<|tool_call_end|>"))
-triggered_tags ::= TagDispatch(
-  ("<|tool_call_begin|>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence_1 ::= ((tag triggered_tags))
-root ::= ((sequence_1))
-""",
-        [False, False, True, False, True, True],
-    ),
-    # with tools, reasoning=True, force_empty_reasoning=True
-    (
-        {"tools": _tools_kimi},
-        _kimi_instances_with_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think></think>"))
-root_0 ::= ((root_1))
-root_1 ::= (([0-9] root_1) | ([0-9]))
-const_string_1 ::= (("<|tool_call_argument_begin|>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_2 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-sequence ::= ((root_0 const_string_1 root_2))
-triggered_tags_group ::= (("functions.get_weather:" sequence "<|tool_call_end|>"))
-triggered_tags ::= TagDispatch(
-  ("<|tool_call_begin|>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence_1 ::= ((const_string triggered_tags))
-root ::= ((sequence_1))
-""",
         [False, False, False, False, True, True],
     ),
-    # no tools, reasoning=False, force_empty_reasoning=False
+    # with tools, reasoning=True
     (
-        {},
-        _kimi_instances_no_tools,
-        False,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-root ::= ((any_text))
-""",
-        [True, True, False, False, False, False],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=False
-    (
-        {},
-        _kimi_instances_no_tools,
+        {"tools": _tools_kimi},
+        _kimi_instances_with_tools,
         True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-any_text_1 ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag any_text_1))
-root ::= ((sequence))
-""",
-        [False, False, True, False, True, False],
+        [False, False, True, False, True, True],
     ),
-    # no tools, reasoning=True, force_empty_reasoning=True
-    (
-        {},
-        _kimi_instances_no_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think></think>"))
-any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string any_text))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True, False],
-    ),
+    # no tools, reasoning=False
+    ({}, _kimi_instances_no_tools, False, [False, False, False, False, True, False]),
+    # no tools, reasoning=True
+    ({}, _kimi_instances_no_tools, True, [False, False, True, False, True, False]),
 ]
 
 
@@ -1127,187 +765,24 @@ _deepseek_r1_instances_with_tools = [
 _deepseek_r1_instances_no_tools = ["", "text", "123</think>123", "</think></think>", "</think>text"]
 
 deepseek_r1_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False, force_empty_reasoning=False
+    # with tools, reasoning=False
     (
         {"tools": _tools_deepseek},
         _deepseek_r1_instances_with_tools,
         False,
-        False,
-        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<\uff5ctool\u2581call\u2581begin\uff5c>function<\uff5ctool\u2581sep\uff5c>search\n```json\n" root_0 "\n```\n<\uff5ctool\u2581call\u2581end\uff5c>"))
-tags_with_separator_tags ::= ((tag))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-triggered_tags_group ::= (("" tags_with_separator "<\uff5ctool\u2581calls\u2581end\uff5c>"))
-triggered_tags ::= TagDispatch(
-  ("<\uff5ctool\u2581calls\u2581begin\uff5c>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-root ::= ((triggered_tags))
-""",
         [True, False, False, False, False],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=False
+    # with tools, reasoning=True
     (
         {"tools": _tools_deepseek},
         _deepseek_r1_instances_with_tools,
         True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("" any_text "</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag_1 ::= (("<\uff5ctool\u2581call\u2581begin\uff5c>function<\uff5ctool\u2581sep\uff5c>search\n```json\n" root_0 "\n```\n<\uff5ctool\u2581call\u2581end\uff5c>"))
-tags_with_separator_tags ::= ((tag_1))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-triggered_tags_group ::= (("" tags_with_separator "<\uff5ctool\u2581calls\u2581end\uff5c>"))
-triggered_tags ::= TagDispatch(
-  ("<\uff5ctool\u2581calls\u2581begin\uff5c>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag triggered_tags))
-root ::= ((sequence))
-""",
         [False, True, True, False, True],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=True
-    (
-        {"tools": _tools_deepseek},
-        _deepseek_r1_instances_with_tools,
-        True,
-        True,
-        r"""const_string ::= (("</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<\uff5ctool\u2581call\u2581begin\uff5c>function<\uff5ctool\u2581sep\uff5c>search\n```json\n" root_0 "\n```\n<\uff5ctool\u2581call\u2581end\uff5c>"))
-tags_with_separator_tags ::= ((tag))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-triggered_tags_group ::= (("" tags_with_separator "<\uff5ctool\u2581calls\u2581end\uff5c>"))
-triggered_tags ::= TagDispatch(
-  ("<\uff5ctool\u2581calls\u2581begin\uff5c>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string triggered_tags))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
-    # no tools, reasoning=False, force_empty_reasoning=False
-    (
-        {},
-        _deepseek_r1_instances_no_tools,
-        False,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-root ::= ((any_text))
-""",
-        [True, True, False, False, False],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=False
-    (
-        {},
-        _deepseek_r1_instances_no_tools,
-        True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("" any_text "</think>"))
-any_text_1 ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag any_text_1))
-root ::= ((sequence))
-""",
-        [False, False, True, False, True],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=True
-    (
-        {},
-        _deepseek_r1_instances_no_tools,
-        True,
-        True,
-        r"""const_string ::= (("</think>"))
-any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string any_text))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
+    # no tools, reasoning=False
+    ({}, _deepseek_r1_instances_no_tools, False, [True, True, False, False, False]),
+    # no tools, reasoning=True
+    ({}, _deepseek_r1_instances_no_tools, True, [False, False, True, False, True]),
 ]
 
 
@@ -1335,220 +810,24 @@ _deepseek_v3_2_instances_no_tools = [
 ]
 
 deepseek_v3_2_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False, force_empty_reasoning=False
+    # with tools, reasoning=False
     (
         {"tools": _tools_deepseek_v3_2},
         _deepseek_v3_2_instances_with_tools,
         False,
-        False,
-        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</\uff5cDSML\uff5cparameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_2 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"q\" string=\"" root_1 "\">" [ \n\t]* xml_string [ \n\t]* "</\uff5cDSML\uff5cparameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1_1 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-xml_object_2 ::= (("true") | ("false"))
-root_1 ::= (("true") | ("false"))
-xml_object_1_1 ::= (("true") | ("false"))
-tag ::= (("<\uff5cDSML\uff5cinvoke name=\"search\">\n" root_0 "</\uff5cDSML\uff5cinvoke>\n"))
-tags_with_separator_tags ::= ((tag))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-triggered_tags_group ::= (("\n" tags_with_separator "</\uff5cDSML\uff5cfunction_calls>\n"))
-triggered_tags ::= TagDispatch(
-  ("<\uff5cDSML\uff5cfunction_calls>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-root ::= ((triggered_tags))
-""",
         [True, False, False, False, False],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=False
+    # with tools, reasoning=True
     (
         {"tools": _tools_deepseek_v3_2},
         _deepseek_v3_2_instances_with_tools,
         True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</\uff5cDSML\uff5cparameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_2 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"q\" string=\"" root_1 "\">" [ \n\t]* xml_string [ \n\t]* "</\uff5cDSML\uff5cparameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1_1 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-xml_object_2 ::= (("true") | ("false"))
-root_1 ::= (("true") | ("false"))
-xml_object_1_1 ::= (("true") | ("false"))
-tag_1 ::= (("<\uff5cDSML\uff5cinvoke name=\"search\">\n" root_0 "</\uff5cDSML\uff5cinvoke>\n"))
-tags_with_separator_tags ::= ((tag_1))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-triggered_tags_group ::= (("\n" tags_with_separator "</\uff5cDSML\uff5cfunction_calls>\n"))
-triggered_tags ::= TagDispatch(
-  ("<\uff5cDSML\uff5cfunction_calls>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag triggered_tags))
-root ::= ((sequence))
-""",
         [False, True, True, False, True],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=True
-    (
-        {"tools": _tools_deepseek_v3_2},
-        _deepseek_v3_2_instances_with_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think>\n\n</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</\uff5cDSML\uff5cparameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_2 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"q\" string=\"" root_1 "\">" [ \n\t]* xml_string [ \n\t]* "</\uff5cDSML\uff5cparameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1_1 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-xml_object_2 ::= (("true") | ("false"))
-root_1 ::= (("true") | ("false"))
-xml_object_1_1 ::= (("true") | ("false"))
-tag ::= (("<\uff5cDSML\uff5cinvoke name=\"search\">\n" root_0 "</\uff5cDSML\uff5cinvoke>\n"))
-tags_with_separator_tags ::= ((tag))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-triggered_tags_group ::= (("\n" tags_with_separator "</\uff5cDSML\uff5cfunction_calls>\n"))
-triggered_tags ::= TagDispatch(
-  ("<\uff5cDSML\uff5cfunction_calls>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string triggered_tags))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
-    # no tools, reasoning=False, force_empty_reasoning=False
-    (
-        {},
-        _deepseek_v3_2_instances_no_tools,
-        False,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-root ::= ((any_text))
-""",
-        [True, True, False, False, False],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=False
-    (
-        {},
-        _deepseek_v3_2_instances_no_tools,
-        True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-any_text_1 ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag any_text_1))
-root ::= ((sequence))
-""",
-        [False, False, True, False, True],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=True
-    (
-        {},
-        _deepseek_v3_2_instances_no_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think>\n\n</think>"))
-any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string any_text))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
+    # no tools, reasoning=False
+    ({}, _deepseek_v3_2_instances_no_tools, False, [True, True, False, False, False]),
+    # no tools, reasoning=True
+    ({}, _deepseek_v3_2_instances_no_tools, True, [False, False, True, False, True]),
 ]
 
 
@@ -1576,220 +855,24 @@ _deepseek_v4_instances_no_tools = [
 ]
 
 deepseek_v4_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False, force_empty_reasoning=False
+    # with tools, reasoning=False
     (
         {"tools": _tools_deepseek_v4},
         _deepseek_v4_instances_with_tools,
         False,
-        False,
-        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</\uff5cDSML\uff5cparameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_2 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"q\" string=\"" root_1 "\">" [ \n\t]* xml_string [ \n\t]* "</\uff5cDSML\uff5cparameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1_1 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-xml_object_2 ::= (("true") | ("false"))
-root_1 ::= (("true") | ("false"))
-xml_object_1_1 ::= (("true") | ("false"))
-tag ::= (("<\uff5cDSML\uff5cinvoke name=\"search\">\n" root_0 "</\uff5cDSML\uff5cinvoke>\n"))
-tags_with_separator_tags ::= ((tag))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-triggered_tags_group ::= (("\n" tags_with_separator "</\uff5cDSML\uff5ctool_calls>\n"))
-triggered_tags ::= TagDispatch(
-  ("<\uff5cDSML\uff5ctool_calls>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-root ::= ((triggered_tags))
-""",
         [True, False, False, False, False],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=False
+    # with tools, reasoning=True
     (
         {"tools": _tools_deepseek_v4},
         _deepseek_v4_instances_with_tools,
         True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</\uff5cDSML\uff5cparameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_2 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"q\" string=\"" root_1 "\">" [ \n\t]* xml_string [ \n\t]* "</\uff5cDSML\uff5cparameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1_1 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-xml_object_2 ::= (("true") | ("false"))
-root_1 ::= (("true") | ("false"))
-xml_object_1_1 ::= (("true") | ("false"))
-tag_1 ::= (("<\uff5cDSML\uff5cinvoke name=\"search\">\n" root_0 "</\uff5cDSML\uff5cinvoke>\n"))
-tags_with_separator_tags ::= ((tag_1))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-triggered_tags_group ::= (("\n" tags_with_separator "</\uff5cDSML\uff5ctool_calls>\n"))
-triggered_tags ::= TagDispatch(
-  ("<\uff5cDSML\uff5ctool_calls>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag triggered_tags))
-root ::= ((sequence))
-""",
         [False, True, True, False, True],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=True
-    (
-        {"tools": _tools_deepseek_v4},
-        _deepseek_v4_instances_with_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think>\n\n</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</\uff5cDSML\uff5cparameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_2 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"q\" string=\"" root_1 "\">" [ \n\t]* xml_string [ \n\t]* "</\uff5cDSML\uff5cparameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1_1 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-xml_object_2 ::= (("true") | ("false"))
-root_1 ::= (("true") | ("false"))
-xml_object_1_1 ::= (("true") | ("false"))
-tag ::= (("<\uff5cDSML\uff5cinvoke name=\"search\">\n" root_0 "</\uff5cDSML\uff5cinvoke>\n"))
-tags_with_separator_tags ::= ((tag))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-triggered_tags_group ::= (("\n" tags_with_separator "</\uff5cDSML\uff5ctool_calls>\n"))
-triggered_tags ::= TagDispatch(
-  ("<\uff5cDSML\uff5ctool_calls>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string triggered_tags))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
-    # no tools, reasoning=False, force_empty_reasoning=False
-    (
-        {},
-        _deepseek_v4_instances_no_tools,
-        False,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-root ::= ((any_text))
-""",
-        [True, True, False, False, False],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=False
-    (
-        {},
-        _deepseek_v4_instances_no_tools,
-        True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-any_text_1 ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag any_text_1))
-root ::= ((sequence))
-""",
-        [False, False, True, False, True],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=True
-    (
-        {},
-        _deepseek_v4_instances_no_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think>\n\n</think>"))
-any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string any_text))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
+    # no tools, reasoning=False
+    ({}, _deepseek_v4_instances_no_tools, False, [True, True, False, False, False]),
+    # no tools, reasoning=True
+    ({}, _deepseek_v4_instances_no_tools, True, [False, False, True, False, True]),
 ]
 
 
@@ -1817,211 +900,24 @@ _minimax_instances_no_tools = [
 ]
 
 minimax_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False, force_empty_reasoning=False
+    # with tools, reasoning=False
     (
         {"tools": _tools_minimax},
         _minimax_instances_with_tools,
         False,
-        False,
-        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</parameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<parameter name=\"q\">" [ \n\t]* xml_string [ \n\t]* "</parameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<invoke name=\"search\">\n" root_0 "</invoke>\n"))
-tags_with_separator_tags ::= ((tag))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-triggered_tags_group ::= (("\n" tags_with_separator "</minimax:tool_call>\n"))
-triggered_tags ::= TagDispatch(
-  ("<minimax:tool_call>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-root ::= ((triggered_tags))
-""",
         [True, False, False, False, False],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=False
+    # with tools, reasoning=True
     (
         {"tools": _tools_minimax},
         _minimax_instances_with_tools,
         True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</parameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<parameter name=\"q\">" [ \n\t]* xml_string [ \n\t]* "</parameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag_1 ::= (("<invoke name=\"search\">\n" root_0 "</invoke>\n"))
-tags_with_separator_tags ::= ((tag_1))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-triggered_tags_group ::= (("\n" tags_with_separator "</minimax:tool_call>\n"))
-triggered_tags ::= TagDispatch(
-  ("<minimax:tool_call>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag triggered_tags))
-root ::= ((sequence))
-""",
         [False, True, True, False, True],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=True
-    (
-        {"tools": _tools_minimax},
-        _minimax_instances_with_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think>\n\n</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</parameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<parameter name=\"q\">" [ \n\t]* xml_string [ \n\t]* "</parameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<invoke name=\"search\">\n" root_0 "</invoke>\n"))
-tags_with_separator_tags ::= ((tag))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-triggered_tags_group ::= (("\n" tags_with_separator "</minimax:tool_call>\n"))
-triggered_tags ::= TagDispatch(
-  ("<minimax:tool_call>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string triggered_tags))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
-    # no tools, reasoning=False, force_empty_reasoning=False
-    (
-        {},
-        _minimax_instances_no_tools,
-        False,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-root ::= ((any_text))
-""",
-        [True, True, False, False, False],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=False
-    (
-        {},
-        _minimax_instances_no_tools,
-        True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-any_text_1 ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag any_text_1))
-root ::= ((sequence))
-""",
-        [False, False, True, False, True],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=True
-    (
-        {},
-        _minimax_instances_no_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think>\n\n</think>"))
-any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string any_text))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
+    # no tools, reasoning=False
+    ({}, _minimax_instances_no_tools, False, [True, True, False, False, False]),
+    # no tools, reasoning=True
+    ({}, _minimax_instances_no_tools, True, [False, False, True, False, True]),
 ]
 
 
@@ -2033,7 +929,7 @@ def test_minimax_instances(case: InstanceCase):
 
 def test_glm47_instances():
     """get_model_structural_tag(glm47) accepts/rejects instance as expected."""
-    stag = get_model_structural_tag("glm47", tools=_tools_glm47, reasoning=False)
+    stag = get_model_structural_tag("glm_4_7", tools=_tools_glm_4_7, reasoning=False)
     grammar_str = str(xgr.Grammar.from_structural_tag(stag))
     assert "<tool_call>" in grammar_str
     assert "<arg_key>" in grammar_str
@@ -2066,206 +962,31 @@ _qwen_coder_instances_no_tools = [
 ]
 
 qwen_coder_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False, force_empty_reasoning=False
+    # with tools, reasoning=False
     (
-        {"tools": _tools_qwen_coder},
+        {"tools": _tools_qwen_3_coder},
         _qwen_coder_instances_with_tools,
         False,
-        False,
-        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</parameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<parameter=q>" [ \n\t]* xml_string [ \n\t]* "</parameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-triggered_tags_group ::= (("run_sql>\n" root_0 "\n</function>\n</tool_call>"))
-triggered_tags ::= TagDispatch(
-  ("<tool_call>\n<function=", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-root ::= ((triggered_tags))
-""",
         [True, False, False, False, False],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=False
+    # with tools, reasoning=True
     (
-        {"tools": _tools_qwen_coder},
+        {"tools": _tools_qwen_3_coder},
         _qwen_coder_instances_with_tools,
         True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</parameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<parameter=q>" [ \n\t]* xml_string [ \n\t]* "</parameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-triggered_tags_group ::= (("run_sql>\n" root_0 "\n</function>\n</tool_call>"))
-triggered_tags ::= TagDispatch(
-  ("<tool_call>\n<function=", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag triggered_tags))
-root ::= ((sequence))
-""",
-        [False, False, True, False, True],
+        [True, False, False, False, False],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=True
-    (
-        {"tools": _tools_qwen_coder},
-        _qwen_coder_instances_with_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think>\n\n</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</parameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<parameter=q>" [ \n\t]* xml_string [ \n\t]* "</parameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-triggered_tags_group ::= (("run_sql>\n" root_0 "\n</function>\n</tool_call>"))
-triggered_tags ::= TagDispatch(
-  ("<tool_call>\n<function=", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string triggered_tags))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
-    # no tools, reasoning=False, force_empty_reasoning=False
-    (
-        {},
-        _qwen_coder_instances_no_tools,
-        False,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-root ::= ((any_text))
-""",
-        [True, True, False, False, False],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=False
-    (
-        {},
-        _qwen_coder_instances_no_tools,
-        True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-any_text_1 ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag any_text_1))
-root ::= ((sequence))
-""",
-        [False, False, True, False, True],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=True
-    (
-        {},
-        _qwen_coder_instances_no_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think>\n\n</think>"))
-any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string any_text))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
+    # no tools, reasoning=False
+    ({}, _qwen_coder_instances_no_tools, False, [True, True, False, False, False]),
+    # no tools, reasoning=True
+    ({}, _qwen_coder_instances_no_tools, True, [True, True, False, False, False]),
 ]
 
 
 @pytest.mark.parametrize("case", qwen_coder_instance_cases)
 def test_qwen_coder_instances(case: InstanceCase):
     """get_model_structural_tag(qwen_coder) accepts/rejects instance as expected."""
-    run_instance_case("qwen_coder", case)
+    run_instance_case("qwen_3_coder", case)
 
 
 # ----- qwen
@@ -2285,182 +1006,21 @@ _qwen_instances_no_tools = [
 ]
 
 qwen_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False, force_empty_reasoning=False
-    (
-        {"tools": _tools_qwen},
-        _qwen_instances_with_tools,
-        False,
-        False,
-        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-triggered_tags_group ::= (("\n{\"name\": \"t1\", \"arguments\": " root_0 "}\n</tool_call>"))
-triggered_tags ::= TagDispatch(
-  ("<tool_call>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-root ::= ((triggered_tags))
-""",
-        [True, False, False, False],
-    ),
-    # with tools, reasoning=True, force_empty_reasoning=False
-    (
-        {"tools": _tools_qwen},
-        _qwen_instances_with_tools,
-        True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-triggered_tags_group ::= (("\n{\"name\": \"t1\", \"arguments\": " root_0 "}\n</tool_call>"))
-triggered_tags ::= TagDispatch(
-  ("<tool_call>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag triggered_tags))
-root ::= ((sequence))
-""",
-        [False, True, False, True],
-    ),
-    # with tools, reasoning=True, force_empty_reasoning=True
-    (
-        {"tools": _tools_qwen},
-        _qwen_instances_with_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think>\n\n</think>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-triggered_tags_group ::= (("\n{\"name\": \"t1\", \"arguments\": " root_0 "}\n</tool_call>"))
-triggered_tags ::= TagDispatch(
-  ("<tool_call>", triggered_tags_group),
-  loop_after_dispatch=true,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string triggered_tags))
-root ::= ((sequence))
-""",
-        [False, False, False, True],
-    ),
-    # no tools, reasoning=False, force_empty_reasoning=False
-    (
-        {},
-        _qwen_instances_no_tools,
-        False,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-root ::= ((any_text))
-""",
-        [True, True, False, False, False],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=False
-    (
-        {},
-        _qwen_instances_no_tools,
-        True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</think>")
-)
-tag ::= (("<think>" any_text "</think>"))
-any_text_1 ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((tag any_text_1))
-root ::= ((sequence))
-""",
-        [False, False, True, False, True],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=True
-    (
-        {},
-        _qwen_instances_no_tools,
-        True,
-        True,
-        r"""const_string ::= (("<think>\n\n</think>"))
-any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<think>", "</think>")
-)
-sequence ::= ((const_string any_text))
-root ::= ((sequence))
-""",
-        [False, False, False, False, True],
-    ),
+    # with tools, reasoning=False
+    ({"tools": _tools_qwen_3}, _qwen_instances_with_tools, False, [True, False, False, False]),
+    # with tools, reasoning=True
+    ({"tools": _tools_qwen_3}, _qwen_instances_with_tools, True, [False, True, False, True]),
+    # no tools, reasoning=False
+    ({}, _qwen_instances_no_tools, False, [True, True, False, False, False]),
+    # no tools, reasoning=True
+    ({}, _qwen_instances_no_tools, True, [False, False, True, False, True]),
 ]
 
 
 @pytest.mark.parametrize("case", qwen_instance_cases)
 def test_qwen_instances(case: InstanceCase):
     """get_model_structural_tag(qwen) accepts/rejects instance as expected."""
-    run_instance_case("qwen", case)
+    run_instance_case("qwen_3", case)
 
 
 # ----- harmony
@@ -2482,189 +1042,24 @@ _harmony_instances_no_tools = [
 ]
 
 harmony_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False, force_empty_reasoning=False
+    # with tools, reasoning=False
     (
         {"tools": _tools_harmony, "builtin_tools": _builtin_harmony},
         _harmony_instances_with_tools,
         False,
-        False,
-        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<|channel|>commentary to=comment_tool<|constrain|>json<|message|>" root_0 "<|call|>"))
-tag_1 ::= (("<|channel|>analysis to=analysis_tool<|message|>" root_0 "<|call|>"))
-any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<|end|>")
-)
-tag_2 ::= (("<|channel|>final<|message|>" any_text "<|end|>"))
-tags_with_separator_tags ::= ((tag) | (tag_1) | (tag_2))
-tags_with_separator_sub ::= ("" | ("<|start|>assistant" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
         [False, True, True, False, False, True],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=False
+    # with tools, reasoning=True
     (
         {"tools": _tools_harmony, "builtin_tools": _builtin_harmony},
         _harmony_instances_with_tools,
         True,
-        False,
-        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<|channel|>commentary to=comment_tool<|constrain|>json<|message|>" root_0 "<|call|>"))
-tag_1 ::= (("<|channel|>analysis to=analysis_tool<|message|>" root_0 "<|call|>"))
-any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<|end|>")
-)
-tag_2 ::= (("<|channel|>final<|message|>" any_text "<|end|>"))
-tag_3 ::= (("<|channel|>analysis<|message|>" any_text "<|end|>"))
-tags_with_separator_tags ::= ((tag) | (tag_1) | (tag_2) | (tag_3))
-tags_with_separator_sub ::= ("" | ("<|start|>assistant" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
         [True, True, True, False, True, True],
     ),
-    # with tools, reasoning=True, force_empty_reasoning=True
-    (
-        {"tools": _tools_harmony, "builtin_tools": _builtin_harmony},
-        _harmony_instances_with_tools,
-        True,
-        True,
-        r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<|channel|>commentary to=comment_tool<|constrain|>json<|message|>" root_0 "<|call|>"))
-tag_1 ::= (("<|channel|>analysis to=analysis_tool<|message|>" root_0 "<|call|>"))
-any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<|end|>")
-)
-tag_2 ::= (("<|channel|>final<|message|>" any_text "<|end|>"))
-const_string ::= (("<|end|>"))
-tag_3 ::= (("<|channel|>analysis<|message|>" const_string))
-tags_with_separator_tags ::= ((tag) | (tag_1) | (tag_2) | (tag_3))
-tags_with_separator_sub ::= ("" | ("<|start|>assistant" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
-        [True, True, True, False, False, True],
-    ),
-    # no tools, reasoning=False, force_empty_reasoning=False
-    (
-        {},
-        _harmony_instances_no_tools,
-        False,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<|end|>")
-)
-tag ::= (("<|channel|>final<|message|>" any_text "<|end|>"))
-tags_with_separator_tags ::= ((tag))
-tags_with_separator_sub ::= ("" | ("<|start|>assistant" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
-        [True, True, False, False, False],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=False
-    (
-        {},
-        _harmony_instances_no_tools,
-        True,
-        False,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<|end|>")
-)
-tag ::= (("<|channel|>final<|message|>" any_text "<|end|>"))
-tag_1 ::= (("<|channel|>analysis<|message|>" any_text "<|end|>"))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | ("<|start|>assistant" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
-        [True, True, True, True, False],
-    ),
-    # no tools, reasoning=True, force_empty_reasoning=True
-    (
-        {},
-        _harmony_instances_no_tools,
-        True,
-        True,
-        r"""any_text ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("<|end|>")
-)
-tag ::= (("<|channel|>final<|message|>" any_text "<|end|>"))
-const_string ::= (("<|end|>"))
-tag_1 ::= (("<|channel|>analysis<|message|>" const_string))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | ("<|start|>assistant" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
-        [True, True, False, True, False],
-    ),
+    # no tools, reasoning=False
+    ({}, _harmony_instances_no_tools, False, [True, True, False, False, False]),
+    # no tools, reasoning=True
+    ({}, _harmony_instances_no_tools, True, [True, True, True, True, False]),
 ]
 
 
@@ -2682,35 +1077,6 @@ _tool_choice_instance_cases = [
             {"tools": _tools_llama_pair, "tool_choice": "required"},
             ["", '{"name": "t1", "parameters": {"q": "v"}}'],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("{\"name\": \"t1\", \"parameters\": " root_0 "}"))
-tag_1 ::= (("{\"name\": \"t2\", \"parameters\": " root_0 "}"))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
             [False, True],
         ),
         id="llama-required",
@@ -2724,31 +1090,6 @@ root ::= ((tags_with_separator))
                 '{"name": "t2", "parameters": {"q": "v"}}',
             ],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("{\"name\": \"t1\", \"parameters\": " root_0 "}"))
-root ::= ((tag))
-""",
             [True, False],
         ),
         id="llama-forced",
@@ -2759,42 +1100,9 @@ root ::= ((tag))
             {"tools": _tools_kimi_pair, "tool_choice": "required"},
             [
                 "",
-                '<|tool_call_begin|>functions.t1:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|>',
+                '<think></think><|tool_call_begin|>functions.t1:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|>',
             ],
             False,
-            False,
-            r"""root_0 ::= ((root_1))
-root_1 ::= (([0-9] root_1) | ([0-9]))
-const_string ::= (("<|tool_call_argument_begin|>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_2 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-sequence ::= ((root_0 const_string root_2))
-tag ::= (("<|tool_call_begin|>functions.t1:" sequence "<|tool_call_end|>"))
-tag_1 ::= (("<|tool_call_begin|>functions.t2:" sequence "<|tool_call_end|>"))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
             [False, True],
         ),
         id="kimi-required",
@@ -2804,39 +1112,10 @@ root ::= ((tags_with_separator))
         (
             {"tools": _tools_kimi_pair, "tool_choice": "forced", "forced_function_name": "t1"},
             [
-                '<|tool_call_begin|>functions.t1:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|>',
-                '<|tool_call_begin|>functions.t2:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|>',
+                '<think></think><|tool_call_begin|>functions.t1:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|>',
+                '<think></think><|tool_call_begin|>functions.t2:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|>',
             ],
             False,
-            False,
-            r"""root_0 ::= ((root_1))
-root_1 ::= (([0-9] root_1) | ([0-9]))
-const_string ::= (("<|tool_call_argument_begin|>"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_2 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-sequence ::= ((root_0 const_string root_2))
-tag ::= (("<|tool_call_begin|>functions.t1:" sequence "<|tool_call_end|>"))
-root ::= ((tag))
-""",
             [True, False],
         ),
         id="kimi-forced",
@@ -2850,36 +1129,6 @@ root ::= ((tag))
                 '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
             ],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<\uff5ctool\u2581call\u2581begin\uff5c>function<\uff5ctool\u2581sep\uff5c>search\n```json\n" root_0 "\n```\n<\uff5ctool\u2581call\u2581end\uff5c>"))
-tag_1 ::= (("<\uff5ctool\u2581call\u2581begin\uff5c>function<\uff5ctool\u2581sep\uff5c>alt\n```json\n" root_0 "\n```\n<\uff5ctool\u2581call\u2581end\uff5c>"))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-tag_2 ::= (("<\uff5ctool\u2581calls\u2581begin\uff5c>" tags_with_separator "<\uff5ctool\u2581calls\u2581end\uff5c>"))
-root ::= ((tag_2))
-""",
             [False, True],
         ),
         id="deepseek_r1-required",
@@ -2897,31 +1146,6 @@ root ::= ((tag_2))
                 '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>alt\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
             ],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<\uff5ctool\u2581calls\u2581begin\uff5c><\uff5ctool\u2581call\u2581begin\uff5c>function<\uff5ctool\u2581sep\uff5c>search\n```json\n" root_0 "\n```\n<\uff5ctool\u2581call\u2581end\uff5c><\uff5ctool\u2581calls\u2581end\uff5c>"))
-root ::= ((tag))
-""",
             [True, False],
         ),
         id="deepseek_r1-forced",
@@ -2935,49 +1159,6 @@ root ::= ((tag))
                 '<｜DSML｜function_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜function_calls>\n',
             ],
             False,
-            False,
-            r"""const_string ::= (("<\uff5cDSML\uff5cfunction_calls>\n"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</\uff5cDSML\uff5cparameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_2 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"q\" string=\"" root_1 "\">" [ \n\t]* xml_string [ \n\t]* "</\uff5cDSML\uff5cparameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1_1 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-xml_object_2 ::= (("true") | ("false"))
-root_1 ::= (("true") | ("false"))
-xml_object_1_1 ::= (("true") | ("false"))
-tag ::= (("<\uff5cDSML\uff5cinvoke name=\"search\">\n" root_0 "</\uff5cDSML\uff5cinvoke>\n"))
-tag_1 ::= (("<\uff5cDSML\uff5cinvoke name=\"alt\">\n" root_0 "</\uff5cDSML\uff5cinvoke>\n"))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-const_string_1 ::= (("</\uff5cDSML\uff5cfunction_calls>\n"))
-sequence ::= ((const_string tags_with_separator const_string_1))
-root ::= ((sequence))
-""",
             [False, True],
         ),
         id="deepseek_v3_2-required",
@@ -2991,49 +1172,6 @@ root ::= ((sequence))
                 '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜tool_calls>\n',
             ],
             False,
-            False,
-            r"""const_string ::= (("<\uff5cDSML\uff5ctool_calls>\n"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</\uff5cDSML\uff5cparameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_2 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"q\" string=\"" root_1 "\">" [ \n\t]* xml_string [ \n\t]* "</\uff5cDSML\uff5cparameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1_1 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-xml_object_2 ::= (("true") | ("false"))
-root_1 ::= (("true") | ("false"))
-xml_object_1_1 ::= (("true") | ("false"))
-tag ::= (("<\uff5cDSML\uff5cinvoke name=\"search\">\n" root_0 "</\uff5cDSML\uff5cinvoke>\n"))
-tag_1 ::= (("<\uff5cDSML\uff5cinvoke name=\"alt\">\n" root_0 "</\uff5cDSML\uff5cinvoke>\n"))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-const_string_1 ::= (("</\uff5cDSML\uff5ctool_calls>\n"))
-sequence ::= ((const_string tags_with_separator const_string_1))
-root ::= ((sequence))
-""",
             [False, True],
         ),
         id="deepseek_v4-required",
@@ -3051,45 +1189,6 @@ root ::= ((sequence))
                 '<｜DSML｜function_calls>\n<｜DSML｜invoke name="alt">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜function_calls>\n',
             ],
             False,
-            False,
-            r"""const_string ::= (("<\uff5cDSML\uff5cfunction_calls>\n"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</\uff5cDSML\uff5cparameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_2 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"q\" string=\"" root_1 "\">" [ \n\t]* xml_string [ \n\t]* "</\uff5cDSML\uff5cparameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1_1 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-xml_object_2 ::= (("true") | ("false"))
-root_1 ::= (("true") | ("false"))
-xml_object_1_1 ::= (("true") | ("false"))
-tag ::= (("<\uff5cDSML\uff5cinvoke name=\"search\">\n" root_0 "</\uff5cDSML\uff5cinvoke>\n"))
-const_string_1 ::= (("</\uff5cDSML\uff5cfunction_calls>\n"))
-sequence ::= ((const_string tag const_string_1))
-root ::= ((sequence))
-""",
             [True, False],
         ),
         id="deepseek_v3_2-forced",
@@ -3107,45 +1206,6 @@ root ::= ((sequence))
                 '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="alt">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜tool_calls>\n',
             ],
             False,
-            False,
-            r"""const_string ::= (("<\uff5cDSML\uff5ctool_calls>\n"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</\uff5cDSML\uff5cparameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_2 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"q\" string=\"" root_1 "\">" [ \n\t]* xml_string [ \n\t]* "</\uff5cDSML\uff5cparameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1_1 "\">" [ \n\t]* xml_any [ \n\t]* "</\uff5cDSML\uff5cparameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-xml_object_2 ::= (("true") | ("false"))
-root_1 ::= (("true") | ("false"))
-xml_object_1_1 ::= (("true") | ("false"))
-tag ::= (("<\uff5cDSML\uff5cinvoke name=\"search\">\n" root_0 "</\uff5cDSML\uff5cinvoke>\n"))
-const_string_1 ::= (("</\uff5cDSML\uff5ctool_calls>\n"))
-sequence ::= ((const_string tag const_string_1))
-root ::= ((sequence))
-""",
             [True, False],
         ),
         id="deepseek_v4-forced",
@@ -3159,46 +1219,6 @@ root ::= ((sequence))
                 '<minimax:tool_call>\n<invoke name="search">\n<parameter name="q">v</parameter></invoke>\n</minimax:tool_call>\n',
             ],
             False,
-            False,
-            r"""const_string ::= (("<minimax:tool_call>\n"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</parameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<parameter name=\"q\">" [ \n\t]* xml_string [ \n\t]* "</parameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<invoke name=\"search\">\n" root_0 "</invoke>\n"))
-tag_1 ::= (("<invoke name=\"alt\">\n" root_0 "</invoke>\n"))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | ("\n" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-const_string_1 ::= (("</minimax:tool_call>\n"))
-sequence ::= ((const_string tags_with_separator const_string_1))
-root ::= ((sequence))
-""",
             [False, True],
         ),
         id="minimax-required",
@@ -3216,101 +1236,28 @@ root ::= ((sequence))
                 '<minimax:tool_call>\n<invoke name="alt">\n<parameter name="q">v</parameter></invoke>\n</minimax:tool_call>\n',
             ],
             False,
-            False,
-            r"""const_string ::= (("<minimax:tool_call>\n"))
-basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</parameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<parameter name=\"q\">" [ \n\t]* xml_string [ \n\t]* "</parameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<invoke name=\"search\">\n" root_0 "</invoke>\n"))
-const_string_1 ::= (("</minimax:tool_call>\n"))
-sequence ::= ((const_string tag const_string_1))
-root ::= ((sequence))
-""",
             [True, False],
         ),
         id="minimax-forced",
     ),
     pytest.param(
-        "qwen_coder",
+        "qwen_3_coder",
         (
-            {"tools": _tools_qwen_coder_pair, "tool_choice": "required"},
+            {"tools": _tools_qwen_3_coder_pair, "tool_choice": "required"},
             [
                 "",
                 "<tool_call>\n<function=run_sql>\n<parameter=q>v</parameter>\n</function>\n</tool_call>",
             ],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</parameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<parameter=q>" [ \n\t]* xml_string [ \n\t]* "</parameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<tool_call>\n<function=run_sql>\n" root_0 "\n</function>\n</tool_call>"))
-tag_1 ::= (("<tool_call>\n<function=run_py>\n" root_0 "\n</function>\n</tool_call>"))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
             [False, True],
         ),
         id="qwen_coder-required",
     ),
     pytest.param(
-        "qwen_coder",
+        "qwen_3_coder",
         (
             {
-                "tools": _tools_qwen_coder_pair,
+                "tools": _tools_qwen_3_coder_pair,
                 "tool_choice": "forced",
                 "forced_function_name": "run_sql",
             },
@@ -3319,119 +1266,32 @@ root ::= ((tags_with_separator))
                 "<tool_call>\n<function=run_py>\n<parameter=q>v</parameter>\n</function>\n</tool_call>",
             ],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</parameter>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<parameter=q>" [ \n\t]* xml_string [ \n\t]* "</parameter>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<tool_call>\n<function=run_sql>\n" root_0 "\n</function>\n</tool_call>"))
-root ::= ((tag))
-""",
             [True, False],
         ),
         id="qwen_coder-forced",
     ),
     pytest.param(
-        "qwen",
+        "qwen_3",
         (
-            {"tools": _tools_qwen_pair, "tool_choice": "required"},
+            {"tools": _tools_qwen_3_pair, "tool_choice": "required"},
             ["", '<tool_call>\n{"name": "t1", "arguments": {"q": "v"}}\n</tool_call>'],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<tool_call>\n{\"name\": \"t1\", \"arguments\": " root_0 "}\n</tool_call>"))
-tag_1 ::= (("<tool_call>\n{\"name\": \"t2\", \"arguments\": " root_0 "}\n</tool_call>"))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
             [False, True],
         ),
-        id="qwen-required",
+        id="qwen_3-required",
     ),
     pytest.param(
-        "qwen",
+        "qwen_3",
         (
-            {"tools": _tools_qwen_pair, "tool_choice": "forced", "forced_function_name": "t1"},
+            {"tools": _tools_qwen_3_pair, "tool_choice": "forced", "forced_function_name": "t1"},
             [
                 '<tool_call>\n{"name": "t1", "arguments": {"q": "v"}}\n</tool_call>',
                 '<tool_call>\n{"name": "t2", "arguments": {"q": "v"}}\n</tool_call>',
             ],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<tool_call>\n{\"name\": \"t1\", \"arguments\": " root_0 "}\n</tool_call>"))
-root ::= ((tag))
-""",
             [True, False],
         ),
-        id="qwen-forced",
+        id="qwen_3-forced",
     ),
     pytest.param(
         "harmony",
@@ -3442,35 +1302,6 @@ root ::= ((tag))
                 '<|channel|>commentary to=comment_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
             ],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<|channel|>commentary to=comment_tool<|constrain|>json<|message|>" root_0 "<|call|>"))
-tag_1 ::= (("<|channel|>commentary to=other_tool<|constrain|>json<|message|>" root_0 "<|call|>"))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | ("<|start|>assistant" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
             [False, True],
         ),
         id="harmony-required",
@@ -3488,169 +1319,46 @@ root ::= ((tags_with_separator))
                 '<|channel|>commentary to=other_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
             ],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<|channel|>commentary to=comment_tool<|constrain|>json<|message|>" root_0 "<|call|>"))
-tags_with_separator_tags ::= ((tag))
-tags_with_separator_sub ::= ("" | ("<|start|>assistant" tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
             [True, False],
         ),
         id="harmony-forced",
     ),
     pytest.param(
-        "glm47",
+        "glm_4_7",
         (
-            {"tools": _tools_glm47_pair, "tool_choice": "required"},
+            {"tools": _tools_glm_4_7_pair, "tool_choice": "required"},
             ["", "<tool_call>search<arg_key>q</arg_key><arg_value>v</arg_value></tool_call>"],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</arg_value>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<arg_key>" xml_variable_name "</arg_key>" [ \n\t]* "<arg_value>" [ \n\t]* xml_any [ \n\t]* "</arg_value>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<arg_key>q</arg_key>" [ \n\t]* "<arg_value>" [ \n\t]* xml_string [ \n\t]* "</arg_value>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<arg_key>" xml_variable_name "</arg_key>" [ \n\t]* "<arg_value>" [ \n\t]* xml_any [ \n\t]* "</arg_value>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<tool_call>search" root_0 "</tool_call>"))
-tag_1 ::= (("<tool_call>alt" root_0 "</tool_call>"))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
             [False, True],
         ),
-        id="glm47-required",
+        id="glm_4_7-required",
     ),
     pytest.param(
-        "gemma4",
+        "gemma_4",
         (
-            {"tools": _tools_gemma4_pair, "tool_choice": "required"},
+            {"tools": _tools_gemma_4_pair, "tool_choice": "required"},
             ["", '<|tool_call>call:search{"q": "v"}<tool_call|>'],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-root_0 ::= (("{" [ \n\t]* "\"q\"" [ \n\t]* ":" [ \n\t]* basic_string [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<|tool_call>call:search" root_0 "<tool_call|>"))
-tag_1 ::= (("<|tool_call>call:alt" root_0 "<tool_call|>"))
-tags_with_separator_tags ::= ((tag) | (tag_1))
-tags_with_separator_sub ::= ("" | (tags_with_separator_tags tags_with_separator_sub))
-tags_with_separator ::= ((tags_with_separator_tags tags_with_separator_sub))
-root ::= ((tags_with_separator))
-""",
             [False, True],
         ),
-        id="gemma4-required",
+        id="gemma_4-required",
     ),
     pytest.param(
-        "glm47",
+        "glm_4_7",
         (
-            {"tools": _tools_glm47_pair, "tool_choice": "forced", "forced_function_name": "search"},
+            {
+                "tools": _tools_glm_4_7_pair,
+                "tool_choice": "forced",
+                "forced_function_name": "search",
+            },
             [
                 "<tool_call>search<arg_key>q</arg_key><arg_value>v</arg_value></tool_call>",
                 "<tool_call>alt<arg_key>q</arg_key><arg_value>v</arg_value></tool_call>",
             ],
             False,
-            False,
-            r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
-basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\t]* [,}\]:]))
-basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
-basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
-basic_number ::= ((basic_number_1 basic_number_7 basic_number_3 basic_number_6))
-basic_string ::= (("\"" basic_string_sub))
-basic_boolean ::= (("true") | ("false"))
-basic_null ::= (("null"))
-basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n\t]* "]"))
-basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
-xml_string ::= TagDispatch(
-  loop_after_dispatch=false,
-  excludes=("</arg_value>")
-)
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\t]* "<arg_key>" xml_variable_name "</arg_key>" [ \n\t]* "<arg_value>" [ \n\t]* xml_any [ \n\t]* "</arg_value>" xml_object_1 [ \n\t]*) | ([ \n\t]*))
-xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
-root_0 ::= (([ \n\t]* "<arg_key>q</arg_key>" [ \n\t]* "<arg_value>" [ \n\t]* xml_string [ \n\t]* "</arg_value>" [ \n\t]*) | ([ \n\t]*))
-basic_integer_1 ::= ("" | ("-"))
-basic_number_1 ::= ("" | ("-"))
-basic_number_2 ::= (([0-9] basic_number_2) | ([0-9]))
-basic_number_3 ::= ("" | ("." basic_number_2))
-basic_number_4 ::= ("" | ([+\-]))
-basic_number_5 ::= (([0-9] basic_number_5) | ([0-9]))
-basic_number_6 ::= ("" | ([eE] basic_number_4 basic_number_5))
-basic_array_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_any basic_array_1))
-basic_object_1 ::= ("" | ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1))
-xml_object_1 ::= ("" | ([ \n\t]* "<arg_key>" xml_variable_name "</arg_key>" [ \n\t]* "<arg_value>" [ \n\t]* xml_any [ \n\t]* "</arg_value>" xml_object_1))
-basic_number_7 ::= (("0") | ([1-9] [0-9]*))
-tag ::= (("<tool_call>search" root_0 "</tool_call>"))
-root ::= ((tag))
-""",
             [True, False],
         ),
-        id="glm47-forced",
+        id="glm_4_7-forced",
     ),
 ]
 
@@ -3672,12 +1380,12 @@ _TOOLS: List[Dict[str, Any]] = [
         ("llama", {"tools": _TOOLS}),
         ("kimi", {"tools": _TOOLS}),
         ("deepseek_r1", {"tools": _TOOLS}),
-        ("qwen_coder", {"tools": _TOOLS}),
-        ("qwen", {"tools": _TOOLS}),
+        ("qwen_3_coder", {"tools": _TOOLS}),
+        ("qwen_3", {"tools": _TOOLS}),
         ("deepseek_v3_2", {"tools": _TOOLS}),
         ("deepseek_v4", {"tools": _TOOLS}),
         ("minimax", {"tools": _TOOLS}),
-        ("gemma4", {"tools": _TOOLS}),
+        ("gemma_4", {"tools": _TOOLS}),
         (
             "harmony",
             {
@@ -3707,12 +1415,12 @@ def test_gemma4_instances():
     """get_model_structural_tag(gemma4) accepts/rejects instances as expected."""
 
     # --- No tools, no reasoning: plain text only ---
-    stag = get_model_structural_tag("gemma4", reasoning=False)
+    stag = get_model_structural_tag("gemma_4", reasoning=False)
     check_stag_with_instance(stag, "Hello world", True)
     check_stag_with_instance(stag, "", True)
 
     # --- No tools, reasoning enabled ---
-    stag = get_model_structural_tag("gemma4", reasoning=True)
+    stag = get_model_structural_tag("gemma_4", reasoning=True)
     check_stag_with_instance(
         stag, "<|channel>thought\nLet me think...<channel|>The answer is 42.", True
     )
@@ -3720,14 +1428,14 @@ def test_gemma4_instances():
     # Missing thinking prefix should be rejected
     check_stag_with_instance(stag, "No thinking here.", False)
 
-    # --- No tools, reasoning with force_empty_reasoning ---
-    stag = get_model_structural_tag("gemma4", reasoning=True, force_empty_reasoning=True)
+    # --- No tools, reasoning with  ---
+    stag = get_model_structural_tag("gemma_4", reasoning=True)
     check_stag_with_instance(stag, "<|channel>thought\n<channel|>Direct answer.", True)
     # Non-empty thinking should be rejected when force_empty
-    check_stag_with_instance(stag, "<|channel>thought\nSome reasoning<channel|>Answer.", False)
+    check_stag_with_instance(stag, "<|channel>thought\nSome reasoning<channel|>Answer.", True)
 
     # --- With tools, no reasoning ---
-    stag = get_model_structural_tag("gemma4", tools=_tools_gemma4, reasoning=False)
+    stag = get_model_structural_tag("gemma_4", tools=_tools_gemma_4, reasoning=False)
     check_stag_with_instance(stag, '<|tool_call>call:get_weather{"q": "Paris"}<tool_call|>', True)
     check_stag_with_instance(stag, "Plain text without tool call.", True)
     # Wrong function name should be rejected
@@ -3742,7 +1450,7 @@ def test_gemma4_instances():
     )
 
     # --- With tools, reasoning enabled ---
-    stag = get_model_structural_tag("gemma4", tools=_tools_gemma4, reasoning=True)
+    stag = get_model_structural_tag("gemma_4", tools=_tools_gemma_4, reasoning=True)
     check_stag_with_instance(
         stag,
         "<|channel>thought\nI should check the weather.<channel|>"
@@ -3752,7 +1460,3 @@ def test_gemma4_instances():
     check_stag_with_instance(
         stag, "<|channel>thought\nThinking...<channel|>Just text, no tool call.", True
     )
-
-
-if __name__ == "__main__":
-    pytest.main(sys.argv)


### PR DESCRIPTION
## Summary

- Remove `force_empty_reasoning` from the public API. `reasoning=False` now has model-specific behavior based on the chat template's non-reasoning format:
  - **Empty reasoning part** (kimi, qwen_3_5): forces the empty reasoning block (e.g. `<think></think>`)
  - **No reasoning part** (llama, qwen_3_coder, deepseek_r1, deepseek_v3_2, deepseek_v4, glm_4_7, gemma_4, minimax): omits the reasoning section entirely
  - **Strip reasoning** (qwen_3): removes the `<think>...</think>` prefix
  - **No analysis channel** (harmony): omits the analysis channel
- Rename model keys for consistency (`qwen` -> `qwen_3`, `qwen_coder` -> `qwen_3_coder`, `glm47` -> `glm_4_7`, `gemma4` -> `gemma_4`)
- Add `qwen_3_5` key for Qwen3.5/3.6 XML tool-call format with empty reasoning part
- Move exclude-token lists from module-level to function-local scope
- Change inner-function `required` tool checks from `ValueError` to `assert`
- Fix Gemma 4 `reasoning=False` to omit reasoning channel instead of forcing empty channel