### PR TITLE
fix: fix the FSM's state merging algorithm. 

### DIFF
--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -1491,7 +1491,10 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentSuccessors(int max_result_num_st
         while (group_begin < siblings.size() && siblings[group_begin].peer == sibling) {
           ++group_begin;
         }
-        if (sibling <= i || outgoing_distinct_count[sibling] != 1 ||
+        // Avoid chaining a Case 2 merge onto a state already merged earlier in this iteration
+        // (typically by Case 1), which can over-merge via transitive closure.
+        if (sibling <= i || union_find_set.Count(sibling) ||
+            outgoing_distinct_count[sibling] != 1 ||
             result.IsEndState(i) != result.IsEndState(sibling)) {
           continue;
         }
@@ -1513,7 +1516,7 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentSuccessors(int max_result_num_st
           union_find_set.Add(i);
           union_find_set.Add(sibling);
           union_find_set.Union(i, sibling);
-          is_equiv_successor = true;
+          is_equiv_precursor = true;
         }
       }
     }

--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -1303,7 +1303,7 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
   return RebuildWithMapping(new_to_old, cnt);
 }
 
-FSMWithStartEnd FSMWithStartEnd::MergeEquivalentSuccessors(int max_result_num_states) const {
+FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states) const {
   if (max_result_num_states < NumStates()) {
     return *this;
   }

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -838,7 +838,7 @@ class FSMWithStartEnd : public FSMWithStartEndBase<FSM> {
    * 2) they are not pointed to by other edges, then we can merge them.
    * \example n0 --(c)--> n1, n0 --(c)--> n2, then we can merge n1 and n2.
    */
-  FSMWithStartEnd MergeEquivalentSuccessors(int max_num_states = 1e5) const;
+  FSMWithStartEnd MergeEquivalentStates(int max_num_states = 1e5) const;
 
   /*!
    * \brief Transform the FSM to a DFA.

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -17,7 +17,6 @@
 #include <stack>
 #include <string>
 #include <tuple>
-#include <variant>
 #include <vector>
 
 #include "compiled_grammar_impl.h"
@@ -1592,7 +1591,7 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Choices(
 
   auto result = FSMWithStartEnd::Union(fsm_list);
   result = result.SimplifyEpsilon();
-  result = result.MergeEquivalentSuccessors();
+  result = result.MergeEquivalentStates();
   return result;
 }
 

--- a/tests/cpp/test_fsm.cc
+++ b/tests/cpp/test_fsm.cc
@@ -493,7 +493,7 @@ TEST(XGrammarFSMTest, MergingNodesTest) {
   EXPECT_EQ(fsm_wse.GetFsm().NumStates(), 5);
 }
 
-TEST(XGrammarFSMTest, MergeEquivalentSuccessorsNoCrossRuleChaining) {
+TEST(XGrammarFSMTest, MergeEquivalentStatesNoCrossRuleChaining) {
   FSMWithStartEnd fsm_wse;
   for (int i = 0; i < 7; ++i) {
     fsm_wse.AddState();

--- a/tests/cpp/test_fsm.cc
+++ b/tests/cpp/test_fsm.cc
@@ -245,7 +245,7 @@ TEST(XGrammarFSMTest, FunctionTest) {
   test_str = "abc";
   EXPECT_TRUE(fsm_wse.AcceptString(test_str));
   fsm_wse = fsm_wse.SimplifyEpsilon();
-  fsm_wse = fsm_wse.MergeEquivalentSuccessors();
+  fsm_wse = fsm_wse.MergeEquivalentStates();
   EXPECT_TRUE(fsm_wse.AcceptString(test_str));
   test_str = "abcd";
   EXPECT_FALSE(fsm_wse.AcceptString(test_str));
@@ -255,7 +255,7 @@ TEST(XGrammarFSMTest, FunctionTest) {
   test_str = "acd";
   EXPECT_TRUE(fsm_wse.AcceptString(test_str));
   fsm_wse = fsm_wse.SimplifyEpsilon();
-  fsm_wse = fsm_wse.MergeEquivalentSuccessors();
+  fsm_wse = fsm_wse.MergeEquivalentStates();
   EXPECT_TRUE(fsm_wse.AcceptString(test_str));
   test_str = "abcd";
   EXPECT_FALSE(fsm_wse.AcceptString(test_str));
@@ -400,7 +400,7 @@ TEST(XGrammarFSMTest, EfficiencyTest) {
   std::cout << "Time taken to simplify epsilon: " << duration.count() << " ms" << std::endl;
   std::cout << "After SimplifyEpsilon Node Numbers:" << fsm_wse.GetFsm().NumStates() << std::endl;
   time_start = std::chrono::high_resolution_clock::now();
-  fsm_wse = fsm_wse.MergeEquivalentSuccessors();
+  fsm_wse = fsm_wse.MergeEquivalentStates();
   time_end = std::chrono::high_resolution_clock::now();
   duration = std::chrono::duration_cast<std::chrono::milliseconds>(time_end - time_start);
   std::cout << "Time taken to simplify transition: " << duration.count() << " ms" << std::endl;
@@ -481,7 +481,7 @@ TEST(XGrammarFSMTest, MergingNodesTest) {
   fsm_wse.GetFsm().AddEdge(6, 8, 'd', 'd');
   fsm_wse.GetFsm().AddEdge(7, 9, 'e', 'e');
   fsm_wse.GetFsm().AddEdge(8, 9, 'e', 'e');
-  fsm_wse = fsm_wse.MergeEquivalentSuccessors();
+  fsm_wse = fsm_wse.MergeEquivalentStates();
   std::string expected_fsm = R"(FSM(num_states=5, start=3, end=[4], edges=[
 0: ['d'->2]
 1: ['b'->0, 'c'->0]
@@ -513,7 +513,7 @@ TEST(XGrammarFSMTest, MergeEquivalentSuccessorsNoCrossRuleChaining) {
   fsm_wse.GetFsm().AddEdge(4, 6, 'm', 'm');
   fsm_wse.GetFsm().AddEdge(5, 6, 'n', 'n');
 
-  auto merged = fsm_wse.MergeEquivalentSuccessors();
+  auto merged = fsm_wse.MergeEquivalentStates();
 
   // Still accepts original strings.
   EXPECT_TRUE(merged.AcceptString("xam"));

--- a/tests/cpp/test_fsm.cc
+++ b/tests/cpp/test_fsm.cc
@@ -493,6 +493,36 @@ TEST(XGrammarFSMTest, MergingNodesTest) {
   EXPECT_EQ(fsm_wse.GetFsm().NumStates(), 5);
 }
 
+TEST(XGrammarFSMTest, MergeEquivalentSuccessorsNoCrossRuleChaining) {
+  FSMWithStartEnd fsm_wse;
+  for (int i = 0; i < 7; ++i) {
+    fsm_wse.AddState();
+  }
+  fsm_wse.SetStartState(0);
+  fsm_wse.AddEndState(6);
+
+  // 2 and 3 are equivalent successors of 0 under 'x' (Case 1).
+  fsm_wse.GetFsm().AddEdge(0, 2, 'x', 'x');
+  fsm_wse.GetFsm().AddEdge(0, 3, 'x', 'x');
+  // 1 is another predecessor of 4 under 'a' (Case 2 candidate with 2).
+  fsm_wse.GetFsm().AddEdge(0, 1, 'y', 'y');
+
+  fsm_wse.GetFsm().AddEdge(1, 4, 'a', 'a');
+  fsm_wse.GetFsm().AddEdge(2, 4, 'a', 'a');
+  fsm_wse.GetFsm().AddEdge(3, 5, 'b', 'b');
+  fsm_wse.GetFsm().AddEdge(4, 6, 'm', 'm');
+  fsm_wse.GetFsm().AddEdge(5, 6, 'n', 'n');
+
+  auto merged = fsm_wse.MergeEquivalentSuccessors();
+
+  // Still accepts original strings.
+  EXPECT_TRUE(merged.AcceptString("xam"));
+  EXPECT_TRUE(merged.AcceptString("xbn"));
+  EXPECT_TRUE(merged.AcceptString("yam"));
+  // Should not over-merge and introduce this path.
+  EXPECT_FALSE(merged.AcceptString("ybn"));
+}
+
 TEST(XGrammarFSMTest, EpsilonSimplificationTest) {
   FSMWithStartEnd fsm_wse;
   for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
As reported in #618, when there are many strings in an enum, the grammar matcher will accept more tokens than expected.  The problem is caused by the FSM's state merging algorithm, which will oversimplify the FSM at present. This PR fixes the problem and adds the tests.