### PR TITLE
fix: reject empty enum arrays in JSON schema validation

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -822,13 +822,14 @@ Result<EnumSpec, SchemaError> SchemaParser::ParseEnum(const picojson::object& sc
   if (!schema.at("enum").is<picojson::array>()) {
     return ResultErr<SchemaError>(SchemaErrorType::kInvalidSchema, "enum must be an array");
   }
-  for (const auto& value : schema.at("enum").get<picojson::array>()) {
-    spec.json_values.push_back(value.serialize());
-  }
-  if (spec.json_values.empty()) {
+  const auto& enum_array = schema.at("enum").get<picojson::array>();
+  if (enum_array.empty()) {
     return ResultErr<SchemaError>(
         SchemaErrorType::kInvalidSchema, "enum array must not be empty"
     );
+  }
+  for (const auto& value : enum_array) {
+    spec.json_values.push_back(value.serialize());
   }
   return ResultOk(std::move(spec));
 }

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2086,7 +2086,7 @@ std::string JSONSchemaConverter::GenerateConst(
 }
 
 std::string JSONSchemaConverter::GenerateEnum(const EnumSpec& spec, const std::string& rule_name) {
-  XGRAMMAR_CHECK(!spec.json_values.empty())
+  XGRAMMAR_DCHECK(!spec.json_values.empty())
       << "GenerateEnum called with empty enum spec for rule: " << rule_name;
   std::string result = "";
   for (size_t i = 0; i < spec.json_values.size(); ++i) {

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2087,7 +2087,8 @@ std::string JSONSchemaConverter::GenerateConst(
 }
 
 std::string JSONSchemaConverter::GenerateEnum(const EnumSpec& spec, const std::string& rule_name) {
-  XGRAMMAR_CHECK(!spec.json_values.empty()) << "GenerateEnum called with empty enum spec";
+  XGRAMMAR_CHECK(!spec.json_values.empty())
+      << "GenerateEnum called with empty enum spec for rule: " << rule_name;
   std::string result = "";
   for (size_t i = 0; i < spec.json_values.size(); ++i) {
     if (i != 0) {

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -824,9 +824,7 @@ Result<EnumSpec, SchemaError> SchemaParser::ParseEnum(const picojson::object& sc
   }
   const auto& enum_array = schema.at("enum").get<picojson::array>();
   if (enum_array.empty()) {
-    return ResultErr<SchemaError>(
-        SchemaErrorType::kInvalidSchema, "enum array must not be empty"
-    );
+    return ResultErr<SchemaError>(SchemaErrorType::kInvalidSchema, "enum array must not be empty");
   }
   for (const auto& value : enum_array) {
     spec.json_values.push_back(value.serialize());

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -825,6 +825,11 @@ Result<EnumSpec, SchemaError> SchemaParser::ParseEnum(const picojson::object& sc
   for (const auto& value : schema.at("enum").get<picojson::array>()) {
     spec.json_values.push_back(value.serialize());
   }
+  if (spec.json_values.empty()) {
+    return ResultErr<SchemaError>(
+        SchemaErrorType::kInvalidSchema, "enum array must not be empty"
+    );
+  }
   return ResultOk(std::move(spec));
 }
 
@@ -2082,15 +2087,13 @@ std::string JSONSchemaConverter::GenerateConst(
 }
 
 std::string JSONSchemaConverter::GenerateEnum(const EnumSpec& spec, const std::string& rule_name) {
+  XGRAMMAR_CHECK(!spec.json_values.empty()) << "GenerateEnum called with empty enum spec";
   std::string result = "";
   for (size_t i = 0; i < spec.json_values.size(); ++i) {
     if (i != 0) {
       result += " | ";
     }
     result += "(\"" + JSONStrToPrintableStr(spec.json_values[i]) + "\")";
-  }
-  if (result.empty()) {
-    return "\"\"";
   }
   return result;
 }

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -196,7 +196,8 @@ std::string XMLToolCallingConverter::GenerateConst(
 std::string XMLToolCallingConverter::GenerateEnum(
     const EnumSpec& spec, const std::string& rule_name
 ) {
-  XGRAMMAR_CHECK(!spec.json_values.empty()) << "GenerateEnum called with empty enum spec";
+  XGRAMMAR_CHECK(!spec.json_values.empty())
+      << "GenerateEnum called with empty enum spec for rule: " << rule_name;
   if (nested_object_level_ <= 1) {
     std::string result;
     for (size_t i = 0; i < spec.json_values.size(); ++i) {

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -196,7 +196,7 @@ std::string XMLToolCallingConverter::GenerateConst(
 std::string XMLToolCallingConverter::GenerateEnum(
     const EnumSpec& spec, const std::string& rule_name
 ) {
-  XGRAMMAR_CHECK(!spec.json_values.empty())
+  XGRAMMAR_DCHECK(!spec.json_values.empty())
       << "GenerateEnum called with empty enum spec for rule: " << rule_name;
   if (nested_object_level_ <= 1) {
     std::string result;

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -196,6 +196,7 @@ std::string XMLToolCallingConverter::GenerateConst(
 std::string XMLToolCallingConverter::GenerateEnum(
     const EnumSpec& spec, const std::string& rule_name
 ) {
+  XGRAMMAR_CHECK(!spec.json_values.empty()) << "GenerateEnum called with empty enum spec";
   if (nested_object_level_ <= 1) {
     std::string result;
     for (size_t i = 0; i < spec.json_values.size(); ++i) {

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -243,6 +243,21 @@ root ::= "{" "" (("\"bars\"" ": " root_prop_0 root_part_0)) "" "}"
     check_schema_with_instance(schema, instance, any_whitespace=False)
 
 
+def test_empty_enum_rejected():
+    """Empty enum [] should raise error, not produce invalid grammar."""
+    schema_obj = '{"type":"object","properties":{"x":{"type":"string","enum":[]}},"required":["x"]}'
+    with pytest.raises(RuntimeError):
+        xgr.Grammar.from_json_schema(schema_obj)
+
+    schema_str = '{"type":"string","enum":[]}'
+    with pytest.raises(RuntimeError):
+        xgr.Grammar.from_json_schema(schema_str)
+
+    schema_int = '{"type":"integer","enum":[]}'
+    with pytest.raises(RuntimeError):
+        xgr.Grammar.from_json_schema(schema_int)
+
+
 def test_optional():
     class MainModel(BaseModel):
         num: int = 0


### PR DESCRIPTION
## Summary

Empty `enum: []` should raise an error since no valid value can be generated. Previously (since v0.2.0) it silently compiled and produced a grammar rule `("")` that matched empty string, causing invalid JSON output like `{"x": }` at runtime.

## Root Cause

The regression was introduced in two steps:

1. **#527** (`f43ef82`): Refactored `VisitEnum` → `ParseEnum`/`EnumSpec` flow. The new `ParseEnum` does not validate that the enum array is non-empty. In v0.1.25, the old code path returned an empty EBNF string which was caught downstream by the EBNF parser ("Expect element, but got root").

2. **#568** (`6898864`): Added `if (result.empty()) return "\"\""` as a defensive fallback in `GenerateEnum`. This was a mechanical copy from `GenerateObject` (where empty result is valid — produces `{}`), but for enum it masks the error by producing `("")` which matches zero characters. The intent was to prevent EBNF parser crashes for empty-parameter tools, but the same pattern does not apply to enums semantically — an empty enum means "no valid value exists", not "accept empty".

## Changes

- `ParseEnum`: return `ResultErr` when enum array is empty (primary fix)
- `GenerateEnum` / `XMLToolCallingConverter::GenerateEnum`: add `XGRAMMAR_CHECK` guard (defensive, now unreachable from normal flow)
- Remove dead `if (result.empty()) return "\"\""` branch in `GenerateEnum`

## Reproduction

```python
import xgrammar as xgr

schema = '{"type":"object","properties":{"x":{"type":"string","enum":[]}},"required":["x"]}'

# v0.1.25: RuntimeError (correct)
# v0.2.0 (before fix): compiles, produces root_prop_0 ::= ("") → allows {"x": }
# After fix: RuntimeError: enum array must not be empty
grammar = xgr.Grammar.from_json_schema(schema)
```

## Test

```bash
python3 -m pytest tests/python/test_json_schema_converter.py::test_empty_enum_rejected -v
# PASSED

python3 -m pytest tests/python/test_json_schema_converter.py -v
# 320 passed
```

Fixes #639

cc @Seven-Streams