### PR TITLE
fix: store FSMEdge rule_id as unsigned 16-bit to support >32767 rules

### DIFF
--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -107,7 +107,10 @@ std::string FSMImplBase<ContainerType>::EdgesToString(std::optional<std::vector<
         std::string char_str = EscapeString(static_cast<TCodepoint>(edge.min));
         result += "'" + char_str + "'->" + std::to_string(edge.target);
       } else if (edge.min == FSMEdge::EdgeType::kRuleRef) {
-        result += "Rule(" + std::to_string(edge.max) + ")->" + std::to_string(edge.target);
+        // Print the unsigned rule_id (GetRefRuleId), not the raw signed `max`,
+        // so rule_ids > 32767 are shown correctly instead of as negatives.
+        result +=
+            "Rule(" + std::to_string(edge.GetRefRuleId()) + ")->" + std::to_string(edge.target);
       } else if (edge.min == FSMEdge::EdgeType::kEpsilon) {
         result += "Eps->" + std::to_string(edge.target);
       } else if (edge.min == FSMEdge::EdgeType::kEOS) {
@@ -246,8 +249,21 @@ class FSM::Impl : public FSMImplBase<std::vector<std::vector<FSMEdge>>> {
     edges_[from].push_back({min, max, to});
   }
 
-  void AddRuleEdge(int from, int to, int16_t rule_id) {
-    AddEdge(from, to, FSMEdge::EdgeType::kRuleRef, rule_id);
+  void AddRuleEdge(int from, int to, int32_t rule_id) {
+    // rule_id is stored in the int16_t `max` field of FSMEdge, but interpreted
+    // as an unsigned 16-bit value by FSMEdge::GetRefRuleId(). That gives a
+    // valid range of [0, 65535]. Reject anything outside the range with a
+    // clear error message instead of silently truncating (which previously
+    // wrapped rule_ids > 32767 to negatives and caused per_rule_fsms[i]
+    // out-of-range crashes in EarleyParser at compile time).
+    XGRAMMAR_CHECK(rule_id >= 0 && rule_id <= 0xFFFF)
+        << "AddRuleEdge: rule_id " << rule_id
+        << " is out of range [0, 65535]. The xgrammar FSM stores rule_ids in "
+           "a 16-bit field; grammars with more than 65536 rules are not "
+           "supported by this build.";
+    AddEdge(
+        from, to, FSMEdge::EdgeType::kRuleRef, static_cast<int16_t>(static_cast<uint16_t>(rule_id))
+    );
   }
 
   void AddEpsilonEdge(int from, int to) { AddEdge(from, to, FSMEdge::EdgeType::kEpsilon, 0); }
@@ -313,7 +329,10 @@ int FSM::Impl::GetNextState(int from, int value, EdgeType edge_type) const {
     return FSM::kNoNextState;
   } else if (edge_type == EdgeType::kRuleRef) {
     for (const auto& edge : edges_[from]) {
-      if (edge.min == EdgeType::kRuleRef && edge.max == value) {
+      // Compare via GetRefRuleId() (unsigned 16-bit read) rather than the raw
+      // signed int16_t `max`, otherwise rule_ids > 32767 sign-extend to negative
+      // and never match the (non-negative) `value`. See FSMEdge::GetRefRuleId.
+      if (edge.min == EdgeType::kRuleRef && edge.GetRefRuleId() == value) {
         return edge.target;
       }
     }
@@ -483,7 +502,7 @@ void FSM::AddEdge(int from, int to, FSMEdge::EdgeType type, int16_t value) {
 
 void FSM::AddEpsilonEdge(int from, int to) { pimpl_->AddEpsilonEdge(from, to); }
 
-void FSM::AddRuleEdge(int from, int to, int16_t rule_id) { pimpl_->AddRuleEdge(from, to, rule_id); }
+void FSM::AddRuleEdge(int from, int to, int32_t rule_id) { pimpl_->AddRuleEdge(from, to, rule_id); }
 
 void FSM::AddEOSEdge(int from, int to) { pimpl_->AddEOSEdge(from, to); }
 
@@ -641,7 +660,10 @@ void CompactFSM::Impl::GetNextStates(
         continue;
       } else if (edge.min > EdgeType::kRuleRef) {
         break;
-      } else if (edge.max == value) {
+      } else if (edge.GetRefRuleId() == value) {
+        // GetRefRuleId() reads `max` as unsigned 16-bit; comparing the raw signed
+        // `max` would fail for rule_ids > 32767 (sign extension). The break above
+        // still holds because all kRuleRef edges share min == kRuleRef.
         targets->push_back(edge.target);
       }
     }
@@ -707,7 +729,10 @@ void CompactFSM::Impl::Advance(
           continue;
         } else if (edge.min > EdgeType::kRuleRef) {
           break;
-        } else if (edge.max == value) {
+        } else if (edge.GetRefRuleId() == value) {
+          // GetRefRuleId() reads `max` as unsigned 16-bit; comparing the raw signed
+          // `max` would fail for rule_ids > 32767 (sign extension). The break above
+          // still holds because all kRuleRef edges share min == kRuleRef.
           result->insert(edge.target);
         }
       }

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -124,8 +124,16 @@ struct alignas(8) FSMEdge {
   /*!
    * \brief Get the rule id of the edge.
    * \return The rule id of the edge. -1 if the edge is not a rule reference.
+   *
+   * NOTE: the rule_id is stored in the int16_t `max` field but is interpreted
+   * as an unsigned 16-bit value, giving a rule_id range of [0, 65535]. Treating
+   * `max` as signed would cause rule_ids > 32767 to wrap to negative values and
+   * crash downstream consumers (e.g. EarleyParser::ExpandNextRuleRefElementOnFSM
+   * indexing into per_rule_fsms). See also AddRuleEdge which enforces the range.
    */
-  int32_t GetRefRuleId() const { return IsRuleRef() ? max : -1; }
+  int32_t GetRefRuleId() const {
+    return IsRuleRef() ? static_cast<int32_t>(static_cast<uint16_t>(max)) : -1;
+  }
 
   /*!
    * \brief Get the auxiliary data index for repeat reference edges.
@@ -144,7 +152,10 @@ struct alignas(8) FSMEdge {
 /*! \brief View into edge_aux_data for a repeat edge (layout: [rule_id, lower, upper]). */
 struct RepeatEdgeRef {
   const int32_t* data;
-  int16_t RuleId() const { return static_cast<int16_t>(data[0]); }
+  // The aux storage is int32_t; previously this getter truncated to int16_t,
+  // which silently wrapped rule_ids > 32767 to negative values. Return the
+  // full int32_t to match how the rule_id is written in AddRepeatEdge.
+  int32_t RuleId() const { return data[0]; }
   int32_t Lower() const { return data[1]; }
   int32_t Upper() const { return data[2]; }
 };
@@ -342,9 +353,10 @@ class FSM {
    * \brief Add a rule reference edge between states.
    * \param from The source state.
    * \param to The target state.
-   * \param rule_id The rule id to reference.
+   * \param rule_id The rule id to reference. Must be in [0, 65535]; the value
+   *               is stored in an int16_t field but interpreted as unsigned.
    */
-  void AddRuleEdge(int from, int to, int16_t rule_id);
+  void AddRuleEdge(int from, int to, int32_t rule_id);
 
   /*!
    * \brief Add an EOS transition between two states.

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1476,7 +1476,7 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::TokenTagDispatch(
     auto [token_id, rule_id] = ttd.trigger_rule_pairs[i];
     fsm.AddTokenEdge(start, dispatch_state, {token_id});
     int target = loop ? start : end_state;
-    fsm.AddRuleEdge(dispatch_state, target, static_cast<int16_t>(rule_id));
+    fsm.AddRuleEdge(dispatch_state, target, rule_id);
   }
   fsm.AddExcludeTokenEdge(start, start, self_loop_exclude);
   return FSMWithStartEnd(fsm, start, ends);


### PR DESCRIPTION
## Summary

`FSMEdge` packs a `kRuleRef` edge's `rule_id` into the signed `int16_t max` field, and `FSMEdge::GetRefRuleId()` returned it sign-extended. Once an optimized grammar has more than **32,767** rules, edges that reference higher rule indices wrap to negative values (e.g. rule_id 33,493 is read back as -32,043). `EarleyParser::ExpandNextRuleRefElementOnFSM` then indexes `per_rule_fsms[ref_rule_id]` with the negative value, dereferences a default-constructed `std::optional`, and throws `std::bad_optional_access`, a hard crash (segfault in release builds). `RepeatEdgeRef::RuleId()` had the same truncation even though its aux storage is already `int32_t`.

## Reproduction

```python
import xgrammar as xgr
from transformers import AutoTokenizer

N = 33000   # > 32767 rules after optimization
lines = ["root ::= sub", "sub ::= " + " | ".join(f"p{i}" for i in range(N))]
for i in range(N):
    lines.append(f'p{i} ::= "a" (p{i+1} | "")' if i < N - 1 else f'p{i} ::= "a"')
gbnf = "\n".join(lines)

tinfo = xgr.TokenizerInfo.from_huggingface(AutoTokenizer.from_pretrained("gpt2"))
xgr.GrammarCompiler(tinfo).compile_grammar(gbnf)   # std::bad_optional_access
```

The threshold is exact: 32,768 rules compiles, 32,770 crashes.

## Fix

Treat the 16-bit storage slot as **unsigned**, extending the valid range from `[0, 32767]` to `[0, 65535]`:

- `FSMEdge::GetRefRuleId()` returns `static_cast<int32_t>(static_cast<uint16_t>(max))`.
- `RepeatEdgeRef::RuleId()` returns the full `int32_t` from its aux storage.
- `FSM::AddRuleEdge` takes `int32_t rule_id` and `XGRAMMAR_CHECK`s `0 <= rule_id <= 0xFFFF`, so grammars beyond 65,535 rules now fail with a clear message instead of silently corrupting.
- The one call site that pre-truncated with `static_cast<int16_t>` is updated accordingly.

Storage layout, struct size, and on-disk serialization are unchanged — only the interpretation of the `max` field widens from signed to unsigned.

## Risk

- Grammars with at most 32,767 rules: bit-identical behavior.
- Grammars with 32,768–65,535 rules: previously crashed, now correct.
- Grammars beyond 65,535 rules: previously crashed silently, now produce a clear `XGRAMMAR_CHECK` at FSM build time.
- No upstream call site reads `FSMEdge::max` directly (bypassing `GetRefRuleId()`) for `kRuleRef` edges, so the signedness change is contained.

## Notes

Independent of the companion `GrammarFSMHasher` fix, though both surface on very large grammars and are best applied together.
