### PR TITLE
fix: stop emitting \/ for forward slashes in JSON output

### DIFF
--- a/3rdparty/picojson/picojson.h
+++ b/3rdparty/picojson/picojson.h
@@ -660,7 +660,6 @@ struct serialize_str_char {
     break
       MAP('"', "\\\"");
       MAP('\\', "\\\\");
-      MAP('/', "\\/");
       MAP('\b', "\\b");
       MAP('\f', "\\f");
       MAP('\n', "\\n");

--- a/cpp/support/encoding.h
+++ b/cpp/support/encoding.h
@@ -393,9 +393,9 @@ std::pair<TCodepoint, int32_t> ParseNextEscaped(
   // C escape characters
   static const std::unordered_map<char, TCodepoint> kEscapeToCodepoint = {
       // clang-format off
-      {'\'', '\''}, {'\"', '\"'}, {'?', '\?'}, {'\\', '\\'}, {'a', '\a'}, {'b', '\b'}, {'f', '\f'},
-      {'n', '\n'}, {'r', '\r'}, {'t', '\t'}, {'v', '\v'}, {'0', '\0'},
-      {'e', '\x1B'}  // clang-format on
+      {'\'', '\''}, {'\"', '\"'}, {'?', '\?'}, {'\\', '\\'}, {'/', '/'}, {'a', '\a'},
+      {'b', '\b'}, {'f', '\f'}, {'n', '\n'}, {'r', '\r'}, {'t', '\t'}, {'v', '\v'},
+      {'0', '\0'}, {'e', '\x1B'}  // clang-format on
   };
   if (data[0] != '\\') {
     return {CharHandlingError::kInvalidEscape, 0};

--- a/tests/python/test_grammar_parser.py
+++ b/tests/python/test_grammar_parser.py
@@ -245,6 +245,19 @@ def test_unicode_escape():
     assert after == expected
 
 
+def test_forward_slash_escape_in_string_literal():
+    # Regression: the EBNF lexer used to reject "\/" in string literals
+    # with "Invalid escape sequence", because the C-style escape table did
+    # not include "/". JSON allows "\/" as an alias for "/", so xgrammar
+    # should accept it consistently.
+    before = r"""root ::= "a\/b"
+"""
+    expected = r"""root ::= (("a/b"))
+"""
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
 def test_complex_grammar():
     """Test a more complex grammar with multiple features."""
     before = """root ::= expr

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2308,5 +2308,24 @@ def test_utf8_array_const():
     assert _is_grammar_accept_string(grammar, '["こんにちは","😊","你好","hello","\\n"]')
 
 
+def test_forward_slash_in_const():
+    # Regression: picojson used to serialize const/enum strings with "\/"
+    # for every "/", which the EBNF lexer then rejected as an invalid
+    # escape sequence (or, in lenient builds, only accepted the escaped
+    # literal form, never the plain JSON the model actually emits).
+    schema = {"const": "http://example.com/path"}
+    grammar = xgr.Grammar.from_json_schema(schema)
+    assert _is_grammar_accept_string(grammar, '"http://example.com/path"')
+    assert not _is_grammar_accept_string(grammar, '"http:\\/\\/example.com\\/path"')
+
+
+def test_forward_slash_in_enum():
+    schema = {"enum": ["a/b", "c/d/e"]}
+    grammar = xgr.Grammar.from_json_schema(schema)
+    assert _is_grammar_accept_string(grammar, '"a/b"')
+    assert _is_grammar_accept_string(grammar, '"c/d/e"')
+    assert not _is_grammar_accept_string(grammar, '"a\\/b"')
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
## Problem

JSON schemas with `const` / `enum` string values that contain `/`
(e.g. URLs, file paths) produced grammars the model could not satisfy.

picojson's serializer escapes every `/` as `\/`, and that serialized
form is pasted verbatim into a grammar literal. So
`{"const": "http://example.com/path"}` ends up rejecting the plain
`"http://example.com/path"` the model emits and accepting only the
`"http:\/\/example.com\/path"` form — grammar-guided decoding stalls
on the first `/`. In some paths the same string also tripped the EBNF
lexer with `Invalid escape sequence`, since `/` was not in its
C-style escape table.

## Fix

- `3rdparty/picojson/picojson.h`: drop the `/` -> `\/` mapping in
  `serialize_str_char`. `\/` is optional in the JSON spec, so not
  emitting it makes serialized const / enum strings match what a model
  naturally generates.
- `cpp/support/encoding.h`: add `\/` -> `/` to the default escape
  table used by `ParseNextEscaped`, keeping the EBNF lexer in sync
  with JSON's relaxed rule so any literal that does contain `\/`
  (hand-written grammars, older serialized structural tags) still
  parses.