### PR TITLE
fix: correct unsound grammars for number/integer range keywords

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1438,21 +1438,29 @@ std::string JSONSchemaConverter::GenerateNumber(
     const NumberSpec& spec, const std::string& rule_name
 ) {
   std::optional<double> start, end;
+  bool exclusive_start = false;
+  bool exclusive_end = false;
   if (spec.minimum.has_value()) {
     start = spec.minimum;
   }
-  if (spec.exclusive_minimum.has_value()) {
+  // When both bounds are present the larger lower bound wins; on a tie the
+  // exclusive one is stricter.
+  if (spec.exclusive_minimum.has_value() &&
+      (!start.has_value() || *spec.exclusive_minimum >= *start)) {
     start = spec.exclusive_minimum;
+    exclusive_start = true;
   }
   if (spec.maximum.has_value()) {
     end = spec.maximum;
   }
-  if (spec.exclusive_maximum.has_value()) {
+  if (spec.exclusive_maximum.has_value() && (!end.has_value() || *spec.exclusive_maximum <= *end)) {
     end = spec.exclusive_maximum;
+    exclusive_end = true;
   }
 
   if (start.has_value() || end.has_value()) {
-    std::string range_regex = GenerateFloatRangeRegex(start, end, 6);
+    std::string range_regex =
+        GenerateFloatRangeRegex(start, end, 6, exclusive_start, exclusive_end);
     return RegexToEBNF(range_regex, false);
   }
   // Note: The format must be "-"? ("0" | ...) not ("0" | "-"? ...)
@@ -2646,7 +2654,7 @@ std::string JSONSchemaConverter::GenerateRangeRegex(
   if (start && !end) {
     if (start.value() <= 0) {
       if (start.value() < 0) {
-        parts.push_back("-" + GenerateSubRangeRegex(-(-start.value()), 1));
+        parts.push_back("-" + GenerateSubRangeRegex(1, -start.value()));
       }
       parts.push_back("0");
       parts.push_back("[1-9]\\d*");
@@ -2656,7 +2664,7 @@ std::string JSONSchemaConverter::GenerateRangeRegex(
 
       if (len == 1) {
         parts.push_back(MakePatternForDigitRange(start_str[0], '9', 0));
-        parts.push_back("[1-9]\\d*");
+        parts.push_back("[1-9]\\d{1,}");
       } else {
         parts.push_back(start_str);
 
@@ -2696,7 +2704,7 @@ std::string JSONSchemaConverter::GenerateRangeRegex(
 
       if (len == 1) {
         parts.push_back("-" + MakePatternForDigitRange(end_str[0], '9', 0));
-        parts.push_back("-[1-9]\\d*");
+        parts.push_back("-[1-9]\\d{1,}");
       } else {
         parts.push_back(std::to_string(end.value()));
 
@@ -2781,24 +2789,313 @@ std::string JSONSchemaConverter::FormatFloat(double value, int precision) {
   return result;
 }
 
-static std::string EscapeDotForRegex(const std::string& s) {
-  std::string result;
-  result.reserve(s.size() + 2);
-  for (char c : s) {
-    if (c == '.') {
-      result += "\\.";
+namespace {
+
+// Helpers for GenerateFloatRangeRegex. Fraction patterns operate on the
+// digit string after the decimal point, compared against a canonical bound
+// fraction (canonical: produced by FormatFloat, so no trailing zeros).
+
+struct FracPatternSet {
+  // Each pattern matches a non-empty fraction digit string.
+  std::vector<std::string> parts;
+  // Whether having no fraction digits at all also satisfies the bound.
+  bool include_empty = false;
+};
+
+std::string DigitClass(char low, char high) {
+  if (low == high) {
+    return std::string(1, low);
+  }
+  return "[" + std::string(1, low) + "-" + std::string(1, high) + "]";
+}
+
+// Matches 0 to max_count free digits.
+std::string FreeDigits(int max_count) {
+  if (max_count <= 0) {
+    return "";
+  }
+  return "\\d{0," + std::to_string(max_count) + "}";
+}
+
+// Matches 0 to max_count zeros.
+std::string OptionalZeros(int max_count) {
+  if (max_count <= 0) {
+    return "";
+  }
+  return "0{0," + std::to_string(max_count) + "}";
+}
+
+// Matches 1 to max_count zeros.
+std::string SomeZeros(int max_count) { return "0{1," + std::to_string(max_count) + "}"; }
+
+// Patterns for fraction strings t (1 <= |t| <= max_len) whose value 0.t is
+// greater than 0.s (or equal when !strict). |s| <= max_len.
+FracPatternSet FracGreaterPatterns(const std::string& s, bool strict, int max_len) {
+  FracPatternSet result;
+  int n = static_cast<int>(s.size());
+  // t agrees with s up to position i, then has a larger digit
+  for (int i = 0; i < n; ++i) {
+    if (s[i] < '9') {
+      result.parts.push_back(
+          s.substr(0, i) + DigitClass(s[i] + 1, '9') + FreeDigits(max_len - i - 1)
+      );
+    }
+  }
+  // t extends s with a nonzero digit (after optional zeros)
+  for (int k = 0; n + k + 1 <= max_len; ++k) {
+    result.parts.push_back(s + std::string(k, '0') + "[1-9]" + FreeDigits(max_len - n - k - 1));
+  }
+  if (!strict) {
+    // t has the same value as s: s plus optional trailing zeros
+    if (n > 0) {
+      result.parts.push_back(s + OptionalZeros(max_len - n));
     } else {
-      result += c;
+      result.include_empty = true;
+      if (max_len >= 1) {
+        result.parts.push_back(SomeZeros(max_len));
+      }
     }
   }
   return result;
 }
 
-std::string JSONSchemaConverter::GenerateFloatRangeRegex(
-    std::optional<double> start, std::optional<double> end, int precision
+// Patterns for fraction strings t (1 <= |t| <= max_len) whose value 0.t is
+// less than 0.s (or equal when !strict). |s| <= max_len.
+FracPatternSet FracLessPatterns(const std::string& s, bool strict, int max_len) {
+  FracPatternSet result;
+  int n = static_cast<int>(s.size());
+  // t agrees with s up to position i, then has a smaller digit
+  for (int i = 0; i < n; ++i) {
+    if (s[i] > '0') {
+      result.parts.push_back(
+          s.substr(0, i) + DigitClass('0', s[i] - 1) + FreeDigits(max_len - i - 1)
+      );
+    }
+  }
+  // t is a proper prefix of s plus optional trailing zeros: strictly smaller,
+  // since the remaining digits of s contain a nonzero one
+  for (int i = 0; i < n; ++i) {
+    if (i == 0) {
+      if (max_len >= 1) {
+        result.parts.push_back(SomeZeros(max_len));
+      }
+    } else {
+      result.parts.push_back(s.substr(0, i) + OptionalZeros(max_len - i));
+    }
+  }
+  if (!strict) {
+    // t has the same value as s
+    if (n > 0) {
+      result.parts.push_back(s + OptionalZeros(max_len - n));
+    } else if (max_len >= 1) {
+      result.parts.push_back(SomeZeros(max_len));
+    }
+  }
+  result.include_empty = n > 0 || !strict;
+  return result;
+}
+
+// Patterns for fraction strings t whose value 0.t lies between 0.a and 0.b.
+// Requires value(0.a) < value(0.b) and b non-empty.
+FracPatternSet FracBetweenPatterns(
+    const std::string& a, bool strict_a, const std::string& b, bool strict_b, int max_len
 ) {
-  if ((start && end) && (start.value() > end.value())) {
-    return "^()$";
+  FracPatternSet result;
+  // Longest common prefix of b and zero-padded a. Always stops before |b|:
+  // value(0.a) < value(0.b) implies b is not a prefix of padded a.
+  int common_len = 0;
+  while (common_len < static_cast<int>(b.size()) &&
+         (common_len < static_cast<int>(a.size()) ? a[common_len] : '0') == b[common_len]) {
+    ++common_len;
+  }
+  std::string common = b.substr(0, common_len);
+  char digit_a = common_len < static_cast<int>(a.size()) ? a[common_len] : '0';
+  char digit_b = b[common_len];
+
+  // a digit strictly between the bounds' digits, then anything
+  if (digit_b - digit_a >= 2) {
+    result.parts.push_back(
+        common + DigitClass(digit_a + 1, digit_b - 1) + FreeDigits(max_len - common_len - 1)
+    );
+  }
+  // lower boundary: t continues with digit_a, the rest must exceed a's suffix
+  if (common_len < static_cast<int>(a.size())) {
+    FracPatternSet sub_lower =
+        FracGreaterPatterns(a.substr(common_len + 1), strict_a, max_len - common_len - 1);
+    for (auto& part : sub_lower.parts) {
+      result.parts.push_back(common + digit_a + std::move(part));
+    }
+    if (sub_lower.include_empty) {
+      result.parts.push_back(common + std::string(1, digit_a));
+    }
+  } else {
+    // a's value equals value(0.common): only nonzero extensions of
+    // common + digit_a ('0') are strictly greater
+    FracPatternSet sub_lower = FracGreaterPatterns("", true, max_len - common_len - 1);
+    for (auto& part : sub_lower.parts) {
+      result.parts.push_back(common + digit_a + std::move(part));
+    }
+    if (!strict_a) {
+      // t has the same value as a
+      if (!a.empty()) {
+        result.parts.push_back(a + OptionalZeros(max_len - static_cast<int>(a.size())));
+      } else {
+        result.include_empty = true;
+        if (max_len >= 1) {
+          result.parts.push_back(SomeZeros(max_len));
+        }
+      }
+    }
+  }
+  // upper boundary: t continues with digit_b, the rest must stay below b's suffix
+  FracPatternSet sub_upper =
+      FracLessPatterns(b.substr(common_len + 1), strict_b, max_len - common_len - 1);
+  for (auto& part : sub_upper.parts) {
+    result.parts.push_back(common + digit_b + std::move(part));
+  }
+  if (sub_upper.include_empty) {
+    result.parts.push_back(common + std::string(1, digit_b));
+  }
+  return result;
+}
+
+// Splits a canonical decimal string from FormatFloat ("12" or "12.34") into
+// integer and fraction parts.
+void SplitDecimal(const std::string& s, std::string* int_part, std::string* frac_part) {
+  size_t dot = s.find('.');
+  if (dot == std::string::npos) {
+    *int_part = s;
+    frac_part->clear();
+  } else {
+    *int_part = s.substr(0, dot);
+    *frac_part = s.substr(dot + 1);
+  }
+}
+
+// Compares the values of two canonical non-negative decimals.
+int CompareDecimal(
+    const std::string& int_a,
+    const std::string& frac_a,
+    const std::string& int_b,
+    const std::string& frac_b
+) {
+  if (int_a.size() != int_b.size()) {
+    return int_a.size() < int_b.size() ? -1 : 1;
+  }
+  if (int_a != int_b) {
+    return int_a < int_b ? -1 : 1;
+  }
+  size_t max_frac = std::max(frac_a.size(), frac_b.size());
+  for (size_t i = 0; i < max_frac; ++i) {
+    char da = i < frac_a.size() ? frac_a[i] : '0';
+    char db = i < frac_b.size() ? frac_b[i] : '0';
+    if (da != db) {
+      return da < db ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+// Strips the ^( )$ anchors added by GenerateRangeRegex, keeping the group.
+std::string StripAnchors(const std::string& regex) { return regex.substr(1, regex.size() - 2); }
+
+int64_t ParseIntCapped(const std::string& digits) {
+  // Bounds beyond 18 digits exceed double's integer precision anyway; cap to
+  // keep the int64 arithmetic below safe.
+  if (digits.size() > 18) {
+    return 999999999999999999LL;
+  }
+  return std::stoll(digits);
+}
+
+// Patterns for unsigned decimals (integer part plus optional fraction of up
+// to `precision` digits) within the given bounds. `low` is required and
+// non-negative; `high` is optional. Patterns for the value 0 are never
+// produced: when low's value is 0 the bound is treated as strict, and the
+// caller emits the zero pattern itself.
+std::vector<std::string> PositiveRangeParts(
+    const std::string& low,
+    bool strict_low,
+    const std::optional<std::string>& high,
+    bool strict_high,
+    int precision
+) {
+  std::vector<std::string> parts;
+  std::string int_low, frac_low;
+  SplitDecimal(low, &int_low, &frac_low);
+  if (int_low == "0" && frac_low.empty()) {
+    strict_low = true;
+  }
+  int64_t int_low_value = ParseIntCapped(int_low);
+  std::string opt_any_frac = "(\\.\\d{1," + std::to_string(precision) + "})?";
+
+  auto add_with_int_part = [&](const std::string& int_part, const FracPatternSet& set) {
+    for (const auto& part : set.parts) {
+      parts.push_back(int_part + "\\." + part);
+    }
+    if (set.include_empty) {
+      parts.push_back(int_part);
+    }
+  };
+
+  if (!high.has_value()) {
+    add_with_int_part(int_low, FracGreaterPatterns(frac_low, strict_low, precision));
+    if (int_low_value < INT64_MAX - 1) {
+      parts.push_back(
+          StripAnchors(GenerateRangeRegex(int_low_value + 1, std::nullopt)) + opt_any_frac
+      );
+    }
+    return parts;
+  }
+
+  std::string int_high, frac_high;
+  SplitDecimal(*high, &int_high, &frac_high);
+  int64_t int_high_value = ParseIntCapped(int_high);
+  int cmp = CompareDecimal(int_low, frac_low, int_high, frac_high);
+  if (cmp > 0 || (cmp == 0 && (strict_low || strict_high))) {
+    return parts;
+  }
+  if (cmp == 0) {
+    // single representable value, with optional redundant trailing zeros
+    if (frac_low.empty()) {
+      parts.push_back(int_low + "(\\." + SomeZeros(precision) + ")?");
+    } else {
+      parts.push_back(
+          int_low + "\\." + frac_low + OptionalZeros(precision - static_cast<int>(frac_low.size()))
+      );
+    }
+    return parts;
+  }
+  if (int_low == int_high) {
+    add_with_int_part(
+        int_low, FracBetweenPatterns(frac_low, strict_low, frac_high, strict_high, precision)
+    );
+  } else {
+    add_with_int_part(int_low, FracGreaterPatterns(frac_low, strict_low, precision));
+    if (int_high_value - int_low_value >= 2) {
+      parts.push_back(
+          StripAnchors(GenerateRangeRegex(int_low_value + 1, int_high_value - 1)) + opt_any_frac
+      );
+    }
+    add_with_int_part(int_high, FracLessPatterns(frac_high, strict_high, precision));
+  }
+  return parts;
+}
+
+}  // namespace
+
+std::string JSONSchemaConverter::GenerateFloatRangeRegex(
+    std::optional<double> start,
+    std::optional<double> end,
+    int precision,
+    bool exclusive_start,
+    bool exclusive_end
+) {
+  if (start && end) {
+    if (start.value() > end.value() ||
+        (start.value() == end.value() && (exclusive_start || exclusive_end))) {
+      return "^()$";
+    }
   }
 
   if (!start && !end) {
@@ -2807,256 +3104,50 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
 
   std::vector<std::string> parts;
 
-  int64_t startInt = 0;
-  int64_t endInt = 0;
-  double startFrac = 0.0;
-  double endFrac = 0.0;
-  bool isStartNegative = false;
-  bool isEndNegative = false;
-
-  if (start) {
-    isStartNegative = start.value() < 0;
-    startInt = static_cast<int64_t>(floor(start.value()));
-    startFrac = start.value() - startInt;
+  // Negative values: x is in [start, end] iff -x is in [-end, -start], so the
+  // positive-range patterns are reused on the negated bounds and prefixed
+  // with '-'.
+  if (!start.has_value() || start.value() < 0) {
+    std::string low = "0";
+    bool strict_low = true;
+    if (end.has_value() && end.value() < 0) {
+      low = FormatFloat(-end.value(), precision);
+      strict_low = exclusive_end;
+    }
+    std::optional<std::string> high;
+    bool strict_high = false;
+    if (start.has_value()) {
+      high = FormatFloat(-start.value(), precision);
+      strict_high = exclusive_start;
+    }
+    for (auto& part : PositiveRangeParts(low, strict_low, high, strict_high, precision)) {
+      parts.push_back("-" + std::move(part));
+    }
   }
 
-  if (end) {
-    isEndNegative = end.value() < 0;
-    endInt = static_cast<int64_t>(floor(end.value()));
-    endFrac = end.value() - endInt;
+  bool zero_allowed =
+      (!start.has_value() || start.value() < 0 || (start.value() == 0 && !exclusive_start)) &&
+      (!end.has_value() || end.value() > 0 || (end.value() == 0 && !exclusive_end));
+  if (zero_allowed) {
+    parts.push_back("0(\\." + SomeZeros(precision) + ")?");
   }
 
-  if (start && !end) {
-    std::string startIntStr = FormatFloat(start.value(), precision);
-    parts.push_back(EscapeDotForRegex(startIntStr));
-
-    if (startFrac > 0.0) {
-      size_t dotPos = startIntStr.find('.');
-      if (dotPos != std::string::npos) {
-        std::string intPartStr = startIntStr.substr(0, dotPos);
-        std::string fracPartStr = startIntStr.substr(dotPos + 1);
-
-        if (!fracPartStr.empty()) {
-          for (size_t i = 0; i < fracPartStr.length(); i++) {
-            if (i == 0) {
-              if (isStartNegative) {
-                for (char d = '0'; d < fracPartStr[0]; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + d + "\\d{0," + std::to_string(precision - 1) + "}"
-                  );
-                }
-              } else {
-                for (char d = fracPartStr[0] + 1; d <= '9'; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + d + "\\d{0," + std::to_string(precision - 1) + "}"
-                  );
-                }
-              }
-            } else {
-              std::string pref = fracPartStr.substr(0, i);
-              if (isStartNegative) {
-                if (fracPartStr[i] > '0') {
-                  for (char d = '0'; d < fracPartStr[i]; d++) {
-                    parts.push_back(
-                        intPartStr + "\\." + pref + d + "\\d{0," +
-                        std::to_string(precision - i - 1) + "}"
-                    );
-                  }
-                }
-              } else {
-                for (char d = fracPartStr[i] + 1; d <= '9'; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + pref + d + "\\d{0," + std::to_string(precision - i - 1) +
-                      "}"
-                  );
-                }
-              }
-            }
-          }
-        }
-      }
+  // Positive values
+  if (!end.has_value() || end.value() > 0) {
+    std::string low = "0";
+    bool strict_low = true;
+    if (start.has_value() && start.value() > 0) {
+      low = FormatFloat(start.value(), precision);
+      strict_low = exclusive_start;
     }
-
-    if (startInt < INT64_MAX - 1) {
-      std::string intRangeRegex = GenerateRangeRegex(startInt + 1, std::nullopt);
-      intRangeRegex = intRangeRegex.substr(1, intRangeRegex.length() - 2);
-      parts.push_back(intRangeRegex + "(\\.\\d{1," + std::to_string(precision) + "})?");
+    std::optional<std::string> high;
+    bool strict_high = false;
+    if (end.has_value()) {
+      high = FormatFloat(end.value(), precision);
+      strict_high = exclusive_end;
     }
-  } else if (!start && end) {
-    std::string endIntStr = FormatFloat(end.value(), precision);
-    parts.push_back(EscapeDotForRegex(endIntStr));
-
-    if (endFrac > 0.0) {
-      size_t dotPos = endIntStr.find('.');
-      if (dotPos != std::string::npos) {
-        std::string intPartStr = endIntStr.substr(0, dotPos);
-        std::string fracPartStr = endIntStr.substr(dotPos + 1);
-
-        if (!fracPartStr.empty()) {
-          for (size_t i = 0; i < fracPartStr.length(); i++) {
-            if (i == 0) {
-              if (isEndNegative) {
-                for (char d = fracPartStr[0] + 1; d <= '9'; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + d + "\\d{0," + std::to_string(precision - 1) + "}"
-                  );
-                }
-              } else {
-                for (char d = '0'; d < fracPartStr[0]; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + d + "\\d{0," + std::to_string(precision - 1) + "}"
-                  );
-                }
-              }
-            } else {
-              if (isEndNegative) {
-                std::string pref = fracPartStr.substr(0, i);
-                for (char d = fracPartStr[i] + 1; d <= '9'; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + pref + d + "\\d{0," + std::to_string(precision - i - 1) +
-                      "}"
-                  );
-                }
-              } else if (fracPartStr[i] > '0') {
-                std::string pref = fracPartStr.substr(0, i);
-                for (char d = '0'; d < fracPartStr[i]; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + pref + d + "\\d{0," + std::to_string(precision - i - 1) +
-                      "}"
-                  );
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    if (endInt > INT64_MIN + 1) {
-      std::string intRangeRegex = GenerateRangeRegex(std::nullopt, endInt - 1);
-      intRangeRegex = intRangeRegex.substr(1, intRangeRegex.length() - 2);
-      parts.push_back(intRangeRegex + "(\\.\\d{1," + std::to_string(precision) + "})?");
-    }
-  } else if (start && end) {
-    if (startInt == endInt) {
-      if (startFrac == 0.0 && endFrac == 0.0) {
-        parts.push_back(std::to_string(startInt));
-      } else {
-        std::string startStr = FormatFloat(start.value(), precision);
-        parts.push_back(EscapeDotForRegex(startStr));
-
-        std::string endStr = FormatFloat(end.value(), precision);
-        if (startStr != endStr) {
-          parts.push_back(EscapeDotForRegex(endStr));
-        }
-      }
-    } else {
-      std::string startStr = FormatFloat(start.value(), precision);
-      parts.push_back(EscapeDotForRegex(startStr));
-
-      std::string endStr = FormatFloat(end.value(), precision);
-      if (startStr != endStr) {
-        parts.push_back(EscapeDotForRegex(endStr));
-      }
-
-      if (endInt > startInt + 1) {
-        std::string intRangeRegex = GenerateRangeRegex(startInt + 1, endInt - 1);
-        intRangeRegex = intRangeRegex.substr(1, intRangeRegex.length() - 2);
-        parts.push_back(intRangeRegex + "(\\.\\d{1," + std::to_string(precision) + "})?");
-      }
-
-      if (startFrac > 0.0) {
-        size_t dotPos = startStr.find('.');
-        if (dotPos != std::string::npos) {
-          std::string intPartStr = startStr.substr(0, dotPos);
-          std::string fracPartStr = startStr.substr(dotPos + 1);
-
-          for (size_t i = 0; i < fracPartStr.length(); i++) {
-            if (i == 0) {
-              if (isStartNegative) {
-                for (char d = '0'; d < fracPartStr[0]; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + d + "\\d{0," + std::to_string(precision - 1) + "}"
-                  );
-                }
-              } else {
-                for (char d = fracPartStr[0] + 1; d <= '9'; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + d + "\\d{0," + std::to_string(precision - 1) + "}"
-                  );
-                }
-              }
-            } else {
-              std::string pref = fracPartStr.substr(0, i);
-              if (isStartNegative) {
-                if (fracPartStr[i] > '0') {
-                  for (char d = '0'; d < fracPartStr[i]; d++) {
-                    parts.push_back(
-                        intPartStr + "\\." + pref + d + "\\d{0," +
-                        std::to_string(precision - i - 1) + "}"
-                    );
-                  }
-                }
-              } else {
-                for (char d = fracPartStr[i] + 1; d <= '9'; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + pref + d + "\\d{0," + std::to_string(precision - i - 1) +
-                      "}"
-                  );
-                }
-              }
-            }
-          }
-        }
-      } else {
-        parts.push_back(std::to_string(startInt) + "\\.\\d{1," + std::to_string(precision) + "}");
-      }
-
-      if (endFrac > 0.0) {
-        size_t dotPos = endStr.find('.');
-        if (dotPos != std::string::npos) {
-          std::string intPartStr = endStr.substr(0, dotPos);
-          std::string fracPartStr = endStr.substr(dotPos + 1);
-
-          for (size_t i = 0; i < fracPartStr.length(); i++) {
-            if (i == 0) {
-              if (isEndNegative) {
-                for (char d = fracPartStr[0] + 1; d <= '9'; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + d + "\\d{0," + std::to_string(precision - 1) + "}"
-                  );
-                }
-              } else {
-                for (char d = '0'; d < fracPartStr[0]; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + d + "\\d{0," + std::to_string(precision - 1) + "}"
-                  );
-                }
-              }
-            } else {
-              if (isEndNegative) {
-                std::string pref = fracPartStr.substr(0, i);
-                for (char d = fracPartStr[i] + 1; d <= '9'; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + pref + d + "\\d{0," + std::to_string(precision - i - 1) +
-                      "}"
-                  );
-                }
-              } else if (fracPartStr[i] > '0') {
-                std::string pref = fracPartStr.substr(0, i);
-                for (char d = '0'; d < fracPartStr[i]; d++) {
-                  parts.push_back(
-                      intPartStr + "\\." + pref + d + "\\d{0," + std::to_string(precision - i - 1) +
-                      "}"
-                  );
-                }
-              }
-            }
-          }
-        }
-      } else {
-        parts.push_back(std::to_string(endInt) + "\\.\\d{1," + std::to_string(precision) + "}");
-      }
+    for (auto& part : PositiveRangeParts(low, strict_low, high, strict_high, precision)) {
+      parts.push_back(std::move(part));
     }
   }
 
@@ -3146,8 +3237,12 @@ std::string GenerateRangeRegex(std::optional<int64_t> start, std::optional<int64
   return JSONSchemaConverter::GenerateRangeRegex(start, end);
 }
 
-std::string GenerateFloatRangeRegex(std::optional<double> start, std::optional<double> end) {
-  return JSONSchemaConverter::GenerateFloatRangeRegex(start, end, 6);
+std::string GenerateFloatRangeRegex(
+    std::optional<double> start, std::optional<double> end, bool exclusive_start, bool exclusive_end
+) {
+  return JSONSchemaConverter::GenerateFloatRangeRegex(
+      start, end, 6, exclusive_start, exclusive_end
+  );
 }
 
 std::string QwenXMLToolCallingToEBNF(const std::string& schema) {

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -420,7 +420,11 @@ class JSONSchemaConverter {
   // Helper for integer/number range regex generation
   static std::string GenerateRangeRegex(std::optional<int64_t> start, std::optional<int64_t> end);
   static std::string GenerateFloatRangeRegex(
-      std::optional<double> start, std::optional<double> end, int precision = 6
+      std::optional<double> start,
+      std::optional<double> end,
+      int precision = 6,
+      bool exclusive_start = false,
+      bool exclusive_end = false
   );
   static std::string MakePatternForDigitRange(char start, char end, int remainingDigits);
   static std::vector<std::string> GenerateNumberPatterns(int64_t lower, int64_t upper);
@@ -436,7 +440,10 @@ class JSONSchemaConverter {
   // Expose for testing
   friend std::string GenerateRangeRegex(std::optional<int64_t> start, std::optional<int64_t> end);
   friend std::string GenerateFloatRangeRegex(
-      std::optional<double> start, std::optional<double> end
+      std::optional<double> start,
+      std::optional<double> end,
+      bool exclusive_start,
+      bool exclusive_end
   );
 };
 
@@ -521,7 +528,12 @@ std::string JSONSchemaToEBNF(
  */
 std::string GenerateRangeRegex(std::optional<int64_t> start, std::optional<int64_t> end);
 
-std::string GenerateFloatRangeRegex(std::optional<double> start, std::optional<double> end);
+std::string GenerateFloatRangeRegex(
+    std::optional<double> start,
+    std::optional<double> end,
+    bool exclusive_start = false,
+    bool exclusive_end = false
+);
 
 /*!
  * \brief Convert a function call to a Grammar.

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -797,12 +797,13 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       )
       .def(
           "xgrammar.tvm_ffi_binding.testing._generate_float_regex",
-          [](ffi::AnyView start, ffi::AnyView end) {
+          [](ffi::AnyView start, ffi::AnyView end, bool exclusive_start, bool exclusive_end) {
             std::optional<double> start_value =
                 start == nullptr ? std::nullopt : std::make_optional(start.cast<double>());
             std::optional<double> end_value =
                 end == nullptr ? std::nullopt : std::make_optional(end.cast<double>());
-            std::string regex_string = GenerateFloatRangeRegex(start_value, end_value);
+            std::string regex_string =
+                GenerateFloatRangeRegex(start_value, end_value, exclusive_start, exclusive_end);
             regex_string.erase(
                 std::remove(regex_string.begin(), regex_string.end(), '\0'), regex_string.end()
             );

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -337,8 +337,13 @@ def _generate_range_regex(start: Optional[int] = None, end: Optional[int] = None
     return _core.testing._generate_range_regex(start, end)
 
 
-def _generate_float_regex(start: Optional[float] = None, end: Optional[float] = None) -> str:
-    return _core.testing._generate_float_regex(start, end)
+def _generate_float_regex(
+    start: Optional[float] = None,
+    end: Optional[float] = None,
+    exclusive_start: bool = False,
+    exclusive_end: bool = False,
+) -> str:
+    return _core.testing._generate_float_regex(start, end, exclusive_start, exclusive_end)
 
 
 def _print_grammar_fsms(grammar: Grammar) -> str:

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -1611,8 +1611,10 @@ def test_generate_range_regex():
 
     # Unbounded ranges (None cases)
     assert _generate_range_regex(None, None) == r"^-?\d+$"
-    assert _generate_range_regex(5, None) == r"^([5-9]|[1-9]\d*)$"
+    assert _generate_range_regex(5, None) == r"^([5-9]|[1-9]\d{1,})$"
     assert _generate_range_regex(None, 0) == r"^(-[1-9]\d*|0)$"
+    assert _generate_range_regex(-5, None) == r"^(-([1-5])|0|[1-9]\d*)$"
+    assert _generate_range_regex(None, -2) == r"^(-[2-9]|-[1-9]\d{1,})$"
 
     # Medium range
     assert (
@@ -2252,40 +2254,50 @@ def test_primitive_type_object():
 
 
 def test_generate_float_regex():
-    assert _generate_float_regex(1.0, 5.0) == r"^(1|5|(([2-4]))(\.\d{1,6})?|1\.\d{1,6}|5\.\d{1,6})$"
+    assert (
+        _generate_float_regex(1.0, 5.0)
+        == r"^(1\.[1-9]\d{0,5}|1\.0[1-9]\d{0,4}|1\.00[1-9]\d{0,3}|1\.000[1-9]\d{0,2}|1\.0000[1-9]\d{0,1}|1\.00000[1-9]|1\.0{1,6}|1|(([2-4]))(\.\d{1,6})?|5\.0{1,6}|5)$"
+    )
 
     assert (
         _generate_float_regex(1.5, 5.75)
-        == r"^(1\.5|5\.75|(([2-4]))(\.\d{1,6})?|1\.6\d{0,5}|1\.7\d{0,5}|1\.8\d{0,5}|1\.9\d{0,5}|5\.0\d{0,5}|5\.1\d{0,5}|5\.2\d{0,5}|5\.3\d{0,5}|5\.4\d{0,5}|5\.5\d{0,5}|5\.6\d{0,5}|5\.70\d{0,4}|5\.71\d{0,4}|5\.72\d{0,4}|5\.73\d{0,4}|5\.74\d{0,4})$"
+        == r"^(1\.[6-9]\d{0,5}|1\.5[1-9]\d{0,4}|1\.50[1-9]\d{0,3}|1\.500[1-9]\d{0,2}|1\.5000[1-9]\d{0,1}|1\.50000[1-9]|1\.50{0,5}|(([2-4]))(\.\d{1,6})?|5\.[0-6]\d{0,5}|5\.7[0-4]\d{0,4}|5\.0{1,6}|5\.70{0,5}|5\.750{0,4}|5)$"
     )
 
     assert (
         _generate_float_regex(-3.14, 2.71828)
-        == r"^(-3\.14|2\.71828|(-([1-3])|0|(1))(\.\d{1,6})?|-3\.0\d{0,5}|-3\.10\d{0,4}|-3\.11\d{0,4}|-3\.12\d{0,4}|-3\.13\d{0,4}|2\.0\d{0,5}|2\.1\d{0,5}|2\.2\d{0,5}|2\.3\d{0,5}|2\.4\d{0,5}|2\.5\d{0,5}|2\.6\d{0,5}|2\.70\d{0,4}|2\.710\d{0,3}|2\.711\d{0,3}|2\.712\d{0,3}|2\.713\d{0,3}|2\.714\d{0,3}|2\.715\d{0,3}|2\.716\d{0,3}|2\.717\d{0,3}|2\.7180\d{0,2}|2\.7181\d{0,2}|2\.71820\d{0,1}|2\.71821\d{0,1}|2\.71822\d{0,1}|2\.71823\d{0,1}|2\.71824\d{0,1}|2\.71825\d{0,1}|2\.71826\d{0,1}|2\.71827\d{0,1})$"
+        == r"^(-0\.[1-9]\d{0,5}|-0\.0[1-9]\d{0,4}|-0\.00[1-9]\d{0,3}|-0\.000[1-9]\d{0,2}|-0\.0000[1-9]\d{0,1}|-0\.00000[1-9]|-(([1-2]))(\.\d{1,6})?|-3\.0\d{0,5}|-3\.1[0-3]\d{0,4}|-3\.0{1,6}|-3\.10{0,5}|-3\.140{0,4}|-3|0(\.0{1,6})?|0\.[1-9]\d{0,5}|0\.0[1-9]\d{0,4}|0\.00[1-9]\d{0,3}|0\.000[1-9]\d{0,2}|0\.0000[1-9]\d{0,1}|0\.00000[1-9]|((1))(\.\d{1,6})?|2\.[0-6]\d{0,5}|2\.70\d{0,4}|2\.71[0-7]\d{0,3}|2\.718[0-1]\d{0,2}|2\.7182[0-7]\d{0,1}|2\.0{1,6}|2\.70{0,5}|2\.710{0,4}|2\.7180{0,3}|2\.71820{0,2}|2\.718280{0,1}|2)$"
     )
 
     assert (
         _generate_float_regex(0.5, None)
-        == r"^(0\.5|0\.6\d{0,5}|0\.7\d{0,5}|0\.8\d{0,5}|0\.9\d{0,5}|([1-9]|[1-9]\d*)(\.\d{1,6})?)$"
+        == r"^(0\.[6-9]\d{0,5}|0\.5[1-9]\d{0,4}|0\.50[1-9]\d{0,3}|0\.500[1-9]\d{0,2}|0\.5000[1-9]\d{0,1}|0\.50000[1-9]|0\.50{0,5}|([1-9]|[1-9]\d{1,})(\.\d{1,6})?)$"
     )
 
     assert (
         _generate_float_regex(None, -1.5)
-        == r"^(-1\.5|-1\.6\d{0,5}|-1\.7\d{0,5}|-1\.8\d{0,5}|-1\.9\d{0,5}|(-[3-9]|-[1-9]\d*)(\.\d{1,6})?)$"
+        == r"^(-1\.[6-9]\d{0,5}|-1\.5[1-9]\d{0,4}|-1\.50[1-9]\d{0,3}|-1\.500[1-9]\d{0,2}|-1\.5000[1-9]\d{0,1}|-1\.50000[1-9]|-1\.50{0,5}|-([2-9]|[1-9]\d{1,})(\.\d{1,6})?)$"
     )
 
     assert _generate_float_regex(None, None) == r"^-?\d+(\.\d{1,6})?$"
 
-    assert _generate_float_regex(3.14159, 3.14159) == r"^(3\.14159)$"
+    assert _generate_float_regex(3.14159, 3.14159) == r"^(3\.141590{0,1})$"
 
     assert _generate_float_regex(10.5, 2.5) == r"^()$"
 
     assert _generate_float_regex(5.123456, 5.123457) == r"^(5\.123456|5\.123457)$"
 
+    assert _generate_float_regex(-0.000001, 0.000001) == r"^(-0\.000001|0(\.0{1,6})?|0\.000001)$"
+
+    # exclusive bounds drop the boundary value itself
     assert (
-        _generate_float_regex(-0.000001, 0.000001)
-        == r"^(-0\.000001|0\.000001|-0\.000000\d{0,0}|0\.000000\d{0,0})$"
+        _generate_float_regex(0, None, exclusive_start=True)
+        == r"^(0\.[1-9]\d{0,5}|0\.0[1-9]\d{0,4}|0\.00[1-9]\d{0,3}|0\.000[1-9]\d{0,2}|0\.0000[1-9]\d{0,1}|0\.00000[1-9]|([1-9]|[1-9]\d{1,})(\.\d{1,6})?)$"
     )
+    assert _generate_float_regex(0, None) == (
+        r"^(0(\.0{1,6})?|0\.[1-9]\d{0,5}|0\.0[1-9]\d{0,4}|0\.00[1-9]\d{0,3}|0\.000[1-9]\d{0,2}|0\.0000[1-9]\d{0,1}|0\.00000[1-9]|([1-9]|[1-9]\d{1,})(\.\d{1,6})?)$"
+    )
+    assert _generate_float_regex(2.5, 2.5, exclusive_end=True) == r"^()$"
 
 
 def test_float_minimum_no_wildcard_in_grammar():
@@ -2309,6 +2321,154 @@ def test_float_minimum_no_wildcard_in_grammar():
     for line in str(grammar3).split("\n"):
         if line.startswith("root"):
             assert "[\\0-\\U0010ffff]" not in line, f"Wildcard found in: {line}"
+
+
+number_range_instances = [
+    # exclusiveMinimum with an integer-valued bound: values in (0, 1) must be
+    # representable and the bound itself must be rejected.
+    ({"type": "number", "exclusiveMinimum": 0}, "0.1", True),
+    ({"type": "number", "exclusiveMinimum": 0}, "0.99", True),
+    ({"type": "number", "exclusiveMinimum": 0}, "0.000001", True),
+    ({"type": "number", "exclusiveMinimum": 0}, "0", False),
+    ({"type": "number", "exclusiveMinimum": 0}, "0.0", False),
+    ({"type": "number", "exclusiveMinimum": 0}, "-1", False),
+    ({"type": "number", "exclusiveMinimum": 0}, "1", True),
+    ({"type": "number", "exclusiveMinimum": 0}, "1.5", True),
+    ({"type": "number", "exclusiveMinimum": 0}, "25", True),
+    # inclusive minimum 0
+    ({"type": "number", "minimum": 0}, "0", True),
+    ({"type": "number", "minimum": 0}, "0.0", True),
+    ({"type": "number", "minimum": 0}, "0.5", True),
+    ({"type": "number", "minimum": 0}, "-0.5", False),
+    # minimum above 1: single-digit integers below the bound must be rejected
+    ({"type": "number", "minimum": 2}, "1", False),
+    ({"type": "number", "minimum": 2}, "1.5", False),
+    ({"type": "number", "minimum": 2}, "2", True),
+    ({"type": "number", "minimum": 2}, "2.0", True),
+    ({"type": "number", "minimum": 2}, "2.5", True),
+    ({"type": "number", "minimum": 2}, "10", True),
+    ({"type": "number", "exclusiveMinimum": 2}, "2", False),
+    ({"type": "number", "exclusiveMinimum": 2}, "2.000001", True),
+    # upper bounds
+    ({"type": "number", "exclusiveMaximum": 1}, "0.99", True),
+    ({"type": "number", "exclusiveMaximum": 1}, "1", False),
+    ({"type": "number", "exclusiveMaximum": 1}, "1.0", False),
+    ({"type": "number", "exclusiveMaximum": 1}, "0", True),
+    ({"type": "number", "exclusiveMaximum": 1}, "-5.5", True),
+    ({"type": "number", "maximum": -2}, "-2", True),
+    ({"type": "number", "maximum": -2}, "-1", False),
+    ({"type": "number", "maximum": -2}, "-1.5", False),
+    ({"type": "number", "maximum": -2}, "-2.5", True),
+    ({"type": "number", "maximum": -2}, "-12", True),
+    # both bounds: values above the maximum must be rejected
+    ({"type": "number", "minimum": 1, "maximum": 5}, "5.7", False),
+    ({"type": "number", "minimum": 1, "maximum": 5}, "1.001", True),
+    ({"type": "number", "minimum": 1, "maximum": 5}, "0.5", False),
+    ({"type": "number", "minimum": 1, "maximum": 5}, "1.5", True),
+    ({"type": "number", "minimum": 1, "maximum": 5}, "5", True),
+    ({"type": "number", "minimum": 1, "maximum": 5}, "5.0", True),
+    ({"type": "number", "exclusiveMinimum": 1, "exclusiveMaximum": 5}, "1", False),
+    ({"type": "number", "exclusiveMinimum": 1, "exclusiveMaximum": 5}, "5", False),
+    ({"type": "number", "exclusiveMinimum": 1, "exclusiveMaximum": 5}, "4.999", True),
+    ({"type": "number", "minimum": -1.5, "maximum": 1.5}, "-1.6", False),
+    ({"type": "number", "minimum": -1.5, "maximum": 1.5}, "-1.5", True),
+    ({"type": "number", "minimum": -1.5, "maximum": 1.5}, "0", True),
+    ({"type": "number", "minimum": -1.5, "maximum": 1.5}, "1.6", False),
+    ({"type": "number", "minimum": 0.1, "maximum": 0.3}, "0.2", True),
+    ({"type": "number", "minimum": 0.1, "maximum": 0.3}, "0.05", False),
+    ({"type": "number", "minimum": 0.1, "maximum": 0.3}, "0.35", False),
+]
+
+
+@pytest.mark.parametrize("schema, instance, accepted", number_range_instances)
+def test_number_range_value_acceptance(schema, instance, accepted):
+    check_schema_with_instance(schema, instance, is_accepted=accepted)
+
+
+integer_range_instances = [
+    ({"type": "integer", "minimum": 2}, "1", False),
+    ({"type": "integer", "minimum": 2}, "2", True),
+    ({"type": "integer", "minimum": 2}, "9", True),
+    ({"type": "integer", "minimum": 2}, "10", True),
+    ({"type": "integer", "minimum": 2}, "0", False),
+    ({"type": "integer", "exclusiveMinimum": 2}, "2", False),
+    ({"type": "integer", "exclusiveMinimum": 2}, "3", True),
+    ({"type": "integer", "maximum": -2}, "-1", False),
+    ({"type": "integer", "maximum": -2}, "-2", True),
+    ({"type": "integer", "maximum": -2}, "-12", True),
+    ({"type": "integer", "minimum": -5}, "-5", True),
+    ({"type": "integer", "minimum": -5}, "-3", True),
+    ({"type": "integer", "minimum": -5}, "-6", False),
+    ({"type": "integer", "minimum": -5}, "0", True),
+    ({"type": "integer", "minimum": -5}, "7", True),
+]
+
+
+@pytest.mark.parametrize("schema, instance, accepted", integer_range_instances)
+def test_integer_range_value_acceptance(schema, instance, accepted):
+    check_schema_with_instance(schema, instance, is_accepted=accepted)
+
+
+number_range_sweep_bounds = [
+    {"minimum": 0},
+    {"exclusiveMinimum": 0},
+    {"maximum": 0},
+    {"exclusiveMaximum": 0},
+    {"minimum": 2},
+    {"exclusiveMinimum": 2},
+    {"minimum": -2},
+    {"maximum": 5},
+    {"minimum": 0.5},
+    {"exclusiveMinimum": 0.5},
+    {"maximum": 0.5},
+    {"exclusiveMaximum": 0.5},
+    {"minimum": 99.5},
+    {"maximum": -2.25},
+    {"minimum": 1, "maximum": 5},
+    {"exclusiveMinimum": 1, "exclusiveMaximum": 5},
+    {"minimum": -1.5, "maximum": 1.5},
+    {"minimum": 0.1, "maximum": 0.3},
+    {"minimum": -5.5, "maximum": -2.25},
+    {"minimum": 9, "maximum": 31},
+    {"minimum": 5.123456, "maximum": 5.123457},
+]
+
+
+@pytest.mark.parametrize("bounds", number_range_sweep_bounds)
+def test_number_range_acceptance_sweep(bounds):
+    """The grammar for a range-constrained number must agree with plain float
+    comparison for every candidate value around the bounds (limited to 6
+    fractional digits, the converter's precision)."""
+
+    def in_range(value: float) -> bool:
+        if "minimum" in bounds and not value >= bounds["minimum"]:
+            return False
+        if "exclusiveMinimum" in bounds and not value > bounds["exclusiveMinimum"]:
+            return False
+        if "maximum" in bounds and not value <= bounds["maximum"]:
+            return False
+        if "exclusiveMaximum" in bounds and not value < bounds["exclusiveMaximum"]:
+            return False
+        return True
+
+    candidates = {0.0, 1.0, -1.0, 0.5, -0.5, 10.0, -10.0, 100.0, -100.0}
+    for bound in bounds.values():
+        for delta in (0.0, 0.000001, 0.1, 0.5, 1.0, 2.0, 10.0):
+            candidates.add(bound + delta)
+            candidates.add(bound - delta)
+
+    grammar = xgr.Grammar.from_json_schema(json.dumps({"type": "number", **bounds}))
+    for value in sorted(candidates):
+        text = f"{value:.6f}".rstrip("0").rstrip(".")
+        if text in ("", "-0"):
+            text = "0"
+        value = float(text)
+        accepted = _is_grammar_accept_string(grammar, text)
+        assert accepted == in_range(value), (
+            f"bounds={bounds} value={text}: grammar "
+            f"{'accepted' if accepted else 'rejected'}, float comparison says "
+            f"{'in range' if in_range(value) else 'out of range'}"
+        )
 
 
 def test_limited_whitespace_cnt():


### PR DESCRIPTION
GenerateFloatRangeRegex produced grammars that were wrong in both directions for "type": "number" schemas with range bounds:

- For integer-valued bounds the fractional patterns were never generated (guarded by startFrac > 0.0), so for {"exclusiveMinimum": 0} every value in (0, 1) was unrepresentable. Under token-masked decoding a model writing 0.1 is silently coerced to 0.
- Exclusive bounds were treated as inclusive: exclusiveMinimum / exclusiveMaximum compiled identically to minimum / maximum, so the excluded bound itself was accepted.
- The unbounded integer alternative used [1-9]\d*, which matches values below the bound ({"minimum": 2} accepted 1). This also affected "type": "integer" schemas via GenerateRangeRegex.
- The both-bounds branch emitted endInt\.\d{1,6}, accepting values above the maximum ([1, 5] accepted 5.7).
- GenerateRangeRegex with only a negative minimum produced an empty subrange ({"type": "integer", "minimum": -5} matched no negative integers at all, only the literal "-").

Rewrite GenerateFloatRangeRegex with a digit-by-digit enumeration of the boundary fraction families (lower bound, upper bound, and two-sided same-integer-part ranges), and plumb exclusive_start / exclusive_end flags from NumberSpec through to the regex generator. Fix the two broken branches in GenerateRangeRegex.

Tests: value-level acceptance tests for number and integer range keywords, plus a sweep comparing grammar acceptance against plain float comparison around every bound; expected-regex tests updated to the corrected generator output (verified value-level first).