### PR TITLE
[feat] support whitespace control for structural tag

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -3236,10 +3236,7 @@ std::string GenerateFloatRangeRegex(std::optional<double> start, std::optional<d
 }
 
 std::string QwenXMLToolCallingToEBNF(
-    const std::string& schema,
-    bool any_order,
-    bool any_whitespace,
-    std::optional<int> max_whitespace_cnt
+    const std::string& schema, bool any_order, std::optional<int> max_whitespace_cnt
 ) {
   picojson::value json_value;
   std::string err = picojson::parse(json_value, schema);
@@ -3248,7 +3245,7 @@ std::string QwenXMLToolCallingToEBNF(
   }
   return JSONSchemaToEBNF(
       json_value,
-      any_whitespace,
+      true,
       std::nullopt,
       std::nullopt,
       true,
@@ -3259,10 +3256,7 @@ std::string QwenXMLToolCallingToEBNF(
 }
 
 std::string MiniMaxXMLToolCallingToEBNF(
-    const std::string& schema,
-    bool any_order,
-    bool any_whitespace,
-    std::optional<int> max_whitespace_cnt
+    const std::string& schema, bool any_order, std::optional<int> max_whitespace_cnt
 ) {
   picojson::value json_value;
   std::string err = picojson::parse(json_value, schema);
@@ -3271,7 +3265,7 @@ std::string MiniMaxXMLToolCallingToEBNF(
   }
   return JSONSchemaToEBNF(
       json_value,
-      any_whitespace,
+      true,
       std::nullopt,
       std::nullopt,
       true,
@@ -3282,10 +3276,7 @@ std::string MiniMaxXMLToolCallingToEBNF(
 }
 
 std::string DeepSeekXMLToolCallingToEBNF(
-    const std::string& schema,
-    bool any_order,
-    bool any_whitespace,
-    std::optional<int> max_whitespace_cnt
+    const std::string& schema, bool any_order, std::optional<int> max_whitespace_cnt
 ) {
   picojson::value json_value;
   std::string err = picojson::parse(json_value, schema);
@@ -3294,7 +3285,7 @@ std::string DeepSeekXMLToolCallingToEBNF(
   }
   return JSONSchemaToEBNF(
       json_value,
-      any_whitespace,
+      true,
       std::nullopt,
       std::nullopt,
       true,
@@ -3305,10 +3296,7 @@ std::string DeepSeekXMLToolCallingToEBNF(
 }
 
 std::string GlmXMLToolCallingToEBNF(
-    const std::string& schema,
-    bool any_order,
-    bool any_whitespace,
-    std::optional<int> max_whitespace_cnt
+    const std::string& schema, bool any_order, std::optional<int> max_whitespace_cnt
 ) {
   picojson::value json_value;
   std::string err = picojson::parse(json_value, schema);
@@ -3317,7 +3305,7 @@ std::string GlmXMLToolCallingToEBNF(
   }
   return JSONSchemaToEBNF(
       json_value,
-      any_whitespace,
+      true,
       std::nullopt,
       std::nullopt,
       true,

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1158,7 +1158,7 @@ void JSONSchemaConverter::AddBasicRules() {
   // Create basic rules with a temporary indent manager for compact format
   auto saved_indent_manager = indent_manager_;
   if (any_whitespace_) {
-    indent_manager_ = IndentManager(std::nullopt, ",", true, std::nullopt);
+    indent_manager_ = IndentManager(std::nullopt, ",", true, max_whitespace_cnt_);
   } else {
     indent_manager_ = IndentManager(std::nullopt, ", ", false, std::nullopt);
   }
@@ -3235,7 +3235,12 @@ std::string GenerateFloatRangeRegex(std::optional<double> start, std::optional<d
   return JSONSchemaConverter::GenerateFloatRangeRegex(start, end, 6);
 }
 
-std::string QwenXMLToolCallingToEBNF(const std::string& schema, bool any_order) {
+std::string QwenXMLToolCallingToEBNF(
+    const std::string& schema,
+    bool any_order,
+    bool any_whitespace,
+    std::optional<int> max_whitespace_cnt
+) {
   picojson::value json_value;
   std::string err = picojson::parse(json_value, schema);
   if (!err.empty()) {
@@ -3243,17 +3248,22 @@ std::string QwenXMLToolCallingToEBNF(const std::string& schema, bool any_order) 
   }
   return JSONSchemaToEBNF(
       json_value,
-      true,
+      any_whitespace,
       std::nullopt,
       std::nullopt,
       true,
-      std::nullopt,
+      max_whitespace_cnt,
       JSONFormat::kQwenXML,
       any_order
   );
 }
 
-std::string MiniMaxXMLToolCallingToEBNF(const std::string& schema, bool any_order) {
+std::string MiniMaxXMLToolCallingToEBNF(
+    const std::string& schema,
+    bool any_order,
+    bool any_whitespace,
+    std::optional<int> max_whitespace_cnt
+) {
   picojson::value json_value;
   std::string err = picojson::parse(json_value, schema);
   if (!err.empty()) {
@@ -3261,17 +3271,22 @@ std::string MiniMaxXMLToolCallingToEBNF(const std::string& schema, bool any_orde
   }
   return JSONSchemaToEBNF(
       json_value,
-      true,
+      any_whitespace,
       std::nullopt,
       std::nullopt,
       true,
-      std::nullopt,
+      max_whitespace_cnt,
       JSONFormat::kMiniMaxXML,
       any_order
   );
 }
 
-std::string DeepSeekXMLToolCallingToEBNF(const std::string& schema, bool any_order) {
+std::string DeepSeekXMLToolCallingToEBNF(
+    const std::string& schema,
+    bool any_order,
+    bool any_whitespace,
+    std::optional<int> max_whitespace_cnt
+) {
   picojson::value json_value;
   std::string err = picojson::parse(json_value, schema);
   if (!err.empty()) {
@@ -3279,17 +3294,22 @@ std::string DeepSeekXMLToolCallingToEBNF(const std::string& schema, bool any_ord
   }
   return JSONSchemaToEBNF(
       json_value,
-      true,
+      any_whitespace,
       std::nullopt,
       std::nullopt,
       true,
-      std::nullopt,
+      max_whitespace_cnt,
       JSONFormat::kDeepSeekXML,
       any_order
   );
 }
 
-std::string GlmXMLToolCallingToEBNF(const std::string& schema, bool any_order) {
+std::string GlmXMLToolCallingToEBNF(
+    const std::string& schema,
+    bool any_order,
+    bool any_whitespace,
+    std::optional<int> max_whitespace_cnt
+) {
   picojson::value json_value;
   std::string err = picojson::parse(json_value, schema);
   if (!err.empty()) {
@@ -3297,11 +3317,11 @@ std::string GlmXMLToolCallingToEBNF(const std::string& schema, bool any_order) {
   }
   return JSONSchemaToEBNF(
       json_value,
-      true,
+      any_whitespace,
       std::nullopt,
       std::nullopt,
       true,
-      std::nullopt,
+      max_whitespace_cnt,
       JSONFormat::kGlmXML,
       any_order
   );

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -549,7 +549,6 @@ std::string GenerateFloatRangeRegex(std::optional<double> start, std::optional<d
  * \brief Convert a function call to a Grammar.
  * \param schema The schema of the parameters of the function call.
  * \param any_order Whether object properties may appear in any order. Default: false.
- * \param any_whitespace Whether to allow any whitespace characters. Default: true.
  * \param max_whitespace_cnt Maximum consecutive whitespace count. Default: std::nullopt
  *   (unlimited).
  * \return The ebnf-grammar to match the requirements of the schema, and
@@ -558,7 +557,6 @@ std::string GenerateFloatRangeRegex(std::optional<double> start, std::optional<d
 std::string QwenXMLToolCallingToEBNF(
     const std::string& schema,
     bool any_order = false,
-    bool any_whitespace = true,
     std::optional<int> max_whitespace_cnt = std::nullopt
 );
 
@@ -566,7 +564,6 @@ std::string QwenXMLToolCallingToEBNF(
  * \brief Convert a function call to a Grammar.
  * \param schema The schema of the parameters of the function call.
  * \param any_order Whether object properties may appear in any order. Default: false.
- * \param any_whitespace Whether to allow any whitespace characters. Default: true.
  * \param max_whitespace_cnt Maximum consecutive whitespace count. Default: std::nullopt
  *   (unlimited).
  * \return The ebnf-grammar to match the requirements of the schema, and
@@ -575,7 +572,6 @@ std::string QwenXMLToolCallingToEBNF(
 std::string MiniMaxXMLToolCallingToEBNF(
     const std::string& schema,
     bool any_order = false,
-    bool any_whitespace = true,
     std::optional<int> max_whitespace_cnt = std::nullopt
 );
 
@@ -583,7 +579,6 @@ std::string MiniMaxXMLToolCallingToEBNF(
  * \brief Convert a function call to a Grammar.
  * \param schema The schema of the parameters of the function call.
  * \param any_order Whether object properties may appear in any order. Default: false.
- * \param any_whitespace Whether to allow any whitespace characters. Default: true.
  * \param max_whitespace_cnt Maximum consecutive whitespace count. Default: std::nullopt
  *   (unlimited).
  * \return The ebnf-grammar to match the requirements of the schema, and
@@ -592,7 +587,6 @@ std::string MiniMaxXMLToolCallingToEBNF(
 std::string DeepSeekXMLToolCallingToEBNF(
     const std::string& schema,
     bool any_order = false,
-    bool any_whitespace = true,
     std::optional<int> max_whitespace_cnt = std::nullopt
 );
 
@@ -600,7 +594,6 @@ std::string DeepSeekXMLToolCallingToEBNF(
  * \brief Convert a function call to a Grammar.
  * \param schema The schema of the parameters of the function call.
  * \param any_order Whether object properties may appear in any order. Default: false.
- * \param any_whitespace Whether to allow any whitespace characters. Default: true.
  * \param max_whitespace_cnt Maximum consecutive whitespace count. Default: std::nullopt
  *   (unlimited).
  * \return The ebnf-grammar to match the requirements of the schema, and
@@ -609,7 +602,6 @@ std::string DeepSeekXMLToolCallingToEBNF(
 std::string GlmXMLToolCallingToEBNF(
     const std::string& schema,
     bool any_order = false,
-    bool any_whitespace = true,
     std::optional<int> max_whitespace_cnt = std::nullopt
 );
 

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -548,34 +548,70 @@ std::string GenerateFloatRangeRegex(std::optional<double> start, std::optional<d
 /*!
  * \brief Convert a function call to a Grammar.
  * \param schema The schema of the parameters of the function call.
+ * \param any_order Whether object properties may appear in any order. Default: false.
+ * \param any_whitespace Whether to allow any whitespace characters. Default: true.
+ * \param max_whitespace_cnt Maximum consecutive whitespace count. Default: std::nullopt
+ *   (unlimited).
  * \return The ebnf-grammar to match the requirements of the schema, and
  * in Qwen xml style.
  */
-std::string QwenXMLToolCallingToEBNF(const std::string& schema, bool any_order = false);
+std::string QwenXMLToolCallingToEBNF(
+    const std::string& schema,
+    bool any_order = false,
+    bool any_whitespace = true,
+    std::optional<int> max_whitespace_cnt = std::nullopt
+);
 
 /*!
  * \brief Convert a function call to a Grammar.
  * \param schema The schema of the parameters of the function call.
+ * \param any_order Whether object properties may appear in any order. Default: false.
+ * \param any_whitespace Whether to allow any whitespace characters. Default: true.
+ * \param max_whitespace_cnt Maximum consecutive whitespace count. Default: std::nullopt
+ *   (unlimited).
  * \return The ebnf-grammar to match the requirements of the schema, and
  * in MiniMax xml style.
  */
-std::string MiniMaxXMLToolCallingToEBNF(const std::string& schema, bool any_order = false);
+std::string MiniMaxXMLToolCallingToEBNF(
+    const std::string& schema,
+    bool any_order = false,
+    bool any_whitespace = true,
+    std::optional<int> max_whitespace_cnt = std::nullopt
+);
 
 /*!
  * \brief Convert a function call to a Grammar.
  * \param schema The schema of the parameters of the function call.
+ * \param any_order Whether object properties may appear in any order. Default: false.
+ * \param any_whitespace Whether to allow any whitespace characters. Default: true.
+ * \param max_whitespace_cnt Maximum consecutive whitespace count. Default: std::nullopt
+ *   (unlimited).
  * \return The ebnf-grammar to match the requirements of the schema, and
  * in DeepSeek xml style.
  */
-std::string DeepSeekXMLToolCallingToEBNF(const std::string& schema, bool any_order = false);
+std::string DeepSeekXMLToolCallingToEBNF(
+    const std::string& schema,
+    bool any_order = false,
+    bool any_whitespace = true,
+    std::optional<int> max_whitespace_cnt = std::nullopt
+);
 
 /*!
  * \brief Convert a function call to a Grammar.
  * \param schema The schema of the parameters of the function call.
+ * \param any_order Whether object properties may appear in any order. Default: false.
+ * \param any_whitespace Whether to allow any whitespace characters. Default: true.
+ * \param max_whitespace_cnt Maximum consecutive whitespace count. Default: std::nullopt
+ *   (unlimited).
  * \return The ebnf-grammar to match the requirements of the schema, and
  * in GLM xml style (<arg_key>key</arg_key><arg_value>value</arg_value>).
  */
-std::string GlmXMLToolCallingToEBNF(const std::string& schema, bool any_order = false);
+std::string GlmXMLToolCallingToEBNF(
+    const std::string& schema,
+    bool any_order = false,
+    bool any_whitespace = true,
+    std::optional<int> max_whitespace_cnt = std::nullopt
+);
 
 }  // namespace xgrammar
 

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -101,7 +101,6 @@ picojson::value JSONSchemaFormat::ToJSON() const {
   }
   obj["style"] = picojson::value(style);
   obj["any_order"] = picojson::value(any_order);
-  obj["any_whitespace"] = picojson::value(any_whitespace);
   if (max_whitespace_cnt.has_value()) {
     obj["max_whitespace_cnt"] = picojson::value(static_cast<int64_t>(*max_whitespace_cnt));
   } else {
@@ -554,14 +553,6 @@ Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
     }
     any_order = any_order_it->second.get<bool>();
   }
-  bool any_whitespace = true;
-  auto any_whitespace_it = obj.find("any_whitespace");
-  if (any_whitespace_it != obj.end() && !any_whitespace_it->second.is<picojson::null>()) {
-    if (!any_whitespace_it->second.is<bool>()) {
-      return ResultErr<ISTError>("any_whitespace must be a boolean");
-    }
-    any_whitespace = any_whitespace_it->second.get<bool>();
-  }
   std::optional<int> max_whitespace_cnt = std::nullopt;
   auto max_whitespace_cnt_it = obj.find("max_whitespace_cnt");
   if (max_whitespace_cnt_it != obj.end() && !max_whitespace_cnt_it->second.is<picojson::null>()) {
@@ -572,7 +563,7 @@ Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
   }
   // here introduces a serialization/deserialization overhead; try to avoid it in the future.
   return ResultOk<JSONSchemaFormat>(
-      json_schema_it->second.serialize(false), style, any_order, any_whitespace, max_whitespace_cnt
+      json_schema_it->second.serialize(false), style, any_order, max_whitespace_cnt
   );
 }
 
@@ -1853,19 +1844,17 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const ConstStringF
 }
 
 Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFormat& format) {
-  // Whitespace control comes from the JSONSchemaFormat node (per-tag).
+  // The whitespace cap comes from the JSONSchemaFormat node (per-tag).
   const static std::unordered_map<
       std::string,
-      std::function<std::string(const std::string&, bool, bool, std::optional<int>)>>
+      std::function<std::string(const std::string&, bool, std::optional<int>)>>
       style_to_grammar_converter = {
           {"json",
-           [](const std::string& json_schema,
-              bool any_order,
-              bool any_whitespace,
-              std::optional<int> max_whitespace_cnt) -> std::string {
+           [](const std::string& json_schema, bool any_order, std::optional<int> max_whitespace_cnt
+           ) -> std::string {
              return JSONSchemaToEBNF(
                  json_schema,
-                 any_whitespace,
+                 /*any_whitespace=*/true,
                  /*indent=*/std::nullopt,
                  /*separators=*/std::nullopt,
                  /*strict_mode=*/true,
@@ -1875,49 +1864,33 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFo
              );
            }},
           {"qwen_xml",
-           [](const std::string& json_schema,
-              bool any_order,
-              bool any_whitespace,
-              std::optional<int> max_whitespace_cnt) -> std::string {
-             return QwenXMLToolCallingToEBNF(
-                 json_schema, any_order, any_whitespace, max_whitespace_cnt
-             );
+           [](const std::string& json_schema, bool any_order, std::optional<int> max_whitespace_cnt
+           ) -> std::string {
+             return QwenXMLToolCallingToEBNF(json_schema, any_order, max_whitespace_cnt);
            }},
           {"minimax_xml",
-           [](const std::string& json_schema,
-              bool any_order,
-              bool any_whitespace,
-              std::optional<int> max_whitespace_cnt) -> std::string {
-             return MiniMaxXMLToolCallingToEBNF(
-                 json_schema, any_order, any_whitespace, max_whitespace_cnt
-             );
+           [](const std::string& json_schema, bool any_order, std::optional<int> max_whitespace_cnt
+           ) -> std::string {
+             return MiniMaxXMLToolCallingToEBNF(json_schema, any_order, max_whitespace_cnt);
            }},
           {"deepseek_xml",
-           [](const std::string& json_schema,
-              bool any_order,
-              bool any_whitespace,
-              std::optional<int> max_whitespace_cnt) -> std::string {
-             return DeepSeekXMLToolCallingToEBNF(
-                 json_schema, any_order, any_whitespace, max_whitespace_cnt
-             );
+           [](const std::string& json_schema, bool any_order, std::optional<int> max_whitespace_cnt
+           ) -> std::string {
+             return DeepSeekXMLToolCallingToEBNF(json_schema, any_order, max_whitespace_cnt);
            }},
           {"glm_xml",
-           [](const std::string& json_schema,
-              bool any_order,
-              bool any_whitespace,
-              std::optional<int> max_whitespace_cnt) -> std::string {
-             return GlmXMLToolCallingToEBNF(
-                 json_schema, any_order, any_whitespace, max_whitespace_cnt
-             );
+           [](const std::string& json_schema, bool any_order, std::optional<int> max_whitespace_cnt
+           ) -> std::string {
+             return GlmXMLToolCallingToEBNF(json_schema, any_order, max_whitespace_cnt);
            }},
       };
   auto converter = style_to_grammar_converter.find(format.style);
   if (converter == style_to_grammar_converter.end()) {
     return ResultErr<ISTError>("Unsupported parsing type: " + format.style);
   }
-  auto sub_grammar = Grammar::FromEBNF(converter->second(
-      format.json_schema, format.any_order, format.any_whitespace, format.max_whitespace_cnt
-  ));
+  auto sub_grammar = Grammar::FromEBNF(
+      converter->second(format.json_schema, format.any_order, format.max_whitespace_cnt)
+  );
   auto added_root_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
   return ResultOk(added_root_rule_id);
 }

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -101,6 +101,12 @@ picojson::value JSONSchemaFormat::ToJSON() const {
   }
   obj["style"] = picojson::value(style);
   obj["any_order"] = picojson::value(any_order);
+  obj["any_whitespace"] = picojson::value(any_whitespace);
+  if (max_whitespace_cnt.has_value()) {
+    obj["max_whitespace_cnt"] = picojson::value(static_cast<int64_t>(*max_whitespace_cnt));
+  } else {
+    obj["max_whitespace_cnt"] = picojson::value();
+  }
   return picojson::value(std::move(obj));
 }
 
@@ -548,9 +554,26 @@ Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
     }
     any_order = any_order_it->second.get<bool>();
   }
-
+  bool any_whitespace = true;
+  auto any_whitespace_it = obj.find("any_whitespace");
+  if (any_whitespace_it != obj.end() && !any_whitespace_it->second.is<picojson::null>()) {
+    if (!any_whitespace_it->second.is<bool>()) {
+      return ResultErr<ISTError>("any_whitespace must be a boolean");
+    }
+    any_whitespace = any_whitespace_it->second.get<bool>();
+  }
+  std::optional<int> max_whitespace_cnt = std::nullopt;
+  auto max_whitespace_cnt_it = obj.find("max_whitespace_cnt");
+  if (max_whitespace_cnt_it != obj.end() && !max_whitespace_cnt_it->second.is<picojson::null>()) {
+    if (!max_whitespace_cnt_it->second.is<double>()) {
+      return ResultErr<ISTError>("max_whitespace_cnt must be an integer or null");
+    }
+    max_whitespace_cnt = static_cast<int>(max_whitespace_cnt_it->second.get<int64_t>());
+  }
   // here introduces a serialization/deserialization overhead; try to avoid it in the future.
-  return ResultOk<JSONSchemaFormat>(json_schema_it->second.serialize(false), style, any_order);
+  return ResultOk<JSONSchemaFormat>(
+      json_schema_it->second.serialize(false), style, any_order, any_whitespace, max_whitespace_cnt
+  );
 }
 
 Result<AnyTextFormat, ISTError> StructuralTagParser::ParseAnyTextFormat(const picojson::object& obj
@@ -1730,6 +1753,8 @@ class StructuralTagGrammarConverter {
   static Result<Grammar, ISTError> Convert(const StructuralTag& structural_tag);
 
  private:
+  StructuralTagGrammarConverter() = default;
+
   /*!
    * \brief Visit a Format and return the rule id of the added rule.
    * \param format The Format to visit.
@@ -1828,44 +1853,71 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const ConstStringF
 }
 
 Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFormat& format) {
-  const static std::unordered_map<std::string, std::function<std::string(const std::string&, bool)>>
+  // Whitespace control comes from the JSONSchemaFormat node (per-tag).
+  const static std::unordered_map<
+      std::string,
+      std::function<std::string(const std::string&, bool, bool, std::optional<int>)>>
       style_to_grammar_converter = {
           {"json",
-           [](const std::string& json_schema, bool any_order) -> std::string {
+           [](const std::string& json_schema,
+              bool any_order,
+              bool any_whitespace,
+              std::optional<int> max_whitespace_cnt) -> std::string {
              return JSONSchemaToEBNF(
                  json_schema,
-                 /*any_whitespace=*/true,
+                 any_whitespace,
                  /*indent=*/std::nullopt,
                  /*separators=*/std::nullopt,
                  /*strict_mode=*/true,
-                 /*max_whitespace_cnt=*/std::nullopt,
+                 max_whitespace_cnt,
                  /*json_format=*/JSONFormat::kJSON,
                  any_order
              );
            }},
           {"qwen_xml",
-           [](const std::string& json_schema, bool any_order) -> std::string {
-             return QwenXMLToolCallingToEBNF(json_schema, any_order);
+           [](const std::string& json_schema,
+              bool any_order,
+              bool any_whitespace,
+              std::optional<int> max_whitespace_cnt) -> std::string {
+             return QwenXMLToolCallingToEBNF(
+                 json_schema, any_order, any_whitespace, max_whitespace_cnt
+             );
            }},
           {"minimax_xml",
-           [](const std::string& json_schema, bool any_order) -> std::string {
-             return MiniMaxXMLToolCallingToEBNF(json_schema, any_order);
+           [](const std::string& json_schema,
+              bool any_order,
+              bool any_whitespace,
+              std::optional<int> max_whitespace_cnt) -> std::string {
+             return MiniMaxXMLToolCallingToEBNF(
+                 json_schema, any_order, any_whitespace, max_whitespace_cnt
+             );
            }},
           {"deepseek_xml",
-           [](const std::string& json_schema, bool any_order) -> std::string {
-             return DeepSeekXMLToolCallingToEBNF(json_schema, any_order);
+           [](const std::string& json_schema,
+              bool any_order,
+              bool any_whitespace,
+              std::optional<int> max_whitespace_cnt) -> std::string {
+             return DeepSeekXMLToolCallingToEBNF(
+                 json_schema, any_order, any_whitespace, max_whitespace_cnt
+             );
            }},
           {"glm_xml",
-           [](const std::string& json_schema, bool any_order) -> std::string {
-             return GlmXMLToolCallingToEBNF(json_schema, any_order);
+           [](const std::string& json_schema,
+              bool any_order,
+              bool any_whitespace,
+              std::optional<int> max_whitespace_cnt) -> std::string {
+             return GlmXMLToolCallingToEBNF(
+                 json_schema, any_order, any_whitespace, max_whitespace_cnt
+             );
            }},
       };
   auto converter = style_to_grammar_converter.find(format.style);
   if (converter == style_to_grammar_converter.end()) {
     return ResultErr<ISTError>("Unsupported parsing type: " + format.style);
   }
-  std::string ebnf = converter->second(format.json_schema, format.any_order);
-  auto sub_grammar = Grammar::FromEBNF(ebnf);
+  auto sub_grammar = Grammar::FromEBNF(converter->second(
+      format.json_schema, format.any_order, format.any_whitespace, format.max_whitespace_cnt
+  ));
   auto added_root_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
   return ResultOk(added_root_rule_id);
 }

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -87,8 +87,21 @@ struct JSONSchemaFormat {
   // Whether to allow object properties to appear in any order. See
   // Grammar::FromJSONSchema / JSONSchemaToEBNF for the semantics.
   bool any_order = false;
-  JSONSchemaFormat(std::string json_schema, std::string style = "json", bool any_order = false)
-      : json_schema(std::move(json_schema)), style(std::move(style)), any_order(any_order) {}
+  // Per-tag whitespace control for the JSON-schema content.
+  bool any_whitespace = true;
+  std::optional<int> max_whitespace_cnt = std::nullopt;
+  JSONSchemaFormat(
+      std::string json_schema,
+      std::string style = "json",
+      bool any_order = false,
+      bool any_whitespace = true,
+      std::optional<int> max_whitespace_cnt = std::nullopt
+  )
+      : json_schema(std::move(json_schema)),
+        style(std::move(style)),
+        any_order(any_order),
+        any_whitespace(any_whitespace),
+        max_whitespace_cnt(max_whitespace_cnt) {}
   picojson::value ToJSON() const;
 };
 

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -87,20 +87,17 @@ struct JSONSchemaFormat {
   // Whether to allow object properties to appear in any order. See
   // Grammar::FromJSONSchema / JSONSchemaToEBNF for the semantics.
   bool any_order = false;
-  // Per-tag whitespace control for the JSON-schema content.
-  bool any_whitespace = true;
+  // Per-tag cap on consecutive whitespace characters in the JSON-schema content.
   std::optional<int> max_whitespace_cnt = std::nullopt;
   JSONSchemaFormat(
       std::string json_schema,
       std::string style = "json",
       bool any_order = false,
-      bool any_whitespace = true,
       std::optional<int> max_whitespace_cnt = std::nullopt
   )
       : json_schema(std::move(json_schema)),
         style(std::move(style)),
         any_order(any_order),
-        any_whitespace(any_whitespace),
         max_whitespace_cnt(max_whitespace_cnt) {}
   picojson::value ToJSON() const;
 };

--- a/cpp/support/compact_2d_array.h
+++ b/cpp/support/compact_2d_array.h
@@ -7,6 +7,7 @@
 
 #include <picojson.h>
 
+#include <climits>
 #include <cstddef>
 #include <cstdint>
 #include <utility>
@@ -325,6 +326,9 @@ inline int32_t Compact2DArray<DataType>::PushBack(const DataType* new_data, int3
   } else {
     data_.insert(data_.end(), new_data, new_data + new_data_len);
   }
+  XGRAMMAR_DCHECK(data_.size() <= static_cast<size_t>(INT32_MAX))
+      << "Compact2DArray data_ size (" << data_.size()
+      << ") exceeds int32_t limit, likely due to unbounded grammar pattern causing state explosion";
   indptr_.push_back(static_cast<int32_t>(data_.size()));
   return static_cast<int32_t>(indptr_.size()) - 2;
 }
@@ -332,6 +336,9 @@ inline int32_t Compact2DArray<DataType>::PushBack(const DataType* new_data, int3
 template <typename DataType>
 inline int32_t Compact2DArray<DataType>::PushBack(const std::vector<DataType>& new_data) {
   data_.insert(data_.end(), new_data.begin(), new_data.end());
+  XGRAMMAR_DCHECK(data_.size() <= static_cast<size_t>(INT32_MAX))
+      << "Compact2DArray data_ size (" << data_.size()
+      << ") exceeds int32_t limit, likely due to unbounded grammar pattern causing state explosion";
   indptr_.push_back(static_cast<int32_t>(data_.size()));
   return static_cast<int32_t>(indptr_.size()) - 2;
 }
@@ -348,6 +355,9 @@ inline int32_t Compact2DArray<DataType>::PushBackNonContiguous(
     data_.push_back(data_1);
     data_.insert(data_.end(), data_2, data_2 + data_2_len);
   }
+  XGRAMMAR_DCHECK(data_.size() <= static_cast<size_t>(INT32_MAX))
+      << "Compact2DArray data_ size (" << data_.size()
+      << ") exceeds int32_t limit, likely due to unbounded grammar pattern causing state explosion";
   indptr_.push_back(static_cast<int32_t>(data_.size()));
   return static_cast<int32_t>(indptr_.size()) - 2;
 }

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -818,25 +818,33 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def(
           "xgrammar.tvm_ffi_binding.testing._qwen_xml_tool_calling_to_ebnf",
           [](ffi::String schema, bool any_order) {
-            return ffi::String(QwenXMLToolCallingToEBNF(schema, any_order));
+            return ffi::String(QwenXMLToolCallingToEBNF(
+                schema, any_order, /*any_whitespace=*/true, /*max_whitespace_cnt=*/std::nullopt
+            ));
           }
       )
       .def(
           "xgrammar.tvm_ffi_binding.testing._minimax_xml_tool_calling_to_ebnf",
           [](ffi::String schema, bool any_order) {
-            return ffi::String(MiniMaxXMLToolCallingToEBNF(schema, any_order));
+            return ffi::String(MiniMaxXMLToolCallingToEBNF(
+                schema, any_order, /*any_whitespace=*/true, /*max_whitespace_cnt=*/std::nullopt
+            ));
           }
       )
       .def(
           "xgrammar.tvm_ffi_binding.testing._deepseek_xml_tool_calling_to_ebnf",
           [](ffi::String schema, bool any_order) {
-            return ffi::String(DeepSeekXMLToolCallingToEBNF(schema, any_order));
+            return ffi::String(DeepSeekXMLToolCallingToEBNF(
+                schema, any_order, /*any_whitespace=*/true, /*max_whitespace_cnt=*/std::nullopt
+            ));
           }
       )
       .def(
           "xgrammar.tvm_ffi_binding.testing._glm_xml_tool_calling_to_ebnf",
           [](ffi::String schema, bool any_order) {
-            return ffi::String(GlmXMLToolCallingToEBNF(schema, any_order));
+            return ffi::String(GlmXMLToolCallingToEBNF(
+                schema, any_order, /*any_whitespace=*/true, /*max_whitespace_cnt=*/std::nullopt
+            ));
           }
       )
       .def(

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -818,33 +818,25 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def(
           "xgrammar.tvm_ffi_binding.testing._qwen_xml_tool_calling_to_ebnf",
           [](ffi::String schema, bool any_order) {
-            return ffi::String(QwenXMLToolCallingToEBNF(
-                schema, any_order, /*any_whitespace=*/true, /*max_whitespace_cnt=*/std::nullopt
-            ));
+            return ffi::String(QwenXMLToolCallingToEBNF(schema, any_order));
           }
       )
       .def(
           "xgrammar.tvm_ffi_binding.testing._minimax_xml_tool_calling_to_ebnf",
           [](ffi::String schema, bool any_order) {
-            return ffi::String(MiniMaxXMLToolCallingToEBNF(
-                schema, any_order, /*any_whitespace=*/true, /*max_whitespace_cnt=*/std::nullopt
-            ));
+            return ffi::String(MiniMaxXMLToolCallingToEBNF(schema, any_order));
           }
       )
       .def(
           "xgrammar.tvm_ffi_binding.testing._deepseek_xml_tool_calling_to_ebnf",
           [](ffi::String schema, bool any_order) {
-            return ffi::String(DeepSeekXMLToolCallingToEBNF(
-                schema, any_order, /*any_whitespace=*/true, /*max_whitespace_cnt=*/std::nullopt
-            ));
+            return ffi::String(DeepSeekXMLToolCallingToEBNF(schema, any_order));
           }
       )
       .def(
           "xgrammar.tvm_ffi_binding.testing._glm_xml_tool_calling_to_ebnf",
           [](ffi::String schema, bool any_order) {
-            return ffi::String(GlmXMLToolCallingToEBNF(
-                schema, any_order, /*any_whitespace=*/true, /*max_whitespace_cnt=*/std::nullopt
-            ));
+            return ffi::String(GlmXMLToolCallingToEBNF(schema, any_order));
           }
       )
       .def(

--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -49,7 +49,6 @@ Use it when you need to constrain the model to output in a fixed pattern such as
   - `{"type": "allowed_tools", "allowed_tools": {"mode": ..., "tools": [...]}}`: limits available tools before applying its `mode`. The `tools` list may contain both function refs and builtin refs (matched by `type`).
 - **reasoning** (`bool`, optional): Whether to enable reasoning mode (`<think>`/`</think>` tags or model-specific equivalents). Default `True`.
 - **any_order** (`bool`, optional): When `True`, applies `any_order=True` to every `JSONSchemaFormat` in the generated structural tag, so each tool's arguments may be emitted in any property order (see [`JSONSchemaFormat`](structural_tag_api) for the exact semantics). Default `False`, which keeps the declared property order with full validation.
-- **any_whitespace** (`bool`, optional): Whether to allow arbitrary whitespace in this content. If False, use fixed formatting.
 - **max_whitespace_cnt** (`Optional[int]`, optional): Caps the number of consecutive whitespace characters. Setting it (e.g. `2`) bounds runs of whitespace, which avoids the unbounded-whitespace outputs some models emit in bad cases that would otherwise blow up grammar compilation/matching.
 
 Passing an unsupported `model` or an invalid `tool_choice` will raise `ValueError`.

--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -19,8 +19,6 @@ The `reasoning` parameter controls whether the model-specific reasoning section 
 
 `get_model_structural_tag` generates a `StructuralTag` for the given model type with the specified tools and options. The returned `StructuralTag` can be used with `Grammar.from_structural_tag` or `GrammarCompiler.compile_structural_tag` to obtain the corresponding grammar.
 
-`get_model_structural_tag` accepts an optional `max_whitespace_cnt` that it applies to every tool-argument schema in the generated structural tag:
-
 Use it when you need to constrain the model to output in a fixed pattern such as "tool name + parameter JSON", e.g. for Llama, Qwen, Kimi, DeepSeek, OpenAI Harmony, etc.
 
 ### Parameters

--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -19,6 +19,8 @@ The `reasoning` parameter controls whether the model-specific reasoning section 
 
 `get_model_structural_tag` generates a `StructuralTag` for the given model type with the specified tools and options. The returned `StructuralTag` can be used with `Grammar.from_structural_tag` or `GrammarCompiler.compile_structural_tag` to obtain the corresponding grammar.
 
+`get_model_structural_tag` accepts an optional `max_whitespace_cnt` that it applies to every tool-argument schema in the generated structural tag:
+
 Use it when you need to constrain the model to output in a fixed pattern such as "tool name + parameter JSON", e.g. for Llama, Qwen, Kimi, DeepSeek, OpenAI Harmony, etc.
 
 ### Parameters
@@ -49,6 +51,8 @@ Use it when you need to constrain the model to output in a fixed pattern such as
   - `{"type": "allowed_tools", "allowed_tools": {"mode": ..., "tools": [...]}}`: limits available tools before applying its `mode`. The `tools` list may contain both function refs and builtin refs (matched by `type`).
 - **reasoning** (`bool`, optional): Whether to enable reasoning mode (`<think>`/`</think>` tags or model-specific equivalents). Default `True`.
 - **any_order** (`bool`, optional): When `True`, applies `any_order=True` to every `JSONSchemaFormat` in the generated structural tag, so each tool's arguments may be emitted in any property order (see [`JSONSchemaFormat`](structural_tag_api) for the exact semantics). Default `False`, which keeps the declared property order with full validation.
+- **any_whitespace** (`bool`, optional): Whether to allow arbitrary whitespace in this content. If False, use fixed formatting.
+- **max_whitespace_cnt** (`Optional[int]`, optional): Caps the number of consecutive whitespace characters. Setting it (e.g. `2`) bounds runs of whitespace, which avoids the unbounded-whitespace outputs some models emit in bad cases that would otherwise blow up grammar compilation/matching.
 
 Passing an unsupported `model` or an invalid `tool_choice` will raise `ValueError`.
 

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -183,12 +183,10 @@ def get_model_structural_tag(
         ``False``, use the non-reasoning mode. For models that do not support
         reasoning, this has no effect. For models that only support reasoning,
         ``False`` means reasoning with empty content.
-
     force_reasoning : bool
         Deprecated. Control whether to keep the reasoning part but leave its content empty.
         Now we will embed the model's specific behavior into the structural tag function, so
         only controlling ``reasoning`` is enough.
-
     any_order : bool
         Relax object property ordering for every tool-argument schema. When
         ``True``, ``any_order=True`` is applied to every :class:`JSONSchemaFormat`
@@ -196,7 +194,6 @@ def get_model_structural_tag(
         in any property order (see :class:`JSONSchemaFormat` for the exact
         semantics). When ``False`` (default), the declared property order is kept
         with full validation. Default: ``False``.
-
     exclude_special_tokens : bool
         Whether to forbid model special tokens (such as ``<think>`` and
         ``</think>``) from appearing inside the free-text and triggered-text
@@ -209,7 +206,10 @@ def get_model_structural_tag(
         (default), arbitrary whitespace is allowed in the JSON content; when
         ``False``, the fixed compact formatting is enforced. Default: ``True``.
     max_whitespace_cnt : Optional[int]
-        Applied to every tool-argument :class:`JSONSchemaFormat`. Default: ``None``.
+        Caps the number of consecutive whitespace characters. Setting it (e.g.
+        ``2``) bounds runs of whitespace, which avoids the unbounded-whitespace
+        outputs some models emit in bad cases that would otherwise blow up grammar
+        compilation/matching. Default: ``None``.
 
     Notes
     -----

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -35,7 +35,6 @@ def get_model_structural_tag(
     force_reasoning: bool = False,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
 ) -> StructuralTag:
     r"""Get a structural tag for a model's reasoning and tool-call output format.
@@ -201,14 +200,11 @@ def get_model_structural_tag(
         free-text spans constrained to exclude those tokens. Set to ``False``
         to allow them to appear as plain text. For models that have no special
         tokens to exclude (such as ``"harmony"``), this has no effect.
-    any_whitespace : bool
-        Applied to every tool-argument :class:`JSONSchemaFormat`. When ``True``
-        (default), arbitrary whitespace is allowed in the JSON content; when
-        ``False``, the fixed compact formatting is enforced. Default: ``True``.
     max_whitespace_cnt : Optional[int]
-        Caps the number of consecutive whitespace characters. Setting it (e.g.
-        ``2``) bounds runs of whitespace, which avoids the unbounded-whitespace
-        outputs some models emit in bad cases that would otherwise blow up grammar
+        Applied to every tool-argument :class:`JSONSchemaFormat`. Caps the number
+        of consecutive whitespace characters. Setting it (e.g. ``2``) bounds runs
+        of whitespace, which avoids the unbounded-whitespace outputs some models
+        emit in bad cases that would otherwise blow up grammar
         compilation/matching. Default: ``None``.
 
     Notes
@@ -244,7 +240,6 @@ def get_model_structural_tag(
         reasoning,
         any_order=any_order,
         exclude_special_tokens=exclude_special_tokens,
-        any_whitespace=any_whitespace,
         max_whitespace_cnt=max_whitespace_cnt,
     )
 
@@ -532,7 +527,6 @@ def get_llama_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
@@ -582,7 +576,6 @@ def get_llama_structural_tag(
                     content=JSONSchemaFormat(
                         json_schema=parameters,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end="}",
@@ -609,7 +602,6 @@ def get_llama_structural_tag(
             content=JSONSchemaFormat(
                 json_schema=_get_function_parameters(function),
                 any_order=any_order,
-                any_whitespace=any_whitespace,
                 max_whitespace_cnt=max_whitespace_cnt,
             ),
             end="}",
@@ -627,7 +619,6 @@ def get_llama_structural_tag(
                     content=JSONSchemaFormat(
                         json_schema=parameters,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end="}",
@@ -647,7 +638,6 @@ def get_kimi_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
@@ -704,7 +694,6 @@ def get_kimi_structural_tag(
                             JSONSchemaFormat(
                                 json_schema=parameters,
                                 any_order=any_order,
-                                any_whitespace=any_whitespace,
                                 max_whitespace_cnt=max_whitespace_cnt,
                             ),
                         ]
@@ -746,7 +735,6 @@ def get_kimi_structural_tag(
                             JSONSchemaFormat(
                                 json_schema=_get_function_parameters(function),
                                 any_order=any_order,
-                                any_whitespace=any_whitespace,
                                 max_whitespace_cnt=max_whitespace_cnt,
                             ),
                         ]
@@ -772,7 +760,6 @@ def get_kimi_structural_tag(
                             JSONSchemaFormat(
                                 json_schema=parameters,
                                 any_order=any_order,
-                                any_whitespace=any_whitespace,
                                 max_whitespace_cnt=max_whitespace_cnt,
                             ),
                         ]
@@ -804,7 +791,6 @@ def get_deepseek_r1_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
@@ -843,7 +829,6 @@ def get_deepseek_r1_structural_tag(
                     content=JSONSchemaFormat(
                         json_schema=parameters,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=f"{JSON_RENDER_END}{TOOL_CALL_END}",
@@ -873,10 +858,7 @@ def get_deepseek_r1_structural_tag(
         suffix_tag = TagFormat(
             begin=f"{TOOL_CALLS_BEGIN}{TOOL_CALL_BEGIN}function{TOOL_SEP}{function.name}{JSON_RENDER_BEGIN}",
             content=JSONSchemaFormat(
-                json_schema=parameters,
-                any_order=any_order,
-                any_whitespace=any_whitespace,
-                max_whitespace_cnt=max_whitespace_cnt,
+                json_schema=parameters, any_order=any_order, max_whitespace_cnt=max_whitespace_cnt
             ),
             end=f"{JSON_RENDER_END}{TOOL_CALL_END}{TOOL_CALLS_END}",
         )
@@ -893,7 +875,6 @@ def get_deepseek_r1_structural_tag(
                     content=JSONSchemaFormat(
                         json_schema=parameters,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=f"{JSON_RENDER_END}{TOOL_CALL_END}",
@@ -920,7 +901,6 @@ def get_deepseek_v3_1_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
@@ -957,7 +937,6 @@ def get_deepseek_v3_1_structural_tag(
                     content=JSONSchemaFormat(
                         json_schema=parameters,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
@@ -987,10 +966,7 @@ def get_deepseek_v3_1_structural_tag(
         suffix_tag = TagFormat(
             begin=f"{TOOL_CALLS_BEGIN}{TOOL_CALL_BEGIN}{function.name}{TOOL_SEP}",
             content=JSONSchemaFormat(
-                json_schema=parameters,
-                any_order=any_order,
-                any_whitespace=any_whitespace,
-                max_whitespace_cnt=max_whitespace_cnt,
+                json_schema=parameters, any_order=any_order, max_whitespace_cnt=max_whitespace_cnt
             ),
             end=f"{TOOL_CALL_END}{TOOL_CALLS_END}",
         )
@@ -1007,7 +983,6 @@ def get_deepseek_v3_1_structural_tag(
                     content=JSONSchemaFormat(
                         json_schema=parameters,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
@@ -1035,7 +1010,6 @@ def get_qwen_3_5_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
@@ -1087,7 +1061,6 @@ def get_qwen_3_5_structural_tag(
                         json_schema=parameters,
                         style="qwen_xml",
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
@@ -1115,7 +1088,6 @@ def get_qwen_3_5_structural_tag(
                 json_schema=_get_function_parameters(function),
                 style="qwen_xml",
                 any_order=any_order,
-                any_whitespace=any_whitespace,
                 max_whitespace_cnt=max_whitespace_cnt,
             ),
             end=TOOL_CALL_END,
@@ -1134,7 +1106,6 @@ def get_qwen_3_5_structural_tag(
                         json_schema=parameters,
                         style="qwen_xml",
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
@@ -1168,7 +1139,6 @@ def get_qwen_3_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
@@ -1219,7 +1189,6 @@ def get_qwen_3_structural_tag(
                     content=JSONSchemaFormat(
                         json_schema=parameters,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
@@ -1245,7 +1214,6 @@ def get_qwen_3_structural_tag(
             content=JSONSchemaFormat(
                 json_schema=_get_function_parameters(function),
                 any_order=any_order,
-                any_whitespace=any_whitespace,
                 max_whitespace_cnt=max_whitespace_cnt,
             ),
             end=TOOL_CALL_END,
@@ -1263,7 +1231,6 @@ def get_qwen_3_structural_tag(
                     content=JSONSchemaFormat(
                         json_schema=parameters,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
@@ -1293,7 +1260,6 @@ def get_harmony_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
@@ -1333,10 +1299,7 @@ def get_harmony_structural_tag(
     def _function_tool_tags(name, parameters):
         """Generate tags for all supported harmony function tool call formats."""
         content = JSONSchemaFormat(
-            json_schema=parameters,
-            any_order=any_order,
-            any_whitespace=any_whitespace,
-            max_whitespace_cnt=max_whitespace_cnt,
+            json_schema=parameters, any_order=any_order, max_whitespace_cnt=max_whitespace_cnt
         )
         return [
             TagFormat(
@@ -1359,10 +1322,7 @@ def get_harmony_structural_tag(
     def _builtin_tool_tags(name, parameters):
         """Generate tags for supported harmony builtin tool call formats."""
         content = JSONSchemaFormat(
-            json_schema=parameters,
-            any_order=any_order,
-            any_whitespace=any_whitespace,
-            max_whitespace_cnt=max_whitespace_cnt,
+            json_schema=parameters, any_order=any_order, max_whitespace_cnt=max_whitespace_cnt
         )
         return [
             TagFormat(
@@ -1437,7 +1397,6 @@ def get_deepseek_v3_2_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
@@ -1481,7 +1440,6 @@ def get_deepseek_v3_2_structural_tag(
                         json_schema=parameters,
                         style=XML_STYLE,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
@@ -1523,7 +1481,6 @@ def get_deepseek_v3_2_structural_tag(
                         json_schema=_get_function_parameters(function),
                         style=XML_STYLE,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
@@ -1544,7 +1501,6 @@ def get_deepseek_v3_2_structural_tag(
                         json_schema=parameters,
                         style=XML_STYLE,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
@@ -1576,7 +1532,6 @@ def get_minimax_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
@@ -1621,7 +1576,6 @@ def get_minimax_structural_tag(
                         json_schema=parameters,
                         style=XML_STYLE,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
@@ -1661,7 +1615,6 @@ def get_minimax_structural_tag(
                         json_schema=_get_function_parameters(function),
                         style=XML_STYLE,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
@@ -1682,7 +1635,6 @@ def get_minimax_structural_tag(
                         json_schema=parameters,
                         style=XML_STYLE,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
@@ -1716,7 +1668,6 @@ def get_glm_4_7_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
@@ -1780,7 +1731,6 @@ def get_glm_4_7_structural_tag(
                         json_schema=parameters,
                         style=XML_STYLE,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
@@ -1808,7 +1758,6 @@ def get_glm_4_7_structural_tag(
                 json_schema=_get_function_parameters(function),
                 style=XML_STYLE,
                 any_order=any_order,
-                any_whitespace=any_whitespace,
                 max_whitespace_cnt=max_whitespace_cnt,
             ),
             end=TOOL_CALL_END,
@@ -1826,7 +1775,6 @@ def get_glm_4_7_structural_tag(
                         json_schema=parameters,
                         style=XML_STYLE,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
@@ -1857,7 +1805,6 @@ def _get_gemma_4_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
@@ -1918,7 +1865,6 @@ def _get_gemma_4_structural_tag(
                     content=JSONSchemaFormat(
                         json_schema=parameters,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
@@ -1945,7 +1891,6 @@ def _get_gemma_4_structural_tag(
             content=JSONSchemaFormat(
                 json_schema=_get_function_parameters(function),
                 any_order=any_order,
-                any_whitespace=any_whitespace,
                 max_whitespace_cnt=max_whitespace_cnt,
             ),
             end=TOOL_CALL_END,
@@ -1963,7 +1908,6 @@ def _get_gemma_4_structural_tag(
                     content=JSONSchemaFormat(
                         json_schema=parameters,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
@@ -1987,7 +1931,6 @@ def get_deepseek_v4_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
-    any_whitespace: bool = True,
     max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
@@ -2029,7 +1972,6 @@ def get_deepseek_v4_structural_tag(
                         json_schema=parameters,
                         style=XML_STYLE,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
@@ -2071,7 +2013,6 @@ def get_deepseek_v4_structural_tag(
                         json_schema=_get_function_parameters(function),
                         style=XML_STYLE,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
@@ -2092,7 +2033,6 @@ def get_deepseek_v4_structural_tag(
                         json_schema=parameters,
                         style=XML_STYLE,
                         any_order=any_order,
-                        any_whitespace=any_whitespace,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -35,6 +35,8 @@ def get_model_structural_tag(
     force_reasoning: bool = False,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
 ) -> StructuralTag:
     r"""Get a structural tag for a model's reasoning and tool-call output format.
 
@@ -202,6 +204,12 @@ def get_model_structural_tag(
         free-text spans constrained to exclude those tokens. Set to ``False``
         to allow them to appear as plain text. For models that have no special
         tokens to exclude (such as ``"harmony"``), this has no effect.
+    any_whitespace : bool
+        Applied to every tool-argument :class:`JSONSchemaFormat`. When ``True``
+        (default), arbitrary whitespace is allowed in the JSON content; when
+        ``False``, the fixed compact formatting is enforced. Default: ``True``.
+    max_whitespace_cnt : Optional[int]
+        Applied to every tool-argument :class:`JSONSchemaFormat`. Default: ``None``.
 
     Notes
     -----
@@ -236,6 +244,8 @@ def get_model_structural_tag(
         reasoning,
         any_order=any_order,
         exclude_special_tokens=exclude_special_tokens,
+        any_whitespace=any_whitespace,
+        max_whitespace_cnt=max_whitespace_cnt,
     )
 
 
@@ -522,6 +532,8 @@ def get_llama_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Llama style structural tag format.
@@ -567,7 +579,12 @@ def get_llama_structural_tag(
             tags.append(
                 TagFormat(
                     begin=(TOOL_OBJECT_BEGIN_PREFIX + name + TOOL_OBJECT_PARAMETERS_PREFIX),
-                    content=JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+                    content=JSONSchemaFormat(
+                        json_schema=parameters,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
+                    ),
                     end="}",
                 )
             )
@@ -590,7 +607,10 @@ def get_llama_structural_tag(
         suffix_tag = TagFormat(
             begin=(TOOL_NAME_PREFIX + function.name + PARAMETERS_FIELD_PREFIX),
             content=JSONSchemaFormat(
-                json_schema=_get_function_parameters(function), any_order=any_order
+                json_schema=_get_function_parameters(function),
+                any_order=any_order,
+                any_whitespace=any_whitespace,
+                max_whitespace_cnt=max_whitespace_cnt,
             ),
             end="}",
         )
@@ -604,7 +624,12 @@ def get_llama_structural_tag(
             tags.append(
                 TagFormat(
                     begin=(TOOL_OBJECT_BEGIN_PREFIX + name + TOOL_OBJECT_PARAMETERS_PREFIX),
-                    content=JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+                    content=JSONSchemaFormat(
+                        json_schema=parameters,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
+                    ),
                     end="}",
                 )
             )
@@ -622,6 +647,8 @@ def get_kimi_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Kimi-K2 style structural tag format.
@@ -674,7 +701,12 @@ def get_kimi_structural_tag(
                         elements=[
                             RegexFormat(pattern=r"\d+"),
                             ConstStringFormat(value=TOOL_CALL_ARGUMENT_BEGIN),
-                            JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+                            JSONSchemaFormat(
+                                json_schema=parameters,
+                                any_order=any_order,
+                                any_whitespace=any_whitespace,
+                                max_whitespace_cnt=max_whitespace_cnt,
+                            ),
                         ]
                     ),
                     end=TOOL_CALL_END,
@@ -712,7 +744,10 @@ def get_kimi_structural_tag(
                             RegexFormat(pattern=r"\d+"),
                             ConstStringFormat(value=TOOL_CALL_ARGUMENT_BEGIN),
                             JSONSchemaFormat(
-                                json_schema=_get_function_parameters(function), any_order=any_order
+                                json_schema=_get_function_parameters(function),
+                                any_order=any_order,
+                                any_whitespace=any_whitespace,
+                                max_whitespace_cnt=max_whitespace_cnt,
                             ),
                         ]
                     ),
@@ -734,7 +769,12 @@ def get_kimi_structural_tag(
                         elements=[
                             RegexFormat(pattern=r"\d+"),
                             ConstStringFormat(value=TOOL_CALL_ARGUMENT_BEGIN),
-                            JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+                            JSONSchemaFormat(
+                                json_schema=parameters,
+                                any_order=any_order,
+                                any_whitespace=any_whitespace,
+                                max_whitespace_cnt=max_whitespace_cnt,
+                            ),
                         ]
                     ),
                     end=TOOL_CALL_END,
@@ -764,6 +804,8 @@ def get_deepseek_r1_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-R1 style structural tag format.
@@ -798,7 +840,12 @@ def get_deepseek_r1_structural_tag(
             tags.append(
                 TagFormat(
                     begin=f"{TOOL_CALL_BEGIN}function{TOOL_SEP}{name}{JSON_RENDER_BEGIN}",
-                    content=JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+                    content=JSONSchemaFormat(
+                        json_schema=parameters,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
+                    ),
                     end=f"{JSON_RENDER_END}{TOOL_CALL_END}",
                 )
             )
@@ -825,7 +872,12 @@ def get_deepseek_r1_structural_tag(
         parameters = _get_function_parameters(function)
         suffix_tag = TagFormat(
             begin=f"{TOOL_CALLS_BEGIN}{TOOL_CALL_BEGIN}function{TOOL_SEP}{function.name}{JSON_RENDER_BEGIN}",
-            content=JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+            content=JSONSchemaFormat(
+                json_schema=parameters,
+                any_order=any_order,
+                any_whitespace=any_whitespace,
+                max_whitespace_cnt=max_whitespace_cnt,
+            ),
             end=f"{JSON_RENDER_END}{TOOL_CALL_END}{TOOL_CALLS_END}",
         )
 
@@ -838,7 +890,12 @@ def get_deepseek_r1_structural_tag(
             tags.append(
                 TagFormat(
                     begin=f"{TOOL_CALL_BEGIN}function{TOOL_SEP}{name}{JSON_RENDER_BEGIN}",
-                    content=JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+                    content=JSONSchemaFormat(
+                        json_schema=parameters,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
+                    ),
                     end=f"{JSON_RENDER_END}{TOOL_CALL_END}",
                 )
             )
@@ -863,6 +920,8 @@ def get_deepseek_v3_1_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V3.1 style structural tag format.
@@ -895,7 +954,12 @@ def get_deepseek_v3_1_structural_tag(
             tags.append(
                 TagFormat(
                     begin=f"{TOOL_CALL_BEGIN}{name}{TOOL_SEP}",
-                    content=JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+                    content=JSONSchemaFormat(
+                        json_schema=parameters,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
+                    ),
                     end=TOOL_CALL_END,
                 )
             )
@@ -922,7 +986,12 @@ def get_deepseek_v3_1_structural_tag(
         parameters = _get_function_parameters(function)
         suffix_tag = TagFormat(
             begin=f"{TOOL_CALLS_BEGIN}{TOOL_CALL_BEGIN}{function.name}{TOOL_SEP}",
-            content=JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+            content=JSONSchemaFormat(
+                json_schema=parameters,
+                any_order=any_order,
+                any_whitespace=any_whitespace,
+                max_whitespace_cnt=max_whitespace_cnt,
+            ),
             end=f"{TOOL_CALL_END}{TOOL_CALLS_END}",
         )
 
@@ -935,7 +1004,12 @@ def get_deepseek_v3_1_structural_tag(
             tags.append(
                 TagFormat(
                     begin=f"{TOOL_CALL_BEGIN}{name}{TOOL_SEP}",
-                    content=JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+                    content=JSONSchemaFormat(
+                        json_schema=parameters,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
+                    ),
                     end=TOOL_CALL_END,
                 )
             )
@@ -961,6 +1035,8 @@ def get_qwen_3_5_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Qwen XML tool-call structural tag format.
@@ -1008,7 +1084,11 @@ def get_qwen_3_5_structural_tag(
                 TagFormat(
                     begin=f"{TOOL_CALL_BEGIN_PREFIX}{name}{TOOL_CALL_BEGIN_SUFFIX}",
                     content=JSONSchemaFormat(
-                        json_schema=parameters, style="qwen_xml", any_order=any_order
+                        json_schema=parameters,
+                        style="qwen_xml",
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
                 )
@@ -1035,6 +1115,8 @@ def get_qwen_3_5_structural_tag(
                 json_schema=_get_function_parameters(function),
                 style="qwen_xml",
                 any_order=any_order,
+                any_whitespace=any_whitespace,
+                max_whitespace_cnt=max_whitespace_cnt,
             ),
             end=TOOL_CALL_END,
         )
@@ -1049,7 +1131,11 @@ def get_qwen_3_5_structural_tag(
                 TagFormat(
                     begin=f"{TOOL_CALL_BEGIN_PREFIX}{name}{TOOL_CALL_BEGIN_SUFFIX}",
                     content=JSONSchemaFormat(
-                        json_schema=parameters, style="qwen_xml", any_order=any_order
+                        json_schema=parameters,
+                        style="qwen_xml",
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
                 )
@@ -1082,6 +1168,8 @@ def get_qwen_3_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Qwen3 style structural tag format.
@@ -1128,7 +1216,12 @@ def get_qwen_3_structural_tag(
             tags.append(
                 TagFormat(
                     begin=(TOOL_CALL_BEGIN_PREFIX + name + ARGUMENTS_FIELD_PREFIX),
-                    content=JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+                    content=JSONSchemaFormat(
+                        json_schema=parameters,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
+                    ),
                     end=TOOL_CALL_END,
                 )
             )
@@ -1150,7 +1243,10 @@ def get_qwen_3_structural_tag(
         suffix_tag = TagFormat(
             begin=(TOOL_CALL_BEGIN_PREFIX + function.name + ARGUMENTS_FIELD_PREFIX),
             content=JSONSchemaFormat(
-                json_schema=_get_function_parameters(function), any_order=any_order
+                json_schema=_get_function_parameters(function),
+                any_order=any_order,
+                any_whitespace=any_whitespace,
+                max_whitespace_cnt=max_whitespace_cnt,
             ),
             end=TOOL_CALL_END,
         )
@@ -1164,7 +1260,12 @@ def get_qwen_3_structural_tag(
             tags.append(
                 TagFormat(
                     begin=(TOOL_CALL_BEGIN_PREFIX + name + ARGUMENTS_FIELD_PREFIX),
-                    content=JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+                    content=JSONSchemaFormat(
+                        json_schema=parameters,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
+                    ),
                     end=TOOL_CALL_END,
                 )
             )
@@ -1192,6 +1293,8 @@ def get_harmony_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get harmony(gpt-oss) style structural tag format.
@@ -1229,7 +1332,12 @@ def get_harmony_structural_tag(
 
     def _function_tool_tags(name, parameters):
         """Generate tags for all supported harmony function tool call formats."""
-        content = JSONSchemaFormat(json_schema=parameters, any_order=any_order)
+        content = JSONSchemaFormat(
+            json_schema=parameters,
+            any_order=any_order,
+            any_whitespace=any_whitespace,
+            max_whitespace_cnt=max_whitespace_cnt,
+        )
         return [
             TagFormat(
                 begin=f"<|channel|>commentary to=functions.{name}<|constrain|>json<|message|>",
@@ -1250,7 +1358,12 @@ def get_harmony_structural_tag(
 
     def _builtin_tool_tags(name, parameters):
         """Generate tags for supported harmony builtin tool call formats."""
-        content = JSONSchemaFormat(json_schema=parameters, any_order=any_order)
+        content = JSONSchemaFormat(
+            json_schema=parameters,
+            any_order=any_order,
+            any_whitespace=any_whitespace,
+            max_whitespace_cnt=max_whitespace_cnt,
+        )
         return [
             TagFormat(
                 begin=f"<|channel|>commentary to={name} code<|message|>",
@@ -1324,6 +1437,8 @@ def get_deepseek_v3_2_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V3.2 style structural tag format.
@@ -1363,7 +1478,11 @@ def get_deepseek_v3_2_structural_tag(
                 TagFormat(
                     begin=(INVOKE_BEGIN_PREFIX + name + INVOKE_BEGIN_SUFFIX),
                     content=JSONSchemaFormat(
-                        json_schema=parameters, style=XML_STYLE, any_order=any_order
+                        json_schema=parameters,
+                        style=XML_STYLE,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
                 )
@@ -1404,6 +1523,8 @@ def get_deepseek_v3_2_structural_tag(
                         json_schema=_get_function_parameters(function),
                         style=XML_STYLE,
                         any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
                 ),
@@ -1420,7 +1541,11 @@ def get_deepseek_v3_2_structural_tag(
                 TagFormat(
                     begin=(INVOKE_BEGIN_PREFIX + name + INVOKE_BEGIN_SUFFIX),
                     content=JSONSchemaFormat(
-                        json_schema=parameters, style=XML_STYLE, any_order=any_order
+                        json_schema=parameters,
+                        style=XML_STYLE,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
                 )
@@ -1451,6 +1576,8 @@ def get_minimax_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get MiniMax-M2.5 style structural tag format.
@@ -1491,7 +1618,11 @@ def get_minimax_structural_tag(
                 TagFormat(
                     begin=(INVOKE_BEGIN_PREFIX + name + INVOKE_BEGIN_SUFFIX),
                     content=JSONSchemaFormat(
-                        json_schema=parameters, style=XML_STYLE, any_order=any_order
+                        json_schema=parameters,
+                        style=XML_STYLE,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
                 )
@@ -1530,6 +1661,8 @@ def get_minimax_structural_tag(
                         json_schema=_get_function_parameters(function),
                         style=XML_STYLE,
                         any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
                 ),
@@ -1546,7 +1679,11 @@ def get_minimax_structural_tag(
                 TagFormat(
                     begin=(INVOKE_BEGIN_PREFIX + name + INVOKE_BEGIN_SUFFIX),
                     content=JSONSchemaFormat(
-                        json_schema=parameters, style=XML_STYLE, any_order=any_order
+                        json_schema=parameters,
+                        style=XML_STYLE,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
                 )
@@ -1579,6 +1716,8 @@ def get_glm_4_7_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get GLM-4.7/GLM-5 style structural tag format.
@@ -1638,7 +1777,11 @@ def get_glm_4_7_structural_tag(
                 TagFormat(
                     begin=f"{TOOL_CALL_BEGIN_PREFIX}{name}",
                     content=JSONSchemaFormat(
-                        json_schema=parameters, style=XML_STYLE, any_order=any_order
+                        json_schema=parameters,
+                        style=XML_STYLE,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
                 )
@@ -1662,7 +1805,11 @@ def get_glm_4_7_structural_tag(
         suffix_tag = TagFormat(
             begin=f"{TOOL_CALL_BEGIN_PREFIX}{function.name}",
             content=JSONSchemaFormat(
-                json_schema=_get_function_parameters(function), style=XML_STYLE, any_order=any_order
+                json_schema=_get_function_parameters(function),
+                style=XML_STYLE,
+                any_order=any_order,
+                any_whitespace=any_whitespace,
+                max_whitespace_cnt=max_whitespace_cnt,
             ),
             end=TOOL_CALL_END,
         )
@@ -1676,7 +1823,11 @@ def get_glm_4_7_structural_tag(
                 TagFormat(
                     begin=f"{TOOL_CALL_BEGIN_PREFIX}{name}",
                     content=JSONSchemaFormat(
-                        json_schema=parameters, style=XML_STYLE, any_order=any_order
+                        json_schema=parameters,
+                        style=XML_STYLE,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=TOOL_CALL_END,
                 )
@@ -1706,6 +1857,8 @@ def _get_gemma_4_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Gemma 4 style structural tag format.
@@ -1762,7 +1915,12 @@ def _get_gemma_4_structural_tag(
             tags.append(
                 TagFormat(
                     begin=TOOL_CALL_BEGIN_PREFIX + name,
-                    content=JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+                    content=JSONSchemaFormat(
+                        json_schema=parameters,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
+                    ),
                     end=TOOL_CALL_END,
                 )
             )
@@ -1785,7 +1943,10 @@ def _get_gemma_4_structural_tag(
         suffix_tag = TagFormat(
             begin=TOOL_CALL_BEGIN_PREFIX + function.name,
             content=JSONSchemaFormat(
-                json_schema=_get_function_parameters(function), any_order=any_order
+                json_schema=_get_function_parameters(function),
+                any_order=any_order,
+                any_whitespace=any_whitespace,
+                max_whitespace_cnt=max_whitespace_cnt,
             ),
             end=TOOL_CALL_END,
         )
@@ -1799,7 +1960,12 @@ def _get_gemma_4_structural_tag(
             tags.append(
                 TagFormat(
                     begin=TOOL_CALL_BEGIN_PREFIX + name,
-                    content=JSONSchemaFormat(json_schema=parameters, any_order=any_order),
+                    content=JSONSchemaFormat(
+                        json_schema=parameters,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
+                    ),
                     end=TOOL_CALL_END,
                 )
             )
@@ -1821,6 +1987,8 @@ def get_deepseek_v4_structural_tag(
     reasoning: bool = True,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
+    any_whitespace: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V4 style structural tag format.
@@ -1858,7 +2026,11 @@ def get_deepseek_v4_structural_tag(
                 TagFormat(
                     begin=(INVOKE_BEGIN_PREFIX + name + INVOKE_BEGIN_SUFFIX),
                     content=JSONSchemaFormat(
-                        json_schema=parameters, style=XML_STYLE, any_order=any_order
+                        json_schema=parameters,
+                        style=XML_STYLE,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
                 )
@@ -1899,6 +2071,8 @@ def get_deepseek_v4_structural_tag(
                         json_schema=_get_function_parameters(function),
                         style=XML_STYLE,
                         any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
                 ),
@@ -1915,7 +2089,11 @@ def get_deepseek_v4_structural_tag(
                 TagFormat(
                     begin=(INVOKE_BEGIN_PREFIX + name + INVOKE_BEGIN_SUFFIX),
                     content=JSONSchemaFormat(
-                        json_schema=parameters, style=XML_STYLE, any_order=any_order
+                        json_schema=parameters,
+                        style=XML_STYLE,
+                        any_order=any_order,
+                        any_whitespace=any_whitespace,
+                        max_whitespace_cnt=max_whitespace_cnt,
                     ),
                     end=INVOKE_END,
                 )

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -1,7 +1,7 @@
 """Defines all structural tag formats."""
 
 import json
-from typing import Any, Dict, List, Literal, Tuple, Type, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
 
 try:
     # Python 3.9+
@@ -47,6 +47,10 @@ class JSONSchemaFormat(BaseModel):
       maxProperties]`` (unbounded when maxProperties is unset).
 
     Applies to every object, nested included."""
+    any_whitespace: bool = True
+    """Whether to allow arbitrary whitespace in this content. If False, use fixed formatting."""
+    max_whitespace_cnt: Optional[int] = None
+    """Max consecutive whitespace characters in this content. None means no limit."""
 
 
 class AnyTextFormat(BaseModel):

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -47,8 +47,6 @@ class JSONSchemaFormat(BaseModel):
       maxProperties]`` (unbounded when maxProperties is unset).
 
     Applies to every object, nested included."""
-    any_whitespace: bool = True
-    """Whether to allow arbitrary whitespace in this content. If False, use fixed formatting."""
     max_whitespace_cnt: Optional[int] = None
     """Max consecutive whitespace characters in this content. None means no limit."""
 

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -1405,20 +1405,3 @@ def test_get_model_structural_tag_max_whitespace_cnt_propagates():
     )
     assert nodes_bounded
     assert all(n.max_whitespace_cnt == 2 for n in nodes_bounded)
-
-
-def test_get_model_structural_tag_any_whitespace_propagates():
-    """get_model_structural_tag applies any_whitespace to every JSONSchemaFormat node."""
-    tools = make_tools(["f", "g"])
-
-    nodes_default = _collect_json_schema_nodes(
-        get_model_structural_tag("qwen_3", tools=tools, reasoning=False)
-    )
-    assert nodes_default  # the generated tag actually contains JSON-schema nodes
-    assert all(n.any_whitespace is True for n in nodes_default)
-
-    nodes_fixed = _collect_json_schema_nodes(
-        get_model_structural_tag("qwen_3", tools=tools, reasoning=False, any_whitespace=False)
-    )
-    assert nodes_fixed
-    assert all(n.any_whitespace is False for n in nodes_fixed)

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -167,6 +167,16 @@ def _collect_excludes(structural_tag: StructuralTag) -> List[List[str]]:
     ]
 
 
+def _collect_json_schema_nodes(structural_tag: StructuralTag) -> List[JSONSchemaFormat]:
+    """Collect nested JSONSchemaFormat nodes."""
+
+    return [
+        format_obj
+        for format_obj in _walk_structural_format(structural_tag.format)
+        if isinstance(format_obj, JSONSchemaFormat)
+    ]
+
+
 # ---------- Shared tool definitions ----------
 
 SIMPLE_SCHEMA = {"type": "object", "properties": {"q": {"type": "string"}}}
@@ -1375,3 +1385,40 @@ def test_any_order_reordered_arguments_accepted_only_when_enabled():
     )
     check_stag_with_instance(st_any_order, ordered, True)
     check_stag_with_instance(st_any_order, reordered, True)
+
+
+# ---------- Test: max_whitespace_cnt propagation ----------
+
+
+def test_get_model_structural_tag_max_whitespace_cnt_propagates():
+    """get_model_structural_tag applies max_whitespace_cnt to every JSONSchemaFormat node."""
+    tools = make_tools(["f", "g"])
+
+    nodes_default = _collect_json_schema_nodes(
+        get_model_structural_tag("qwen_3", tools=tools, reasoning=False)
+    )
+    assert nodes_default  # the generated tag actually contains JSON-schema nodes
+    assert all(n.max_whitespace_cnt is None for n in nodes_default)
+
+    nodes_bounded = _collect_json_schema_nodes(
+        get_model_structural_tag("qwen_3", tools=tools, reasoning=False, max_whitespace_cnt=2)
+    )
+    assert nodes_bounded
+    assert all(n.max_whitespace_cnt == 2 for n in nodes_bounded)
+
+
+def test_get_model_structural_tag_any_whitespace_propagates():
+    """get_model_structural_tag applies any_whitespace to every JSONSchemaFormat node."""
+    tools = make_tools(["f", "g"])
+
+    nodes_default = _collect_json_schema_nodes(
+        get_model_structural_tag("qwen_3", tools=tools, reasoning=False)
+    )
+    assert nodes_default  # the generated tag actually contains JSON-schema nodes
+    assert all(n.any_whitespace is True for n in nodes_default)
+
+    nodes_fixed = _collect_json_schema_nodes(
+        get_model_structural_tag("qwen_3", tools=tools, reasoning=False, any_whitespace=False)
+    )
+    assert nodes_fixed
+    assert all(n.any_whitespace is False for n in nodes_fixed)

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -4147,22 +4147,17 @@ def test_json_schema_format_any_order_via_pydantic():
     check_stag_with_instance(st_ordered, '{"b": "x", "a": 1}', False)
 
 
-# ---------- Per-tag whitespace control (JSONSchemaFormat.any_whitespace / max_whitespace_cnt) ----------
+# ---------- Per-tag whitespace control (JSONSchemaFormat.max_whitespace_cnt) ----------
 
 _WS_SCHEMA = {"type": "object", "properties": {"a": {"type": "integer"}}, "required": ["a"]}
 
 
-def _ws_stag(
-    *, any_whitespace: bool = True, max_whitespace_cnt: Optional[int] = None
-) -> StructuralTag:
+def _ws_stag(*, max_whitespace_cnt: Optional[int] = None) -> StructuralTag:
     return StructuralTag(
         format=TagFormat(
             begin="<call>",
             content=JSONSchemaFormat(
-                json_schema=_WS_SCHEMA,
-                style="json",
-                any_whitespace=any_whitespace,
-                max_whitespace_cnt=max_whitespace_cnt,
+                json_schema=_WS_SCHEMA, style="json", max_whitespace_cnt=max_whitespace_cnt
             ),
             end="</call>",
         )
@@ -4183,18 +4178,6 @@ def test_structural_tag_max_whitespace_cnt():
     # Beyond the bound: accepted only without the limit.
     assert _is_grammar_accept_string(g_unbounded, _ws_instance(5))
     assert not _is_grammar_accept_string(g_bounded, _ws_instance(5))
-
-
-def test_structural_tag_any_whitespace_false():
-    g_any = xgr.Grammar.from_structural_tag(_ws_stag(any_whitespace=True))
-    g_fixed = xgr.Grammar.from_structural_tag(_ws_stag(any_whitespace=False))
-    # any_whitespace=True accepts arbitrary spacing.
-    assert _is_grammar_accept_string(g_any, _ws_instance(0))
-    assert _is_grammar_accept_string(g_any, _ws_instance(3))
-    # any_whitespace=False enforces the fixed compact format (single space after colon).
-    assert _is_grammar_accept_string(g_fixed, _ws_instance(1))
-    assert not _is_grammar_accept_string(g_fixed, _ws_instance(0))
-    assert not _is_grammar_accept_string(g_fixed, _ws_instance(3))
 
 
 def test_structural_tag_per_tag_whitespace_independent():

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -6,7 +6,7 @@ import pytest
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
-from xgrammar.structural_tag import StructuralTag
+from xgrammar.structural_tag import JSONSchemaFormat, SequenceFormat, StructuralTag, TagFormat
 from xgrammar.testing import _is_grammar_accept_string
 
 
@@ -4145,6 +4145,93 @@ def test_json_schema_format_any_order_via_pydantic():
         format=JSONSchemaFormat(json_schema=any_order_schema, any_order=False)
     )
     check_stag_with_instance(st_ordered, '{"b": "x", "a": 1}', False)
+
+
+# ---------- Per-tag whitespace control (JSONSchemaFormat.any_whitespace / max_whitespace_cnt) ----------
+
+_WS_SCHEMA = {"type": "object", "properties": {"a": {"type": "integer"}}, "required": ["a"]}
+
+
+def _ws_stag(
+    *, any_whitespace: bool = True, max_whitespace_cnt: Optional[int] = None
+) -> StructuralTag:
+    return StructuralTag(
+        format=TagFormat(
+            begin="<call>",
+            content=JSONSchemaFormat(
+                json_schema=_WS_SCHEMA,
+                style="json",
+                any_whitespace=any_whitespace,
+                max_whitespace_cnt=max_whitespace_cnt,
+            ),
+            end="</call>",
+        )
+    )
+
+
+def _ws_instance(num_spaces: int) -> str:
+    return '<call>{"a":' + " " * num_spaces + "1}</call>"
+
+
+def test_structural_tag_max_whitespace_cnt():
+    g_unbounded = xgr.Grammar.from_structural_tag(_ws_stag())
+    g_bounded = xgr.Grammar.from_structural_tag(_ws_stag(max_whitespace_cnt=2))
+    # Within the bound: accepted by both.
+    for n in (1, 2):
+        assert _is_grammar_accept_string(g_unbounded, _ws_instance(n))
+        assert _is_grammar_accept_string(g_bounded, _ws_instance(n))
+    # Beyond the bound: accepted only without the limit.
+    assert _is_grammar_accept_string(g_unbounded, _ws_instance(5))
+    assert not _is_grammar_accept_string(g_bounded, _ws_instance(5))
+
+
+def test_structural_tag_any_whitespace_false():
+    g_any = xgr.Grammar.from_structural_tag(_ws_stag(any_whitespace=True))
+    g_fixed = xgr.Grammar.from_structural_tag(_ws_stag(any_whitespace=False))
+    # any_whitespace=True accepts arbitrary spacing.
+    assert _is_grammar_accept_string(g_any, _ws_instance(0))
+    assert _is_grammar_accept_string(g_any, _ws_instance(3))
+    # any_whitespace=False enforces the fixed compact format (single space after colon).
+    assert _is_grammar_accept_string(g_fixed, _ws_instance(1))
+    assert not _is_grammar_accept_string(g_fixed, _ws_instance(0))
+    assert not _is_grammar_accept_string(g_fixed, _ws_instance(3))
+
+
+def test_structural_tag_per_tag_whitespace_independent():
+    # Two JSONSchemaFormat nodes can carry different whitespace controls: <a> bounded, <b> not.
+    stag = StructuralTag(
+        format=SequenceFormat(
+            elements=[
+                TagFormat(
+                    begin="<a>",
+                    content=JSONSchemaFormat(
+                        json_schema=_WS_SCHEMA, style="json", max_whitespace_cnt=2
+                    ),
+                    end="</a>",
+                ),
+                TagFormat(
+                    begin="<b>",
+                    content=JSONSchemaFormat(json_schema=_WS_SCHEMA, style="json"),
+                    end="</b>",
+                ),
+            ]
+        )
+    )
+    g = xgr.Grammar.from_structural_tag(stag)
+    a = lambda n: '<a>{"a":' + " " * n + "1}</a>"
+    b = lambda n: '<b>{"a":' + " " * n + "1}</b>"
+    assert _is_grammar_accept_string(g, a(2) + b(5))
+    # The first tag rejects 5 consecutive whitespaces even though the second one allows them.
+    assert not _is_grammar_accept_string(g, a(5) + b(5))
+
+
+def test_structural_tag_max_whitespace_cnt_compile_cache():
+    # The per-tag setting is part of the serialized tag JSON (the cache key), so no collision.
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]), cache_enabled=True)
+    g_unbounded = compiler.compile_structural_tag(_ws_stag()).grammar
+    g_bounded = compiler.compile_structural_tag(_ws_stag(max_whitespace_cnt=2)).grammar
+    assert _is_grammar_accept_string(g_unbounded, _ws_instance(5))
+    assert not _is_grammar_accept_string(g_bounded, _ws_instance(5))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some models, in bad-case generations, emit unbounded runs of whitespace, which inflates the Earley parser's state set and can blow up grammar compilation/matching.

Adds two whitespace controls — `any_whitespace` and `max_whitespace_cnt` — as parameters of the structural-tag compile interface (`GrammarCompiler.compile_structural_tag` / `Grammar.from_structural_tag`), mirroring `compile_json_schema`.
