### PR TITLE
fix: resolve ruff issues in DeepSeek encoding helpers

### DIFF
--- a/tests/python/encoding_dsv32.py
+++ b/tests/python/encoding_dsv32.py
@@ -59,7 +59,7 @@ tool_output_template: str = "\n<result>{content}</result>"
 def to_json(value: Any) -> str:
     try:
         return json.dumps(value, ensure_ascii=False)
-    except:
+    except Exception:
         return json.dumps(value, ensure_ascii=True)
 
 
@@ -118,7 +118,7 @@ def decode_dsml_to_arguments(
         + ", ".join([_decode_value(k, v, string=is_str) for k, (v, is_str) in tool_args.items()])
         + "}"
     )
-    return dict(name=tool_name, arguments=tool_args_json)
+    return {"name": tool_name, "arguments": tool_args_json}
 
 
 def render_tools(tools: List[Dict[str, Union[str, Dict[str, Any]]]]) -> str:

--- a/tests/python/encoding_dsv4.py
+++ b/tests/python/encoding_dsv4.py
@@ -96,7 +96,7 @@ def to_json(value: Any) -> str:
     """Serialize a value to JSON string."""
     try:
         return json.dumps(value, ensure_ascii=False)
-    except:
+    except Exception:
         return json.dumps(value, ensure_ascii=True)
 
 
@@ -141,7 +141,7 @@ def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
 
     try:
         arguments = json.loads(tool_call["arguments"])
-    except Exception as err:
+    except Exception:
         arguments = {"arguments": tool_call["arguments"]}
 
     for k, v in arguments.items():
@@ -180,7 +180,7 @@ def decode_dsml_to_arguments(
         + ", ".join([_decode_value(k, v, string=is_str) for k, (v, is_str) in tool_args.items()])
         + "}"
     )
-    return dict(name=tool_name, arguments=tool_args_json)
+    return {"name": tool_name, "arguments": tool_args_json}
 
 
 def render_tools(tools: List[Dict[str, Union[str, Dict[str, Any]]]]) -> str:


### PR DESCRIPTION
## Summary
- replace bare `except` with `except Exception` in the DeepSeek V3.2 and V4 test encoding helpers
- replace `dict(...)` calls with dict literals and remove the unused exception variable in the V4 helper