### PR TITLE
fix: fix the `GrammarMatcher.accept_token` with HF processor.

### DIFF
--- a/python/xgrammar/contrib/hf.py
+++ b/python/xgrammar/contrib/hf.py
@@ -92,7 +92,7 @@ class LogitsProcessor(transformers.LogitsProcessor):
         else:
             for i in range(self.batch_size):
                 if not self.matchers[i].is_terminated():
-                    sampled_token = input_ids[i][-1]
+                    sampled_token = int(input_ids[i][-1].item())
                     assert self.matchers[i].accept_token(sampled_token)
 
         for i in range(self.batch_size):

--- a/python/xgrammar/contrib/hf.py
+++ b/python/xgrammar/contrib/hf.py
@@ -92,7 +92,7 @@ class LogitsProcessor(transformers.LogitsProcessor):
         else:
             for i in range(self.batch_size):
                 if not self.matchers[i].is_terminated():
-                    sampled_token = int(input_ids[i][-1].item())
+                    sampled_token = input_ids[i][-1].item()
                     assert self.matchers[i].accept_token(sampled_token)
 
         for i in range(self.batch_size):


### PR DESCRIPTION
As reported in #617, this PR fixes the behavior of `GrammarMatcher.accept_token` with the HF processor.