### PR TITLE
fix(structural_tag): align deepseek_v3_2/v4 invoke separator with chat template

### DIFF
--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -1244,7 +1244,13 @@ def get_deepseek_v3_2_structural_tag(
     """
     INVOKE_BEGIN_PREFIX = '<｜DSML｜invoke name="'
     INVOKE_BEGIN_SUFFIX = '">\n'
+    # INVOKE_END keeps a trailing "\n" so the final invoke is followed by a
+    # single "\n" before </｜DSML｜function_calls>, matching the official
+    # DeepSeek-V3.2 chat template. The separator between consecutive invokes
+    # is intentionally empty: the chat template joins tool calls with a single
+    # "\n" and that "\n" is already supplied by INVOKE_END.
     INVOKE_END = "</｜DSML｜invoke>\n"
+    INVOKE_SEPARATOR = ""
     TOOL_CALLS_PREFIX = "\n\n"
     FUNCTION_CALLS_BEGIN = "<｜DSML｜function_calls>\n"
     FUNCTION_CALLS_END = "</｜DSML｜function_calls>"
@@ -1272,7 +1278,7 @@ def get_deepseek_v3_2_structural_tag(
         # generate function calling triggered tag
         if len(tags) > 0:
             function_calling_tags = TagsWithSeparatorFormat(
-                tags=tags, separator="\n", at_least_one=True
+                tags=tags, separator=INVOKE_SEPARATOR, at_least_one=True
             )
 
             suffix_tag = TriggeredTagsFormat(
@@ -1323,7 +1329,9 @@ def get_deepseek_v3_2_structural_tag(
         suffix_tag = SequenceFormat(
             elements=[
                 ConstStringFormat(value=TOOL_CALLS_PREFIX + FUNCTION_CALLS_BEGIN),
-                TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True),
+                TagsWithSeparatorFormat(
+                    tags=tags, separator=INVOKE_SEPARATOR, at_least_one=True
+                ),
                 ConstStringFormat(value=FUNCTION_CALLS_END),
             ]
         )
@@ -1682,7 +1690,11 @@ def get_deepseek_v4_structural_tag(
     """
     INVOKE_BEGIN_PREFIX = '<｜DSML｜invoke name="'
     INVOKE_BEGIN_SUFFIX = '">\n'
+    # See get_deepseek_v3_2_structural_tag for the rationale on INVOKE_END +
+    # INVOKE_SEPARATOR splitting the single "\n" join that the chat template
+    # uses between consecutive <｜DSML｜invoke> blocks.
     INVOKE_END = "</｜DSML｜invoke>\n"
+    INVOKE_SEPARATOR = ""
     TOOL_CALLS_PREFIX = "\n\n"
     FUNCTION_CALLS_BEGIN = "<｜DSML｜tool_calls>\n"
     FUNCTION_CALLS_END = "</｜DSML｜tool_calls>"
@@ -1710,7 +1722,7 @@ def get_deepseek_v4_structural_tag(
         # generate function calling triggered tag
         if len(tags) > 0:
             function_calling_tags = TagsWithSeparatorFormat(
-                tags=tags, separator="\n", at_least_one=True
+                tags=tags, separator=INVOKE_SEPARATOR, at_least_one=True
             )
 
             suffix_tag = TriggeredTagsFormat(
@@ -1761,7 +1773,9 @@ def get_deepseek_v4_structural_tag(
         suffix_tag = SequenceFormat(
             elements=[
                 ConstStringFormat(value=TOOL_CALLS_PREFIX + FUNCTION_CALLS_BEGIN),
-                TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True),
+                TagsWithSeparatorFormat(
+                    tags=tags, separator=INVOKE_SEPARATOR, at_least_one=True
+                ),
                 ConstStringFormat(value=FUNCTION_CALLS_END),
             ]
         )

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -1329,9 +1329,7 @@ def get_deepseek_v3_2_structural_tag(
         suffix_tag = SequenceFormat(
             elements=[
                 ConstStringFormat(value=TOOL_CALLS_PREFIX + FUNCTION_CALLS_BEGIN),
-                TagsWithSeparatorFormat(
-                    tags=tags, separator=INVOKE_SEPARATOR, at_least_one=True
-                ),
+                TagsWithSeparatorFormat(tags=tags, separator=INVOKE_SEPARATOR, at_least_one=True),
                 ConstStringFormat(value=FUNCTION_CALLS_END),
             ]
         )
@@ -1773,9 +1771,7 @@ def get_deepseek_v4_structural_tag(
         suffix_tag = SequenceFormat(
             elements=[
                 ConstStringFormat(value=TOOL_CALLS_PREFIX + FUNCTION_CALLS_BEGIN),
-                TagsWithSeparatorFormat(
-                    tags=tags, separator=INVOKE_SEPARATOR, at_least_one=True
-                ),
+                TagsWithSeparatorFormat(tags=tags, separator=INVOKE_SEPARATOR, at_least_one=True),
                 ConstStringFormat(value=FUNCTION_CALLS_END),
             ]
         )

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -1200,9 +1200,7 @@ def test_deepseek_dsml_parallel_invokes_double_newline_rejected(
     grammar = xgr.Grammar.from_structural_tag(structural_tag)
     chat_template_output = prefix + _dsml_two_call_output(block_name)
     double_newline_output = chat_template_output.replace(
-        "</｜DSML｜invoke>\n<｜DSML｜invoke",
-        "</｜DSML｜invoke>\n\n<｜DSML｜invoke",
-        1,
+        "</｜DSML｜invoke>\n<｜DSML｜invoke", "</｜DSML｜invoke>\n\n<｜DSML｜invoke", 1
     )
     assert not _is_grammar_accept_string(grammar, double_newline_output), (
         f"Grammar wrongly accepted double-newline join for {model}/{tool_choice}:\n"

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -1100,3 +1100,111 @@ def test_no_parameter_tools_build_grammar(format_type: str, kwargs: Dict[str, An
     structural_tag = get_model_structural_tag(format_type, **kwargs)
     grammar = xgr.Grammar.from_structural_tag(structural_tag)
     assert grammar is not None
+
+
+# ---------- Regression: deepseek_v3_2 / deepseek_v4 parallel invoke separator ----------
+#
+# The DeepSeek-V3.2 and DeepSeek-V4 chat templates render multiple tool calls
+# inside a single <｜DSML｜function_calls>...</｜DSML｜function_calls> (or
+# <｜DSML｜tool_calls>...) wrapper, joined by a single "\n" between
+# </｜DSML｜invoke> and the next <｜DSML｜invoke>. Prior to this regression
+# guard, the built-in structural tag forced a double "\n" between consecutive
+# invokes (INVOKE_END's trailing "\n" plus a "\n" separator on
+# TagsWithSeparatorFormat), preventing the model from emitting the
+# in-distribution single-newline join under constrained decoding.
+
+_DSML_TOOLS_PAIR = [
+    {
+        "function": {
+            "name": "search",
+            "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+        }
+    },
+    {
+        "function": {
+            "name": "alt",
+            "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+        }
+    },
+]
+
+
+def _dsml_two_call_output(block_name: str) -> str:
+    """Render exactly what the official chat template emits for 2 parallel calls."""
+    invoke_a = (
+        '<｜DSML｜invoke name="search">\n'
+        '<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter>'
+        "</｜DSML｜invoke>"
+    )
+    invoke_b = (
+        '<｜DSML｜invoke name="alt">\n'
+        '<｜DSML｜parameter name="q" string="true">v</｜DSML｜parameter>'
+        "</｜DSML｜invoke>"
+    )
+    tool_calls = "\n".join([invoke_a, invoke_b])
+    return f"<｜DSML｜{block_name}>\n{tool_calls}\n</｜DSML｜{block_name}>"
+
+
+@pytest.mark.parametrize(
+    "model,block_name,tool_choice,prefix",
+    [
+        ("deepseek_v3_2", "function_calls", "auto", ""),
+        ("deepseek_v3_2", "function_calls", "required", "\n\n"),
+        ("deepseek_v4", "tool_calls", "auto", ""),
+        ("deepseek_v4", "tool_calls", "required", "\n\n"),
+    ],
+    ids=[
+        "deepseek_v3_2-auto-parallel",
+        "deepseek_v3_2-required-parallel",
+        "deepseek_v4-auto-parallel",
+        "deepseek_v4-required-parallel",
+    ],
+)
+def test_deepseek_dsml_parallel_invokes_single_newline_accepted(
+    model: str, block_name: str, tool_choice: str, prefix: str
+):
+    """Regression: grammar must accept the chat-template's single-\\n invoke join."""
+    structural_tag = get_model_structural_tag(
+        model, tools=_DSML_TOOLS_PAIR, tool_choice=tool_choice, reasoning=False
+    )
+    grammar = xgr.Grammar.from_structural_tag(structural_tag)
+    chat_template_output = prefix + _dsml_two_call_output(block_name)
+    assert _is_grammar_accept_string(grammar, chat_template_output), (
+        f"Grammar rejected chat-template output for {model}/{tool_choice}:\n"
+        f"{chat_template_output!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "model,block_name,tool_choice,prefix",
+    [
+        ("deepseek_v3_2", "function_calls", "auto", ""),
+        ("deepseek_v3_2", "function_calls", "required", "\n\n"),
+        ("deepseek_v4", "tool_calls", "auto", ""),
+        ("deepseek_v4", "tool_calls", "required", "\n\n"),
+    ],
+    ids=[
+        "deepseek_v3_2-auto-parallel",
+        "deepseek_v3_2-required-parallel",
+        "deepseek_v4-auto-parallel",
+        "deepseek_v4-required-parallel",
+    ],
+)
+def test_deepseek_dsml_parallel_invokes_double_newline_rejected(
+    model: str, block_name: str, tool_choice: str, prefix: str
+):
+    """Regression: grammar must NOT accept the out-of-distribution double-\\n join."""
+    structural_tag = get_model_structural_tag(
+        model, tools=_DSML_TOOLS_PAIR, tool_choice=tool_choice, reasoning=False
+    )
+    grammar = xgr.Grammar.from_structural_tag(structural_tag)
+    chat_template_output = prefix + _dsml_two_call_output(block_name)
+    double_newline_output = chat_template_output.replace(
+        "</｜DSML｜invoke>\n<｜DSML｜invoke",
+        "</｜DSML｜invoke>\n\n<｜DSML｜invoke",
+        1,
+    )
+    assert not _is_grammar_accept_string(grammar, double_newline_output), (
+        f"Grammar wrongly accepted double-newline join for {model}/{tool_choice}:\n"
+        f"{double_newline_output!r}"
+    )

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -56,6 +56,15 @@ TOOL_SCENARIOS = [
     (2, "required"),
 ]
 
+# Scenarios where we render multiple parallel tool calls in the assistant
+# message. Used in addition to TOOL_SCENARIOS to exercise the join/separator
+# between consecutive invoke blocks (regression for the DeepSeek-V3.2
+# double-newline grammar mismatch).
+PARALLEL_TOOL_SCENARIOS = [
+    (2, "auto", 2),
+    (2, "required", 2),
+]
+
 # (stag_key, model_id, reasoning, template_kwargs)
 # Excluded:
 #   - Llama-4: pythonic tool call format, needs separate structural tag
@@ -278,7 +287,9 @@ def validate_output(stag_key, tools, tool_choice, reasoning, model_output):
 def generate_test_cases():
     cases = []
     for stag_key, model_id, reasoning, template_kwargs in MODEL_CONFIGS:
-        for num_tools, tool_choice_str in TOOL_SCENARIOS:
+        scenarios = [(n, c, 1 if n > 0 else 0) for n, c in TOOL_SCENARIOS]
+        scenarios.extend(PARALLEL_TOOL_SCENARIOS)
+        for num_tools, tool_choice_str, num_tool_calls in scenarios:
             if num_tools > 0 and model_id in SKIP_TOOLS:
                 continue
             if reasoning:
@@ -291,21 +302,49 @@ def generate_test_cases():
                         num_tools,
                         tool_choice_str,
                         template_kwargs,
+                        num_tool_calls,
                     )
                 )
                 if model_id not in SKIP_EMPTY_REASONING:
                     cases.append(
-                        (stag_key, model_id, True, "", num_tools, tool_choice_str, template_kwargs)
+                        (
+                            stag_key,
+                            model_id,
+                            True,
+                            "",
+                            num_tools,
+                            tool_choice_str,
+                            template_kwargs,
+                            num_tool_calls,
+                        )
                     )
             else:
                 cases.append(
-                    (stag_key, model_id, False, None, num_tools, tool_choice_str, template_kwargs)
+                    (
+                        stag_key,
+                        model_id,
+                        False,
+                        None,
+                        num_tools,
+                        tool_choice_str,
+                        template_kwargs,
+                        num_tool_calls,
+                    )
                 )
     return cases
 
 
 def case_id(case):
-    stag_key, model_id, reasoning, reasoning_content, num_tools, tool_choice_str, _ = case
+    (
+        stag_key,
+        model_id,
+        reasoning,
+        reasoning_content,
+        num_tools,
+        tool_choice_str,
+        _,
+        num_tool_calls,
+    ) = case
     model_short = model_id.split("/")[-1] if "/" in model_id else model_id.replace("ENCODER:", "")
     if not reasoning:
         r_tag = "off"
@@ -313,7 +352,9 @@ def case_id(case):
         r_tag = "on"
     else:
         r_tag = "empty"
-    return f"{stag_key}-{model_short}-r{r_tag}-{num_tools}t-{tool_choice_str}"
+    return (
+        f"{stag_key}-{model_short}-r{r_tag}-{num_tools}t-{tool_choice_str}-{num_tool_calls}calls"
+    )
 
 
 TEST_CASES = generate_test_cases()
@@ -330,10 +371,10 @@ def test_reasoning_stag(case):
         num_tools,
         tool_choice_str,
         template_kwargs,
+        num_tool_calls,
     ) = case
     tools = make_tools(num_tools)
     tool_choice = make_tool_choice(tool_choice_str, tools or [])
-    num_tool_calls = 1 if num_tools > 0 else 0
     assistant_msg = make_assistant_msg(stag_key, reasoning_content, num_tool_calls)
     model_output = extract_model_output(stag_key, model_id, assistant_msg, tools, template_kwargs)
     validate_output(stag_key, tools, tool_choice, reasoning, model_output)

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -60,10 +60,7 @@ TOOL_SCENARIOS = [
 # message. Used in addition to TOOL_SCENARIOS to exercise the join/separator
 # between consecutive invoke blocks (regression for the DeepSeek-V3.2
 # double-newline grammar mismatch).
-PARALLEL_TOOL_SCENARIOS = [
-    (2, "auto", 2),
-    (2, "required", 2),
-]
+PARALLEL_TOOL_SCENARIOS = [(2, "auto", 2), (2, "required", 2)]
 
 # (stag_key, model_id, reasoning, template_kwargs)
 # Excluded:
@@ -352,9 +349,7 @@ def case_id(case):
         r_tag = "on"
     else:
         r_tag = "empty"
-    return (
-        f"{stag_key}-{model_short}-r{r_tag}-{num_tools}t-{tool_choice_str}-{num_tool_calls}calls"
-    )
+    return f"{stag_key}-{model_short}-r{r_tag}-{num_tools}t-{tool_choice_str}-{num_tool_calls}calls"
 
 
 TEST_CASES = generate_test_cases()


### PR DESCRIPTION
## Fixes

Fixes #637

## Summary

The built-in `deepseek_v3_2` (and `deepseek_v4`) structural tags concatenated consecutive `<｜DSML｜invoke>` blocks with **two newlines** — `INVOKE_END = "</｜DSML｜invoke>\n"` plus `TagsWithSeparatorFormat(separator="\n", ...)`. DeepSeek-V3.2's official chat template trains the model with a **single newline** join between tool calls:

```python
# encoding_dsv32.py (vendored at tests/python/encoding_dsv32.py)
tool_call_template = '<{dsml_token}invoke name="{name}">\n{arguments}\n</{dsml_token}invoke>'  # NO trailing \n
"\n".join(tool_calls)                                                                        # single \n separator
```

Under constrained greedy decoding (temperature=0), the model's per-step distribution after `</｜DSML｜invoke>` puts overwhelming mass on the in-distribution `\n<｜DSML｜invoke ...` continuation, which the grammar **forbids** (the grammar only allows `\n\n<｜DSML｜invoke ...`). The decoder then falls through to the legal `</｜DSML｜function_calls>` close-block token, so when the user prompt asks for **N** parallel tool calls only **1** is emitted.

This surfaced as an SGLang nightly regression for all four DeepSeek-V3.2 variants (DP8, DP8+MTP, TP8, TP8+MTP) after [sgl-project/sglang#21722](https://github.com/sgl-project/sglang/pull/21722) routed DeepSeek-V3.2 onto `xgrammar.get_model_structural_tag(model="deepseek_v3_2", ...)`. See #637 for the full context.

## Fix

Set `TagsWithSeparatorFormat`'s `separator=""` for the `deepseek_v3_2` and `deepseek_v4` `auto` and `required` branches — the single `\n` already comes from `INVOKE_END`. Seven other built-in templates in the same file already use `separator=""` with `at_least_one=True`, so this is a well-trodden code path.

```diff
-    INVOKE_END = "</｜DSML｜invoke>\n"
+    INVOKE_END = "</｜DSML｜invoke>\n"
+    INVOKE_SEPARATOR = ""
     ...
-        function_calling_tags = TagsWithSeparatorFormat(
-            tags=tags, separator="\n", at_least_one=True
-        )
+        function_calling_tags = TagsWithSeparatorFormat(
+            tags=tags, separator=INVOKE_SEPARATOR, at_least_one=True
+        )
```

## Why this wasn't caught earlier

`tests/python/test_builtin_structural_tag_alignment.py` only renders a single tool call (`num_tool_calls = 1 if num_tools > 0 else 0`), so the join between consecutive invoke blocks was never exercised against the chat template. PR #610 (which aligned `FUNCTION_CALLS_END` with the template) was unable to spot this for the same reason. The existing `test_tool_choice_instances[deepseek_v3_2-required]` case also only used a single call.

## Test plan

- Added regression tests (`test_deepseek_dsml_parallel_invokes_single_newline_accepted`, `..._double_newline_rejected`) parametrised across `{deepseek_v3_2, deepseek_v4} × {auto, required}` that build the structural tag, compile a `Grammar`, and assert the chat-template byte sequence (single `\n` between invokes) is accepted while the previously-required double-`\n` sequence is rejected.
- Extended `test_builtin_structural_tag_alignment.py` with a `PARALLEL_TOOL_SCENARIOS` table that renders 2 parallel calls through the actual chat templates, exercising the consecutive-invoke join end-to-end for every model in `MODEL_CONFIGS`.
- Verified both regression tests **fail on `main`** without the fix and **pass with the fix**.
- Full `tests/python/test_builtin_structural_tag.py` run: only previously-failing `test_strict_or_missing_parameters` cases (unrelated to this change — same 15 failures on `main`) still fail; all other 168 tests pass.
- `tests/python/test_structural_tag_converter.py` and `tests/python/test_grammar_matcher_structural_tag.py`: 1009 passed, 12 skipped (HF_TOKEN gated).

(End-to-end recovery of the SGLang nightly will be verified once xgrammar releases and sglang pins it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
