### PR TITLE
Fix segfault in RepetitionRangeExpander from wrong grammar object lookup

### DIFF
--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1806,7 +1806,7 @@ int32_t RepetitionRangeExpanderImpl::HandleRepetitionRange(
   // Now, we transform {lower, upper} into {max{threshold, lower}, upper}.
   // Case 2.2 upper is unbounded. We will transform it into {lower} {0, inf}.
   if (upper == -1) {
-    const auto& rule_expr = base_grammar_->GetGrammarExpr(grammar_expr_id);
+    const auto& rule_expr = builder_->GetGrammarExpr(grammar_expr_id);
     if (rule_expr.type == GrammarBuilder::GrammarExprType::kCharacterClass) {
       std::vector<GrammarBuilder::CharacterClassElement> character_ranges;
       bool is_negative = rule_expr[0];

--- a/tests/cpp/test_repetition_range.cc
+++ b/tests/cpp/test_repetition_range.cc
@@ -1,4 +1,5 @@
-/**
+/*!
+ *  Copyright (c) 2026 by Contributors
  * \file tests/cpp/test_repetition_range.cc
  * \brief Regression test for RepetitionRangeExpander segfault when
  *        grammar_expr_id (a builder ID) is looked up in base_grammar_.

--- a/tests/cpp/test_repetition_range.cc
+++ b/tests/cpp/test_repetition_range.cc
@@ -1,0 +1,24 @@
+/**
+ * \file tests/cpp/test_repetition_range.cc
+ * \brief Regression test for RepetitionRangeExpander segfault when
+ *        grammar_expr_id (a builder ID) is looked up in base_grammar_.
+ */
+
+#include <gtest/gtest.h>
+#include <xgrammar/xgrammar.h>
+
+#include "grammar_functor.h"
+
+using namespace xgrammar;
+
+// HandleRepetitionRange looks up grammar_expr_id (a builder ID) in
+// base_grammar_ instead of builder_. The first expansion inflates the
+// builder's ID space; the second expansion's grammar_expr_id then
+// exceeds base_grammar_'s expression count, causing an OOB / segfault.
+TEST(RepetitionRangeExpanderTest, UnboundedRepetitionAboveThresholdDoesNotCrash) {
+  // Two unbounded repeats with lower > kUnzipThreshold (128) in the
+  // same rule. The first expand creates many builder expressions; the
+  // second's grammar_expr_id lands out of bounds in base_grammar_.
+  auto grammar = Grammar::FromEBNF(R"(root ::= [a-z]{129,} [0-9]{129,})");
+  EXPECT_NO_THROW(RepetitionRangeExpander::Apply(grammar));
+}


### PR DESCRIPTION
## What

One-line fix: `base_grammar_->GetGrammarExpr(grammar_expr_id)` → `builder_->GetGrammarExpr(grammar_expr_id)` in `HandleRepetitionRange`.

## Bug

`HandleRepetitionRange` indexes into `base_grammar_` with `grammar_expr_id`, but `grammar_expr_id` is an expression ID allocated by `builder_` — a different grammar object with its own ID space. The two ID spaces start roughly aligned but diverge as the mutator creates expressions that don't exist in the original grammar. When the builder's ID exceeds the original grammar's expression count, the lookup goes out of bounds.

The bug is reachable whenever `upper == -1` (unbounded repetition) and `lower > kUnzipThreshold` (128). A single such repeat usually doesn't crash because the builder hasn't diverged far enough yet, but a second one in the same grammar reliably does — the first expansion inflates the builder's ID space, and the second expansion's `grammar_expr_id` lands past the end of `base_grammar_`'s expression array.

Even when the lookup happens to stay in bounds (e.g., a grammar with only one large unbounded repeat), it reads the wrong expression. The code checks whether the expression is a `kCharacterClass` to decide between `AddCharacterClassStar` and a recursive rule fallback. A false negative here means character classes silently take the slower recursive path; a false positive on a non-character-class expression would be worse.

## Fix

One token change at `cpp/grammar_functor.cc:1809`.

## Test

`[a-z]{129,} [0-9]{129,}` — two unbounded repeats above threshold in the same rule — segfaults without the fix and passes with it.