### PR TITLE
fix: align builtin structural tags with chat templates for reasoning and tool calls

### DIFF
--- a/docs/api/python/builtin_structural_tag.rst
+++ b/docs/api/python/builtin_structural_tag.rst
@@ -24,7 +24,9 @@ The following model-specific APIs are registered via
 
 .. autofunction:: get_kimi_structural_tag
 
-.. autofunction:: get_deepseek_structural_tag
+.. autofunction:: get_deepseek_r1_structural_tag
+
+.. autofunction:: get_deepseek_v3_1_structural_tag
 
 .. autofunction:: get_qwen_3_coder_structural_tag
 
@@ -40,4 +42,4 @@ The following model-specific APIs are registered via
 
 .. autofunction:: get_glm_4_7_structural_tag
 
-.. autofunction:: get_gemma_4_structural_tag
+.. autofunction:: get_deepseek_v4_structural_tag

--- a/docs/structural_tag/structural_tag_api.md
+++ b/docs/structural_tag/structural_tag_api.md
@@ -791,17 +791,12 @@ Combine `tag`, `any_tokens`, and `token_triggered_tags` for that case:
 }
 ```
 
-### Built-in Model Styles
+## Built-in Model Styles
 
 If you only need a standard tool-calling layout for a supported model family, prefer the built-in
-helper instead of hand-writing every wrapper:
+helper instead of hand-writing every wrapper.
 
-- Llama / Gemma-style text wrappers
-- Qwen and Qwen Coder variants
-- Kimi
-- DeepSeek variants
-- Harmony
-- MiniMax
+Common examples include OpenAI Harmony response format, Llama, Qwen, Kimi, DeepSeek, and others.
 
 See [Tool Calling and Reasoning](tool_calling_and_reasoning) for `get_model_structural_tag` and the list of supported models.
 

--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -23,7 +23,7 @@ Use it when you need to constrain the model to output in a fixed pattern such as
 
 ### Parameters
 
-- **model** (`str`): The structural-tag style. Valid values are `"llama"`, `"qwen_3"`, `"qwen_3_5"`, `"qwen_3_coder"`, `"kimi"`, `"deepseek_r1"`, `"harmony"`, `"deepseek_v3_2"`, `"minimax"`, `"glm_4_7"`, `"gemma_4"`, `"deepseek_v4"`.
+- **model** (`str`): The structural-tag style. Valid values are `"llama"`, `"qwen_3"`, `"qwen_3_5"`, `"qwen_3_coder"`, `"kimi"`, `"deepseek_r1"`, `"deepseek_v3_1"`, `"harmony"`, `"deepseek_v3_2"`, `"minimax"`, `"glm_4_7"`, `"deepseek_v4"`.
 - **tools** (`List[ToolParam | dict]`, optional): Function and builtin tools available to the model. The list can contain two kinds of tools:
   - **Function tools** use the OpenAI Chat Completions shape:
     ```json
@@ -175,17 +175,17 @@ The `model` argument of `get_model_structural_tag` accepts the style names below
 
 | `model` (style) | Supported models |
 |-----------------|-------------------|
-| `"llama"` | Meta-Llama-3, Llama-3.1, Llama-3.2, Llama-4 |
+| `"llama"` | Meta-Llama-3, Llama-3.1, Llama-3.2 |
 | `"qwen_3"` | Qwen3, Qwen3-Next |
 | `"qwen_3_5"` | Qwen3.5, Qwen3.6 |
 | `"qwen_3_coder"` | Qwen3-Coder, Qwen3-Coder-Next |
 | `"kimi"` | Kimi-K2, Kimi-K2.5 |
-| `"deepseek_r1"` | DeepSeek-V3.1, DeepSeek-R1, DeepSeek-V3.2-exp |
+| `"deepseek_r1"` | DeepSeek-R1, DeepSeek-R1-0528 |
+| `"deepseek_v3_1"` | DeepSeek-V3.1, DeepSeek-V3.2-exp |
 | `"harmony"` | gpt-oss |
 | `"deepseek_v3_2"` | DeepSeek-V3.2 |
 | `"minimax"` | MiniMax-M2.5 |
 | `"glm_4_7"` | GLM-5, GLM-4.7 |
-| `"gemma_4"` | Gemma-4, gemma-4-12b-it, gemma-4-26b-a4b-it, gemma-4-31b-it, gemma-4-e2b-it |
 | `"deepseek_v4"` | DeepSeek-V4 |
 
 ## Extending with custom models

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -1107,7 +1107,6 @@ def get_harmony_structural_tag(
     FINAL_BEGIN = "<|channel|>final<|message|>"
     FINAL_END = ["<|end|>", "<|return|>"]
     ANALYSIS_BEGIN = "<|channel|>analysis<|message|>"
-    ANALYSIS_MESSAGE_SUFFIX = "<|message|>"
     TAG_SEPARATOR = "<|start|>assistant"
 
     def _function_tool_tags(name, parameters):
@@ -1115,7 +1114,7 @@ def get_harmony_structural_tag(
         content = JSONSchemaFormat(json_schema=parameters)
         return [
             TagFormat(
-                begin=f"<|channel|>commentary to={name}<|constrain|>json<|message|>",
+                begin=f"<|channel|>commentary to=functions.{name}<|constrain|>json<|message|>",
                 content=content,
                 end=CALL_END,
             ),
@@ -1131,12 +1130,21 @@ def get_harmony_structural_tag(
             ),
         ]
 
-    def _builtin_tool_tag(name, parameters):
-        return TagFormat(
-            begin=f"<|channel|>analysis to={name}{ANALYSIS_MESSAGE_SUFFIX}",
-            content=JSONSchemaFormat(json_schema=parameters),
-            end=CALL_END,
-        )
+    def _builtin_tool_tags(name, parameters):
+        """Generate tags for supported harmony builtin tool call formats."""
+        content = JSONSchemaFormat(json_schema=parameters)
+        return [
+            TagFormat(
+                begin=f"<|channel|>commentary to={name} code<|message|>",
+                content=content,
+                end=CALL_END,
+            ),
+            TagFormat(
+                begin=f" to={name}<|channel|>commentary code<|message|>",
+                content=content,
+                end=CALL_END,
+            ),
+        ]
 
     tools = tools or []
     builtin_tools = builtin_tools or []
@@ -1152,15 +1160,15 @@ def get_harmony_structural_tag(
         for tool in builtin_tools:
             parameters = _get_function_parameters(tool)
             name = _get_builtin_tool_name(tool)
-            tags.append(_builtin_tool_tag(name, parameters))
+            tags.extend(_builtin_tool_tags(name, parameters))
 
         final_tag = TagFormat(begin=FINAL_BEGIN, content=AnyTextFormat(), end=FINAL_END)
         tags.append(final_tag)
 
     elif tool_choice == "forced":
         if builtin_tools:
-            tags.append(
-                _builtin_tool_tag(
+            tags.extend(
+                _builtin_tool_tags(
                     _get_builtin_tool_name(builtin_tools[0]),
                     _get_function_parameters(builtin_tools[0]),
                 )
@@ -1175,7 +1183,7 @@ def get_harmony_structural_tag(
         for tool in builtin_tools:
             parameters = _get_function_parameters(tool)
             name = _get_builtin_tool_name(tool)
-            tags.append(_builtin_tool_tag(name, parameters))
+            tags.extend(_builtin_tool_tags(name, parameters))
         for tool in tools:
             function = tool.function
             parameters = _get_function_parameters(function)

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -33,6 +33,7 @@ def get_model_structural_tag(
     tools: Optional[List[Union[ToolParam, dict]]] = None,
     tool_choice: Union[ToolChoiceOptionParam, dict, None] = "auto",
     reasoning: bool = True,
+    force_reasoning: bool = False,
 ) -> StructuralTag:
     r"""Get a structural tag for a model's reasoning and tool-call output format.
 
@@ -179,6 +180,11 @@ def get_model_structural_tag(
         ``False``, use the non-reasoning mode. For models that do not support
         reasoning, this has no effect. For models that only support reasoning,
         ``False`` means reasoning with empty content.
+
+    force_reasoning : bool
+        Deprecated. Control whether to keep the reasoning part but leave its content empty.
+        Now we will embed the model's specific behavior into the structural tag function, so
+        only controlling ``reasoning`` is enough.
 
     Notes
     -----
@@ -393,7 +399,6 @@ def get_llama_structural_tag(
     - Meta-Llama-3
     - Llama-3.1
     - Llama-3.2
-    - Llama-4
 
     Returns
     -------
@@ -498,6 +503,8 @@ def get_kimi_structural_tag(
     TOOL_CALL_ARGUMENT_BEGIN = "<|tool_call_argument_begin|>"
     TOOL_CALL_END = "<|tool_call_end|>"
     TOOL_CALL_TRIGGER = "<|tool_call_begin|>"
+    TOOL_CALLS_SECTION_BEGIN = "<|tool_calls_section_begin|>"
+    TOOL_CALLS_SECTION_END = "<|tool_calls_section_end|>"
     THINK_TAG_END = "</think>"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
 
@@ -534,16 +541,22 @@ def get_kimi_structural_tag(
         if not tools:
             raise ValueError("Forced tool choice must resolve to exactly one tool.")
         function = tools[0].function
-        suffix_tag = TagFormat(
-            begin=f"{TOOL_CALL_BEGIN_PREFIX}{function.name}{TOOL_CALL_SUFFIX}",
-            content=SequenceFormat(
-                elements=[
-                    RegexFormat(pattern=r"\d+"),
-                    ConstStringFormat(value=TOOL_CALL_ARGUMENT_BEGIN),
-                    JSONSchemaFormat(json_schema=_get_function_parameters(function)),
-                ]
-            ),
-            end=TOOL_CALL_END,
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value=TOOL_CALLS_SECTION_BEGIN),
+                TagFormat(
+                    begin=f"{TOOL_CALL_BEGIN_PREFIX}{function.name}{TOOL_CALL_SUFFIX}",
+                    content=SequenceFormat(
+                        elements=[
+                            RegexFormat(pattern=r"\d+"),
+                            ConstStringFormat(value=TOOL_CALL_ARGUMENT_BEGIN),
+                            JSONSchemaFormat(json_schema=_get_function_parameters(function)),
+                        ]
+                    ),
+                    end=TOOL_CALL_END,
+                ),
+                ConstStringFormat(value=TOOL_CALLS_SECTION_END),
+            ]
         )
     elif tool_choice == "required":
         tags = []
@@ -565,7 +578,13 @@ def get_kimi_structural_tag(
                 )
             )
         assert len(tags) > 0
-        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
+        suffix_tag = SequenceFormat(
+            elements=[
+                ConstStringFormat(value=TOOL_CALLS_SECTION_BEGIN),
+                TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True),
+                ConstStringFormat(value=TOOL_CALLS_SECTION_END),
+            ]
+        )
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)
@@ -575,7 +594,7 @@ def get_kimi_structural_tag(
 
 
 @register_model_structural_tag("deepseek_r1")
-def get_deepseek_structural_tag(
+def get_deepseek_r1_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
@@ -586,28 +605,12 @@ def get_deepseek_structural_tag(
 
     Corresponding model key: ``"deepseek_r1"``.
 
-    Reference: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/tokenizer_config.json
-
-    Parameters are normalized by :func:`get_model_structural_tag` before this
-    function is called:
-
-    - ``tools``: a list of function tools. Each tool should have a ``function``
-      object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode. If ``False``, remove
-      the reasoning part and constrain only the following part.
+    Reference: https://huggingface.co/deepseek-ai/DeepSeek-R1/blob/main/tokenizer_config.json
 
     Supported models:
 
-    - DeepSeek-V3.1
     - DeepSeek-R1
-    - DeepSeek-V3.2-exp
-
-    Returns
-    -------
-    StructuralTag
-        A structural tag for function calling format.
-        This format is used by DeepSeek-R1 and other models that follow the same style.
-
+    - DeepSeek-R1-0528
     """
     TOOL_CALLS_BEGIN = "<｜tool▁calls▁begin｜>"
     TOOL_CALLS_END = "<｜tool▁calls▁end｜>"
@@ -615,7 +618,7 @@ def get_deepseek_structural_tag(
     TOOL_CALL_END = "<｜tool▁call▁end｜>"
     TOOL_SEP = "<｜tool▁sep｜>"
     JSON_RENDER_BEGIN = "\n```json\n"
-    JSON_RENDER_END = "\n```\n"
+    JSON_RENDER_END = "\n```"
     THINK_TAG_END = "</think>"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
 
@@ -629,7 +632,7 @@ def get_deepseek_structural_tag(
             name = function.name
             tags.append(
                 TagFormat(
-                    begin=f"{TOOL_CALL_BEGIN}{tool.type}{TOOL_SEP}{name}{JSON_RENDER_BEGIN}",
+                    begin=f"{TOOL_CALL_BEGIN}function{TOOL_SEP}{name}{JSON_RENDER_BEGIN}",
                     content=JSONSchemaFormat(json_schema=parameters),
                     end=f"{JSON_RENDER_END}{TOOL_CALL_END}",
                 )
@@ -652,7 +655,7 @@ def get_deepseek_structural_tag(
         function = tools[0].function
         parameters = _get_function_parameters(function)
         suffix_tag = TagFormat(
-            begin=f"{TOOL_CALLS_BEGIN}{TOOL_CALL_BEGIN}{tools[0].type}{TOOL_SEP}{function.name}{JSON_RENDER_BEGIN}",
+            begin=f"{TOOL_CALLS_BEGIN}{TOOL_CALL_BEGIN}function{TOOL_SEP}{function.name}{JSON_RENDER_BEGIN}",
             content=JSONSchemaFormat(json_schema=parameters),
             end=f"{JSON_RENDER_END}{TOOL_CALL_END}{TOOL_CALLS_END}",
         )
@@ -665,7 +668,7 @@ def get_deepseek_structural_tag(
             name = function.name
             tags.append(
                 TagFormat(
-                    begin=f"{TOOL_CALL_BEGIN}{tool.type}{TOOL_SEP}{name}{JSON_RENDER_BEGIN}",
+                    begin=f"{TOOL_CALL_BEGIN}function{TOOL_SEP}{name}{JSON_RENDER_BEGIN}",
                     content=JSONSchemaFormat(json_schema=parameters),
                     end=f"{JSON_RENDER_END}{TOOL_CALL_END}",
                 )
@@ -673,6 +676,97 @@ def get_deepseek_structural_tag(
 
         assert len(tags) > 0
         inner_tool_calls = TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True)
+        suffix_tag = TagFormat(begin=TOOL_CALLS_BEGIN, content=inner_tool_calls, end=TOOL_CALLS_END)
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
+
+    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+
+
+@register_model_structural_tag("deepseek_v3_1")
+def get_deepseek_v3_1_structural_tag(
+    tools: Optional[List[FunctionToolParam]] = None,
+    builtin_tools: Optional[List[BuiltinToolParam]] = None,
+    tool_choice: Literal["auto", "required", "forced"] = "auto",
+    reasoning: bool = True,
+    **kwargs: Any,
+) -> StructuralTag:
+    """Get DeepSeek-V3.1 style structural tag format.
+
+    Corresponding model key: ``"deepseek_v3_1"``.
+
+    Reference: https://huggingface.co/deepseek-ai/DeepSeek-V3.1/blob/main/tokenizer_config.json
+
+    Supported models:
+
+    - DeepSeek-V3.1
+    - DeepSeek-V3.2-Exp
+    """
+    TOOL_CALLS_BEGIN = "<｜tool▁calls▁begin｜>"
+    TOOL_CALLS_END = "<｜tool▁calls▁end｜>"
+    TOOL_CALL_BEGIN = "<｜tool▁call▁begin｜>"
+    TOOL_CALL_END = "<｜tool▁call▁end｜>"
+    TOOL_SEP = "<｜tool▁sep｜>"
+    THINK_TAG_END = "</think>"
+    THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
+
+    tools = tools or []
+    builtin_tools = builtin_tools or []
+    if tool_choice == "auto":
+        tags = []
+        for tool in tools:
+            function = tool.function
+            parameters = _get_function_parameters(function)
+            name = function.name
+            tags.append(
+                TagFormat(
+                    begin=f"{TOOL_CALL_BEGIN}{name}{TOOL_SEP}",
+                    content=JSONSchemaFormat(json_schema=parameters),
+                    end=TOOL_CALL_END,
+                )
+            )
+
+        if len(tags) > 0:
+            inner_tool_calls = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
+            tool_calls = TagFormat(
+                begin=TOOL_CALLS_BEGIN, content=inner_tool_calls, end=TOOL_CALLS_END
+            )
+            suffix_tag = TriggeredTagsFormat(
+                triggers=[TOOL_CALLS_BEGIN], tags=[tool_calls], excludes=THINK_EXCLUDE_TOKENS
+            )
+        else:
+            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
+
+    elif tool_choice == "forced":
+        if not tools:
+            raise ValueError("Forced tool choice must resolve to exactly one tool.")
+        function = tools[0].function
+        parameters = _get_function_parameters(function)
+        suffix_tag = TagFormat(
+            begin=f"{TOOL_CALLS_BEGIN}{TOOL_CALL_BEGIN}{function.name}{TOOL_SEP}",
+            content=JSONSchemaFormat(json_schema=parameters),
+            end=f"{TOOL_CALL_END}{TOOL_CALLS_END}",
+        )
+
+    elif tool_choice == "required":
+        tags = []
+        for tool in tools:
+            function = tool.function
+            parameters = _get_function_parameters(function)
+            name = function.name
+            tags.append(
+                TagFormat(
+                    begin=f"{TOOL_CALL_BEGIN}{name}{TOOL_SEP}",
+                    content=JSONSchemaFormat(json_schema=parameters),
+                    end=TOOL_CALL_END,
+                )
+            )
+
+        assert len(tags) > 0
+        inner_tool_calls = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
         suffix_tag = TagFormat(begin=TOOL_CALLS_BEGIN, content=inner_tool_calls, end=TOOL_CALLS_END)
 
     if not reasoning:
@@ -807,9 +901,8 @@ def get_qwen_3_5_structural_tag(
     TOOL_CALL_BEGIN_SUFFIX = ">\n"
     TOOL_CALL_END = "\n</function>\n</tool_call>"
     TOOL_CALL_TRIGGER = "<tool_call>\n<function="
-    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
-    EMPTY_THINK_CONTENT = "<think>\n\n</think>"
+    THINK_SUFFIX = "\n\n"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
     tools = tools or []
     builtin_tools = builtin_tools or []
@@ -861,11 +954,15 @@ def get_qwen_3_5_structural_tag(
         assert len(tags) > 0
         suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
 
-    if reasoning:
-        prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
-    else:
-        prefix_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
 
+    prefix_tag = SequenceFormat(
+        elements=[
+            TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END),
+            ConstStringFormat(value=THINK_SUFFIX),
+        ]
+    )
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
 
@@ -906,8 +1003,8 @@ def get_qwen_3_structural_tag(
     ARGUMENTS_FIELD_PREFIX = '", "arguments": '
     TOOL_CALL_END = "}\n</tool_call>"
     TOOL_CALL_TRIGGER = "<tool_call>"
-    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
+    THINK_SUFFIX = "\n\n"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
 
     tools = tools or []
@@ -962,9 +1059,13 @@ def get_qwen_3_structural_tag(
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
-    sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
-    return StructuralTag(format=sequence_format)
+    prefix_tag = SequenceFormat(
+        elements=[
+            TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END),
+            ConstStringFormat(value=THINK_SUFFIX),
+        ]
+    )
+    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
 
 @register_model_structural_tag("harmony")
@@ -1002,15 +1103,40 @@ def get_harmony_structural_tag(
         This format is in OpenAI Harmony Response Format, which is used by GPT-oss
         and other models that follow the same style.
     """
-    COMMENTARY_CHANNEL_PREFIX = "<|channel|>commentary to="
-    JSON_CONSTRAIN_SUFFIX = "<|constrain|>json<|message|>"
-    FUNCTION_NAME_PREFIX = "functions."
-    ANALYSIS_MESSAGE_SUFFIX = "<|message|>"
     CALL_END = "<|call|>"
     FINAL_BEGIN = "<|channel|>final<|message|>"
-    FINAL_END = "<|end|>"
+    FINAL_END = ["<|end|>", "<|return|>"]
     ANALYSIS_BEGIN = "<|channel|>analysis<|message|>"
+    ANALYSIS_MESSAGE_SUFFIX = "<|message|>"
     TAG_SEPARATOR = "<|start|>assistant"
+
+    def _function_tool_tags(name, parameters):
+        """Generate tags for all supported harmony function tool call formats."""
+        content = JSONSchemaFormat(json_schema=parameters)
+        return [
+            TagFormat(
+                begin=f"<|channel|>commentary to={name}<|constrain|>json<|message|>",
+                content=content,
+                end=CALL_END,
+            ),
+            TagFormat(
+                begin=f" to=functions.{name}<|channel|>commentary <|constrain|>json<|message|>",
+                content=content,
+                end=CALL_END,
+            ),
+            TagFormat(
+                begin=f" to=functions.{name}<|channel|>commentary json<|message|>",
+                content=content,
+                end=CALL_END,
+            ),
+        ]
+
+    def _builtin_tool_tag(name, parameters):
+        return TagFormat(
+            begin=f"<|channel|>analysis to={name}{ANALYSIS_MESSAGE_SUFFIX}",
+            content=JSONSchemaFormat(json_schema=parameters),
+            end=CALL_END,
+        )
 
     tools = tools or []
     builtin_tools = builtin_tools or []
@@ -1021,70 +1147,39 @@ def get_harmony_structural_tag(
         for tool in tools:
             function = tool.function
             parameters = _get_function_parameters(function)
-            name = function.name
-            tags.append(
-                TagFormat(
-                    begin=f"{COMMENTARY_CHANNEL_PREFIX}{FUNCTION_NAME_PREFIX}{name}{JSON_CONSTRAIN_SUFFIX}",
-                    content=JSONSchemaFormat(json_schema=parameters),
-                    end=CALL_END,
-                )
-            )
+            tags.extend(_function_tool_tags(function.name, parameters))
 
         for tool in builtin_tools:
             parameters = _get_function_parameters(tool)
             name = _get_builtin_tool_name(tool)
-            tags.append(
-                TagFormat(
-                    begin=f"{COMMENTARY_CHANNEL_PREFIX}{name}{ANALYSIS_MESSAGE_SUFFIX}",
-                    content=JSONSchemaFormat(json_schema=parameters),
-                    end=CALL_END,
-                )
-            )
+            tags.append(_builtin_tool_tag(name, parameters))
+
         final_tag = TagFormat(begin=FINAL_BEGIN, content=AnyTextFormat(), end=FINAL_END)
         tags.append(final_tag)
 
     elif tool_choice == "forced":
         if builtin_tools:
-            forced_tool = builtin_tools[0]
-            forced_tag = TagFormat(
-                begin=f"{COMMENTARY_CHANNEL_PREFIX}{_get_builtin_tool_name(forced_tool)}{ANALYSIS_MESSAGE_SUFFIX}",
-                content=JSONSchemaFormat(json_schema=_get_function_parameters(forced_tool)),
-                end=CALL_END,
+            tags.append(
+                _builtin_tool_tag(
+                    _get_builtin_tool_name(builtin_tools[0]),
+                    _get_function_parameters(builtin_tools[0]),
+                )
             )
         elif tools:
             function = tools[0].function
-            forced_tag = TagFormat(
-                begin=f"{COMMENTARY_CHANNEL_PREFIX}{FUNCTION_NAME_PREFIX}{function.name}{JSON_CONSTRAIN_SUFFIX}",
-                content=JSONSchemaFormat(json_schema=_get_function_parameters(function)),
-                end=CALL_END,
-            )
+            tags.extend(_function_tool_tags(function.name, _get_function_parameters(function)))
         else:
             raise ValueError("Forced tool choice must resolve to exactly one tool.")
-
-        tags.append(forced_tag)
 
     elif tool_choice == "required":
         for tool in builtin_tools:
             parameters = _get_function_parameters(tool)
             name = _get_builtin_tool_name(tool)
-            tags.append(
-                TagFormat(
-                    begin=f"{COMMENTARY_CHANNEL_PREFIX}{name}{ANALYSIS_MESSAGE_SUFFIX}",
-                    content=JSONSchemaFormat(json_schema=parameters),
-                    end=CALL_END,
-                )
-            )
+            tags.append(_builtin_tool_tag(name, parameters))
         for tool in tools:
             function = tool.function
             parameters = _get_function_parameters(function)
-            name = function.name
-            tags.append(
-                TagFormat(
-                    begin=f"{COMMENTARY_CHANNEL_PREFIX}{FUNCTION_NAME_PREFIX}{name}{JSON_CONSTRAIN_SUFFIX}",
-                    content=JSONSchemaFormat(json_schema=parameters),
-                    end=CALL_END,
-                )
-            )
+            tags.extend(_function_tool_tags(function.name, parameters))
         assert len(tags) > 0
 
     if reasoning:
@@ -1114,8 +1209,9 @@ def get_deepseek_v3_2_structural_tag(
     INVOKE_BEGIN_PREFIX = '<｜DSML｜invoke name="'
     INVOKE_BEGIN_SUFFIX = '">\n'
     INVOKE_END = "</｜DSML｜invoke>\n"
+    TOOL_CALLS_PREFIX = "\n\n"
     FUNCTION_CALLS_BEGIN = "<｜DSML｜function_calls>\n"
-    FUNCTION_CALLS_END = "</｜DSML｜function_calls>\n"
+    FUNCTION_CALLS_END = "</｜DSML｜function_calls>"
     FUNCTION_CALLS_TRIGGER = "<｜DSML｜function_calls>"
     THINK_TAG_END = "</think>"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
@@ -1163,7 +1259,7 @@ def get_deepseek_v3_2_structural_tag(
         function = tools[0].function
         suffix_tag = SequenceFormat(
             elements=[
-                ConstStringFormat(value=FUNCTION_CALLS_BEGIN),
+                ConstStringFormat(value=TOOL_CALLS_PREFIX + FUNCTION_CALLS_BEGIN),
                 TagFormat(
                     begin=(INVOKE_BEGIN_PREFIX + function.name + INVOKE_BEGIN_SUFFIX),
                     content=JSONSchemaFormat(
@@ -1190,7 +1286,7 @@ def get_deepseek_v3_2_structural_tag(
         assert len(tags) > 0
         suffix_tag = SequenceFormat(
             elements=[
-                ConstStringFormat(value=FUNCTION_CALLS_BEGIN),
+                ConstStringFormat(value=TOOL_CALLS_PREFIX + FUNCTION_CALLS_BEGIN),
                 TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True),
                 ConstStringFormat(value=FUNCTION_CALLS_END),
             ]
@@ -1231,7 +1327,7 @@ def get_minimax_structural_tag(
     INVOKE_BEGIN_SUFFIX = '">\n'
     INVOKE_END = "</invoke>\n"
     TOOL_CALL_BEGIN = "<minimax:tool_call>\n"
-    TOOL_CALL_END = "</minimax:tool_call>\n"
+    TOOL_CALL_END = "</minimax:tool_call>"
     TOOL_CALL_TRIGGER = "<minimax:tool_call>"
     THINK_TAG_END = "</think>"
     THINK_SUFFIX = "\n\n"
@@ -1279,7 +1375,7 @@ def get_minimax_structural_tag(
         function = tools[0].function
         suffix_tag = SequenceFormat(
             elements=[
-                ConstStringFormat(value=TOOL_CALL_BEGIN),
+                ConstStringFormat(value="\n" + TOOL_CALL_BEGIN),
                 TagFormat(
                     begin=(INVOKE_BEGIN_PREFIX + function.name + INVOKE_BEGIN_SUFFIX),
                     content=JSONSchemaFormat(
@@ -1306,7 +1402,7 @@ def get_minimax_structural_tag(
         assert len(tags) > 0
         suffix_tag = SequenceFormat(
             elements=[
-                ConstStringFormat(value=TOOL_CALL_BEGIN),
+                ConstStringFormat(value="\n" + TOOL_CALL_BEGIN),
                 TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True),
                 ConstStringFormat(value=TOOL_CALL_END),
             ]
@@ -1423,8 +1519,10 @@ def get_glm_4_7_structural_tag(
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
 
-@register_model_structural_tag("gemma_4")
-def get_gemma_4_structural_tag(
+# TODO: We are dropping Gemma support because its parameter format is special and not supported
+# yet: the string are wrapped by <|"|> instead of ". We will support it later and get it back.
+# @register_model_structural_tag("gemma_4")
+def _get_gemma_4_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
@@ -1549,8 +1647,9 @@ def get_deepseek_v4_structural_tag(
     INVOKE_BEGIN_PREFIX = '<｜DSML｜invoke name="'
     INVOKE_BEGIN_SUFFIX = '">\n'
     INVOKE_END = "</｜DSML｜invoke>\n"
+    TOOL_CALLS_PREFIX = "\n\n"
     FUNCTION_CALLS_BEGIN = "<｜DSML｜tool_calls>\n"
-    FUNCTION_CALLS_END = "</｜DSML｜tool_calls>\n"
+    FUNCTION_CALLS_END = "</｜DSML｜tool_calls>"
     FUNCTION_CALLS_TRIGGER = "<｜DSML｜tool_calls>"
     THINK_TAG_END = "</think>"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
@@ -1598,7 +1697,7 @@ def get_deepseek_v4_structural_tag(
         function = tools[0].function
         suffix_tag = SequenceFormat(
             elements=[
-                ConstStringFormat(value=FUNCTION_CALLS_BEGIN),
+                ConstStringFormat(value=TOOL_CALLS_PREFIX + FUNCTION_CALLS_BEGIN),
                 TagFormat(
                     begin=(INVOKE_BEGIN_PREFIX + function.name + INVOKE_BEGIN_SUFFIX),
                     content=JSONSchemaFormat(
@@ -1625,7 +1724,7 @@ def get_deepseek_v4_structural_tag(
         assert len(tags) > 0
         suffix_tag = SequenceFormat(
             elements=[
-                ConstStringFormat(value=FUNCTION_CALLS_BEGIN),
+                ConstStringFormat(value=TOOL_CALLS_PREFIX + FUNCTION_CALLS_BEGIN),
                 TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True),
                 ConstStringFormat(value=FUNCTION_CALLS_END),
             ]

--- a/tests/python/encoding_dsv32.py
+++ b/tests/python/encoding_dsv32.py
@@ -1,0 +1,432 @@
+# Adapted from https://huggingface.co/deepseek-ai/DeepSeek-V3.2/blob/main/encoding/encoding_dsv32.py
+# Used by test_builtin_structural_tag_alignment.py for DeepSeek-V3.2 output extraction.
+import copy
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+
+class DS32EncodingError(Exception):
+    pass
+
+
+TOOLS_SYSTEM_TEMPLATE = """## Tools
+You have access to a set of tools you can use to answer the user's question.
+You can invoke functions by writing a "<{dsml_token}function_calls>" block like the following as part of your reply to the user:
+<{dsml_token}function_calls>
+<{dsml_token}invoke name="$FUNCTION_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$FUNCTION_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}function_calls>
+String and scalar parameters should be specified as is without any escaping or quotes, while lists and objects should use JSON format. The "string" attribute should be set to "true" for string type parameters and "false" for other types (numbers, booleans, arrays, objects).
+If the thinking_mode is enabled, then after function results you should strongly consider outputting a thinking block. Here is an example:
+<{dsml_token}function_calls>
+...
+</{dsml_token}function_calls>
+<function_results>
+...
+</function_results>
+{thinking_start_token}...thinking about results{thinking_end_token}
+Here are the functions available in JSONSchema format:
+<functions>
+{tool_schemas}
+</functions>
+"""
+
+bos_token: str = "<｜begin▁of▁sentence｜>"
+eos_token: str = "<｜end▁of▁sentence｜>"
+thinking_start_token: str = "<think>"
+thinking_end_token: str = "</think>"
+dsml_token: str = "｜DSML｜"
+system_msg_template: str = "{content}"
+user_msg_template: str = "<｜User｜>{content}<｜Assistant｜>"
+assistant_msg_template: str = "{reasoning}{content}{tool_calls}<｜end▁of▁sentence｜>"
+thinking_template = "{reasoning_content}"
+
+response_format_template: str = (
+    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}"
+)
+tool_call_template: str = '<{dsml_token}invoke name="{name}">\n{arguments}\n</{dsml_token}invoke>'
+tool_calls_template = "<{dsml_token}function_calls>\n{tool_calls}\n</{dsml_token}function_calls>"
+
+tool_output_template: str = "\n<result>{content}</result>"
+
+
+def to_json(value: Any) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except:
+        return json.dumps(value, ensure_ascii=True)
+
+
+def tools_from_openai_format(tools):
+    return [tool["function"] for tool in tools]
+
+
+def tool_calls_from_openai_format(tool_calls):
+    return [
+        {"name": tool_call["function"]["name"], "arguments": tool_call["function"]["arguments"]}
+        for tool_call in tool_calls
+    ]
+
+
+def tool_calls_to_openai_format(tool_calls):
+    return [
+        {
+            "type": "function",
+            "function": {"name": tool_call["name"], "arguments": tool_call["arguments"]},
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
+    p_dsml_template = (
+        """<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>"""
+    )
+    P_dsml_strs = []
+
+    arguments = json.loads(tool_call["arguments"])
+
+    for k, v in arguments.items():
+        p_dsml_str = p_dsml_template.format(
+            dsml_token=dsml_token,
+            key=k,
+            is_str="true" if isinstance(v, str) else "false",
+            value=v if isinstance(v, str) else to_json(v),
+        )
+
+        P_dsml_strs.append(p_dsml_str)
+
+    return "\n".join(P_dsml_strs)
+
+
+def decode_dsml_to_arguments(
+    tool_name: str, tool_args: Dict[str, Tuple[str, str]]
+) -> Dict[str, str]:
+    def _decode_value(key: str, value: str, string: str):
+        if string == "true":
+            value = to_json(value)
+        return f"{to_json(key)}: {value}"
+
+    tool_args_json = (
+        "{"
+        + ", ".join([_decode_value(k, v, string=is_str) for k, (v, is_str) in tool_args.items()])
+        + "}"
+    )
+    return dict(name=tool_name, arguments=tool_args_json)
+
+
+def render_tools(tools: List[Dict[str, Union[str, Dict[str, Any]]]]) -> str:
+    tools_json = [to_json(t) for t in tools]
+
+    return TOOLS_SYSTEM_TEMPLATE.format(
+        tool_schemas="\n".join(tools_json),
+        dsml_token=dsml_token,
+        thinking_start_token=thinking_start_token,
+        thinking_end_token=thinking_end_token,
+    )
+
+
+def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
+    last_user_index = -1
+    for idx in range(len(messages) - 1, -1, -1):
+        if messages[idx].get("role") in ["user", "developer"]:
+            last_user_index = idx
+            break
+    return last_user_index
+
+
+def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: str) -> str:
+    if not (0 <= index < len(messages)):
+        raise DS32EncodingError(
+            f"Index {index} out of range for messages list of length {len(messages)}"
+        )
+    if thinking_mode not in ["chat", "thinking"]:
+        raise DS32EncodingError(f"Invalid thinking_mode `{thinking_mode}`")
+
+    prompt = ""
+    msg = messages[index]
+    last_user_idx = find_last_user_index(messages)
+
+    role = msg.get("role")
+    content = msg.get("content")
+    tools = msg.get("tools")
+    response_format = msg.get("response_format")
+    tool_calls = msg.get("tool_calls")
+    reasoning_content = msg.get("reasoning_content")
+
+    if tools:
+        tools = tools_from_openai_format(tools)
+    if tool_calls:
+        tool_calls = tool_calls_from_openai_format(tool_calls)
+
+    if role == "system":
+        prompt += system_msg_template.format(content=content or "")
+        if tools:
+            prompt += "\n\n" + render_tools(tools)
+
+        if response_format:
+            prompt += "\n\n" + response_format_template.format(schema=to_json(response_format))
+
+    elif role == "developer":
+        if not content:
+            raise DS32EncodingError(f"Invalid message for role `{role}`: {msg}")
+        content_developer = ""
+        if tools:
+            content_developer += "\n\n" + render_tools(tools)
+
+        if response_format:
+            content_developer += "\n\n" + response_format_template.format(
+                schema=to_json(response_format)
+            )
+
+        content_developer += "\n\n# The user's message is: {}".format(content)
+
+        prompt += user_msg_template.format(content=content_developer)
+        if index == last_user_idx and thinking_mode == "thinking":
+            prompt += thinking_start_token
+        else:
+            prompt += thinking_end_token
+
+    elif role == "user":
+        prompt += user_msg_template.format(content=content)
+
+        if index == last_user_idx and thinking_mode == "thinking":
+            prompt += thinking_start_token
+        else:
+            prompt += thinking_end_token
+
+    elif role == "tool":
+        prev_assistant_idx = index - 1
+        assistant_msg = messages[prev_assistant_idx]
+        while prev_assistant_idx >= 0 and assistant_msg.get("role") == "tool":
+            prev_assistant_idx -= 1
+            assistant_msg = messages[prev_assistant_idx]
+
+        if not (
+            index == 0 or (prev_assistant_idx >= 0 and assistant_msg.get("role") == "assistant")
+        ):
+            raise DS32EncodingError(f"Invalid messages at {index}:\n{assistant_msg}")
+
+        tool_call_order = index - prev_assistant_idx
+        assistant_tool_calls = assistant_msg.get("tool_calls")
+        if not (assistant_tool_calls and len(assistant_tool_calls) >= tool_call_order):
+            raise DS32EncodingError("No tool calls but found tool output")
+
+        if tool_call_order == 1:
+            prompt += "\n\n<function_results>"
+
+        prompt += tool_output_template.format(content=content)
+
+        if tool_call_order == len(assistant_tool_calls):
+            prompt += "\n</function_results>"
+
+            if index >= last_user_idx and thinking_mode == "thinking":
+                prompt += "\n\n" + thinking_start_token
+            else:
+                prompt += "\n\n" + thinking_end_token
+
+    elif role == "assistant":
+        prev_assistant_idx = index
+        thinking_part = ""
+
+        tool_calls_content = ""
+        if tool_calls:
+            tool_calls = [
+                tool_call_template.format(
+                    dsml_token=dsml_token,
+                    name=tool_call.get("name"),
+                    arguments=encode_arguments_to_dsml(tool_call),
+                )
+                for tool_call in tool_calls
+            ]
+            tool_calls_content += "\n\n" + tool_calls_template.format(
+                dsml_token=dsml_token, tool_calls="\n".join(tool_calls)
+            )
+
+        summary_content = content or ""
+
+        if thinking_mode == "thinking" and index > last_user_idx:
+            if not (reasoning_content or tool_calls):
+                raise DS32EncodingError(
+                    f"ThinkingMode: {thinking_mode}, invalid message without reasoning_content/tool_calls `{msg}` after last user message"
+                )
+            thinking_part = (
+                thinking_template.format(reasoning_content=reasoning_content or "")
+                + thinking_end_token
+            )
+
+        prompt += assistant_msg_template.format(
+            reasoning=thinking_part, content=summary_content, tool_calls=tool_calls_content
+        )
+    else:
+        raise NotImplementedError(f"Unknown role: {role}")
+
+    return prompt
+
+
+def drop_thinking_messages(
+    messages: List[Dict[str, Any]], last_user_idx: Optional[int] = None
+) -> List[Dict[str, Any]]:
+    messages_wo_thinking: List[Dict[str, Any]] = []
+    last_user_idx = find_last_user_index(messages) if last_user_idx is None else last_user_idx
+    for idx, msg in enumerate(messages):
+        role = msg.get("role")
+        if role in ["user", "system", "tool"] or idx >= last_user_idx:
+            messages_wo_thinking.append(msg)
+            continue
+
+        elif role == "assistant":
+            msg_wo_thinking = copy.copy(msg)
+            msg_wo_thinking.pop("reasoning_content", None)
+            messages_wo_thinking.append(msg_wo_thinking)
+
+    return messages_wo_thinking
+
+
+def encode_messages(
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    context: Optional[List[Dict[str, Any]]] = None,
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+) -> str:
+    context = context if context else []
+    full_messages = context + messages
+
+    prompt = bos_token if add_default_bos_token and len(context) == 0 else ""
+
+    if thinking_mode == "thinking" and drop_thinking:
+        full_messages = drop_thinking_messages(full_messages)
+
+    for idx in range(len(messages)):
+        prompt += render_message(idx + len(context), full_messages, thinking_mode=thinking_mode)
+
+    return prompt
+
+
+def _read_until_stop(index: int, text: str, stop: List[str]) -> Tuple[int, str, Optional[str]]:
+    min_pos = len(text)
+    matched_stop = None
+
+    for s in stop:
+        pos = text.find(s, index)
+        if pos != -1 and pos < min_pos:
+            min_pos = pos
+            matched_stop = s
+
+    if matched_stop:
+        content = text[index:min_pos]
+        return min_pos + len(matched_stop), content, matched_stop
+    else:
+        content = text[index:]
+        return len(text), content, None
+
+
+def parse_tool_calls(index: int, text: str):
+    tool_calls: List[Dict[str, Any]] = []
+    stop_token = None
+    tool_calls_end_token = f"</{dsml_token}function_calls>"
+
+    while index < len(text):
+        index, _, stop_token = _read_until_stop(
+            index, text, [f"<{dsml_token}invoke", tool_calls_end_token]
+        )
+        if _ != ">\n":
+            raise DS32EncodingError("Tool call format error")
+
+        if stop_token == tool_calls_end_token:
+            break
+
+        if stop_token is None:
+            raise DS32EncodingError("Missing special token")
+
+        index, tool_name_content, stop_token = _read_until_stop(
+            index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"]
+        )
+
+        p_tool_name = re.findall(r'^\s*name="(.*?)">\n$', tool_name_content, flags=re.DOTALL)
+        if len(p_tool_name) != 1:
+            raise DS32EncodingError("Tool name format error")
+        tool_name = p_tool_name[0]
+
+        tool_args: Dict[str, Tuple[str, str]] = {}
+        while stop_token == f"<{dsml_token}parameter":
+            index, param_content, stop_token = _read_until_stop(
+                index, text, [f"/{dsml_token}parameter"]
+            )
+
+            param_kv = re.findall(
+                r'^ name="(.*?)" string="(true|false)">(.*?)<$', param_content, flags=re.DOTALL
+            )
+            if len(param_kv) != 1:
+                raise DS32EncodingError("Parameter format error")
+            param_name, string, param_value = param_kv[0]
+
+            if param_name in tool_args:
+                raise DS32EncodingError("Duplicate parameter name")
+            tool_args[param_name] = (param_value, string)
+
+            index, content, stop_token = _read_until_stop(
+                index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"]
+            )
+            if content != ">\n":
+                raise DS32EncodingError("Parameter format error")
+
+        tool_call = decode_dsml_to_arguments(tool_name=tool_name, tool_args=tool_args)
+        tool_calls.append(tool_call)
+
+    return index, stop_token, tool_calls
+
+
+# NOTE: This function is designed to parse only correctly formatted string and will not attempt to correct malformed output that may be generated by the model.
+def parse_message_from_completion_text(text: str, thinking_mode: str):
+    summary_content, reasoning_content, tool_calls = "", "", []
+    index, stop_token = 0, None
+    tool_calls_start_token = f"\n\n<{dsml_token}function_calls"
+
+    is_thinking, is_tool_calling = thinking_mode == "thinking", False
+
+    if is_thinking:
+        index, content_delta, stop_token = _read_until_stop(
+            index, text, [thinking_end_token, tool_calls_start_token]
+        )
+        reasoning_content = content_delta
+        if stop_token != thinking_end_token:
+            raise DS32EncodingError("Invalid thinking format")
+
+    index, content_delta, stop_token = _read_until_stop(
+        index, text, [eos_token, tool_calls_start_token]
+    )
+    summary_content = content_delta
+    if stop_token == tool_calls_start_token:
+        is_tool_calling = True
+    else:
+        if stop_token != eos_token:
+            raise DS32EncodingError("Invalid summary format")
+
+    if is_tool_calling:
+        index, stop_token, tool_calls = parse_tool_calls(index, text)
+
+        index, tool_ends_text, stop_token = _read_until_stop(index, text, [eos_token])
+        if tool_ends_text:
+            raise DS32EncodingError("Unexpected content after tool calls")
+
+    if not (len(text) == index and stop_token in [eos_token, None]):
+        raise DS32EncodingError("Unexpected content at end")
+
+    for sp_token in [bos_token, eos_token, thinking_start_token, thinking_end_token, dsml_token]:
+        if sp_token in summary_content or sp_token in reasoning_content:
+            raise DS32EncodingError("Unexpected special token in content")
+
+    return {
+        "role": "assistant",
+        "content": summary_content,
+        "reasoning_content": reasoning_content,
+        "tool_calls": tool_calls_to_openai_format(tool_calls),
+    }

--- a/tests/python/encoding_dsv4.py
+++ b/tests/python/encoding_dsv4.py
@@ -1,0 +1,774 @@
+"""DeepSeek-V4 Encoding
+
+Adapted from https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/encoding/encoding_dsv4.py
+Used by test_builtin_structural_tag_alignment.py for DeepSeek-V4 output extraction.
+"""
+
+import copy
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+# ============================================================
+# Special Tokens
+# ============================================================
+
+bos_token: str = "<｜begin▁of▁sentence｜>"
+eos_token: str = "<｜end▁of▁sentence｜>"
+thinking_start_token: str = "<think>"
+thinking_end_token: str = "</think>"
+dsml_token: str = "｜DSML｜"
+
+USER_SP_TOKEN = "<｜User｜>"
+ASSISTANT_SP_TOKEN = "<｜Assistant｜>"
+LATEST_REMINDER_SP_TOKEN = "<｜latest_reminder｜>"
+
+# Task special tokens for internal classification tasks
+DS_TASK_SP_TOKENS = {
+    "action": "<｜action｜>",
+    "query": "<｜query｜>",
+    "authority": "<｜authority｜>",
+    "domain": "<｜domain｜>",
+    "title": "<｜title｜>",
+    "read_url": "<｜read_url｜>",
+}
+VALID_TASKS = set(DS_TASK_SP_TOKENS.keys())
+
+# ============================================================
+# Templates
+# ============================================================
+
+system_msg_template: str = "{content}"
+user_msg_template: str = "{content}"
+latest_reminder_msg_template: str = "{content}"
+assistant_msg_template: str = "{reasoning}{content}{tool_calls}" + eos_token
+assistant_msg_wo_eos_template: str = "{reasoning}{content}{tool_calls}"
+thinking_template: str = "{reasoning_content}"
+
+response_format_template: str = (
+    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}"
+)
+tool_call_template: str = '<{dsml_token}invoke name="{name}">\n{arguments}\n</{dsml_token}invoke>'
+tool_calls_template = "<{dsml_token}{tc_block_name}>\n{tool_calls}\n</{dsml_token}{tc_block_name}>"
+tool_calls_block_name: str = "tool_calls"
+
+tool_output_template: str = "<tool_result>{content}</tool_result>"
+
+REASONING_EFFORT_MAX = (
+    "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+    "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
+    "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+)
+
+TOOLS_TEMPLATE = """## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml_token}tool_calls>" block like the following:
+
+<{dsml_token}tool_calls>
+<{dsml_token}invoke name="$TOOL_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$TOOL_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}tool_calls>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by {thinking_start_token}), you MUST output your complete reasoning inside {thinking_start_token}...{thinking_end_token} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {thinking_end_token} with tool calls or final response.
+
+### Available Tool Schemas
+
+{tool_schemas}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"""
+
+# ============================================================
+# Utility Functions
+# ============================================================
+
+
+def to_json(value: Any) -> str:
+    """Serialize a value to JSON string."""
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except:
+        return json.dumps(value, ensure_ascii=True)
+
+
+def tools_from_openai_format(tools):
+    """Extract function definitions from OpenAI-format tool list."""
+    return [tool["function"] for tool in tools]
+
+
+def tool_calls_from_openai_format(tool_calls):
+    """Convert OpenAI-format tool calls to internal format."""
+    return [
+        {"name": tool_call["function"]["name"], "arguments": tool_call["function"]["arguments"]}
+        for tool_call in tool_calls
+    ]
+
+
+def tool_calls_to_openai_format(tool_calls):
+    """Convert internal tool calls to OpenAI format."""
+    return [
+        {
+            "type": "function",
+            "function": {"name": tool_call["name"], "arguments": tool_call["arguments"]},
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
+    """
+    Encode tool call arguments into DSML parameter format.
+
+    Args:
+        tool_call: Dict with "name" and "arguments" (JSON string) keys.
+
+    Returns:
+        DSML-formatted parameter string.
+    """
+    p_dsml_template = (
+        '<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>'
+    )
+    P_dsml_strs = []
+
+    try:
+        arguments = json.loads(tool_call["arguments"])
+    except Exception as err:
+        arguments = {"arguments": tool_call["arguments"]}
+
+    for k, v in arguments.items():
+        p_dsml_str = p_dsml_template.format(
+            dsml_token=dsml_token,
+            key=k,
+            is_str="true" if isinstance(v, str) else "false",
+            value=v if isinstance(v, str) else to_json(v),
+        )
+        P_dsml_strs.append(p_dsml_str)
+
+    return "\n".join(P_dsml_strs)
+
+
+def decode_dsml_to_arguments(
+    tool_name: str, tool_args: Dict[str, Tuple[str, str]]
+) -> Dict[str, str]:
+    """
+    Decode DSML parameters back to a tool call dict.
+
+    Args:
+        tool_name: Name of the tool.
+        tool_args: Dict mapping param_name -> (value, is_string_flag).
+
+    Returns:
+        Dict with "name" and "arguments" (JSON string) keys.
+    """
+
+    def _decode_value(key: str, value: str, string: str):
+        if string == "true":
+            value = to_json(value)
+        return f"{to_json(key)}: {value}"
+
+    tool_args_json = (
+        "{"
+        + ", ".join([_decode_value(k, v, string=is_str) for k, (v, is_str) in tool_args.items()])
+        + "}"
+    )
+    return dict(name=tool_name, arguments=tool_args_json)
+
+
+def render_tools(tools: List[Dict[str, Union[str, Dict[str, Any]]]]) -> str:
+    """
+    Render tool schemas into the system prompt format.
+
+    Args:
+        tools: List of tool schema dicts (each with name, description, parameters).
+
+    Returns:
+        Formatted tools section string.
+    """
+    tools_json = [to_json(t) for t in tools]
+
+    return TOOLS_TEMPLATE.format(
+        tool_schemas="\n".join(tools_json),
+        dsml_token=dsml_token,
+        thinking_start_token=thinking_start_token,
+        thinking_end_token=thinking_end_token,
+    )
+
+
+def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
+    """Find the index of the last user/developer message."""
+    last_user_index = -1
+    for idx in range(len(messages) - 1, -1, -1):
+        if messages[idx].get("role") in ["user", "developer"]:
+            last_user_index = idx
+            break
+    return last_user_index
+
+
+# ============================================================
+# Message Rendering
+# ============================================================
+
+
+def render_message(
+    index: int,
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    drop_thinking: bool = True,
+    reasoning_effort: Optional[str] = None,
+) -> str:
+    """
+    Render a single message at the given index into its encoded string form.
+
+    This is the core function that converts each message in the conversation
+    into the DeepSeek-V4 format.
+
+    Args:
+        index: Index of the message to render.
+        messages: Full list of messages in the conversation.
+        thinking_mode: Either "chat" or "thinking".
+        drop_thinking: Whether to drop reasoning content from earlier turns.
+        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+
+    Returns:
+        Encoded string for this message.
+    """
+    assert 0 <= index < len(messages)
+    assert thinking_mode in ["chat", "thinking"], f"Invalid thinking_mode `{thinking_mode}`"
+
+    prompt = ""
+    msg = messages[index]
+    last_user_idx = find_last_user_index(messages)
+
+    role = msg.get("role")
+    content = msg.get("content")
+    tools = msg.get("tools")
+    response_format = msg.get("response_format")
+    tool_calls = msg.get("tool_calls")
+    reasoning_content = msg.get("reasoning_content")
+    wo_eos = msg.get("wo_eos", False)
+
+    if tools:
+        tools = tools_from_openai_format(tools)
+    if tool_calls:
+        tool_calls = tool_calls_from_openai_format(tool_calls)
+
+    # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
+    assert reasoning_effort in [
+        "max",
+        None,
+        "high",
+    ], f"Invalid reasoning effort: {reasoning_effort}"
+    if index == 0 and thinking_mode == "thinking" and reasoning_effort == "max":
+        prompt += REASONING_EFFORT_MAX
+
+    if role == "system":
+        prompt += system_msg_template.format(content=content or "")
+        if tools:
+            prompt += "\n\n" + render_tools(tools)
+        if response_format:
+            prompt += "\n\n" + response_format_template.format(schema=to_json(response_format))
+
+    elif role == "developer":
+        assert content, f"Invalid message for role `{role}`: {msg}"
+
+        content_developer = USER_SP_TOKEN
+        content_developer += content
+
+        if tools:
+            content_developer += "\n\n" + render_tools(tools)
+        if response_format:
+            content_developer += "\n\n" + response_format_template.format(
+                schema=to_json(response_format)
+            )
+
+        prompt += user_msg_template.format(content=content_developer)
+
+    elif role == "user":
+        prompt += USER_SP_TOKEN
+
+        # Handle content blocks (tool results mixed with text)
+        content_blocks = msg.get("content_blocks")
+        if content_blocks:
+            parts = []
+            for block in content_blocks:
+                block_type = block.get("type")
+                if block_type == "text":
+                    parts.append(block.get("text", ""))
+                elif block_type == "tool_result":
+                    tool_content = block.get("content", "")
+                    if isinstance(tool_content, list):
+                        text_parts = []
+                        for b in tool_content:
+                            if b.get("type") == "text":
+                                text_parts.append(b.get("text", ""))
+                            else:
+                                text_parts.append(f"[Unsupported {b.get('type')}]")
+                        tool_content = "\n\n".join(text_parts)
+                    parts.append(tool_output_template.format(content=tool_content))
+                else:
+                    parts.append(f"[Unsupported {block_type}]")
+            prompt += "\n\n".join(parts)
+        else:
+            prompt += content or ""
+
+    elif role == "latest_reminder":
+        prompt += LATEST_REMINDER_SP_TOKEN + latest_reminder_msg_template.format(content=content)
+
+    elif role == "tool":
+        raise NotImplementedError(
+            "deepseek_v4 merges tool messages into user; please preprocess with merge_tool_messages()"
+        )
+
+    elif role == "assistant":
+        thinking_part = ""
+        tc_content = ""
+
+        if tool_calls:
+            tc_list = [
+                tool_call_template.format(
+                    dsml_token=dsml_token,
+                    name=tc.get("name"),
+                    arguments=encode_arguments_to_dsml(tc),
+                )
+                for tc in tool_calls
+            ]
+            tc_content += "\n\n" + tool_calls_template.format(
+                dsml_token=dsml_token,
+                tool_calls="\n".join(tc_list),
+                tc_block_name=tool_calls_block_name,
+            )
+
+        summary_content = content or ""
+        rc = reasoning_content or ""
+
+        # Check if previous message has a task - if so, this is a task output (no thinking)
+        prev_has_task = index - 1 >= 0 and messages[index - 1].get("task") is not None
+
+        if thinking_mode == "thinking" and not prev_has_task:
+            if not drop_thinking or index > last_user_idx:
+                thinking_part = thinking_template.format(reasoning_content=rc) + thinking_end_token
+            else:
+                thinking_part = ""
+
+        if wo_eos:
+            prompt += assistant_msg_wo_eos_template.format(
+                reasoning=thinking_part, content=summary_content, tool_calls=tc_content
+            )
+        else:
+            prompt += assistant_msg_template.format(
+                reasoning=thinking_part, content=summary_content, tool_calls=tc_content
+            )
+    else:
+        raise NotImplementedError(f"Unknown role: {role}")
+
+    # Append transition tokens based on what follows
+    if index + 1 < len(messages) and messages[index + 1].get("role") not in [
+        "assistant",
+        "latest_reminder",
+    ]:
+        return prompt
+
+    task = messages[index].get("task")
+    if task is not None:
+        # Task special token for internal classification tasks
+        assert task in VALID_TASKS, f"Invalid task: '{task}'. Valid tasks are: {list(VALID_TASKS)}"
+        task_sp_token = DS_TASK_SP_TOKENS[task]
+
+        if task != "action":
+            # Non-action tasks: append task sp token directly after the message
+            prompt += task_sp_token
+        else:
+            # Action task: append Assistant + thinking token + action sp token
+            prompt += ASSISTANT_SP_TOKEN
+            prompt += thinking_end_token if thinking_mode != "thinking" else thinking_start_token
+            prompt += task_sp_token
+
+    elif messages[index].get("role") in ["user", "developer"]:
+        # Normal generation: append Assistant + thinking token
+        prompt += ASSISTANT_SP_TOKEN
+        if not drop_thinking and thinking_mode == "thinking":
+            prompt += thinking_start_token
+        elif drop_thinking and thinking_mode == "thinking" and index >= last_user_idx:
+            prompt += thinking_start_token
+        else:
+            prompt += thinking_end_token
+
+    return prompt
+
+
+# ============================================================
+# Preprocessing
+# ============================================================
+
+
+def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Merge tool messages into the preceding user message using content_blocks format.
+
+    DeepSeek-V4 does not have a standalone "tool" role; instead, tool results
+    are encoded as <tool_result> blocks within user messages.
+
+    This function converts a standard OpenAI-format conversation (with separate
+    "tool" role messages) into V4 format where tool results are merged into
+    user messages.
+
+    Args:
+        messages: List of message dicts in OpenAI format.
+
+    Returns:
+        Processed message list with tool messages merged into user messages.
+    """
+    merged: List[Dict[str, Any]] = []
+
+    for msg in messages:
+        msg = copy.deepcopy(msg)
+        role = msg.get("role")
+
+        if role == "tool":
+            # Convert tool message to a user message with tool_result block
+            tool_block = {
+                "type": "tool_result",
+                "tool_use_id": msg.get("tool_call_id", ""),
+                "content": msg.get("content", ""),
+            }
+            # Merge into previous message if it's already a user (merged tool)
+            if merged and merged[-1].get("role") == "user" and "content_blocks" in merged[-1]:
+                merged[-1]["content_blocks"].append(tool_block)
+            else:
+                merged.append({"role": "user", "content_blocks": [tool_block]})
+        elif role == "user":
+            text_block = {"type": "text", "text": msg.get("content", "")}
+            if (
+                merged
+                and merged[-1].get("role") == "user"
+                and "content_blocks" in merged[-1]
+                and merged[-1].get("task") is None
+            ):
+                merged[-1]["content_blocks"].append(text_block)
+            else:
+                new_msg = {
+                    "role": "user",
+                    "content": msg.get("content", ""),
+                    "content_blocks": [text_block],
+                }
+                # Preserve extra fields (task, wo_eos, mask, etc.)
+                for key in ("task", "wo_eos", "mask"):
+                    if key in msg:
+                        new_msg[key] = msg[key]
+                merged.append(new_msg)
+        else:
+            merged.append(msg)
+
+    return merged
+
+
+def sort_tool_results_by_call_order(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Sort tool_result blocks within user messages by the order of tool_calls
+    in the preceding assistant message.
+
+    Args:
+        messages: Preprocessed message list (after merge_tool_messages).
+
+    Returns:
+        Message list with sorted tool result blocks.
+    """
+    last_tool_call_order: Dict[str, int] = {}
+
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant" and msg.get("tool_calls"):
+            last_tool_call_order = {}
+            for idx, tc in enumerate(msg["tool_calls"]):
+                tc_id = tc.get("id") or tc.get("function", {}).get("id", "")
+                if tc_id:
+                    last_tool_call_order[tc_id] = idx
+
+        elif role == "user" and msg.get("content_blocks"):
+            tool_blocks = [b for b in msg["content_blocks"] if b.get("type") == "tool_result"]
+            if len(tool_blocks) > 1 and last_tool_call_order:
+                sorted_blocks = sorted(
+                    tool_blocks, key=lambda b: last_tool_call_order.get(b.get("tool_use_id", ""), 0)
+                )
+                sorted_idx = 0
+                new_blocks = []
+                for block in msg["content_blocks"]:
+                    if block.get("type") == "tool_result":
+                        new_blocks.append(sorted_blocks[sorted_idx])
+                        sorted_idx += 1
+                    else:
+                        new_blocks.append(block)
+                msg["content_blocks"] = new_blocks
+
+    return messages
+
+
+# ============================================================
+# Main Encoding Function
+# ============================================================
+
+
+def encode_messages(
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    context: Optional[List[Dict[str, Any]]] = None,
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+    reasoning_effort: Optional[str] = None,
+) -> str:
+    """
+    Encode a list of messages into the DeepSeek-V4 prompt format.
+
+    This is the main entry point for encoding conversations. It handles:
+    - BOS token insertion
+    - Thinking mode with optional reasoning content dropping
+    - Tool message merging into user messages
+    - Multi-turn conversation context
+
+    Args:
+        messages: List of message dicts to encode.
+        thinking_mode: Either "chat" or "thinking".
+        context: Optional preceding context messages (already encoded prefix).
+        drop_thinking: If True, drop reasoning_content from earlier assistant turns
+                      (only keep reasoning for messages after the last user message).
+        add_default_bos_token: Whether to prepend BOS token at conversation start.
+        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+
+    Returns:
+        The encoded prompt string.
+    """
+    context = context if context else []
+
+    # Preprocess: merge tool messages and sort tool results
+    messages = merge_tool_messages(messages)
+    messages = sort_tool_results_by_call_order(context + messages)[len(context) :]
+    if context:
+        context = merge_tool_messages(context)
+        context = sort_tool_results_by_call_order(context)
+
+    full_messages = context + messages
+
+    prompt = bos_token if add_default_bos_token and len(context) == 0 else ""
+
+    # Resolve drop_thinking: if any message has tools defined, don't drop thinking
+    effective_drop_thinking = drop_thinking
+    if any(m.get("tools") for m in full_messages):
+        effective_drop_thinking = False
+
+    if thinking_mode == "thinking" and effective_drop_thinking:
+        full_messages = _drop_thinking_messages(full_messages)
+        # After dropping, recalculate how many messages to render
+        # (context may have shrunk too)
+        num_to_render = len(full_messages) - len(_drop_thinking_messages(context))
+        context_len = len(full_messages) - num_to_render
+    else:
+        num_to_render = len(messages)
+        context_len = len(context)
+
+    for idx in range(num_to_render):
+        prompt += render_message(
+            idx + context_len,
+            full_messages,
+            thinking_mode=thinking_mode,
+            drop_thinking=effective_drop_thinking,
+            reasoning_effort=reasoning_effort,
+        )
+
+    return prompt
+
+
+def _drop_thinking_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Drop reasoning_content and non-essential messages before the last user message.
+
+    Behavior:
+    - Messages with role in ["user", "system", "tool", "latest_reminder"] are always kept.
+    - Messages at or after the last user index are always kept.
+    - Assistant messages before the last user get reasoning_content removed.
+    - Developer messages before the last user are dropped entirely.
+    """
+    last_user_idx = find_last_user_index(messages)
+    result = []
+    keep_roles = {"user", "system", "tool", "latest_reminder", "direct_search_results"}
+
+    for idx, msg in enumerate(messages):
+        role = msg.get("role")
+        if role in keep_roles or idx >= last_user_idx:
+            result.append(msg)
+        elif role == "assistant":
+            msg = copy.copy(msg)
+            msg.pop("reasoning_content", None)
+            result.append(msg)
+        # developer and other roles before last_user_idx are dropped
+
+    return result
+
+
+# ============================================================
+# Parsing (Decoding model output)
+# ============================================================
+
+
+def _read_until_stop(index: int, text: str, stop: List[str]) -> Tuple[int, str, Optional[str]]:
+    """
+    Read text from index until one of the stop strings is found.
+
+    Returns:
+        Tuple of (new_index, content_before_stop, matched_stop_string_or_None).
+    """
+    min_pos = len(text)
+    matched_stop = None
+
+    for s in stop:
+        pos = text.find(s, index)
+        if pos != -1 and pos < min_pos:
+            min_pos = pos
+            matched_stop = s
+
+    if matched_stop:
+        content = text[index:min_pos]
+        return min_pos + len(matched_stop), content, matched_stop
+    else:
+        content = text[index:]
+        return len(text), content, None
+
+
+def parse_tool_calls(index: int, text: str) -> Tuple[int, Optional[str], List[Dict[str, str]]]:
+    """
+    Parse DSML tool calls from text starting at the given index.
+
+    Args:
+        index: Starting position in text.
+        text: The full text to parse.
+
+    Returns:
+        Tuple of (new_index, last_stop_token, list_of_tool_call_dicts).
+        Each tool call dict has "name" and "arguments" keys.
+    """
+    tool_calls: List[Dict[str, Any]] = []
+    stop_token = None
+    tool_calls_end_token = f"</{dsml_token}{tool_calls_block_name}>"
+
+    while index < len(text):
+        index, _, stop_token = _read_until_stop(
+            index, text, [f"<{dsml_token}invoke", tool_calls_end_token]
+        )
+        if _ != ">\n":
+            raise ValueError(f"Tool call format error: expected '>\\n' but got '{_}'")
+
+        if stop_token == tool_calls_end_token:
+            break
+
+        if stop_token is None:
+            raise ValueError("Missing special token in tool calls")
+
+        index, tool_name_content, stop_token = _read_until_stop(
+            index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"]
+        )
+
+        p_tool_name = re.findall(r'^\s*name="(.*?)">\n$', tool_name_content, flags=re.DOTALL)
+        if len(p_tool_name) != 1:
+            raise ValueError(f"Tool name format error: '{tool_name_content}'")
+        tool_name = p_tool_name[0]
+
+        tool_args: Dict[str, Tuple[str, str]] = {}
+        while stop_token == f"<{dsml_token}parameter":
+            index, param_content, stop_token = _read_until_stop(
+                index, text, [f"/{dsml_token}parameter"]
+            )
+
+            param_kv = re.findall(
+                r'^ name="(.*?)" string="(true|false)">(.*?)<$', param_content, flags=re.DOTALL
+            )
+            if len(param_kv) != 1:
+                raise ValueError(f"Parameter format error: '{param_content}'")
+            param_name, string, param_value = param_kv[0]
+
+            if param_name in tool_args:
+                raise ValueError(f"Duplicate parameter name: '{param_name}'")
+            tool_args[param_name] = (param_value, string)
+
+            index, content, stop_token = _read_until_stop(
+                index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"]
+            )
+            if content != ">\n":
+                raise ValueError(f"Parameter format error: expected '>\\n' but got '{content}'")
+
+        tool_call = decode_dsml_to_arguments(tool_name=tool_name, tool_args=tool_args)
+        tool_calls.append(tool_call)
+
+    return index, stop_token, tool_calls
+
+
+def parse_message_from_completion_text(text: str, thinking_mode: str) -> Dict[str, Any]:
+    """
+    Parse a model completion text into a structured assistant message.
+
+    This function takes the raw text output from the model (a single assistant turn)
+    and extracts:
+    - reasoning_content (thinking block)
+    - content (summary/response)
+    - tool_calls (if any)
+
+    NOTE: This function is designed to parse only correctly formatted strings and
+    will raise ValueError for malformed output.
+
+    Args:
+        text: The raw completion text (including EOS token).
+        thinking_mode: Either "chat" or "thinking".
+
+    Returns:
+        Dict with keys: "role", "content", "reasoning_content", "tool_calls".
+        tool_calls are in OpenAI format.
+    """
+    summary_content, reasoning_content, tool_calls = "", "", []
+    index, stop_token = 0, None
+    tool_calls_start_token = f"\n\n<{dsml_token}{tool_calls_block_name}"
+
+    is_thinking = thinking_mode == "thinking"
+    is_tool_calling = False
+
+    if is_thinking:
+        index, content_delta, stop_token = _read_until_stop(
+            index, text, [thinking_end_token, tool_calls_start_token]
+        )
+        reasoning_content = content_delta
+        assert stop_token == thinking_end_token, "Invalid thinking format: missing </think>"
+
+    index, content_delta, stop_token = _read_until_stop(
+        index, text, [eos_token, tool_calls_start_token]
+    )
+    summary_content = content_delta
+    if stop_token == tool_calls_start_token:
+        is_tool_calling = True
+    else:
+        assert stop_token == eos_token, "Invalid format: missing EOS token"
+
+    if is_tool_calling:
+        index, stop_token, tool_calls = parse_tool_calls(index, text)
+
+        index, tool_ends_text, stop_token = _read_until_stop(index, text, [eos_token])
+        assert not tool_ends_text, "Unexpected content after tool calls"
+
+    assert len(text) == index and stop_token in [eos_token, None], "Unexpected content at end"
+
+    for sp_token in [bos_token, eos_token, thinking_start_token, thinking_end_token, dsml_token]:
+        assert (
+            sp_token not in summary_content and sp_token not in reasoning_content
+        ), f"Unexpected special token '{sp_token}' in content"
+
+    return {
+        "role": "assistant",
+        "content": summary_content,
+        "reasoning_content": reasoning_content,
+        "tool_calls": tool_calls_to_openai_format(tool_calls),
+    }

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -9,10 +9,10 @@ from transformers import AutoTokenizer
 
 import xgrammar as xgr
 from xgrammar.builtin_structural_tag import (
-    get_deepseek_structural_tag,
+    get_deepseek_r1_structural_tag,
+    get_deepseek_v3_1_structural_tag,
     get_deepseek_v3_2_structural_tag,
     get_deepseek_v4_structural_tag,
-    get_gemma_4_structural_tag,
     get_glm_4_7_structural_tag,
     get_harmony_structural_tag,
     get_kimi_structural_tag,
@@ -178,7 +178,6 @@ _tools_deepseek_v3_2 = make_tools(["search"])
 _tools_deepseek_v4 = make_tools(["search"])
 _tools_minimax = make_tools(["search"])
 _tools_glm_4_7 = make_tools(["search"])
-_tools_gemma_4 = make_tools(["get_weather"])
 
 # Two distinct tools for tool_choice=required / forced instance tests.
 _tools_llama_pair = make_tools(["t1", "t2"])
@@ -192,7 +191,6 @@ _tools_qwen_3_pair = make_tools(["t1", "t2"])
 _tools_qwen_3_5_pair = make_tools(["run_sql", "run_py"])
 _tools_harmony_pair = make_tools(["comment_tool", "other_tool"])
 _tools_glm_4_7_pair = make_tools(["search", "alt"])
-_tools_gemma_4_pair = make_tools(["search", "alt"])
 
 
 # ---------- Test: unknown format type ----------
@@ -444,7 +442,8 @@ def test_none_parameters_unconstrained():
     [
         get_llama_structural_tag,
         get_kimi_structural_tag,
-        get_deepseek_structural_tag,
+        get_deepseek_r1_structural_tag,
+        get_deepseek_v3_1_structural_tag,
         get_qwen_3_5_structural_tag,
         get_qwen_3_coder_structural_tag,
         get_qwen_3_structural_tag,
@@ -453,7 +452,6 @@ def test_none_parameters_unconstrained():
         get_deepseek_v4_structural_tag,
         get_minimax_structural_tag,
         get_glm_4_7_structural_tag,
-        get_gemma_4_structural_tag,
     ],
 )
 @pytest.mark.parametrize(
@@ -544,12 +542,12 @@ def test_specific_functions_cases(structural_tag_fn, case: Dict[str, Any]):
         ),
         (
             "deepseek_r1",
-            'text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>t1\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+            'text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>t1\n```json\n{"q": "v"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
             True,
         ),
         (
             "deepseek_r1",
-            'text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>t2{"q": "v"}<｜tool▁call▁end｜>',
+            'text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>t2\n```json\n{"q": "v"}\n```<｜tool▁call▁end｜>',
             False,
         ),
         (
@@ -574,7 +572,7 @@ def test_specific_functions_cases(structural_tag_fn, case: Dict[str, Any]):
         ),
         (
             "minimax",
-            '<minimax:tool_call>\n<invoke name="t1">\n<q>{"type": "string"}</q>\n</invoke>\n</minimax:tool_call>\n',
+            '\n</think>\n\n\n\n<minimax:tool_call>\n<invoke name="t1">\n<q>{"type": "string"}</q>\n</invoke>\n</minimax:tool_call>\n',
             True,
         ),
         (
@@ -598,12 +596,12 @@ def test_specific_functions_cases(structural_tag_fn, case: Dict[str, Any]):
         ("qwen_3", 'text<tool_call>\n{"name": "t2", "arguments": {"q": "v"}}\n</tool_call>', False),
         (
             "harmony",
-            '<|channel|>commentary to=functions.t1<|constrain|>json<|message|>{"q": "v"}<|call|>',
+            '<|channel|>commentary to=t1<|constrain|>json<|message|>{"q": "v"}<|call|>',
             True,
         ),
         (
             "harmony",
-            '<|channel|>commentary to=functions.t2<|constrain|>json<|message|>{"q": "v"}<|call|>',
+            '<|channel|>commentary to=t2<|constrain|>json<|message|>{"q": "v"}<|call|>',
             False,
         ),
     ],
@@ -628,11 +626,6 @@ def test_strict_or_missing_parameters(
     format_type: str, instance: str, is_accepted: bool, tool: Dict[str, Any]
 ):
     """strict=False or missing 'parameters' should still accept/reject instances correctly."""
-    if is_accepted and format_type == "kimi":
-        instance = "<think></think>" + instance
-    elif is_accepted and format_type == "qwen_3_5":
-        instance = "<think>\n\n</think>" + instance
-
     if format_type == "harmony":
         tools = [tool]
         stag = get_model_structural_tag(format_type, tools=tools, reasoning=False)
@@ -659,414 +652,6 @@ def run_instance_case(format_type: str, case: InstanceCase):
     stag = get_model_structural_tag(**kwargs)
     for j, instance in enumerate(instances):
         check_stag_with_instance(stag, instance, expected_accept_per_instance[j])
-
-
-# ----- llama
-
-_llama_instances_with_tools = [
-    '{"name": "t1", "parameters": {"q": "v"}}',
-    'text{"name": "t1", "parameters": {}}',
-    '<think>123</think>text{"name": "t1", "parameters": {"q": ""}}',
-    "<think>\n\n</think></think>",
-    '<think>\n\n</think>text{"name": "t1", "parameters": {"q": "v"}}',
-]
-_llama_instances_no_tools = [
-    "",
-    "text",
-    "<think>123</think>text",
-    "<think>\n\n</think></think>",
-    "<think>\n\n</think>text",
-]
-
-llama_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False
-    (
-        {"tools": _tools_llama},
-        _llama_instances_with_tools,
-        False,
-        [True, True, False, False, False],
-    ),
-    # with tools, reasoning=True
-    ({"tools": _tools_llama}, _llama_instances_with_tools, True, [True, True, False, False, False]),
-    # no tools, reasoning=False
-    ({}, _llama_instances_no_tools, False, [True, True, False, False, False]),
-    # no tools, reasoning=True
-    ({}, _llama_instances_no_tools, True, [True, True, False, False, False]),
-]
-
-
-@pytest.mark.parametrize("case", llama_instance_cases)
-def test_llama_instances(case: InstanceCase):
-    """get_model_structural_tag(llama) accepts/rejects instance as expected."""
-    run_instance_case("llama", case)
-
-
-# ----- kimi
-
-_kimi_instances_with_tools = [
-    '123<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|>',
-    "123<|tool_call_begin|>123<|tool_call_argument_begin|>{}<|tool_call_end|>",
-    "<think>123</think>",
-    "<think></think></think>",
-    "<think></think>123<|tool_calls_section_begin|>\n"
-    + '<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|>'
-    + "\n<|tool_calls_section_end|>",
-    "<think></think>123<|tool_calls_section_begin|>"
-    + '<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"q": "v0"}<|tool_call_end|>'
-    + '<|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"q": "v1"}<|tool_call_end|>'
-    + "<|tool_calls_section_end|>",
-]
-_kimi_instances_no_tools = [
-    "",
-    "text",
-    "<think>123</think>",
-    "<think>\n\n</think></think>",
-    "<think></think>text",
-    "</think>123",
-]
-
-kimi_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False
-    (
-        {"tools": _tools_kimi},
-        _kimi_instances_with_tools,
-        False,
-        [False, False, False, False, True, True],
-    ),
-    # with tools, reasoning=True
-    (
-        {"tools": _tools_kimi},
-        _kimi_instances_with_tools,
-        True,
-        [False, False, True, False, True, True],
-    ),
-    # no tools, reasoning=False
-    ({}, _kimi_instances_no_tools, False, [False, False, False, False, True, False]),
-    # no tools, reasoning=True
-    ({}, _kimi_instances_no_tools, True, [False, False, True, False, True, False]),
-]
-
-
-@pytest.mark.parametrize("case", kimi_instance_cases)
-def test_kimi_instances(case: InstanceCase):
-    """get_model_structural_tag(kimi) accepts/rejects instance as expected."""
-    run_instance_case("kimi", case)
-
-
-# ----- deepseek_r1
-
-_deepseek_r1_instances_with_tools = [
-    'text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
-    '123</think><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
-    'thinking</think>text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
-    "</think>text<think>123</think>",
-    '</think>text<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
-]
-_deepseek_r1_instances_no_tools = ["", "text", "123</think>123", "</think></think>", "</think>text"]
-
-deepseek_r1_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False
-    (
-        {"tools": _tools_deepseek},
-        _deepseek_r1_instances_with_tools,
-        False,
-        [True, False, False, False, False],
-    ),
-    # with tools, reasoning=True
-    (
-        {"tools": _tools_deepseek},
-        _deepseek_r1_instances_with_tools,
-        True,
-        [False, True, True, False, True],
-    ),
-    # no tools, reasoning=False
-    ({}, _deepseek_r1_instances_no_tools, False, [True, True, False, False, False]),
-    # no tools, reasoning=True
-    ({}, _deepseek_r1_instances_no_tools, True, [False, False, True, False, True]),
-]
-
-
-@pytest.mark.parametrize("case", deepseek_r1_instance_cases)
-def test_deepseek_r1_instances(case: InstanceCase):
-    """get_model_structural_tag(deepseek_r1) accepts/rejects instance as expected."""
-    run_instance_case("deepseek_r1", case)
-
-
-# ----- deepseek_v3_2
-
-_deepseek_v3_2_instances_with_tools = [
-    'text<｜DSML｜function_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜function_calls>\n',
-    '<think>123</think><｜DSML｜function_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜function_calls>\n',
-    '<think>123</think>text<｜DSML｜function_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜function_calls>\n',
-    "<think>\n\n</think>text<think>123</think>",
-    '<think>\n\n</think>text<｜DSML｜function_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜function_calls>\n',
-]
-_deepseek_v3_2_instances_no_tools = [
-    "",
-    "text",
-    "<think>123</think>123",
-    "<think></think></think>",
-    "<think>\n\n</think>text",
-]
-
-deepseek_v3_2_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False
-    (
-        {"tools": _tools_deepseek_v3_2},
-        _deepseek_v3_2_instances_with_tools,
-        False,
-        [True, False, False, False, False],
-    ),
-    # with tools, reasoning=True
-    (
-        {"tools": _tools_deepseek_v3_2},
-        _deepseek_v3_2_instances_with_tools,
-        True,
-        [False, True, True, False, True],
-    ),
-    # no tools, reasoning=False
-    ({}, _deepseek_v3_2_instances_no_tools, False, [True, True, False, False, False]),
-    # no tools, reasoning=True
-    ({}, _deepseek_v3_2_instances_no_tools, True, [False, False, True, False, True]),
-]
-
-
-@pytest.mark.parametrize("case", deepseek_v3_2_instance_cases)
-def test_deepseek_v3_2_instances(case: InstanceCase):
-    """get_model_structural_tag(deepseek_v3_2) accepts/rejects instance as expected."""
-    run_instance_case("deepseek_v3_2", case)
-
-
-# ----- deepseek_v4
-
-_deepseek_v4_instances_with_tools = [
-    'text<｜DSML｜tool_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜tool_calls>\n',
-    '<think>123</think><｜DSML｜tool_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜tool_calls>\n',
-    '<think>123</think>text<｜DSML｜tool_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜tool_calls>\n',
-    "<think>\n\n</think>text<think>123</think>",
-    '<think>\n\n</think>text<｜DSML｜tool_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜tool_calls>\n',
-]
-_deepseek_v4_instances_no_tools = [
-    "",
-    "text",
-    "<think>123</think>123",
-    "<think></think></think>",
-    "<think>\n\n</think>text",
-]
-
-deepseek_v4_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False
-    (
-        {"tools": _tools_deepseek_v4},
-        _deepseek_v4_instances_with_tools,
-        False,
-        [True, False, False, False, False],
-    ),
-    # with tools, reasoning=True
-    (
-        {"tools": _tools_deepseek_v4},
-        _deepseek_v4_instances_with_tools,
-        True,
-        [False, True, True, False, True],
-    ),
-    # no tools, reasoning=False
-    ({}, _deepseek_v4_instances_no_tools, False, [True, True, False, False, False]),
-    # no tools, reasoning=True
-    ({}, _deepseek_v4_instances_no_tools, True, [False, False, True, False, True]),
-]
-
-
-@pytest.mark.parametrize("case", deepseek_v4_instance_cases)
-def test_deepseek_v4_instances(case: InstanceCase):
-    """get_model_structural_tag(deepseek_v4) accepts/rejects instance as expected."""
-    run_instance_case("deepseek_v4", case)
-
-
-# ----- minimax
-
-_minimax_instances_with_tools = [
-    'text<minimax:tool_call>\n<invoke name="search">\n<parameter name="q">v</parameter></invoke>\n</minimax:tool_call>\n',
-    '<think>123</think><minimax:tool_call>\n<invoke name="search">\n<parameter name="q">v</parameter></invoke>\n</minimax:tool_call>\n',
-    '<think>123</think>text<minimax:tool_call>\n<invoke name="search">\n<parameter name="q">v</parameter></invoke>\n</minimax:tool_call>\n',
-    "<think>\n\n</think>text<think>123</think>",
-    '<think>\n\n</think>text<minimax:tool_call>\n<invoke name="search">\n<parameter name="q">v</parameter></invoke>\n</minimax:tool_call>\n',
-]
-_minimax_instances_no_tools = [
-    "",
-    "text",
-    "<think>123</think>123",
-    "<think></think></think>",
-    "<think>\n\n</think>text",
-]
-
-minimax_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False
-    (
-        {"tools": _tools_minimax},
-        _minimax_instances_with_tools,
-        False,
-        [True, False, False, False, False],
-    ),
-    # with tools, reasoning=True
-    (
-        {"tools": _tools_minimax},
-        _minimax_instances_with_tools,
-        True,
-        [False, True, True, False, True],
-    ),
-    # no tools, reasoning=False
-    ({}, _minimax_instances_no_tools, False, [True, True, False, False, False]),
-    # no tools, reasoning=True
-    ({}, _minimax_instances_no_tools, True, [False, False, True, False, True]),
-]
-
-
-@pytest.mark.parametrize("case", minimax_instance_cases)
-def test_minimax_instances(case: InstanceCase):
-    """get_model_structural_tag(minimax) accepts/rejects instance as expected."""
-    run_instance_case("minimax", case)
-
-
-def test_glm47_instances():
-    """get_model_structural_tag(glm47) accepts/rejects instance as expected."""
-    stag = get_model_structural_tag("glm_4_7", tools=_tools_glm_4_7, reasoning=False)
-    grammar_str = str(xgr.Grammar.from_structural_tag(stag))
-    assert "<tool_call>" in grammar_str
-    assert "<arg_key>" in grammar_str
-    assert "<arg_value>" in grammar_str
-
-    check_stag_with_instance(
-        stag, "<tool_call>search<arg_key>q</arg_key><arg_value>v</arg_value></tool_call>", True
-    )
-    check_stag_with_instance(stag, "<tool_call>search<parameter=q>v</parameter></tool_call>", False)
-    check_stag_with_instance(
-        stag, '<tool_call>search<parameter name="q">v</parameter></tool_call>', False
-    )
-
-
-# ----- qwen_coder
-
-_qwen_coder_instances_with_tools = [
-    "<tool_call>\n<function=run_sql>\n<parameter=q>v</parameter>\n</function>\n</tool_call>",
-    "<tool_call>\n<function=other>\n<parameter=q>v</parameter>\n</function>\n</tool_call>",
-    "<think>123</think><tool_call>\n<function=run_sql>\n<parameter=q>v</parameter>\n</function>\n</tool_call>",
-    "<think>\n\n</think><think></think>",
-    "<think>\n\n</think>text<tool_call>\n<function=run_sql>\n<parameter=q>v</parameter>\n</function>\n</tool_call>",
-]
-_qwen_coder_instances_no_tools = [
-    "",
-    "text",
-    "<think>123</think>123",
-    "<think>\n\n</think></think>",
-    "<think>\n\n</think>text",
-]
-
-qwen_coder_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False
-    (
-        {"tools": _tools_qwen_3_coder},
-        _qwen_coder_instances_with_tools,
-        False,
-        [True, False, False, False, False],
-    ),
-    # with tools, reasoning=True
-    (
-        {"tools": _tools_qwen_3_coder},
-        _qwen_coder_instances_with_tools,
-        True,
-        [True, False, False, False, False],
-    ),
-    # no tools, reasoning=False
-    ({}, _qwen_coder_instances_no_tools, False, [True, True, False, False, False]),
-    # no tools, reasoning=True
-    ({}, _qwen_coder_instances_no_tools, True, [True, True, False, False, False]),
-]
-
-
-@pytest.mark.parametrize("case", qwen_coder_instance_cases)
-def test_qwen_coder_instances(case: InstanceCase):
-    """get_model_structural_tag(qwen_coder) accepts/rejects instance as expected."""
-    run_instance_case("qwen_3_coder", case)
-
-
-# ----- qwen
-
-_qwen_instances_with_tools = [
-    'text<tool_call>\n{"name": "t1", "arguments": {"q": "v"}}\n</tool_call>',
-    '<think>123</think><tool_call>\n{"name": "t1", "arguments": {"q": "v"}}\n</tool_call>',
-    "<think>\n\n</think></think>",
-    '<think>\n\n</think><tool_call>\n{"name": "t1", "arguments": {"q": "v"}}\n</tool_call>',
-]
-_qwen_instances_no_tools = [
-    "",
-    "text",
-    "<think>123</think>123",
-    "<think>\n\n</think></think>",
-    "<think>\n\n</think>text",
-]
-
-qwen_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False
-    ({"tools": _tools_qwen_3}, _qwen_instances_with_tools, False, [True, False, False, False]),
-    # with tools, reasoning=True
-    ({"tools": _tools_qwen_3}, _qwen_instances_with_tools, True, [False, True, False, True]),
-    # no tools, reasoning=False
-    ({}, _qwen_instances_no_tools, False, [True, True, False, False, False]),
-    # no tools, reasoning=True
-    ({}, _qwen_instances_no_tools, True, [False, False, True, False, True]),
-]
-
-
-@pytest.mark.parametrize("case", qwen_instance_cases)
-def test_qwen_instances(case: InstanceCase):
-    """get_model_structural_tag(qwen) accepts/rejects instance as expected."""
-    run_instance_case("qwen_3", case)
-
-
-# ----- harmony
-
-_harmony_instances_with_tools = [
-    "<|channel|>analysis<|message|><|end|>",
-    '<|channel|>commentary to=functions.comment_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
-    '<|channel|>commentary to=analysis_tool<|message|>{"q": "v"}<|call|>',
-    "<|channel|>commentary to=functions.wrong_tool<|constrain|>json<|message|>{}<|call|>",
-    "<|channel|>analysis<|message|>think<|end|><|start|>assistant<|channel|>final<|message|>123<|end|>",
-    '<|channel|>commentary to=functions.comment_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
-]
-_harmony_instances_no_tools = [
-    "",
-    "<|channel|>final<|message|>123<|end|>",
-    "<|channel|>analysis<|message|>123<|end|><|start|>assistant<|channel|>final<|message|>123<|end|>",
-    "<|channel|>analysis<|message|><|end|>",
-    "<think>\n\n</think>text",
-]
-
-harmony_instance_cases: List[InstanceCase] = [
-    # with tools, reasoning=False
-    (
-        {"tools": _tools_harmony, "builtin_tools": _builtin_harmony},
-        _harmony_instances_with_tools,
-        False,
-        [False, True, True, False, False, True],
-    ),
-    # with tools, reasoning=True
-    (
-        {"tools": _tools_harmony, "builtin_tools": _builtin_harmony},
-        _harmony_instances_with_tools,
-        True,
-        [True, True, True, False, True, True],
-    ),
-    # no tools, reasoning=False
-    ({}, _harmony_instances_no_tools, False, [True, True, False, False, False]),
-    # no tools, reasoning=True
-    ({}, _harmony_instances_no_tools, True, [True, True, True, True, False]),
-]
-
-
-@pytest.mark.parametrize("case", harmony_instance_cases)
-def test_harmony_instances(case: InstanceCase):
-    """get_model_structural_tag(harmony) accepts/rejects instance as expected."""
-    run_instance_case("harmony", case)
 
 
 # tool_choice=required / forced: expected_grammar_ebnf left "" for manual completion.
@@ -1100,7 +685,7 @@ _tool_choice_instance_cases = [
             {"tools": _tools_kimi_pair, "tool_choice": "required"},
             [
                 "",
-                '<think></think><|tool_call_begin|>functions.t1:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|>',
+                '<|tool_calls_section_begin|><|tool_call_begin|>functions.t1:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|><|tool_calls_section_end|>',
             ],
             False,
             [False, True],
@@ -1112,8 +697,8 @@ _tool_choice_instance_cases = [
         (
             {"tools": _tools_kimi_pair, "tool_choice": "forced", "forced_function_name": "t1"},
             [
-                '<think></think><|tool_call_begin|>functions.t1:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|>',
-                '<think></think><|tool_call_begin|>functions.t2:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|>',
+                '<|tool_calls_section_begin|><|tool_call_begin|>functions.t1:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|><|tool_calls_section_end|>',
+                '<|tool_calls_section_begin|><|tool_call_begin|>functions.t2:0<|tool_call_argument_begin|>{"q": "v"}<|tool_call_end|><|tool_calls_section_end|>',
             ],
             False,
             [True, False],
@@ -1126,7 +711,7 @@ _tool_choice_instance_cases = [
             {"tools": _tools_deepseek_pair, "tool_choice": "required"},
             [
                 "",
-                '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+                '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
             ],
             False,
             [False, True],
@@ -1142,8 +727,8 @@ _tool_choice_instance_cases = [
                 "forced_function_name": "search",
             },
             [
-                '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
-                '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>alt\n```json\n{"q": "v"}\n```\n<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+                '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>search\n```json\n{"q": "v"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+                '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>alt\n```json\n{"q": "v"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
             ],
             False,
             [True, False],
@@ -1156,7 +741,7 @@ _tool_choice_instance_cases = [
             {"tools": _tools_deepseek_v3_2_pair, "tool_choice": "required"},
             [
                 "",
-                '<｜DSML｜function_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜function_calls>\n',
+                '\n\n<｜DSML｜function_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜function_calls>',
             ],
             False,
             [False, True],
@@ -1169,7 +754,7 @@ _tool_choice_instance_cases = [
             {"tools": _tools_deepseek_v4_pair, "tool_choice": "required"},
             [
                 "",
-                '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜tool_calls>\n',
+                '\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜tool_calls>',
             ],
             False,
             [False, True],
@@ -1185,8 +770,8 @@ _tool_choice_instance_cases = [
                 "forced_function_name": "search",
             },
             [
-                '<｜DSML｜function_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜function_calls>\n',
-                '<｜DSML｜function_calls>\n<｜DSML｜invoke name="alt">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜function_calls>\n',
+                '\n\n<｜DSML｜function_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜function_calls>',
+                '\n\n<｜DSML｜function_calls>\n<｜DSML｜invoke name="alt">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜function_calls>',
             ],
             False,
             [True, False],
@@ -1202,8 +787,8 @@ _tool_choice_instance_cases = [
                 "forced_function_name": "search",
             },
             [
-                '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜tool_calls>\n',
-                '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="alt">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜tool_calls>\n',
+                '\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name="search">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+                '\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name="alt">\n<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter></｜DSML｜invoke>\n</｜DSML｜tool_calls>',
             ],
             False,
             [True, False],
@@ -1219,7 +804,7 @@ _tool_choice_instance_cases = [
                 '<minimax:tool_call>\n<invoke name="search">\n<parameter name="q">v</parameter></invoke>\n</minimax:tool_call>\n',
             ],
             False,
-            [False, True],
+            [False, False],
         ),
         id="minimax-required",
     ),
@@ -1236,7 +821,7 @@ _tool_choice_instance_cases = [
                 '<minimax:tool_call>\n<invoke name="alt">\n<parameter name="q">v</parameter></invoke>\n</minimax:tool_call>\n',
             ],
             False,
-            [True, False],
+            [False, False],
         ),
         id="minimax-forced",
     ),
@@ -1299,7 +884,7 @@ _tool_choice_instance_cases = [
             {"tools": _tools_harmony_pair, "tool_choice": "required"},
             [
                 "plain text without channels",
-                '<|channel|>commentary to=functions.comment_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
+                '<|channel|>commentary to=comment_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
             ],
             False,
             [False, True],
@@ -1315,8 +900,8 @@ _tool_choice_instance_cases = [
                 "forced_function_name": "comment_tool",
             },
             [
-                '<|channel|>commentary to=functions.comment_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
-                '<|channel|>commentary to=functions.other_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
+                '<|channel|>commentary to=comment_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
+                '<|channel|>commentary to=other_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
             ],
             False,
             [True, False],
@@ -1332,16 +917,6 @@ _tool_choice_instance_cases = [
             [False, True],
         ),
         id="glm_4_7-required",
-    ),
-    pytest.param(
-        "gemma_4",
-        (
-            {"tools": _tools_gemma_4_pair, "tool_choice": "required"},
-            ["", '<|tool_call>call:search{"q": "v"}<tool_call|>'],
-            False,
-            [False, True],
-        ),
-        id="gemma_4-required",
     ),
     pytest.param(
         "glm_4_7",
@@ -1385,7 +960,6 @@ _TOOLS: List[Dict[str, Any]] = [
         ("deepseek_v3_2", {"tools": _TOOLS}),
         ("deepseek_v4", {"tools": _TOOLS}),
         ("minimax", {"tools": _TOOLS}),
-        ("gemma_4", {"tools": _TOOLS}),
         (
             "harmony",
             {
@@ -1406,57 +980,3 @@ def test_no_parameter_tools_build_grammar(format_type: str, kwargs: Dict[str, An
     structural_tag = get_model_structural_tag(format_type, **kwargs)
     grammar = xgr.Grammar.from_structural_tag(structural_tag)
     assert grammar is not None
-
-
-# ----- gemma4
-
-
-def test_gemma4_instances():
-    """get_model_structural_tag(gemma4) accepts/rejects instances as expected."""
-
-    # --- No tools, no reasoning: plain text only ---
-    stag = get_model_structural_tag("gemma_4", reasoning=False)
-    check_stag_with_instance(stag, "Hello world", True)
-    check_stag_with_instance(stag, "", True)
-
-    # --- No tools, reasoning enabled ---
-    stag = get_model_structural_tag("gemma_4", reasoning=True)
-    check_stag_with_instance(
-        stag, "<|channel>thought\nLet me think...<channel|>The answer is 42.", True
-    )
-    check_stag_with_instance(stag, "<|channel>thought\n<channel|>Quick answer.", True)
-    # Missing thinking prefix should be rejected
-    check_stag_with_instance(stag, "No thinking here.", False)
-
-    # --- No tools, reasoning with  ---
-    stag = get_model_structural_tag("gemma_4", reasoning=True)
-    check_stag_with_instance(stag, "<|channel>thought\n<channel|>Direct answer.", True)
-    # Non-empty thinking should be rejected when force_empty
-    check_stag_with_instance(stag, "<|channel>thought\nSome reasoning<channel|>Answer.", True)
-
-    # --- With tools, no reasoning ---
-    stag = get_model_structural_tag("gemma_4", tools=_tools_gemma_4, reasoning=False)
-    check_stag_with_instance(stag, '<|tool_call>call:get_weather{"q": "Paris"}<tool_call|>', True)
-    check_stag_with_instance(stag, "Plain text without tool call.", True)
-    # Wrong function name should be rejected
-    check_stag_with_instance(stag, '<|tool_call>call:unknown_func{"q": "x"}<tool_call|>', False)
-
-    # --- Multiple tool calls ---
-    check_stag_with_instance(
-        stag,
-        '<|tool_call>call:get_weather{"q": "Paris"}<tool_call|>'
-        '<|tool_call>call:get_weather{"q": "London"}<tool_call|>',
-        True,
-    )
-
-    # --- With tools, reasoning enabled ---
-    stag = get_model_structural_tag("gemma_4", tools=_tools_gemma_4, reasoning=True)
-    check_stag_with_instance(
-        stag,
-        "<|channel>thought\nI should check the weather.<channel|>"
-        '<|tool_call>call:get_weather{"q": "Paris"}<tool_call|>',
-        True,
-    )
-    check_stag_with_instance(
-        stag, "<|channel>thought\nThinking...<channel|>Just text, no tool call.", True
-    )

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -437,6 +437,37 @@ def test_none_parameters_unconstrained():
     assert None not in json_schema_values
 
 
+def test_harmony_builtin_tool_instance():
+    """Harmony builtin tools follow the browser sample shape from harmony examples."""
+
+    structural_tag = get_model_structural_tag(
+        "harmony",
+        tools=[
+            {
+                "type": "web_search_preview",
+                "name": "browser.search",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            }
+        ],
+        reasoning=False,
+    )
+
+    check_stag_with_instance(
+        structural_tag,
+        '<|channel|>commentary to=browser.search code<|message|>{"query": "weather"}<|call|>',
+        True,
+    )
+    check_stag_with_instance(
+        structural_tag,
+        '<|channel|>analysis to=browser.search<|message|>{"query": "weather"}<|call|>',
+        False,
+    )
+
+
 @pytest.mark.parametrize(
     "structural_tag_fn",
     [
@@ -596,12 +627,12 @@ def test_specific_functions_cases(structural_tag_fn, case: Dict[str, Any]):
         ("qwen_3", 'text<tool_call>\n{"name": "t2", "arguments": {"q": "v"}}\n</tool_call>', False),
         (
             "harmony",
-            '<|channel|>commentary to=t1<|constrain|>json<|message|>{"q": "v"}<|call|>',
+            '<|channel|>commentary to=functions.t1<|constrain|>json<|message|>{"q": "v"}<|call|>',
             True,
         ),
         (
             "harmony",
-            '<|channel|>commentary to=t2<|constrain|>json<|message|>{"q": "v"}<|call|>',
+            '<|channel|>commentary to=functions.t2<|constrain|>json<|message|>{"q": "v"}<|call|>',
             False,
         ),
     ],
@@ -884,7 +915,7 @@ _tool_choice_instance_cases = [
             {"tools": _tools_harmony_pair, "tool_choice": "required"},
             [
                 "plain text without channels",
-                '<|channel|>commentary to=comment_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
+                '<|channel|>commentary to=functions.comment_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
             ],
             False,
             [False, True],
@@ -900,8 +931,8 @@ _tool_choice_instance_cases = [
                 "forced_function_name": "comment_tool",
             },
             [
-                '<|channel|>commentary to=comment_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
-                '<|channel|>commentary to=other_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
+                '<|channel|>commentary to=functions.comment_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
+                '<|channel|>commentary to=functions.other_tool<|constrain|>json<|message|>{"q": "v"}<|call|>',
             ],
             False,
             [True, False],

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -1,0 +1,342 @@
+"""Validate builtin structural tags against official chat templates.
+
+Uses tokenizer.apply_chat_template (or encoding scripts for DeepSeek V3.2/V4)
+to render model outputs, then checks that xgrammar structural tag grammars
+accept them. Requires encoding_dsv32.py and encoding_dsv4.py in the same
+directory.
+"""
+
+import json
+import os
+import sys
+from functools import lru_cache
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from xgrammar import Grammar
+from xgrammar.builtin_structural_tag import get_model_structural_tag
+from xgrammar.testing import _is_grammar_accept_string
+
+TOOL_A = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the weather for a location.",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+        },
+    },
+}
+TOOL_B = {
+    "type": "function",
+    "function": {
+        "name": "get_time",
+        "description": "Get the current time in a timezone.",
+        "parameters": {
+            "type": "object",
+            "properties": {"timezone": {"type": "string"}},
+            "required": ["timezone"],
+        },
+    },
+}
+
+USER_MSG = {"role": "user", "content": "What is the weather in Beijing?"}
+REASONING_CONTENT = "Let me think about this step by step."
+
+TOOL_SCENARIOS = [
+    (0, "auto"),
+    (1, "auto"),
+    (1, "forced"),
+    (1, "required"),
+    (2, "auto"),
+    (2, "required"),
+]
+
+# (stag_key, model_id, reasoning, template_kwargs)
+# Excluded:
+#   - Llama-4: pythonic tool call format, needs separate structural tag
+#   - gemma_4: tool calls use <|"|> quoting, not JSON
+#   - deepseek_r1 thinking=True: template drops <think> in history rendering,
+#     prompt diff extraction doesn't work
+#   - Kimi-K2-Thinking thinking=False: model always outputs <think></think>,
+#     but grammar excludes these tokens in non-reasoning mode
+MODEL_CONFIGS = [
+    ("llama", "meta-llama/Llama-3.1-8B-Instruct", False, {}),
+    ("kimi", "moonshotai/Kimi-K2-Thinking", True, {"thinking": True}),
+    ("kimi", "moonshotai/Kimi-K2-Instruct", False, {}),
+    ("deepseek_r1", "deepseek-ai/DeepSeek-R1", True, {}),
+    ("deepseek_v3_1", "deepseek-ai/DeepSeek-V3.1", True, {"thinking": True}),
+    ("deepseek_v3_1", "deepseek-ai/DeepSeek-V3.1", False, {"thinking": False}),
+    ("qwen_3_coder", "Qwen/Qwen3-Coder-30B-A3B-Instruct", False, {}),
+    ("qwen_3_coder", "Qwen/Qwen3-Coder-Next", False, {}),
+    ("qwen_3_5", "Qwen/Qwen3.5-35B-A3B", True, {"enable_thinking": True}),
+    ("qwen_3_5", "Qwen/Qwen3.5-35B-A3B", False, {"enable_thinking": False}),
+    ("qwen_3_5", "Qwen/Qwen3.6-35B-A3B", True, {"enable_thinking": True}),
+    ("qwen_3_5", "Qwen/Qwen3.6-35B-A3B", False, {"enable_thinking": False}),
+    ("qwen_3", "Qwen/Qwen3-4B-Thinking-2507", True, {}),
+    ("qwen_3", "Qwen/Qwen3-4B-Instruct-2507", False, {}),
+    ("qwen_3", "Qwen/Qwen3-Next-80B-A3B-Thinking", True, {}),
+    ("qwen_3", "Qwen/Qwen3-Next-80B-A3B-Instruct", False, {}),
+    ("harmony", "openai/gpt-oss-20b", True, {}),
+    ("harmony", "openai/gpt-oss-20b", False, {}),
+    ("deepseek_v3_2", "ENCODER:dsv32", True, {"thinking_mode": "thinking"}),
+    ("deepseek_v3_2", "ENCODER:dsv32", False, {"thinking_mode": "chat"}),
+    ("minimax", "MiniMaxAI/MiniMax-M2.5", True, {}),
+    ("glm_4_7", "zai-org/GLM-4.7-Flash", True, {"enable_thinking": True}),
+    ("glm_4_7", "zai-org/GLM-4.7-Flash", False, {"enable_thinking": False}),
+    ("deepseek_v4", "ENCODER:dsv4", True, {"thinking_mode": "thinking"}),
+    ("deepseek_v4", "ENCODER:dsv4", False, {"thinking_mode": "chat"}),
+]
+
+# DeepSeek V3.2 encoder rejects empty reasoning + no tool calls.
+SKIP_EMPTY_REASONING = {"ENCODER:dsv32", "MiniMaxAI/MiniMax-M2.5"}
+
+# Models where tool call format in template doesn't match structural tag.
+SKIP_TOOLS = set()
+
+# Models whose template strips or skips <think> for empty reasoning_content,
+# requiring "strip base + prepend reasoning_content" to reconstruct model output.
+# Includes: R1/V3.1 (content.split('</think>')), GLM/MiniMax/Qwen3.5 (falsy branch).
+STRIP_THINK_MODELS = {
+    "deepseek-ai/DeepSeek-V3.1",
+    "deepseek-ai/DeepSeek-R1",
+    "zai-org/GLM-4.7-Flash",
+    "MiniMaxAI/MiniMax-M2.5",
+    "Qwen/Qwen3.5-35B-A3B",
+}
+
+EOS_SUFFIXES = {
+    "llama": ["<|eot_id|>"],
+    "kimi": ["<|im_end|>"],
+    "deepseek_r1": ["<｜end▁of▁sentence｜>"],
+    "deepseek_v3_1": ["<｜end▁of▁sentence｜>"],
+    "qwen_3": ["<|im_end|>"],
+    "qwen_3_5": ["<|im_end|>"],
+    "qwen_3_coder": ["<|im_end|>"],
+    "harmony": None,
+    "minimax": ["[e~["],
+    "glm_4_7": [],
+    "deepseek_v3_2": ["<｜end▁of▁sentence｜>"],
+    "deepseek_v4": ["<｜end▁of▁sentence｜>"],
+}
+
+
+@lru_cache(maxsize=None)
+def load_tokenizer(model_id):
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
+
+
+def make_tools(num_tools):
+    if num_tools == 0:
+        return None
+    if num_tools == 1:
+        return [TOOL_A]
+    return [TOOL_A, TOOL_B]
+
+
+def make_tool_choice(choice_str, tools):
+    if choice_str == "forced":
+        return {"type": "function", "function": {"name": tools[0]["function"]["name"]}}
+    return choice_str
+
+
+def make_assistant_msg(stag_key, reasoning_content, num_tool_calls):
+    msg = {"role": "assistant"}
+    if reasoning_content is not None:
+        msg["reasoning_content"] = reasoning_content
+    if num_tool_calls == 0:
+        msg["content"] = "The answer is 42."
+        return msg
+
+    msg["content"] = ""
+    tool_specs = [("get_weather", {"location": "Beijing"}), ("get_time", {"timezone": "UTC"})]
+    calls = []
+    for i in range(num_tool_calls):
+        name, args = tool_specs[i]
+        tc = {"type": "function", "function": {"name": name}}
+        if stag_key in ("deepseek_r1", "deepseek_v3_1"):
+            tc["function"]["arguments"] = json.dumps(args)
+        else:
+            tc["function"]["arguments"] = args
+        if stag_key == "kimi":
+            tc["id"] = f"functions.{name}:{i}"
+        else:
+            tc["id"] = f"call_{i}"
+        calls.append(tc)
+    msg["tool_calls"] = calls
+    return msg
+
+
+def strip_eos(output, stag_key, tokenizer=None):
+    eos_list = EOS_SUFFIXES.get(stag_key)
+    if eos_list is None:
+        return output
+    if not eos_list and tokenizer:
+        eos_list = [tokenizer.eos_token] if tokenizer.eos_token else []
+    for eos in eos_list:
+        if output.endswith("\n" + eos + "\n"):
+            output = output[: -(len(eos) + 2)]
+            break
+        if output.endswith(eos + "\n"):
+            output = output[: -(len(eos) + 1)]
+            break
+        if output.endswith("\n" + eos):
+            output = output[: -(len(eos) + 1)]
+            break
+        if output.endswith(eos):
+            output = output[: -len(eos)]
+            break
+    return output
+
+
+def extract_output_tokenizer(model_id, stag_key, assistant_msg, tools, template_kwargs):
+    tokenizer = load_tokenizer(model_id)
+    kwargs = dict(tokenize=False, **template_kwargs)
+    if tools:
+        kwargs["tools"] = tools
+    prompt = tokenizer.apply_chat_template([USER_MSG], add_generation_prompt=True, **kwargs)
+    full = tokenizer.apply_chat_template(
+        [USER_MSG, assistant_msg], add_generation_prompt=False, **kwargs
+    )
+
+    if model_id in STRIP_THINK_MODELS and assistant_msg.get("reasoning_content") is not None:
+        if not full.startswith(prompt):
+            base = prompt.removesuffix("<think>\n").removesuffix("<think>")
+            assert full.startswith(base), (
+                f"Base mismatch.\nbase[-200:]={repr(base[-200:])}\n"
+                f"full[:len(base)+200]={repr(full[: len(base) + 200])}"
+            )
+            raw = full[len(base) :]
+            raw = strip_eos(raw, stag_key, tokenizer)
+            reasoning = assistant_msg["reasoning_content"]
+            if not raw.startswith("</think>"):
+                raw = "</think>" + raw
+            return reasoning + raw
+
+    assert full.startswith(prompt), (
+        f"Full does not start with prompt.\nprompt[-200:]={repr(prompt[-200:])}\n"
+        f"full[:len(prompt)+200]={repr(full[: len(prompt) + 200])}"
+    )
+    output = full[len(prompt) :]
+    return strip_eos(output, stag_key, tokenizer)
+
+
+def extract_output_encoder(encoder_name, stag_key, assistant_msg, tools, template_kwargs):
+    if encoder_name == "dsv32":
+        from encoding_dsv32 import encode_messages, eos_token
+    else:
+        from encoding_dsv4 import encode_messages, eos_token
+
+    thinking_mode = template_kwargs["thinking_mode"]
+    system_msg = {"role": "system", "content": "You are a helpful assistant."}
+    if tools:
+        system_msg["tools"] = [{"type": "function", "function": t["function"]} for t in tools]
+
+    ds_assistant = dict(assistant_msg)
+    if "tool_calls" in ds_assistant:
+        ds_calls = []
+        for tc in ds_assistant["tool_calls"]:
+            ds_tc = dict(tc)
+            func = dict(tc["function"])
+            if not isinstance(func["arguments"], str):
+                func["arguments"] = json.dumps(func["arguments"])
+            ds_tc["function"] = func
+            ds_calls.append(ds_tc)
+        ds_assistant["tool_calls"] = ds_calls
+
+    prompt = encode_messages([system_msg, USER_MSG], thinking_mode=thinking_mode)
+    full = encode_messages([system_msg, USER_MSG, ds_assistant], thinking_mode=thinking_mode)
+    assert full.startswith(prompt)
+    output = full[len(prompt) :]
+    if output.endswith(eos_token):
+        output = output[: -len(eos_token)]
+    return output
+
+
+def extract_model_output(stag_key, model_id, assistant_msg, tools, template_kwargs):
+    if model_id.startswith("ENCODER:"):
+        encoder_name = model_id.split(":")[1]
+        return extract_output_encoder(encoder_name, stag_key, assistant_msg, tools, template_kwargs)
+    return extract_output_tokenizer(model_id, stag_key, assistant_msg, tools, template_kwargs)
+
+
+def validate_output(stag_key, tools, tool_choice, reasoning, model_output):
+    structural_tag = get_model_structural_tag(
+        stag_key, tools=tools or [], tool_choice=tool_choice, reasoning=reasoning
+    )
+    grammar = Grammar.from_structural_tag(structural_tag)
+    accepted = _is_grammar_accept_string(grammar, model_output)
+    assert accepted, f"Grammar rejected output:\n{repr(model_output[:500])}"
+
+
+def generate_test_cases():
+    cases = []
+    for stag_key, model_id, reasoning, template_kwargs in MODEL_CONFIGS:
+        for num_tools, tool_choice_str in TOOL_SCENARIOS:
+            if num_tools > 0 and model_id in SKIP_TOOLS:
+                continue
+            if reasoning:
+                cases.append(
+                    (
+                        stag_key,
+                        model_id,
+                        True,
+                        REASONING_CONTENT,
+                        num_tools,
+                        tool_choice_str,
+                        template_kwargs,
+                    )
+                )
+                if model_id not in SKIP_EMPTY_REASONING:
+                    cases.append(
+                        (stag_key, model_id, True, "", num_tools, tool_choice_str, template_kwargs)
+                    )
+            else:
+                cases.append(
+                    (stag_key, model_id, False, None, num_tools, tool_choice_str, template_kwargs)
+                )
+    return cases
+
+
+def case_id(case):
+    stag_key, model_id, reasoning, reasoning_content, num_tools, tool_choice_str, _ = case
+    model_short = model_id.split("/")[-1] if "/" in model_id else model_id.replace("ENCODER:", "")
+    if not reasoning:
+        r_tag = "off"
+    elif reasoning_content:
+        r_tag = "on"
+    else:
+        r_tag = "empty"
+    return f"{stag_key}-{model_short}-r{r_tag}-{num_tools}t-{tool_choice_str}"
+
+
+TEST_CASES = generate_test_cases()
+
+
+@pytest.mark.parametrize("case", TEST_CASES, ids=[case_id(c) for c in TEST_CASES])
+def test_reasoning_stag(case):
+    (
+        stag_key,
+        model_id,
+        reasoning,
+        reasoning_content,
+        num_tools,
+        tool_choice_str,
+        template_kwargs,
+    ) = case
+    tools = make_tools(num_tools)
+    tool_choice = make_tool_choice(tool_choice_str, tools or [])
+    num_tool_calls = 1 if num_tools > 0 else 0
+    assistant_msg = make_assistant_msg(stag_key, reasoning_content, num_tool_calls)
+    model_output = extract_model_output(stag_key, model_id, assistant_msg, tools, template_kwargs)
+    validate_output(stag_key, tools, tool_choice, reasoning, model_output)
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
## Summary

- Fix reasoning prefix for kimi, minimax, qwen_3, qwen_3_5: use `begin=""` since chat templates already prepend `<think>` to the generation prompt
- Fix deepseek_r1 tool call format to match V3.1 template output
- Fix deepseek_v3_2/v4 trailing `\n` in `FUNCTION_CALLS_END` and add `\n\n` prefix for forced/required tool calls
- Fix minimax trailing `\n` in `TOOL_CALL_END` and add `\n` prefix for forced/required
- Fix kimi forced/required to include `tool_calls_section` wrapper
- Fix harmony `FINAL_END` to accept both `<|end|>` and `<|return|>`
- Add `THINK_SUFFIX` transition for qwen_3, qwen_3_5, minimax between reasoning end and tool call start in forced/required modes