### PR TITLE
fix: escape JSON schema property keys

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1610,7 +1610,7 @@ std::string JSONSchemaConverter::GenerateArray(
 }
 
 std::string JSONSchemaConverter::FormatPropertyKey(const std::string& key) {
-  return "\"\\\"" + key + "\\\"\"";
+  return "\"" + JSONStrToPrintableStr(picojson::value(key).serialize()) + "\"";
 }
 
 std::string JSONSchemaConverter::FormatProperty(

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1314,6 +1314,7 @@ std::string JSONSchemaConverter::GetKeyPatternExcluding(
   }
 
   // Build trie from property names
+  // TODO(linzhang): The trie only excludes the literal unescaped spelling of each property name.
   TrieNode root;
   for (const auto& prop : properties) {
     TrieNode* cur = &root;

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2396,6 +2396,38 @@ def test_utf8_string_in_const():
     assert _is_grammar_accept_string(grammar, '"常数constじょうすう\\n\\r\\t"')
 
 
+def test_control_char_in_property_key():
+    vocab = [bytes([i]) for i in range(256)]
+    metadata = json.dumps(
+        {
+            "vocab_type": 0,
+            "vocab_size": 256,
+            "prepend_space_in_tokenization": False,
+            "add_prefix_space": False,
+            "stop_token_ids": [0],
+        }
+    )
+    tokenizer_info = xgr.TokenizerInfo.from_vocab_and_metadata(vocab, metadata)
+    schema = {
+        "type": "object",
+        "properties": {"key\x01ctrl": {"type": "string"}},
+        "required": ["key\x01ctrl"],
+    }
+
+    compiler = xgr.GrammarCompiler(tokenizer_info)
+    grammar = compiler.compile_json_schema(json.dumps(schema))
+
+    matcher = xgr.GrammarMatcher(grammar)
+    for token_id in b'{"key':
+        assert matcher.accept_token(token_id)
+    assert not matcher.accept_token(1)
+
+    matcher = xgr.GrammarMatcher(grammar)
+    for token_id in b'{"key':
+        assert matcher.accept_token(token_id)
+    assert matcher.accept_token(ord("\\"))
+
+
 def test_utf8_object_array_in_enum():
     schema = {
         "type": "object",


### PR DESCRIPTION
## Summary
- Escape fixed JSON schema property keys through JSON serialization before embedding them in EBNF.
- Add a byte-level regression test that rejects raw control bytes and accepts JSON escape output.

## Validation
- python -m pytest tests/python/test_json_schema_converter.py -k control_char_in_property_key
- python -m pytest tests/python/test_json_schema_converter.py -k "control_char_in_property_key or utf8"