### PR TITLE
Lock excluded-string prefixes in TagDispatch for XML parameter values

### DIFF
--- a/cpp/fsm_builder.cc
+++ b/cpp/fsm_builder.cc
@@ -784,9 +784,15 @@ class TrieFSMBuilderImpl {
       const std::vector<std::string>& excluded_patterns,
       std::vector<int32_t>* end_states,
       bool allow_overlap,
-      bool add_back_edges
+      bool add_back_edges,
+      bool lock_excluded_prefixes
   );
-  void AddBackEdges(FSM* fsm, int start, const std::unordered_set<int>& ends);
+  void AddBackEdges(
+      FSM* fsm,
+      int start,
+      const std::unordered_set<int>& ends,
+      const std::unordered_set<int>& locked_states
+  );
 };
 
 std::optional<FSMWithStartEnd> TrieFSMBuilderImpl::Build(
@@ -794,11 +800,16 @@ std::optional<FSMWithStartEnd> TrieFSMBuilderImpl::Build(
     const std::vector<std::string>& excluded_patterns,
     std::vector<int32_t>* end_states,
     bool allow_overlap,
-    bool add_back_edges
+    bool add_back_edges,
+    bool lock_excluded_prefixes
 ) {
   FSM fsm(1);
   int start = 0;
   std::unordered_set<int> ends;
+  // The longest proper prefix state of each excluded pattern. When lock_excluded_prefixes is set,
+  // these states get no back edges so the prefix can only be completed into the full excluded
+  // pattern (see header doc).
+  std::unordered_set<int> locked_states;
 
   if (end_states) {
     end_states->clear();
@@ -842,6 +853,7 @@ std::optional<FSMWithStartEnd> TrieFSMBuilderImpl::Build(
       }
 
       int current_state = 0;
+      int penultimate_state = start;
       for (const auto& ch : excluded_pattern) {
         int16_t ch_int16 = static_cast<int16_t>(static_cast<uint8_t>(ch));
         int next_state = fsm.GetNextState(current_state, ch_int16);
@@ -849,6 +861,7 @@ std::optional<FSMWithStartEnd> TrieFSMBuilderImpl::Build(
           next_state = fsm.AddState();
           fsm.AddEdge(current_state, next_state, ch_int16, ch_int16);
         }
+        penultimate_state = current_state;
         current_state = next_state;
         if (!allow_overlap && ends.count(current_state) > 0) {
           return std::nullopt;
@@ -860,10 +873,16 @@ std::optional<FSMWithStartEnd> TrieFSMBuilderImpl::Build(
 
       ends.insert(current_state);
       dead_state_set.insert(current_state);
+      // The longest proper prefix (e.g. "</parameter" of "</parameter>"). Locking it forces
+      // completion of the excluded pattern; the start state is never locked since it must keep
+      // matching ordinary content.
+      if (lock_excluded_prefixes && penultimate_state != start) {
+        locked_states.insert(penultimate_state);
+      }
     }
 
-    // Add back edges.
-    AddBackEdges(&fsm, start, ends);
+    // Add back edges. Locked prefixes are excluded so they cannot fall back to ordinary content.
+    AddBackEdges(&fsm, start, ends, locked_states);
 
     // Remove the edges to excluded end states.
     if (dead_state_set.size() != 0) {
@@ -890,7 +909,12 @@ std::optional<FSMWithStartEnd> TrieFSMBuilderImpl::Build(
   return FSMWithStartEnd(fsm, start, is_end_state);
 }
 
-void TrieFSMBuilderImpl::AddBackEdges(FSM* fsm, int start, const std::unordered_set<int>& ends) {
+void TrieFSMBuilderImpl::AddBackEdges(
+    FSM* fsm,
+    int start,
+    const std::unordered_set<int>& ends,
+    const std::unordered_set<int>& locked_states
+) {
   // Build an Aho-Corasick automaton by adding back edges.
   // When matching on the trie fails, we should go back to the start state and
   // find the next match. Back edges represent such state transitions.
@@ -939,7 +963,13 @@ void TrieFSMBuilderImpl::AddBackEdges(FSM* fsm, int start, const std::unordered_
     }
 
     // Step 2. Add i--(c)-->start for c not in the edge set of i.
-    f_add_range_edges(i, cur_edges_set);
+    // Skipped for the longest prefix of an excluded pattern: such a state must complete the
+    // excluded pattern (its only forward char) or restart on a pattern-initial char (kept by
+    // Step 1), but it must not absorb an arbitrary char back into ordinary content. This is what
+    // forbids drifting "</parameter" into a malformed end marker like "</parameter1>".
+    if (locked_states.count(i) == 0) {
+      f_add_range_edges(i, cur_edges_set);
+    }
 
     // Step 3. Update the edges of i.
     cur_edges.clear();
@@ -959,10 +989,11 @@ std::optional<FSMWithStartEnd> TrieFSMBuilder::Build(
     const std::vector<std::string>& exclude_patterns,
     std::vector<int32_t>* end_states,
     bool allow_overlap,
-    bool add_back_edges
+    bool add_back_edges,
+    bool lock_excluded_prefixes
 ) {
   return TrieFSMBuilderImpl().Build(
-      patterns, exclude_patterns, end_states, allow_overlap, add_back_edges
+      patterns, exclude_patterns, end_states, allow_overlap, add_back_edges, lock_excluded_prefixes
   );
 }
 

--- a/cpp/fsm_builder.h
+++ b/cpp/fsm_builder.h
@@ -43,6 +43,13 @@ class TrieFSMBuilder {
    * std::nullopt.
    * \param add_back_edges Whether to add back edges to the FSM. This complements the trie to an
    * Aho-Corasick automaton.
+   * \param lock_excluded_prefixes If true, the longest proper prefix state of each excluded
+   * pattern (e.g. the state reached after "</parameter" for excluded pattern "</parameter>") gets
+   * no Aho-Corasick back edges. This forces such a prefix to be completed into the full excluded
+   * pattern instead of being reinterpreted as ordinary content, which prevents constrained
+   * decoding from drifting into malformed end markers (e.g. "</parameter1>"). Shorter prefixes
+   * (e.g. the state after "<" or "</p") keep their back edges, so legitimate content such as
+   * "<div>" or "</p>" is still accepted.
    * \return If success, the FSM with start and end states. Otherwise, std::nullopt.
    */
   static std::optional<FSMWithStartEnd> Build(
@@ -50,7 +57,8 @@ class TrieFSMBuilder {
       const std::vector<std::string>& excluded_patterns,
       std::vector<int32_t>* end_states = nullptr,
       bool allow_overlap = true,
-      bool add_back_edges = false
+      bool add_back_edges = false,
+      bool lock_excluded_prefixes = false
   );
 };
 

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -135,12 +135,13 @@ int32_t GrammarBuilder::AddChoices(const std::vector<int32_t>& choices) {
 
 int32_t GrammarBuilder::AddTagDispatch(const Grammar::Impl::TagDispatch& tag_dispatch) {
   std::vector<int32_t> data;
-  data.reserve(tag_dispatch.tag_rule_pairs.size() * 2 + 2);
+  data.reserve(tag_dispatch.tag_rule_pairs.size() * 2 + 3);
   for (const auto& [tag, rule_id] : tag_dispatch.tag_rule_pairs) {
     data.push_back(AddByteString(tag));
     data.push_back(rule_id);
   }
   data.push_back(static_cast<int32_t>(tag_dispatch.loop_after_dispatch));
+  data.push_back(static_cast<int32_t>(tag_dispatch.lock_excluded_prefixes));
   std::vector<int32_t> exclude_str_expr_ids;
   for (const auto& exclude_str : tag_dispatch.excludes) {
     exclude_str_expr_ids.push_back(AddByteString(exclude_str));

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -90,6 +90,7 @@ class SubGrammarAdderImpl : public GrammarMutator {
     }
     new_tag_dispatch.loop_after_dispatch = old_tag_dispatch.loop_after_dispatch;
     new_tag_dispatch.excludes = old_tag_dispatch.excludes;
+    new_tag_dispatch.lock_excluded_prefixes = old_tag_dispatch.lock_excluded_prefixes;
     return builder_->AddTagDispatch(new_tag_dispatch);
   }
 
@@ -1118,7 +1119,8 @@ class GrammarFSMBuilderImpl {
   static std::optional<FSMWithStartEnd> BuildTagDispatch(
       const std::vector<std::pair<std::string, int>>& string_trigger_rules,
       bool loop_after_dispatch,
-      const std::vector<std::string>& excluded_strings
+      const std::vector<std::string>& excluded_strings,
+      bool lock_excluded_prefixes
   );
   static FSMWithStartEnd BuildNegativeCharacterClass(const GrammarExpr& expr);
 };
@@ -1605,7 +1607,8 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Choices(
 std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildTagDispatch(
     const std::vector<std::pair<std::string, int>>& string_trigger_rules,
     bool loop_after_dispatch,
-    const std::vector<std::string>& excluded_strings
+    const std::vector<std::string>& excluded_strings,
+    bool lock_excluded_prefixes
 ) {
   std::vector<std::string> tag_names;
   tag_names.reserve(string_trigger_rules.size());
@@ -1613,7 +1616,9 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildTagDispatch(
     tag_names.push_back(tag_name);
   }
   std::vector<int> end_states;
-  auto trie_result = TrieFSMBuilder::Build(tag_names, excluded_strings, &end_states, true, true);
+  auto trie_result = TrieFSMBuilder::Build(
+      tag_names, excluded_strings, &end_states, true, true, lock_excluded_prefixes
+  );
   if (!trie_result.has_value()) {
     return std::nullopt;
   }
@@ -1657,7 +1662,10 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::TagDispatch(
   );
 
   return BuildTagDispatch(
-      string_trigger_rules, tag_dispatch.loop_after_dispatch, tag_dispatch.excludes
+      string_trigger_rules,
+      tag_dispatch.loop_after_dispatch,
+      tag_dispatch.excludes,
+      tag_dispatch.lock_excluded_prefixes
   );
 }
 

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -197,7 +197,15 @@ class Grammar::Impl {
     bool loop_after_dispatch;
     /*! \brief The strings that are excluded by the tag dispatch. */
     std::vector<std::string> excludes;
-    static const int kTagDispatchExtraParameter = 2;
+    /*!
+     * \brief If true, once the matched content reaches the longest proper prefix of an excluded
+     * string (e.g. "</parameter" of "</parameter>"), it must complete that excluded string instead
+     * of falling back to ordinary content. This prevents constrained decoding from drifting into a
+     * malformed end marker such as "</parameter1>". Defaults to false to preserve the plain
+     * "any content until the excluded string" semantics used by e.g. reasoning sections.
+     */
+    bool lock_excluded_prefixes = false;
+    static const int kTagDispatchExtraParameter = 3;
   };
 
   /*! \brief Get the tag dispatch from the grammar expr. */
@@ -221,8 +229,12 @@ class Grammar::Impl {
         grammar_expr[grammar_expr.size() - TagDispatch::kTagDispatchExtraParameter]
     );
 
-    auto exclude_str_expr = GetGrammarExpr(
+    result.lock_excluded_prefixes = static_cast<bool>(
         grammar_expr[grammar_expr.size() - TagDispatch::kTagDispatchExtraParameter + 1]
+    );
+
+    auto exclude_str_expr = GetGrammarExpr(
+        grammar_expr[grammar_expr.size() - TagDispatch::kTagDispatchExtraParameter + 2]
     );
     XGRAMMAR_DCHECK(exclude_str_expr.type == GrammarExprType::kChoices);
     result.excludes.reserve(exclude_str_expr.size());

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -934,7 +934,7 @@ int32_t EBNFParser::ParseTagDispatch() {
   Grammar::Impl::TagDispatch tag_dispatch;
 
   static const std::unordered_set<std::string> kValidNamedArgs = {
-      "loop_after_dispatch", "excludes"
+      "loop_after_dispatch", "excludes", "lock_excluded_prefixes"
   };
   for (const auto& [name, _] : args.named_arguments) {
     if (kValidNamedArgs.count(name) == 0) {
@@ -994,6 +994,17 @@ int32_t EBNFParser::ParseTagDispatch() {
       }
       tag_dispatch.excludes.push_back(str_node->value);
     }
+  }
+
+  // lock_excluded_prefixes
+  tag_dispatch.lock_excluded_prefixes = false;
+  if (auto it = args.named_arguments.find("lock_excluded_prefixes");
+      it != args.named_arguments.end()) {
+    auto bool_node = std::get_if<MacroIR::BooleanNode>(it->second.get());
+    if (bool_node == nullptr) {
+      ReportParseError("lock_excluded_prefixes must be a boolean literal", delta_element);
+    }
+    tag_dispatch.lock_excluded_prefixes = bool_node->value;
   }
 
   // Well-formedness checks: string excludes vs string triggers

--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -142,6 +142,10 @@ std::string GrammarPrinter::PrintTagDispatch(const GrammarExpr& grammar_expr) {
   }
   result +=
       indent + "loop_after_dispatch=" + PrintBoolean(tag_dispatch.loop_after_dispatch) + ",\n";
+  if (tag_dispatch.lock_excluded_prefixes) {
+    result += indent +
+              "lock_excluded_prefixes=" + PrintBoolean(tag_dispatch.lock_excluded_prefixes) + ",\n";
+  }
   result += indent + "excludes=(";
   for (int i = 0; i < static_cast<int>(tag_dispatch.excludes.size()); ++i) {
     if (i > 0) result += ", ";

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -61,10 +61,14 @@ void XMLToolCallingConverter::AddBasicRules() {
   nested_object_level_ = 1;
   // The outer part, xml format, is at level 1.
   // Add XML string rule
+  // lock_excluded_prefixes=true forces a started end marker (e.g. "</parameter") to be completed
+  // into the full suffix instead of drifting into ordinary content (e.g. "</parameter1>"), which
+  // otherwise causes malformed tool-call arguments / runaway generation under constrained decoding.
   ebnf_script_creator_.AddRule(
       kXMLString,
       "TagDispatch("
       "loop_after_dispatch=false,"
+      "lock_excluded_prefixes=true,"
       "excludes=(\"" +
           xml_wrapper_.parameter_suffix +
           "\")"

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -71,7 +71,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -86,6 +86,29 @@ root ::=  [ \n\t]* (("<parameter=name>" [ \n\t]* xml_string [ \n\t]* "</paramete
         "required": ["name", "age"],
     }
     _check_qwen_grammar(schema, expected_grammar, input_str, accepted)
+
+
+# Regression for the malformed end-marker drift: a string-typed parameter value must not be able
+# to drift past the longest prefix of the end marker (e.g. "</parameter") into a malformed marker
+# such as "</parameter1>". Legitimate '<'-containing content (HTML, shorter close tags) must still
+# be accepted, per https://github.com/mlc-ai/xgrammar/issues/489.
+test_string_end_marker_lock_input_str_accepted = (
+    ("<parameter=city>Shanghai</parameter>", True),
+    ("<parameter=city><div>x</div></parameter>", True),
+    ("<parameter=city>a</p>b</parameter>", True),
+    ("<parameter=city>1 < 2 & 3 > 0</parameter>", True),
+    ("<parameter=city>Shanghai</parameter1>", False),
+    ("<parameter=city>Shanghai</parameter_function>", False),
+    ("<parameter=city>Shanghai</parameterX>", False),
+    ("<parameter=city>Shanghai</parameter/>", False),
+)
+
+
+@pytest.mark.parametrize("input_str, accepted", test_string_end_marker_lock_input_str_accepted)
+def test_string_end_marker_lock(input_str: str, accepted: bool):
+    schema = {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}
+    ebnf_grammar = _qwen_xml_tool_calling_to_ebnf(schema)
+    check_grammar_with_instance(ebnf_grammar, input_str, accepted)
 
 
 test_additional_properties_schema_input_str_accepted = (
@@ -114,7 +137,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -156,7 +179,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -202,7 +225,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -247,7 +270,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -296,7 +319,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -372,7 +395,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -423,7 +446,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -468,7 +491,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -511,7 +534,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -553,7 +576,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -601,7 +624,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -656,7 +679,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -710,7 +733,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -790,7 +813,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -849,7 +872,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -918,7 +941,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</｜DSML｜parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>" ([ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -966,7 +989,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</｜DSML｜parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>" ([ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -1014,7 +1037,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</｜DSML｜parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>" ([ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -1065,7 +1088,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</｜DSML｜parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>" ([ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -1134,7 +1157,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</｜DSML｜parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>" ([ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -1191,7 +1214,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</｜DSML｜parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>" ([ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
@@ -1249,7 +1272,7 @@ basic_boolean ::= "true" | "false"
 basic_null ::= "null"
 basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
 basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
+xml_string ::= TagDispatch(loop_after_dispatch=false,lock_excluded_prefixes=true,excludes=("</｜DSML｜parameter>"))
 xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>" ([ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -194,6 +194,7 @@ basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n
 basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
 xml_string ::= TagDispatch(
   loop_after_dispatch=false,
+  lock_excluded_prefixes=true,
   excludes=("</parameter>")
 )
 xml_any ::= ((xml_string) | (basic_array) | (basic_object))
@@ -306,6 +307,7 @@ basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n
 basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
 xml_string ::= TagDispatch(
   loop_after_dispatch=false,
+  lock_excluded_prefixes=true,
   excludes=("</parameter>")
 )
 xml_any ::= ((xml_string) | (basic_array) | (basic_object))
@@ -389,6 +391,7 @@ basic_array ::= (("[" [ \n\t]* basic_any basic_array_1 [ \n\t]* "]") | ("[" [ \n
 basic_object ::= (("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any basic_object_1 [ \n\t]* "}") | ("{" [ \n\t]* "}"))
 xml_string ::= TagDispatch(
   loop_after_dispatch=false,
+  lock_excluded_prefixes=true,
   excludes=("</\uff5cDSML\uff5cparameter>")
 )
 xml_any ::= ((xml_string) | (basic_array) | (basic_object))


### PR DESCRIPTION
## Summary

Fix XML tool-call string parameter values drifting past the end-marker prefix under constrained decoding. Closes #650 (reported downstream at sgl-project/sglang#27336).

For `qwen_xml` / `minimax_xml` / `deepseek_xml` / `glm_xml`, a `string` parameter value is compiled as `TagDispatch(excludes=("</parameter>"))` — "any content until the end marker". The Aho-Corasick back edges added for the excluded string let the value drift past the longest end-marker prefix (`</parameter`) back into ordinary content. Under constrained decoding the token mask at `</parameter` therefore allows any byte (not just `>`), so the model can emit a malformed end marker like `</parameter1>` / `</parameter_function>` and then either leak it into the parsed arguments or keep generating to the length limit.

This is a regression from #511 (which relaxed XML string values to allow `<`/HTML per #489): before #511 the value forbade `<`, so the end marker was effectively forced.

## Modifications

- `TagDispatch` gains a `lock_excluded_prefixes` option (struct field + EBNF named arg + parser/printer + builder encoding). Default `false` preserves current behaviour.
- `fsm_builder.cc`: when the option is set, the **longest proper prefix** state of each excluded string is excluded from `AddBackEdges`, so it cannot fall back to content — it must complete the excluded string (or restart a fresh match on a pattern-initial char, which keeps shorter prefixes / legitimate `<`-content working).
- `json_schema_converter_ext.cc`: enable `lock_excluded_prefixes=true` for the XML parameter-value rule (`kXMLString`). All four XML formats benefit; reasoning / `any_text` TagDispatch is untouched.

## Behaviour

For a `{"city": string}` schema:

| Value emitted | Before | After |
|---|---|---|
| `Shanghai</parameter>` | accept | accept |
| `<div>x</div></parameter>` (HTML) | accept | accept |
| `1 < 2 & 3 > 0</parameter>` | accept | accept |
| `Shanghai</parameter1>` | **accept (drift)** | **reject** |
| `Shanghai</parameter_function>` | **accept (drift)** | **reject** |

Reasoning `any_text ::= TagDispatch(excludes=("</think>"))` is unchanged (still accepts arbitrary content containing prefixes of the delimiter).

## Tests

- `tests/python/test_function_calling_converter.py`: new `test_string_end_marker_lock` (malformed markers rejected, HTML / `<`-content accepted); existing expected-grammar strings updated to include the new flag.
- `tests/python/test_structural_tag_converter.py`: expected XML grammars updated; `test_any_text_format` (and the rest of the suite) confirms reasoning/any_text semantics are preserved.
- Full local run: `test_function_calling_converter.py`, `test_structural_tag_converter.py`, `test_builtin_structural_tag.py` → 1326 passed.
