### PR TITLE
fix: escape dot in float boundary values for regex generation

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2684,6 +2684,19 @@ std::string JSONSchemaConverter::FormatFloat(double value, int precision) {
   return result;
 }
 
+static std::string EscapeDotForRegex(const std::string& s) {
+  std::string result;
+  result.reserve(s.size() + 2);
+  for (char c : s) {
+    if (c == '.') {
+      result += "\\.";
+    } else {
+      result += c;
+    }
+  }
+  return result;
+}
+
 std::string JSONSchemaConverter::GenerateFloatRangeRegex(
     std::optional<double> start, std::optional<double> end, int precision
 ) {
@@ -2718,7 +2731,7 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
 
   if (start && !end) {
     std::string startIntStr = FormatFloat(start.value(), precision);
-    parts.push_back(startIntStr);
+    parts.push_back(EscapeDotForRegex(startIntStr));
 
     if (startFrac > 0.0) {
       size_t dotPos = startIntStr.find('.');
@@ -2774,7 +2787,7 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
     }
   } else if (!start && end) {
     std::string endIntStr = FormatFloat(end.value(), precision);
-    parts.push_back(endIntStr);
+    parts.push_back(EscapeDotForRegex(endIntStr));
 
     if (endFrac > 0.0) {
       size_t dotPos = endIntStr.find('.');
@@ -2833,20 +2846,20 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
         parts.push_back(std::to_string(startInt));
       } else {
         std::string startStr = FormatFloat(start.value(), precision);
-        parts.push_back(startStr);
+        parts.push_back(EscapeDotForRegex(startStr));
 
         std::string endStr = FormatFloat(end.value(), precision);
         if (startStr != endStr) {
-          parts.push_back(endStr);
+          parts.push_back(EscapeDotForRegex(endStr));
         }
       }
     } else {
       std::string startStr = FormatFloat(start.value(), precision);
-      parts.push_back(startStr);
+      parts.push_back(EscapeDotForRegex(startStr));
 
       std::string endStr = FormatFloat(end.value(), precision);
       if (startStr != endStr) {
-        parts.push_back(endStr);
+        parts.push_back(EscapeDotForRegex(endStr));
       }
 
       if (endInt > startInt + 1) {

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2158,36 +2158,59 @@ def test_generate_float_regex():
 
     assert (
         _generate_float_regex(1.5, 5.75)
-        == r"^(1.5|5.75|(([2-4]))(\.\d{1,6})?|1\.6\d{0,5}|1\.7\d{0,5}|1\.8\d{0,5}|1\.9\d{0,5}|5\.0\d{0,5}|5\.1\d{0,5}|5\.2\d{0,5}|5\.3\d{0,5}|5\.4\d{0,5}|5\.5\d{0,5}|5\.6\d{0,5}|5\.70\d{0,4}|5\.71\d{0,4}|5\.72\d{0,4}|5\.73\d{0,4}|5\.74\d{0,4})$"
+        == r"^(1\.5|5\.75|(([2-4]))(\.\d{1,6})?|1\.6\d{0,5}|1\.7\d{0,5}|1\.8\d{0,5}|1\.9\d{0,5}|5\.0\d{0,5}|5\.1\d{0,5}|5\.2\d{0,5}|5\.3\d{0,5}|5\.4\d{0,5}|5\.5\d{0,5}|5\.6\d{0,5}|5\.70\d{0,4}|5\.71\d{0,4}|5\.72\d{0,4}|5\.73\d{0,4}|5\.74\d{0,4})$"
     )
 
     assert (
         _generate_float_regex(-3.14, 2.71828)
-        == r"^(-3.14|2.71828|(-([1-3])|0|(1))(\.\d{1,6})?|-3\.0\d{0,5}|-3\.10\d{0,4}|-3\.11\d{0,4}|-3\.12\d{0,4}|-3\.13\d{0,4}|2\.0\d{0,5}|2\.1\d{0,5}|2\.2\d{0,5}|2\.3\d{0,5}|2\.4\d{0,5}|2\.5\d{0,5}|2\.6\d{0,5}|2\.70\d{0,4}|2\.710\d{0,3}|2\.711\d{0,3}|2\.712\d{0,3}|2\.713\d{0,3}|2\.714\d{0,3}|2\.715\d{0,3}|2\.716\d{0,3}|2\.717\d{0,3}|2\.7180\d{0,2}|2\.7181\d{0,2}|2\.71820\d{0,1}|2\.71821\d{0,1}|2\.71822\d{0,1}|2\.71823\d{0,1}|2\.71824\d{0,1}|2\.71825\d{0,1}|2\.71826\d{0,1}|2\.71827\d{0,1})$"
+        == r"^(-3\.14|2\.71828|(-([1-3])|0|(1))(\.\d{1,6})?|-3\.0\d{0,5}|-3\.10\d{0,4}|-3\.11\d{0,4}|-3\.12\d{0,4}|-3\.13\d{0,4}|2\.0\d{0,5}|2\.1\d{0,5}|2\.2\d{0,5}|2\.3\d{0,5}|2\.4\d{0,5}|2\.5\d{0,5}|2\.6\d{0,5}|2\.70\d{0,4}|2\.710\d{0,3}|2\.711\d{0,3}|2\.712\d{0,3}|2\.713\d{0,3}|2\.714\d{0,3}|2\.715\d{0,3}|2\.716\d{0,3}|2\.717\d{0,3}|2\.7180\d{0,2}|2\.7181\d{0,2}|2\.71820\d{0,1}|2\.71821\d{0,1}|2\.71822\d{0,1}|2\.71823\d{0,1}|2\.71824\d{0,1}|2\.71825\d{0,1}|2\.71826\d{0,1}|2\.71827\d{0,1})$"
     )
 
     assert (
         _generate_float_regex(0.5, None)
-        == r"^(0.5|0\.6\d{0,5}|0\.7\d{0,5}|0\.8\d{0,5}|0\.9\d{0,5}|([1-9]|[1-9]\d*)(\.\d{1,6})?)$"
+        == r"^(0\.5|0\.6\d{0,5}|0\.7\d{0,5}|0\.8\d{0,5}|0\.9\d{0,5}|([1-9]|[1-9]\d*)(\.\d{1,6})?)$"
     )
 
     assert (
         _generate_float_regex(None, -1.5)
-        == r"^(-1.5|-1\.6\d{0,5}|-1\.7\d{0,5}|-1\.8\d{0,5}|-1\.9\d{0,5}|(-[3-9]|-[1-9]\d*)(\.\d{1,6})?)$"
+        == r"^(-1\.5|-1\.6\d{0,5}|-1\.7\d{0,5}|-1\.8\d{0,5}|-1\.9\d{0,5}|(-[3-9]|-[1-9]\d*)(\.\d{1,6})?)$"
     )
 
     assert _generate_float_regex(None, None) == r"^-?\d+(\.\d{1,6})?$"
 
-    assert _generate_float_regex(3.14159, 3.14159) == r"^(3.14159)$"
+    assert _generate_float_regex(3.14159, 3.14159) == r"^(3\.14159)$"
 
     assert _generate_float_regex(10.5, 2.5) == r"^()$"
 
-    assert _generate_float_regex(5.123456, 5.123457) == r"^(5.123456|5.123457)$"
+    assert _generate_float_regex(5.123456, 5.123457) == r"^(5\.123456|5\.123457)$"
 
     assert (
         _generate_float_regex(-0.000001, 0.000001)
-        == r"^(-0.000001|0.000001|-0\.000000\d{0,0}|0\.000000\d{0,0})$"
+        == r"^(-0\.000001|0\.000001|-0\.000000\d{0,0}|0\.000000\d{0,0})$"
     )
+
+
+def test_float_minimum_no_wildcard_in_grammar():
+    """Float minimum/maximum boundary values should not produce regex wildcard in grammar."""
+    schema = '{"type":"number","minimum":0.5}'
+    grammar = xgr.Grammar.from_json_schema(schema)
+    grammar_str = str(grammar)
+    # The root rule should use literal "." not wildcard [\0-\U0010ffff]
+    for line in grammar_str.split("\n"):
+        if line.startswith("root"):
+            assert "[\\0-\\U0010ffff]" not in line, f"Wildcard found in: {line}"
+
+    schema2 = '{"type":"number","maximum":9.5}'
+    grammar2 = xgr.Grammar.from_json_schema(schema2)
+    for line in str(grammar2).split("\n"):
+        if line.startswith("root"):
+            assert "[\\0-\\U0010ffff]" not in line, f"Wildcard found in: {line}"
+
+    schema3 = '{"type":"number","minimum":0.5,"maximum":9.5}'
+    grammar3 = xgr.Grammar.from_json_schema(schema3)
+    for line in str(grammar3).split("\n"):
+        if line.startswith("root"):
+            assert "[\\0-\\U0010ffff]" not in line, f"Wildcard found in: {line}"
 
 
 def test_limited_whitespace_cnt():


### PR DESCRIPTION
## Summary

`FormatFloat(0.5)` returns `"0.5"` which was pushed directly into regex parts in `GenerateFloatRangeRegex`. The unescaped `.` was interpreted as the regex wildcard (match any character), producing grammar rules like:

```
root ::= (("0" [\0-\U0010ffff] "5") | ...)
                ^^^^^^^^^^^^^^^^ should be "."
```

This allowed invalid outputs like `0,5` (European decimal) at runtime, since any character was accepted in place of the decimal point.

This is a long-standing bug affecting both v0.1.25 and v0.2.0.

## Root Cause

In `GenerateFloatRangeRegex`, boundary values from `FormatFloat` are pushed directly into regex `parts` without escaping the `.` character. Other parts of the same function already use `"\\."` explicitly (e.g., `intPartStr + "\\." + d + ...`), but the boundary value strings themselves were never escaped.

## Changes

- Add `EscapeDotForRegex()` static helper that replaces `.` with `\\.`
- Apply it to all 6 `parts.push_back(FormatFloat(...))` calls in `GenerateFloatRangeRegex`
- Update `test_generate_float_regex` expected values to use escaped dots
- Add `test_float_minimum_no_wildcard_in_grammar` end-to-end test

## Reproduction

```python
import xgrammar as xgr

# Before fix: "0" [\0-\U0010ffff] "5" (wildcard)
# After fix:  "0" "." "5" (literal dot)
schema = '{"type":"number","minimum":0.5}'
grammar = xgr.Grammar.from_json_schema(schema)
print(grammar)
```

Confirm with regex API:
```python
# Escaped dot → correct
g1 = xgr.Grammar.from_regex(r'0\.5')   # root ::= (("0" "." "5"))

# Unescaped dot → bug (before fix)
g2 = xgr.Grammar.from_regex('0.5')     # root ::= (("0" [\0-\U0010ffff] "5"))
```

## Test

```bash
python3 -m pytest tests/python/test_json_schema_converter.py::test_generate_float_regex tests/python/test_json_schema_converter.py::test_float_minimum_no_wildcard_in_grammar -v
# 2 passed

python3 -m pytest tests/python/test_json_schema_converter.py -v
# 320 passed
```

Fixes #640

cc @Seven-Streams