### PR TITLE
perf: reduce structural-tag compile time at high tool count

### DIFF
--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -569,7 +569,15 @@ class CompactFSM::Impl : public FSMImplBase<Compact2DArray<FSMEdge>> {
   using EdgeType = FSMEdge::EdgeType;
 
  public:
-  using FSMImplBase<Compact2DArray<FSMEdge>>::FSMImplBase;
+  Impl() = default;
+
+  Impl(const Compact2DArray<FSMEdge>& edges, std::vector<int32_t> edge_aux_data = {})
+      : FSMImplBase<Compact2DArray<FSMEdge>>(edges, std::move(edge_aux_data)),
+        edge_num_(ComputeEdgeNum(edges_)) {}
+
+  Impl(Compact2DArray<FSMEdge>&& edges, std::vector<int32_t> edge_aux_data = {})
+      : FSMImplBase<Compact2DArray<FSMEdge>>(std::move(edges), std::move(edge_aux_data)),
+        edge_num_(ComputeEdgeNum(edges_)) {}
 
   void GetNextStates(int from, int value, EdgeType edge_type, std::vector<int>* target) const;
 
@@ -583,8 +591,21 @@ class CompactFSM::Impl : public FSMImplBase<Compact2DArray<FSMEdge>> {
 
   FSM ToFSM() const;
 
+  size_t GetNumEdges() const { return edge_num_; }
+
+  size_t edge_num_ = 0;
+
   friend std::size_t MemorySize(const Impl& impl) {
-    return MemorySize(impl.edges_) + MemorySize(impl.edge_aux_data_);
+    return MemorySize(impl.edges_) + MemorySize(impl.edge_aux_data_) + sizeof(impl.edge_num_);
+  }
+
+ private:
+  static size_t ComputeEdgeNum(const Compact2DArray<FSMEdge>& edges) {
+    size_t edge_num = 0;
+    for (int i = 0; i < edges.size(); ++i) {
+      edge_num += edges[i].size();
+    }
+    return edge_num;
   }
 };
 
@@ -593,7 +614,9 @@ XGRAMMAR_MEMBER_TABLE(
     "edges",
     &CompactFSM::Impl::edges_,
     "edge_aux_data",
-    &CompactFSM::Impl::edge_aux_data_
+    &CompactFSM::Impl::edge_aux_data_,
+    "edge_num",
+    &CompactFSM::Impl::edge_num_
 );
 
 void CompactFSM::Impl::GetNextStates(
@@ -776,6 +799,8 @@ void CompactFSM::GetReachableStates(const std::vector<int>& from, std::unordered
     const {
   pimpl_->GetReachableStates(from, result);
 }
+
+size_t CompactFSM::GetNumEdges() const { return pimpl_->GetNumEdges(); }
 
 FSM CompactFSM::ToFSM() const { return pimpl_->ToFSM(); }
 
@@ -1282,57 +1307,154 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentSuccessors(int max_result_num_st
   if (max_result_num_states < NumStates()) {
     return *this;
   }
+  // No merge is possible with fewer than 4 states (need >=2 sources sharing a target,
+  // or >=2 sinks sharing a source).
+  if (NumStates() < 4) {
+    return Copy();
+  }
   bool changed = true;
   FSMWithStartEnd result = Copy();
   result.GetFsm()->SortEdges();
   UnionFindSet<int> union_find_set;
+
+  // A compact edge view used for incoming/outgoing CSR rows. `peer` means source state in
+  // incoming_edges and target state in outgoing_edges.
+  struct EndpointEdge {
+    int peer;  // source in incoming_edges, target in outgoing_edges
+    int16_t min;
+    int16_t max;
+
+    bool operator<(const EndpointEdge& other) const {
+      return std::tie(peer, min, max) < std::tie(other.peer, other.min, other.max);
+    }
+  };
+
+  // Scratch buffers reused across iterations to avoid repeated vector allocation.
+  // Number of incoming edges for each state, used to size the incoming CSR rows.
+  std::vector<int32_t> incoming_row_sizes;
+  // Number of outgoing edges for each state, used to size the outgoing CSR rows.
+  std::vector<int32_t> outgoing_row_sizes;
+  // Write positions while filling incoming_edges rows.
+  std::vector<int32_t> incoming_write_positions;
+  // Write positions while filling outgoing_edges rows.
+  std::vector<int32_t> outgoing_write_positions;
+  // Incoming edges grouped by target state.
+  Compact2DArray<EndpointEdge> incoming_edges;
+  // Outgoing edges grouped by source state.
+  Compact2DArray<EndpointEdge> outgoing_edges;
+  // Number of distinct predecessor states for each state.
+  std::vector<int> incoming_distinct_count;
+  // Number of distinct successor states for each state.
+  std::vector<int> outgoing_distinct_count;
+  // The only predecessor state when incoming_distinct_count[state] == 1.
+  std::vector<int> single_incoming_source;
+  // The only successor state when outgoing_distinct_count[state] == 1.
+  std::vector<int> single_outgoing_target;
+  // Terminal end states collected for leaf-state merging.
+  std::vector<int32_t> no_successor_end_states;
+  // Terminal non-end states collected for leaf-state merging.
+  std::vector<int32_t> no_successor_non_end_states;
+
   while (changed) {
+    int n = result.NumStates();
     union_find_set.Clear();
-    std::vector<std::unordered_map<int, std::vector<FSMEdge>>> previous_states(result.NumStates());
-    std::vector<std::unordered_map<int, std::vector<FSMEdge>>> next_states(result.NumStates());
-    // Initialize the previous states.
-    for (int i = 0; i < result.NumStates(); i++) {
-      const auto& edges = result.GetFsm().GetEdges(i);
+
+    // First pass: count row sizes for the incoming/outgoing CSR arrays.
+    incoming_row_sizes.assign(n, 0);
+    outgoing_row_sizes.assign(n, 0);
+    for (int source = 0; source < n; ++source) {
+      const auto& edges = result.GetFsm().GetEdges(source);
+      outgoing_row_sizes[source] = static_cast<int32_t>(edges.size());
       for (const auto& edge : edges) {
-        if (previous_states[edge.target].find(i) == previous_states[edge.target].end()) {
-          previous_states[edge.target][i] = std::vector<FSMEdge>();
-        }
-        previous_states[edge.target][i].push_back(edge);
-        if (next_states[i].find(edge.target) == next_states[i].end()) {
-          next_states[i][edge.target] = std::vector<FSMEdge>();
-        }
-        next_states[i][edge.target].push_back(edge);
+        ++incoming_row_sizes[edge.target];
       }
     }
+
+    // Allocate CSR rows. The underlying storage is reset and reused across iterations.
+    incoming_edges.ResetWithRowSizes(incoming_row_sizes);
+    outgoing_edges.ResetWithRowSizes(outgoing_row_sizes);
+    incoming_write_positions.assign(n, 0);
+    outgoing_write_positions.assign(n, 0);
+
+    // Second pass: fill incoming and outgoing rows. Incoming rows are naturally grouped by
+    // source because we scan source states in order; outgoing rows are sorted by target below.
+    for (int source = 0; source < n; ++source) {
+      const auto& edges = result.GetFsm().GetEdges(source);
+      auto outgoing_row = outgoing_edges.MutableRowAt(source);
+      for (const auto& edge : edges) {
+        incoming_edges.MutableRowAt(edge.target
+        )[incoming_write_positions[edge.target]++] = {source, edge.min, edge.max};
+        outgoing_row[outgoing_write_positions[source]++] = {edge.target, edge.min, edge.max};
+      }
+      std::sort(outgoing_row.begin(), outgoing_row.end());
+    }
+
+    // Identify states with exactly one distinct predecessor/successor. These states are the
+    // candidates for the two local merge rules below.
+    incoming_distinct_count.assign(n, 0);
+    outgoing_distinct_count.assign(n, 0);
+    single_incoming_source.assign(n, -1);
+    single_outgoing_target.assign(n, -1);
+    for (int state = 0; state < n; ++state) {
+      auto incoming_row = incoming_edges[state];
+      if (incoming_row.size() > 0) {
+        incoming_distinct_count[state] = 1;
+        single_incoming_source[state] = incoming_row[0].peer;
+        for (int32_t i = 1; i < incoming_row.size(); ++i) {
+          if (incoming_row[i].peer != incoming_row[i - 1].peer) {
+            ++incoming_distinct_count[state];
+            single_incoming_source[state] = -1;
+          }
+        }
+      }
+      auto outgoing_row = outgoing_edges[state];
+      if (outgoing_row.size() > 0) {
+        outgoing_distinct_count[state] = 1;
+        single_outgoing_target[state] = outgoing_row[0].peer;
+        for (int32_t i = 1; i < outgoing_row.size(); ++i) {
+          if (outgoing_row[i].peer != outgoing_row[i - 1].peer) {
+            ++outgoing_distinct_count[state];
+            single_outgoing_target[state] = -1;
+          }
+        }
+      }
+    }
+
     // Case 1: Like ab | ac | ad, then they can be merged into a(b | c | d).
     bool is_equiv_successor = false;
-    for (int i = 0; i < static_cast<int>(previous_states.size()); i++) {
-      if (previous_states[i].size() != 1 || union_find_set.Count(i)) {
+    for (int i = 0; i < n; i++) {
+      if (incoming_distinct_count[i] != 1 || union_find_set.Count(i)) {
         continue;
       }
-      const auto& previous_state = previous_states[i].begin()->first;
-      const auto& edges_to_i = previous_states[i].begin()->second;
-      const auto& siblings = next_states[previous_state];
-      for (const auto& [sibling, edges_to_sibling] : siblings) {
-        if (sibling <= i || previous_states[sibling].size() != 1 ||
+      int previous_state = single_incoming_source[i];
+      auto edges_to_i = incoming_edges[i];
+      auto siblings = outgoing_edges[previous_state];
+      int32_t group_begin = 0;
+      while (group_begin < siblings.size()) {
+        int sibling = siblings[group_begin].peer;
+        int32_t group_end = group_begin + 1;
+        while (group_end < siblings.size() && siblings[group_end].peer == sibling) {
+          ++group_end;
+        }
+        auto edges_to_sibling = siblings.Slice(group_begin, group_end);
+        group_begin = group_end;
+        if (sibling <= i || incoming_distinct_count[sibling] != 1 ||
             result.IsEndState(sibling) != result.IsEndState(i)) {
           continue;
         }
-        bool is_equiv = true;
-
-        // Check if the edges are the same.
+        // Check if the edges from previous_state to i and sibling are the same.
         if (edges_to_i.size() != edges_to_sibling.size()) {
-          break;  // Different edges, not equivalent.
+          continue;  // Different edges, not equivalent.
         }
-        for (int i = 0; i < static_cast<int>(edges_to_i.size()); i++) {
-          if (edges_to_i[i].min != edges_to_sibling[i].min ||
-              edges_to_i[i].max != edges_to_sibling[i].max) {
+        bool is_equiv = true;
+        for (int32_t j = 0; j < edges_to_i.size(); ++j) {
+          if (edges_to_i[j].min != edges_to_sibling[j].min ||
+              edges_to_i[j].max != edges_to_sibling[j].max) {
             is_equiv = false;
             break;  // Different edge ranges, not equivalent.
           }
         }
-
-        // Merge the nodes.
+        // Merge the equivalent successor states.
         if (is_equiv) {
           union_find_set.Add(i);
           union_find_set.Add(sibling);
@@ -1344,11 +1466,12 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentSuccessors(int max_result_num_st
 
     // Case 2: Like ba | ca | da, then they can be merged into (b | c | d)a.
     bool is_equiv_precursor = false;
-    std::vector<int32_t> no_successor_end_states;
-    std::vector<int32_t> no_successor_non_end_states;
+    no_successor_end_states.clear();
+    no_successor_non_end_states.clear();
 
-    for (int i = 0; i < static_cast<int>(next_states.size()); i++) {
-      if (next_states[i].empty()) {
+    for (int i = 0; i < n; i++) {
+      int outgoing_count = outgoing_distinct_count[i];
+      if (outgoing_count == 0) {
         if (result.IsEndState(i)) {
           no_successor_end_states.push_back(i);
         } else {
@@ -1356,30 +1479,36 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentSuccessors(int max_result_num_st
         }
         continue;  // Skip states with no successors.
       }
-      if (next_states[i].size() != 1 || union_find_set.Count(i)) {
+      if (outgoing_count != 1 || union_find_set.Count(i)) {
         continue;  // Skip states with multiple successors.
       }
-      const auto& next_state = next_states[i].begin()->first;
-      const auto& node_edges = result.GetFsm().GetEdges(i);
-      const auto& siblings = previous_states[next_state];
-      for (const auto& [sibling, edges_to_sibling] : siblings) {
-        if (sibling <= i || next_states[sibling].size() != 1 ||
+      int next_state = single_outgoing_target[i];
+      auto node_edges = outgoing_edges[i];
+      auto siblings = incoming_edges[next_state];
+      int32_t group_begin = 0;
+      while (group_begin < siblings.size()) {
+        int sibling = siblings[group_begin].peer;
+        while (group_begin < siblings.size() && siblings[group_begin].peer == sibling) {
+          ++group_begin;
+        }
+        if (sibling <= i || outgoing_distinct_count[sibling] != 1 ||
             result.IsEndState(i) != result.IsEndState(sibling)) {
           continue;
         }
-        const auto& sibling_node_edges = result.GetFsm().GetEdges(sibling);
+        auto sibling_node_edges = outgoing_edges[sibling];
         if (sibling_node_edges.size() != node_edges.size()) {
           continue;  // Different number of edges, not equivalent.
         }
+        // Check if the sibling state has the same outgoing edges as i.
         bool is_equiv = true;
-        for (int i = 0; i < static_cast<int>(sibling_node_edges.size()); i++) {
-          if (sibling_node_edges[i].min != node_edges[i].min ||
-              sibling_node_edges[i].max != node_edges[i].max) {
+        for (int32_t j = 0; j < node_edges.size(); ++j) {
+          if (sibling_node_edges[j].min != node_edges[j].min ||
+              sibling_node_edges[j].max != node_edges[j].max) {
             is_equiv = false;
             break;
           }
         }
-
+        // Merge the equivalent precursor states.
         if (is_equiv) {
           union_find_set.Add(i);
           union_find_set.Add(sibling);
@@ -1411,6 +1540,8 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentSuccessors(int max_result_num_st
 
     changed = is_equiv_successor || is_equiv_precursor;
     if (changed) {
+      // Rebuild the FSM with the equivalent states merged, then repeat until no local merge
+      // rule applies.
       auto eq_classes = union_find_set.GetAllSets();
       std::vector<int> old_to_new(result.NumStates(), -1);
       for (size_t i = 0; i < eq_classes.size(); i++) {

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -533,6 +533,12 @@ class CompactFSM {
    */
   void GetReachableStates(const std::vector<int>& from, std::unordered_set<int>* result) const;
 
+  /*!
+   * \brief Get the number of edges in the compact FSM.
+   * \return The number of edges.
+   */
+  size_t GetNumEdges() const;
+
   /****************** CompactFSM Auxiliary Data ******************/
 
   /*! \brief Get the edge auxiliary data. */
@@ -861,12 +867,7 @@ class CompactFSMWithStartEnd : public FSMWithStartEndBase<CompactFSM> {
   CompactFSMWithStartEnd() = default;
 
   explicit CompactFSMWithStartEnd(const CompactFSM& fsm, int start, const std::vector<bool>& ends)
-      : FSMWithStartEndBase<CompactFSM>(fsm, start, ends) {
-    edge_num_ = 0;
-    for (int i = 0; i < fsm.NumStates(); i++) {
-      edge_num_ += fsm.GetEdges(i).size();
-    }
-  }
+      : FSMWithStartEndBase<CompactFSM>(fsm, start, ends), edge_num_(fsm.GetNumEdges()) {}
 
   using FSMWithStartEndBase<CompactFSM>::FSMWithStartEndBase;
 

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -262,13 +262,15 @@ void GrammarBuilder::UpdateLookaheadAssertion(
 std::string GrammarBuilder::GetNewRuleName(const std::string& name_hint) {
   if (rule_name_to_id_.count(name_hint) == 0) {
     return name_hint;
-  } else {
-    int cnt = 1;
-    while (rule_name_to_id_.count(name_hint + "_" + std::to_string(cnt)) != 0) {
-      ++cnt;
-    }
-    return name_hint + "_" + std::to_string(cnt);
   }
+  int& cnt = next_cnt_per_hint_[name_hint];
+  if (cnt == 0) {
+    cnt = 1;
+  }
+  while (rule_name_to_id_.count(name_hint + "_" + std::to_string(cnt)) != 0) {
+    ++cnt;
+  }
+  return name_hint + "_" + std::to_string(cnt);
 }
 
 int32_t GrammarBuilder::GetRuleId(const std::string& name) const {

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -208,6 +208,8 @@ class GrammarBuilder {
   std::shared_ptr<Grammar::Impl> grammar_;
   // Map from rule name to rule id.
   std::unordered_map<std::string, int32_t> rule_name_to_id_;
+  // Cache of next suffix index per name_hint for GetNewRuleName.
+  std::unordered_map<std::string, int> next_cnt_per_hint_;
 };
 
 }  // namespace xgrammar

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -1044,7 +1045,6 @@ class GrammarCompilerSub {
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
-
   compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
   if (tokenizer_info_.GetVocabSize() == 0) {

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -15,6 +15,7 @@
 #include <queue>
 #include <set>
 #include <stack>
+#include <string>
 #include <tuple>
 #include <variant>
 #include <vector>
@@ -749,6 +750,7 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
         root_grammar_expr.type == GrammarExprType::kTokenTagDispatch) {
       return grammar;
     }
+    BuildRuleLookaheadInfo();
     for (int i = 0; i < static_cast<int>(grammar->NumRules()); ++i) {
       auto rule = grammar->GetRule(i);
       if (i == grammar->GetRootRuleId()) {
@@ -769,112 +771,77 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
 
   bool IsExactLookaheadAssertion(int32_t rule_id) {
     XGRAMMAR_DCHECK(base_grammar_->GetRule(rule_id).lookahead_assertion_id != -1);
-    bool found = false;
-    for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
-      auto rule = base_grammar_->GetRule(i);
-      auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
-      if (grammar_expr.type == GrammarExprType::kTagDispatch) {
-        auto tag_dispatch = base_grammar_->GetTagDispatch(grammar_expr);
-        for (const auto& [trigger, rid] : tag_dispatch.tag_rule_pairs) {
-          if (rid == rule_id) {
-            return false;
-          }
-        }
-        continue;
-      }
-      if (grammar_expr.type == GrammarExprType::kTokenTagDispatch) {
-        auto ttd = base_grammar_->GetTokenTagDispatch(grammar_expr);
-        for (const auto& [token_id, rid] : ttd.trigger_rule_pairs) {
-          if (rid == rule_id) {
-            return false;
-          }
-        }
-        continue;
-      }
-      XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kChoices);
-      for (auto sequence_id : grammar_expr) {
-        auto sequence_expr = base_grammar_->GetGrammarExpr(sequence_id);
-        if (sequence_expr.type != GrammarExprType::kSequence) {
-          continue;
-        }
-        auto last_element = base_grammar_->GetGrammarExpr(sequence_expr.end()[-1]);
-        if (last_element.type == GrammarExprType::kRuleRef && last_element[0] == rule_id &&
-            i != rule_id) {
-          return false;
-        }
-
-        for (int j = 0; j < sequence_expr.size() - 1; ++j) {
-          auto element_expr = base_grammar_->GetGrammarExpr(sequence_expr[j]);
-          if (element_expr.type != GrammarExprType::kRuleRef || element_expr[0] != rule_id) {
-            continue;
-          }
-          if (found) {
-            return false;
-          }
-          found = true;
-        }
-      }
-    }
-    return found;
+    return CanUseDerivedLookahead(rule_id);
   }
 
   int32_t DetectLookaheadAssertion(int32_t rule_id) {
-    std::vector<int32_t> found_sequence;  // Element ids
-    bool found = false;
+    if (!CanUseDerivedLookahead(rule_id)) {
+      return -1;
+    }
+    return builder_->AddSequence(rule_lookahead_infos_[rule_id].suffix_after_first_occurrence);
+  }
+
+ private:
+  struct RuleLookaheadInfo {
+    bool is_triggered_by_dispatch = false;
+    bool appears_as_last_in_other_rule = false;
+    int non_last_occurrence_count = 0;
+    std::vector<int32_t> suffix_after_first_occurrence;
+  };
+
+  bool CanUseDerivedLookahead(int32_t rule_id) const {
+    const auto& info = rule_lookahead_infos_[rule_id];
+    return !info.is_triggered_by_dispatch && !info.appears_as_last_in_other_rule &&
+           info.non_last_occurrence_count == 1;
+  }
+
+  void BuildRuleLookaheadInfo() {
+    rule_lookahead_infos_.assign(base_grammar_->NumRules(), RuleLookaheadInfo{});
     for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
       auto rule = base_grammar_->GetRule(i);
       auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
       if (grammar_expr.type == GrammarExprType::kTagDispatch) {
         auto tag_dispatch = base_grammar_->GetTagDispatch(grammar_expr);
-        for (const auto& [trigger, rid] : tag_dispatch.tag_rule_pairs) {
-          if (rid == rule_id) {
-            return -1;
-          }
+        for (const auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
+          rule_lookahead_infos_[rule_id].is_triggered_by_dispatch = true;
         }
         continue;
       }
       if (grammar_expr.type == GrammarExprType::kTokenTagDispatch) {
-        auto ttd = base_grammar_->GetTokenTagDispatch(grammar_expr);
-        for (const auto& [token_id, rid] : ttd.trigger_rule_pairs) {
-          if (rid == rule_id) {
-            return -1;
-          }
+        auto token_tag_dispatch = base_grammar_->GetTokenTagDispatch(grammar_expr);
+        for (const auto& [token_id, rule_id] : token_tag_dispatch.trigger_rule_pairs) {
+          rule_lookahead_infos_[rule_id].is_triggered_by_dispatch = true;
         }
         continue;
       }
       XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kChoices);
       for (auto sequence_id : grammar_expr) {
         auto sequence_expr = base_grammar_->GetGrammarExpr(sequence_id);
-        if (sequence_expr.type != GrammarExprType::kSequence) {
+        if (sequence_expr.type != GrammarExprType::kSequence || sequence_expr.size() == 0) {
           continue;
         }
         auto last_element = base_grammar_->GetGrammarExpr(sequence_expr.end()[-1]);
-        if (last_element.type == GrammarExprType::kRuleRef && last_element[0] == rule_id &&
-            i != rule_id) {
-          return -1;
+        if (last_element.type == GrammarExprType::kRuleRef && i != last_element[0]) {
+          rule_lookahead_infos_[last_element[0]].appears_as_last_in_other_rule = true;
         }
-
         for (int j = 0; j < sequence_expr.size() - 1; ++j) {
           auto element_expr = base_grammar_->GetGrammarExpr(sequence_expr[j]);
-          if (element_expr.type != GrammarExprType::kRuleRef || element_expr[0] != rule_id) {
+          if (element_expr.type != GrammarExprType::kRuleRef) {
             continue;
           }
-          if (found) {
-            return -1;
+          auto& info = rule_lookahead_infos_[element_expr[0]];
+          if (info.non_last_occurrence_count == 0) {
+            info.suffix_after_first_occurrence.assign(
+                sequence_expr.begin() + j + 1, sequence_expr.end()
+            );
           }
-          found = true;
-          for (int k = j + 1; k < sequence_expr.size(); ++k) {
-            found_sequence.push_back(sequence_expr[k]);
-          }
+          ++info.non_last_occurrence_count;
         }
       }
     }
-
-    if (!found) {
-      return -1;
-    }
-    return builder_->AddSequence(found_sequence);
   }
+
+  std::vector<RuleLookaheadInfo> rule_lookahead_infos_;
 };
 
 /*!
@@ -1626,10 +1593,6 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Choices(
   auto result = FSMWithStartEnd::Union(fsm_list);
   result = result.SimplifyEpsilon();
   result = result.MergeEquivalentSuccessors();
-  auto result_raw = result.MinimizeDFA();
-  if (result_raw.IsOk()) {
-    result = std::move(result_raw).Unwrap();
-  }
   return result;
 }
 

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -1717,7 +1717,7 @@ std::optional<ISTError> StructuralTagAnalyzer::VisitSub(RepeatFormat* format) {
 
 class StructuralTagGrammarConverter {
  public:
-  static Result<Grammar, ISTError> Convert(const StructuralTag& structural_tag);
+  Result<Grammar, ISTError> Convert(const StructuralTag& structural_tag);
 
  private:
   /*!
@@ -1771,14 +1771,13 @@ bool StructuralTagGrammarConverter::IsPrefix(
 
 Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(const StructuralTag& structural_tag
 ) {
-  auto converter = StructuralTagGrammarConverter();
-  auto result = converter.Visit(structural_tag.format);
+  auto result = Visit(structural_tag.format);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }
   // Add a root rule
   auto root_rule_id = std::move(result).Unwrap();
-  return ResultOk(converter.AddRootRuleAndGetGrammar(root_rule_id));
+  return ResultOk(AddRootRuleAndGetGrammar(root_rule_id));
 }
 
 Grammar StructuralTagGrammarConverter::AddRootRuleAndGetGrammar(int ref_rule_id) {
@@ -1845,7 +1844,8 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFo
   if (converter == style_to_grammar_converter.end()) {
     return ResultErr<ISTError>("Unsupported parsing type: " + format.style);
   }
-  auto sub_grammar = Grammar::FromEBNF(converter->second(format.json_schema));
+  std::string ebnf = converter->second(format.json_schema);
+  auto sub_grammar = Grammar::FromEBNF(ebnf);
   auto added_root_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
   return ResultOk(added_root_rule_id);
 }
@@ -2409,12 +2409,15 @@ Result<Grammar, StructuralTagError> StructuralTagToGrammar(
   if (err.has_value()) {
     return ResultErr(std::move(err).value());
   }
-  auto result = StructuralTagGrammarConverter().Convert(structural_tag);
+
+  auto converter = StructuralTagGrammarConverter();
+  auto result = converter.Convert(structural_tag);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }
-  auto unwrapped_result = std::move(result).Unwrap();
-  return ResultOk(GrammarNormalizer::Apply(std::move(unwrapped_result)));
+  auto normalized_grammar = GrammarNormalizer::Apply(std::move(result).Unwrap());
+
+  return ResultOk(std::move(normalized_grammar));
 }
 
 }  // namespace xgrammar

--- a/cpp/support/compact_2d_array.h
+++ b/cpp/support/compact_2d_array.h
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 #include "logging.h"
@@ -68,6 +69,13 @@ class Compact2DArray {
     /*! \brief Get the size of the row. */
     int32_t size() const { return data_len; }
 
+    /*! \brief Get a sub-row in [begin, end). */
+    Row Slice(int32_t begin, int32_t end) const {
+      XGRAMMAR_DCHECK(begin >= 0 && begin <= end && end <= data_len)
+          << "Compact2DArray Row slice is out of bound";
+      return {data + begin, end - begin};
+    }
+
     friend std::ostream& operator<<(std::ostream& os, const Row& row) {
       os << "[";
       for (auto i = 0; i < row.data_len; ++i) {
@@ -81,11 +89,64 @@ class Compact2DArray {
     }
   };
 
+  /*!
+   * \brief The mutable struct representing a row in the Compact2DArray.
+   */
+  struct MutableRow {
+    /*! \brief The value type is DataType. */
+    using value_type = DataType;
+
+    /*! \brief Pointer to the data of the row. */
+    DataType* data;
+    /*! \brief Length of the row data. */
+    int32_t data_len;
+
+    /*!
+     * \brief Access an element in the row.
+     * \param i Index of the element to access.
+     * \return Reference to the element at index i.
+     */
+    DataType& operator[](int32_t i) const {
+      XGRAMMAR_DCHECK(i >= 0 && i < data_len)
+          << "Index " << i << " of the Compact2DArray MutableRow is out of bound";
+      return data[i];
+    }
+
+    /*! \brief Get the beginning iterator of the row. */
+    DataType* begin() const { return data; }
+    /*! \brief Get the end iterator of the row. */
+    DataType* end() const { return data + data_len; }
+    /*! \brief Get the size of the row. */
+    int32_t size() const { return data_len; }
+  };
+
   /*! \brief The value type is Row. */
   using value_type = Row;
 
   /*! \brief Default constructor. */
   Compact2DArray() = default;
+
+  /*!
+   * \brief Construct a Compact2DArray from an existing CSR representation.
+   * \param data All row elements stored contiguously.
+   * \param indptr Row start offsets. Must start with 0, be non-decreasing, and end with
+   * data.size().
+   * \return The constructed Compact2DArray.
+   */
+  static Compact2DArray FromDataAndIndptr(std::vector<DataType> data, std::vector<int32_t> indptr);
+
+  /*!
+   * \brief Construct a Compact2DArray from row sizes with default-constructed data.
+   * \param row_sizes The size of each row.
+   * \return The constructed Compact2DArray.
+   */
+  static Compact2DArray FromRowSizes(const std::vector<int32_t>& row_sizes);
+
+  /*!
+   * \brief Reset the Compact2DArray from row sizes with default-constructed data.
+   * \param row_sizes The size of each row.
+   */
+  void ResetWithRowSizes(const std::vector<int32_t>& row_sizes);
 
   /****************** Accessors ******************/
 
@@ -102,6 +163,13 @@ class Compact2DArray {
    * \return Row struct representing the i-th row.
    */
   Row operator[](int32_t i) const;
+
+  /*!
+   * \brief Access a mutable row in the Compact2DArray.
+   * \param i Index of the row to access.
+   * \return MutableRow struct representing the i-th row.
+   */
+  MutableRow MutableRowAt(int32_t i);
 
   /****************** Modifiers ******************/
 
@@ -196,6 +264,54 @@ inline typename Compact2DArray<DataType>::Row Compact2DArray<DataType>::operator
   int32_t start = indptr_[i];
   int32_t end = indptr_[i + 1];
   return {data_.data() + start, end - start};
+}
+
+template <typename DataType>
+inline typename Compact2DArray<DataType>::MutableRow Compact2DArray<DataType>::MutableRowAt(
+    int32_t i
+) {
+  XGRAMMAR_DCHECK(i >= 0 && i < size()) << "Compact2DArray index " << i << " is out of bound";
+  int32_t start = indptr_[i];
+  int32_t end = indptr_[i + 1];
+  return {data_.data() + start, end - start};
+}
+
+template <typename DataType>
+inline Compact2DArray<DataType> Compact2DArray<DataType>::FromDataAndIndptr(
+    std::vector<DataType> data, std::vector<int32_t> indptr
+) {
+  XGRAMMAR_CHECK(!indptr.empty()) << "Compact2DArray indptr cannot be empty";
+  XGRAMMAR_CHECK(indptr.front() == 0) << "Compact2DArray indptr must start with 0";
+  for (int32_t i = 1; i < static_cast<int32_t>(indptr.size()); ++i) {
+    XGRAMMAR_CHECK(indptr[i - 1] <= indptr[i]) << "Compact2DArray indptr must be non-decreasing";
+  }
+  XGRAMMAR_CHECK(indptr.back() == static_cast<int32_t>(data.size()))
+      << "Compact2DArray indptr must end with data.size()";
+
+  Compact2DArray result;
+  result.data_ = std::move(data);
+  result.indptr_ = std::move(indptr);
+  return result;
+}
+
+template <typename DataType>
+inline Compact2DArray<DataType> Compact2DArray<DataType>::FromRowSizes(
+    const std::vector<int32_t>& row_sizes
+) {
+  Compact2DArray result;
+  result.ResetWithRowSizes(row_sizes);
+  return result;
+}
+
+template <typename DataType>
+inline void Compact2DArray<DataType>::ResetWithRowSizes(const std::vector<int32_t>& row_sizes) {
+  indptr_.resize(row_sizes.size() + 1);
+  indptr_[0] = 0;
+  for (int32_t i = 0; i < static_cast<int32_t>(row_sizes.size()); ++i) {
+    XGRAMMAR_CHECK(row_sizes[i] >= 0) << "Compact2DArray row size cannot be negative";
+    indptr_[i + 1] = indptr_[i] + row_sizes[i];
+  }
+  data_.assign(indptr_.back(), DataType{});
 }
 
 template <typename DataType>

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v11";
+  static constexpr const char kXGrammarSerializeVersion[] = "v12";
 };
 
 /*!

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -42,7 +42,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v11"
+    assert xgr.get_serialization_version() == "v12"
 
 
 def test_serialize_grammar():
@@ -62,7 +62,7 @@ def test_serialize_grammar():
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v11",
+        "__VERSION__": "v12",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -82,14 +82,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v11",
+        "__VERSION__": "v12",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v11"
+    expected_json["__VERSION__"] = "v12"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -141,7 +141,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v11"}'
+        '"__VERSION__":"v12"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -215,6 +215,7 @@ def test_serialize_compiled_grammar():
                     "indptr_": [0, 5, 6, 6, 7, 8, 9, 9, 10, 11],
                 },
                 "edge_aux_data": [],
+                "edge_num": 11,
             },
             "per_rule_fsms": [
                 [
@@ -228,6 +229,7 @@ def test_serialize_compiled_grammar():
                             "indptr_": [0, 5, 6, 6, 7, 8, 9, 9, 10, 11],
                         },
                         "edge_aux_data": [],
+                        "edge_num": 11,
                     },
                     0, [0, 2], False, 11,
                 ],
@@ -242,6 +244,7 @@ def test_serialize_compiled_grammar():
                             "indptr_": [0, 5, 6, 6, 7, 8, 9, 9, 10, 11],
                         },
                         "edge_aux_data": [],
+                        "edge_num": 11,
                     },
                     7, [6], False, 11,
                 ],
@@ -255,7 +258,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v11",
+        "__VERSION__": "v12",
     }
 
     class AdaptiveTokenMask(BaseModel):


### PR DESCRIPTION
## TL;DR
On the BFCL tool-calling workload (Llama 3.1 8B, `tool_choice="required"`), `compile_structural_tag` cold time at 1000 tools drops from **21.7s → 2.1s (-90%)**.

## Bottlenecks (1000 tools, baseline)
1. **`GrammarBuilder::GetNewRuleName` is O(N) per call.** For each new rule it probes `name_hint`, `name_hint_1`, `name_hint_2`, ... from scratch against `rule_name_to_id_`. With ~11k rules sharing a small set of name hints this becomes O(N^2) overall and dominates baseline time.
2. **`MinimizeDFA` in `Choices()` is wasted work.** State count is essentially unchanged after Hopcroft minimization (e.g. 160,002 → 160,578), but the call itself takes ~580 ms.
3. **`MergeEquivalentSuccessors` thrashes hash maps.** It rebuilds `vector<unordered_map<int, vector<FSMEdge>>>` for predecessor and successor groups every iteration. `build_maps` accounts for ~75% of its runtime, dominated by hash-map and small-vector allocations across 11k+ rules where most rules have <30 states.

## Changes

### 1. `GrammarBuilder::GetNewRuleName`
Cache the next available suffix per `name_hint` so repeated calls with the same hint are amortized O(1) instead of O(N).

### 2. Drop `MinimizeDFA` in `Choices()`
Remove the call to `MinimizeDFA()` after `Union → SimplifyEpsilon → MergeEquivalentSuccessors`. It does not reduce states on these grammars and scales super-linearly in state count.

### 3. CSR-based `MergeEquivalentSuccessors`
- Replace per-state `unordered_map<int, vector<FSMEdge>>` with two `Compact2DArray<EndpointEdge>` (incoming/outgoing edges). Two passes compute row sizes and fill rows directly; no hash map, no per-edge small allocations.
- Hoist scratch buffers (`row_sizes`, `write_positions`, `incoming_edges`, `outgoing_edges`, distinct-peer info) out of the iteration loop and reuse capacity across iterations.
- Early-exit when `NumStates() < 4`: no equivalent-successor merge is structurally possible.

### 4. `Compact2DArray` API extensions (supporting change)
- `FromRowSizes(row_sizes)` / `ResetWithRowSizes(row_sizes)`: size-driven construction with default-initialized data.
- `FromDataAndIndptr(data, indptr)`: move in a pre-built CSR.
- `MutableRowAt(i)`: in-place writable row.
- `Row::Slice(begin, end)`: sub-row view.

### 5. Cache `edge_num` on `CompactFSM` (supporting change)
`CompactFSMWithStartEnd::GetNumEdges()` becomes O(1). Bumps the serialization version `v11 → v12` because `CompactFSM` now serializes an extra field.

## Speedup
BFCL, Llama 3.1 8B, `tool_choice="required"`, `--repeats 1`, `max_threads=64`.

| tool_count | before | after | speedup |
|---:|---:|---:|---:|
| 100  | 501 ms     | 164 ms  | -67% |
| 200  | 1,312 ms   | 308 ms  | -77% |
| 500  | 3,971 ms   | 757 ms  | -81% |
| 1000 | 21,713 ms  | 2,085 ms | **-90%** |

Within the FSM stage at 1000 tools: removing `MinimizeDFA` saves ~580 ms, and `MergeEquivalentSuccessors` itself drops from ~230 ms to ~90 ms.