### PR TITLE
fix: avoid GrammarFSMHasher crash on rules reached via merged states

### DIFF
--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -2365,8 +2365,13 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
         int32_t ref_rule_id = edge.GetRefRuleId();
         if (ref_rule_id == fsm_index) {
           hash_and_target.insert({kSelfRecursionFlag, edge.target});
+        } else if (!grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].has_value()) {
+          // Cross-rule BFS (e.g. after MergeEquivalentStates merges states between
+          // per-rule FSMs) may reach an edge whose referee hasn't been hashed yet.
+          // Fall back to a sentinel so the hash is still well-defined; the cache
+          // will simply not hit for this rule, but we won't crash the host process.
+          hash_and_target.insert({kUnKnownFlag, edge.target});
         } else {
-          XGRAMMAR_CHECK(grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].has_value());
           hash_and_target.insert(
               {grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].value(), edge.target}
           );
@@ -2378,8 +2383,12 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
           uint64_t base_hash = kSelfRecursionFlag;
           uint64_t repeat_hash = HashCombine(base_hash, info.Lower(), info.Upper());
           hash_and_target.insert({repeat_hash, edge.target});
+        } else if (!grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].has_value()) {
+          // See note above; same fallback for repeat-ref edges.
+          uint64_t base_hash = kUnKnownFlag;
+          uint64_t repeat_hash = HashCombine(base_hash, info.Lower(), info.Upper());
+          hash_and_target.insert({static_cast<int32_t>(repeat_hash), edge.target});
         } else {
-          XGRAMMAR_CHECK(grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].has_value());
           uint64_t base_hash = grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].value();
           uint64_t repeat_hash = HashCombine(base_hash, info.Lower(), info.Upper());
           hash_and_target.insert({static_cast<int32_t>(repeat_hash), edge.target});


### PR DESCRIPTION
## Summary

`GrammarFSMHasherImpl::HashFsm` crashes the host process via `XGRAMMAR_CHECK` (`cpp/grammar_functor.cc`, the `kRuleRef` and `kRepeatRef` branches) when the FSM walk reaches an edge whose referenced rule has not been hashed yet.

The hasher's topological order is computed over the GrammarExpr AST (`RuleRefGraphFinder`), but `HashFsm` walks the **post-optimization** FSM. After `MergeEquivalentStates` fuses states across per-rule FSM regions, the BFS in `HashFsm` can cross those bridges into a rule that the AST-derived order has not scheduled yet, so `per_rule_fsm_hashes[ref_rule_id]` is still `nullopt` and the `XGRAMMAR_CHECK` aborts. In an embedding host (e.g. vLLM) this takes down the whole process.

## Reproduction

A large right-recursive rule chain reliably triggers it:

```python
import xgrammar as xgr
from transformers import AutoTokenizer

N = 6000
lines = ["root ::= sub", "sub ::= " + " | ".join(f"p{i}" for i in range(N))]
for i in range(N):
    lines.append(f'p{i} ::= "a" (p{i+1} | "")' if i < N - 1 else f'p{i} ::= "a"')
gbnf = "\n".join(lines)

tinfo = xgr.TokenizerInfo.from_huggingface(AutoTokenizer.from_pretrained("gpt2"))
xgr.GrammarCompiler(tinfo).compile_grammar(gbnf)   # RuntimeError: Check failed: per_rule_fsm_hashes[ref_rule_id].has_value()
```

## Fix

Replace the two hard `XGRAMMAR_CHECK`s in `HashFsm` with a graceful fallback to the existing `kUnKnownFlag` sentinel (already used by the partial-hash path). The cross-grammar cache simply does not hit for the affected rules; grammar matching uses the real FSM and is unchanged.

## Risk

Low. The fallback is only reachable on the exact condition that previously aborted; no other grammar shape is affected, and `kUnKnownFlag` is already a valid hash outcome elsewhere in this function.

## Notes

Discovered alongside a separate `int16_t` rule-id overflow that also surfaces on very large grammars (companion PR). This PR alone makes chains up to ~16k rules compile; the companion PR is needed beyond that.
