### PR TITLE
feat: add a new param to control exclude strs for builtin structural tag.

### DIFF
--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -168,6 +168,20 @@ structural_tag = get_model_structural_tag(
 )
 ```
 
+### Special tokens in text
+
+By default, special tokens like `<think>` / `</think>` are not allowed in free text. Pass `exclude_special_tokens_in_text=False` to allow them:
+
+```python
+structural_tag = get_model_structural_tag(
+    "qwen_3",
+    tools=tools,
+    exclude_special_tokens_in_text=False,
+)
+```
+
+Defaults to `True`. No effect for models without special tokens (e.g. `harmony`).
+
 ---
 
 ## Supported models

--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -180,7 +180,7 @@ structural_tag = get_model_structural_tag(
 )
 ```
 
-Defaults to `False`. No effect for models without special tokens (e.g. `harmony`).
+Defaults to `True`. No effect for models without special tokens (e.g. `harmony`).
 
 ---
 

--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -170,17 +170,17 @@ structural_tag = get_model_structural_tag(
 
 ### Special tokens in text
 
-By default, special tokens like `<think>` / `</think>` are not allowed in free text. Pass `exclude_special_tokens_in_text=False` to allow them:
+By default, special tokens like `<think>` / `</think>` are not allowed in free text. Pass `exclude_special_tokens=False` to allow them:
 
 ```python
 structural_tag = get_model_structural_tag(
     "qwen_3",
     tools=tools,
-    exclude_special_tokens_in_text=False,
+    exclude_special_tokens=False,
 )
 ```
 
-Defaults to `True`. No effect for models without special tokens (e.g. `harmony`).
+Defaults to `False`. No effect for models without special tokens (e.g. `harmony`).
 
 ---
 

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -34,7 +34,7 @@ def get_model_structural_tag(
     reasoning: bool = True,
     force_reasoning: bool = False,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
 ) -> StructuralTag:
     r"""Get a structural tag for a model's reasoning and tool-call output format.
 
@@ -195,7 +195,7 @@ def get_model_structural_tag(
         semantics). When ``False`` (default), the declared property order is kept
         with full validation. Default: ``False``.
 
-    exclude_special_tokens_in_text : bool
+    exclude_special_tokens : bool
         Whether to forbid model special tokens (such as ``<think>`` and
         ``</think>``) from appearing inside the free-text and triggered-text
         spans of the structural tag. Defaults to ``True``, which keeps the
@@ -235,7 +235,7 @@ def get_model_structural_tag(
         simplified_tool_choice,
         reasoning,
         any_order=any_order,
-        exclude_special_tokens_in_text=exclude_special_tokens_in_text,
+        exclude_special_tokens=exclude_special_tokens,
     )
 
 
@@ -430,19 +430,19 @@ def _get_builtin_tool_name(tool: BuiltinToolParam) -> str:
     return tool.name or tool.type
 
 
-def _text_excludes(exclude_special_tokens_in_text: bool, tokens: List[str]) -> List[str]:
+def _text_excludes(exclude_special_tokens: bool, tokens: List[str]) -> List[str]:
     """Resolve the tokens to forbid inside a structural tag's free-text spans.
 
     Built-in structural tags normally forbid model special tokens (such as
     ``<think>`` and ``</think>``) from appearing inside the free-text and
     triggered-text spans, so the model cannot emit them as plain text. Some
     downstream setups do not want this restriction. When
-    ``exclude_special_tokens_in_text`` is ``True`` (the default), this returns
+    ``exclude_special_tokens`` is ``True`` (the default), this returns
     *tokens* unchanged; when ``False``, it returns an empty list so nothing is
     excluded.
     """
 
-    return list(tokens) if exclude_special_tokens_in_text else []
+    return list(tokens) if exclude_special_tokens else []
 
 
 def _filter_allowed_tools(
@@ -521,7 +521,7 @@ def get_llama_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Llama style structural tag format.
@@ -576,11 +576,11 @@ def get_llama_structural_tag(
             suffix_tag = TriggeredTagsFormat(
                 triggers=[TOOLS_TRIGGER],
                 tags=tags,
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
             )
         else:
             suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS)
             )
 
     elif tool_choice == "forced":
@@ -621,7 +621,7 @@ def get_kimi_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Kimi-K2 style structural tag format.
@@ -690,12 +690,12 @@ def get_kimi_structural_tag(
                 triggers=[TOOL_CALLS_SECTION_BEGIN],
                 tags=[tool_calls],
                 excludes=_text_excludes(
-                    exclude_special_tokens_in_text, [*THINK_EXCLUDE_TOKENS, TOOL_CALL_BEGIN]
+                    exclude_special_tokens, [*THINK_EXCLUDE_TOKENS, TOOL_CALL_BEGIN]
                 ),
             )
         else:
             suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS)
             )
 
     elif tool_choice == "forced":
@@ -763,7 +763,7 @@ def get_deepseek_r1_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-R1 style structural tag format.
@@ -811,11 +811,11 @@ def get_deepseek_r1_structural_tag(
             suffix_tag = TriggeredTagsFormat(
                 triggers=[TOOL_CALLS_BEGIN],
                 tags=[tool_calls],
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
             )
         else:
             suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS)
             )
 
     elif tool_choice == "forced":
@@ -862,7 +862,7 @@ def get_deepseek_v3_1_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V3.1 style structural tag format.
@@ -908,11 +908,11 @@ def get_deepseek_v3_1_structural_tag(
             suffix_tag = TriggeredTagsFormat(
                 triggers=[TOOL_CALLS_BEGIN],
                 tags=[tool_calls],
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
             )
         else:
             suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS)
             )
 
     elif tool_choice == "forced":
@@ -960,7 +960,7 @@ def get_qwen_3_5_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Qwen XML tool-call structural tag format.
@@ -1018,11 +1018,11 @@ def get_qwen_3_5_structural_tag(
             suffix_tag = TriggeredTagsFormat(
                 triggers=[TOOL_CALL_TRIGGER],
                 tags=tags,
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
             )
         else:
             suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS)
             )
 
     elif tool_choice == "forced":
@@ -1081,7 +1081,7 @@ def get_qwen_3_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Qwen3 style structural tag format.
@@ -1136,11 +1136,11 @@ def get_qwen_3_structural_tag(
             suffix_tag = TriggeredTagsFormat(
                 triggers=[TOOL_CALL_TRIGGER],
                 tags=tags,
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
             )
         else:
             suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS)
             )
 
     elif tool_choice == "forced":
@@ -1191,7 +1191,7 @@ def get_harmony_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get harmony(gpt-oss) style structural tag format.
@@ -1323,7 +1323,7 @@ def get_deepseek_v3_2_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V3.2 style structural tag format.
@@ -1384,11 +1384,11 @@ def get_deepseek_v3_2_structural_tag(
                         end=FUNCTION_CALLS_END,
                     )
                 ],
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
             )
         else:
             suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS)
             )
 
     elif tool_choice == "forced":
@@ -1450,7 +1450,7 @@ def get_minimax_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get MiniMax-M2.5 style structural tag format.
@@ -1510,11 +1510,11 @@ def get_minimax_structural_tag(
                         begin=TOOL_CALL_BEGIN, content=function_calling_tags, end=TOOL_CALL_END
                     )
                 ],
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
             )
         else:
             suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS)
             )
 
     elif tool_choice == "forced":
@@ -1578,7 +1578,7 @@ def get_glm_4_7_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get GLM-4.7/GLM-5 style structural tag format.
@@ -1648,11 +1648,11 @@ def get_glm_4_7_structural_tag(
             suffix_tag = TriggeredTagsFormat(
                 triggers=[TOOL_CALL_TRIGGER],
                 tags=tags,
-                excludes=_text_excludes(exclude_special_tokens_in_text, TEXT_EXCLUDES),
+                excludes=_text_excludes(exclude_special_tokens, TEXT_EXCLUDES),
             )
         else:
             suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens_in_text, REASONING_EXCLUDES)
+                excludes=_text_excludes(exclude_special_tokens, REASONING_EXCLUDES)
             )
 
     elif tool_choice == "forced":
@@ -1689,9 +1689,7 @@ def get_glm_4_7_structural_tag(
 
     prefix_tag = TagFormat(
         begin="",
-        content=AnyTextFormat(
-            excludes=_text_excludes(exclude_special_tokens_in_text, REASONING_EXCLUDES)
-        ),
+        content=AnyTextFormat(excludes=_text_excludes(exclude_special_tokens, REASONING_EXCLUDES)),
         end=THINK_TAG_END,
     )
 
@@ -1707,7 +1705,7 @@ def _get_gemma_4_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Gemma 4 style structural tag format.
@@ -1773,11 +1771,11 @@ def _get_gemma_4_structural_tag(
             suffix_tag = TriggeredTagsFormat(
                 triggers=[TOOL_CALL_TRIGGER],
                 tags=tags,
-                excludes=_text_excludes(exclude_special_tokens_in_text, GEMMA4_EXCLUDE_TOKENS),
+                excludes=_text_excludes(exclude_special_tokens, GEMMA4_EXCLUDE_TOKENS),
             )
         else:
             suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens_in_text, GEMMA4_EXCLUDE_TOKENS)
+                excludes=_text_excludes(exclude_special_tokens, GEMMA4_EXCLUDE_TOKENS)
             )
 
     elif tool_choice == "forced":
@@ -1822,7 +1820,7 @@ def get_deepseek_v4_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
-    exclude_special_tokens_in_text: bool = True,
+    exclude_special_tokens: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V4 style structural tag format.
@@ -1881,11 +1879,11 @@ def get_deepseek_v4_structural_tag(
                         end=FUNCTION_CALLS_END,
                     )
                 ],
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
             )
         else:
             suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS)
             )
 
     elif tool_choice == "forced":

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -34,6 +34,7 @@ def get_model_structural_tag(
     reasoning: bool = True,
     force_reasoning: bool = False,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
 ) -> StructuralTag:
     r"""Get a structural tag for a model's reasoning and tool-call output format.
 
@@ -194,6 +195,14 @@ def get_model_structural_tag(
         semantics). When ``False`` (default), the declared property order is kept
         with full validation. Default: ``False``.
 
+    exclude_special_tokens_in_text : bool
+        Whether to forbid model special tokens (such as ``<think>`` and
+        ``</think>``) from appearing inside the free-text and triggered-text
+        spans of the structural tag. Defaults to ``True``, which keeps the
+        free-text spans constrained to exclude those tokens. Set to ``False``
+        to allow them to appear as plain text. For models that have no special
+        tokens to exclude (such as ``"harmony"``), this has no effect.
+
     Notes
     -----
     If a tool's ``parameters`` field is omitted or ``None``, its generated
@@ -221,7 +230,12 @@ def get_model_structural_tag(
     )
 
     return func(
-        function_tools, builtin_tools, simplified_tool_choice, reasoning, any_order=any_order
+        function_tools,
+        builtin_tools,
+        simplified_tool_choice,
+        reasoning,
+        any_order=any_order,
+        exclude_special_tokens_in_text=exclude_special_tokens_in_text,
     )
 
 
@@ -416,6 +430,21 @@ def _get_builtin_tool_name(tool: BuiltinToolParam) -> str:
     return tool.name or tool.type
 
 
+def _text_excludes(exclude_special_tokens_in_text: bool, tokens: List[str]) -> List[str]:
+    """Resolve the tokens to forbid inside a structural tag's free-text spans.
+
+    Built-in structural tags normally forbid model special tokens (such as
+    ``<think>`` and ``</think>``) from appearing inside the free-text and
+    triggered-text spans, so the model cannot emit them as plain text. Some
+    downstream setups do not want this restriction. When
+    ``exclude_special_tokens_in_text`` is ``True`` (the default), this returns
+    *tokens* unchanged; when ``False``, it returns an empty list so nothing is
+    excluded.
+    """
+
+    return list(tokens) if exclude_special_tokens_in_text else []
+
+
 def _filter_allowed_tools(
     tools: List[FunctionToolParam],
     builtin_tools: List[BuiltinToolParam],
@@ -492,6 +521,7 @@ def get_llama_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Llama style structural tag format.
@@ -544,10 +574,14 @@ def get_llama_structural_tag(
 
         if len(tags) > 0:
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOLS_TRIGGER], tags=tags, excludes=THINK_EXCLUDE_TOKENS
+                triggers=[TOOLS_TRIGGER],
+                tags=tags,
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+            )
 
     elif tool_choice == "forced":
         if not tools:
@@ -587,6 +621,7 @@ def get_kimi_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Kimi-K2 style structural tag format.
@@ -654,10 +689,14 @@ def get_kimi_structural_tag(
             suffix_tag = TriggeredTagsFormat(
                 triggers=[TOOL_CALLS_SECTION_BEGIN],
                 tags=[tool_calls],
-                excludes=[*THINK_EXCLUDE_TOKENS, TOOL_CALL_BEGIN],
+                excludes=_text_excludes(
+                    exclude_special_tokens_in_text, [*THINK_EXCLUDE_TOKENS, TOOL_CALL_BEGIN]
+                ),
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+            )
 
     elif tool_choice == "forced":
         if not tools:
@@ -724,6 +763,7 @@ def get_deepseek_r1_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-R1 style structural tag format.
@@ -769,10 +809,14 @@ def get_deepseek_r1_structural_tag(
                 begin=TOOL_CALLS_BEGIN, content=inner_tool_calls, end=TOOL_CALLS_END
             )
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALLS_BEGIN], tags=[tool_calls], excludes=THINK_EXCLUDE_TOKENS
+                triggers=[TOOL_CALLS_BEGIN],
+                tags=[tool_calls],
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+            )
 
     elif tool_choice == "forced":
         if not tools:
@@ -818,6 +862,7 @@ def get_deepseek_v3_1_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V3.1 style structural tag format.
@@ -861,10 +906,14 @@ def get_deepseek_v3_1_structural_tag(
                 begin=TOOL_CALLS_BEGIN, content=inner_tool_calls, end=TOOL_CALLS_END
             )
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALLS_BEGIN], tags=[tool_calls], excludes=THINK_EXCLUDE_TOKENS
+                triggers=[TOOL_CALLS_BEGIN],
+                tags=[tool_calls],
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+            )
 
     elif tool_choice == "forced":
         if not tools:
@@ -911,6 +960,7 @@ def get_qwen_3_5_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Qwen XML tool-call structural tag format.
@@ -966,10 +1016,14 @@ def get_qwen_3_5_structural_tag(
 
         if len(tags) > 0:
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=THINK_EXCLUDE_TOKENS
+                triggers=[TOOL_CALL_TRIGGER],
+                tags=tags,
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+            )
 
     elif tool_choice == "forced":
         if not tools:
@@ -1027,6 +1081,7 @@ def get_qwen_3_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Qwen3 style structural tag format.
@@ -1079,10 +1134,14 @@ def get_qwen_3_structural_tag(
             )
         if len(tags) > 0:
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=THINK_EXCLUDE_TOKENS
+                triggers=[TOOL_CALL_TRIGGER],
+                tags=tags,
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+            )
 
     elif tool_choice == "forced":
         if not tools:
@@ -1132,6 +1191,7 @@ def get_harmony_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get harmony(gpt-oss) style structural tag format.
@@ -1263,6 +1323,7 @@ def get_deepseek_v3_2_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V3.2 style structural tag format.
@@ -1323,10 +1384,12 @@ def get_deepseek_v3_2_structural_tag(
                         end=FUNCTION_CALLS_END,
                     )
                 ],
-                excludes=THINK_EXCLUDE_TOKENS,
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+            )
 
     elif tool_choice == "forced":
         if not tools:
@@ -1387,6 +1450,7 @@ def get_minimax_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get MiniMax-M2.5 style structural tag format.
@@ -1446,10 +1510,12 @@ def get_minimax_structural_tag(
                         begin=TOOL_CALL_BEGIN, content=function_calling_tags, end=TOOL_CALL_END
                     )
                 ],
-                excludes=THINK_EXCLUDE_TOKENS,
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+            )
 
     elif tool_choice == "forced":
         if not tools:
@@ -1512,6 +1578,7 @@ def get_glm_4_7_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get GLM-4.7/GLM-5 style structural tag format.
@@ -1579,10 +1646,14 @@ def get_glm_4_7_structural_tag(
 
         if len(tags) > 0:
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=TEXT_EXCLUDES
+                triggers=[TOOL_CALL_TRIGGER],
+                tags=tags,
+                excludes=_text_excludes(exclude_special_tokens_in_text, TEXT_EXCLUDES),
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=REASONING_EXCLUDES)
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(exclude_special_tokens_in_text, REASONING_EXCLUDES)
+            )
 
     elif tool_choice == "forced":
         if not tools:
@@ -1617,7 +1688,11 @@ def get_glm_4_7_structural_tag(
         return StructuralTag(format=suffix_tag)
 
     prefix_tag = TagFormat(
-        begin="", content=AnyTextFormat(excludes=REASONING_EXCLUDES), end=THINK_TAG_END
+        begin="",
+        content=AnyTextFormat(
+            excludes=_text_excludes(exclude_special_tokens_in_text, REASONING_EXCLUDES)
+        ),
+        end=THINK_TAG_END,
     )
 
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
@@ -1632,6 +1707,7 @@ def _get_gemma_4_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Gemma 4 style structural tag format.
@@ -1695,10 +1771,14 @@ def _get_gemma_4_structural_tag(
 
         if len(tags) > 0:
             suffix_tag = TriggeredTagsFormat(
-                triggers=[TOOL_CALL_TRIGGER], tags=tags, excludes=GEMMA4_EXCLUDE_TOKENS
+                triggers=[TOOL_CALL_TRIGGER],
+                tags=tags,
+                excludes=_text_excludes(exclude_special_tokens_in_text, GEMMA4_EXCLUDE_TOKENS),
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=GEMMA4_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(exclude_special_tokens_in_text, GEMMA4_EXCLUDE_TOKENS)
+            )
 
     elif tool_choice == "forced":
         if not tools:
@@ -1742,6 +1822,7 @@ def get_deepseek_v4_structural_tag(
     tool_choice: Literal["auto", "required", "forced"] = "auto",
     reasoning: bool = True,
     any_order: bool = False,
+    exclude_special_tokens_in_text: bool = True,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V4 style structural tag format.
@@ -1800,10 +1881,12 @@ def get_deepseek_v4_structural_tag(
                         end=FUNCTION_CALLS_END,
                     )
                 ],
-                excludes=THINK_EXCLUDE_TOKENS,
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS),
             )
         else:
-            suffix_tag = AnyTextFormat(excludes=THINK_EXCLUDE_TOKENS)
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(exclude_special_tokens_in_text, THINK_EXCLUDE_TOKENS)
+            )
 
     elif tool_choice == "forced":
         if not tools:

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -551,7 +551,7 @@ def test_kimi_auto_requires_tool_calls_section():
     # <|tool_call_begin|> outside the <|tool_calls_section_begin|> wrapper. It is
     # on by default; passed explicitly here to make the dependency clear.
     structural_tag = get_model_structural_tag(
-        "kimi", tools=_tools_kimi, reasoning=False, exclude_special_tokens_in_text=True
+        "kimi", tools=_tools_kimi, reasoning=False, exclude_special_tokens=True
     )
 
     assert "<|tool_calls_section_begin|>" in structural_tag.model_dump_json()
@@ -656,7 +656,7 @@ def test_specific_functions_cases(structural_tag_fn, case: Dict[str, Any]):
     assert None not in _collect_json_schema_values(structural_tag)
 
 
-# ---------- Test: exclude_special_tokens_in_text ----------
+# ---------- Test: exclude_special_tokens ----------
 
 # Model keys whose built-in structural tags forbid special tokens (e.g. <think>)
 # from appearing in free-text spans when the exclusion is enabled. Harmony has no
@@ -678,7 +678,7 @@ _EXCLUDE_TOKEN_MODELS = [
 @pytest.mark.parametrize("model", _EXCLUDE_TOKEN_MODELS)
 # Tools present -> TriggeredTagsFormat excludes; no tools -> AnyTextFormat excludes.
 @pytest.mark.parametrize("tools", [make_tools(["search"]), []])
-def test_exclude_special_tokens_in_text_default_excludes_think_tokens(model, tools):
+def test_exclude_special_tokens_default_excludes_think_tokens(model, tools):
     """By default the built-in structural tag excludes the special tokens from free text."""
 
     structural_tag = get_model_structural_tag(model, tools=tools, reasoning=True)
@@ -690,11 +690,11 @@ def test_exclude_special_tokens_in_text_default_excludes_think_tokens(model, too
 
 @pytest.mark.parametrize("model", _EXCLUDE_TOKEN_MODELS)
 @pytest.mark.parametrize("tools", [make_tools(["search"]), []])
-def test_exclude_special_tokens_in_text_false_excludes_nothing(model, tools):
-    """Opting out with ``exclude_special_tokens_in_text=False`` excludes nothing from free text."""
+def test_exclude_special_tokens_false_excludes_nothing(model, tools):
+    """Opting out with ``exclude_special_tokens=False`` excludes nothing from free text."""
 
     structural_tag = get_model_structural_tag(
-        model, tools=tools, reasoning=True, exclude_special_tokens_in_text=False
+        model, tools=tools, reasoning=True, exclude_special_tokens=False
     )
     assert all(excludes == [] for excludes in _collect_excludes(structural_tag))
     # The less-restrictive grammar must still build.
@@ -702,24 +702,24 @@ def test_exclude_special_tokens_in_text_false_excludes_nothing(model, tools):
 
 
 @pytest.mark.parametrize("flag", [False, True])
-def test_exclude_special_tokens_in_text_harmony_is_no_op(flag):
+def test_exclude_special_tokens_harmony_is_no_op(flag):
     """Harmony has no special tokens to exclude, so the flag never adds excludes."""
 
     structural_tag = get_model_structural_tag(
-        "harmony", tools=make_tools(["search"]), exclude_special_tokens_in_text=flag
+        "harmony", tools=make_tools(["search"]), exclude_special_tokens=flag
     )
     assert all(excludes == [] for excludes in _collect_excludes(structural_tag))
 
 
-def test_exclude_special_tokens_in_text_passed_to_specific_function():
+def test_exclude_special_tokens_passed_to_specific_function():
     """The flag also reaches the model-specific builders directly via kwargs."""
 
     tools = [FunctionToolParam(function={"name": "search", "parameters": SIMPLE_SCHEMA})]
 
-    off = get_qwen_3_structural_tag(tools=tools, exclude_special_tokens_in_text=False)
+    off = get_qwen_3_structural_tag(tools=tools, exclude_special_tokens=False)
     assert all(excludes == [] for excludes in _collect_excludes(off))
 
-    on = get_qwen_3_structural_tag(tools=tools, exclude_special_tokens_in_text=True)
+    on = get_qwen_3_structural_tag(tools=tools, exclude_special_tokens=True)
     flat = [token for excludes in _collect_excludes(on) for token in excludes]
     assert "<think>" in flat
     assert "</think>" in flat
@@ -836,7 +836,7 @@ def test_strict_or_missing_parameters(
     # without the tool-calls section) get rejected; passed explicitly here to
     # make the dependency clear.
     stag = get_model_structural_tag(
-        format_type, tools=tools, reasoning=False, exclude_special_tokens_in_text=True
+        format_type, tools=tools, reasoning=False, exclude_special_tokens=True
     )
 
     check_stag_with_instance(stag, instance, is_accepted)

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -157,6 +157,16 @@ def _collect_json_schema_values(structural_tag: StructuralTag) -> List[Any]:
     ]
 
 
+def _collect_excludes(structural_tag: StructuralTag) -> List[List[str]]:
+    """Collect every ``excludes`` list from nested AnyText / TriggeredTags nodes."""
+
+    return [
+        list(format_obj.excludes)
+        for format_obj in _walk_structural_format(structural_tag.format)
+        if getattr(format_obj, "excludes", None) is not None
+    ]
+
+
 # ---------- Shared tool definitions ----------
 
 SIMPLE_SCHEMA = {"type": "object", "properties": {"q": {"type": "string"}}}
@@ -537,7 +547,12 @@ def test_harmony_builtin_tool_instance():
 def test_kimi_auto_requires_tool_calls_section():
     """Kimi auto tool calls must use the official section wrapper."""
 
-    structural_tag = get_model_structural_tag("kimi", tools=_tools_kimi, reasoning=False)
+    # Excluding special tokens in free text is what forbids a bare
+    # <|tool_call_begin|> outside the <|tool_calls_section_begin|> wrapper. It is
+    # on by default; passed explicitly here to make the dependency clear.
+    structural_tag = get_model_structural_tag(
+        "kimi", tools=_tools_kimi, reasoning=False, exclude_special_tokens_in_text=True
+    )
 
     assert "<|tool_calls_section_begin|>" in structural_tag.model_dump_json()
     check_stag_with_instance(
@@ -639,6 +654,75 @@ def test_specific_functions_cases(structural_tag_fn, case: Dict[str, Any]):
     assert isinstance(structural_tag, StructuralTag)
     xgr.Grammar.from_structural_tag(structural_tag)
     assert None not in _collect_json_schema_values(structural_tag)
+
+
+# ---------- Test: exclude_special_tokens_in_text ----------
+
+# Model keys whose built-in structural tags forbid special tokens (e.g. <think>)
+# from appearing in free-text spans when the exclusion is enabled. Harmony has no
+# such excludes and is covered separately.
+_EXCLUDE_TOKEN_MODELS = [
+    "llama",
+    "kimi",
+    "deepseek_r1",
+    "deepseek_v3_1",
+    "deepseek_v3_2",
+    "deepseek_v4",
+    "qwen_3",
+    "qwen_3_5",
+    "minimax",
+    "glm_4_7",
+]
+
+
+@pytest.mark.parametrize("model", _EXCLUDE_TOKEN_MODELS)
+# Tools present -> TriggeredTagsFormat excludes; no tools -> AnyTextFormat excludes.
+@pytest.mark.parametrize("tools", [make_tools(["search"]), []])
+def test_exclude_special_tokens_in_text_default_excludes_think_tokens(model, tools):
+    """By default the built-in structural tag excludes the special tokens from free text."""
+
+    structural_tag = get_model_structural_tag(model, tools=tools, reasoning=True)
+    flat = [token for excludes in _collect_excludes(structural_tag) for token in excludes]
+    assert "<think>" in flat
+    assert "</think>" in flat
+    xgr.Grammar.from_structural_tag(structural_tag)
+
+
+@pytest.mark.parametrize("model", _EXCLUDE_TOKEN_MODELS)
+@pytest.mark.parametrize("tools", [make_tools(["search"]), []])
+def test_exclude_special_tokens_in_text_false_excludes_nothing(model, tools):
+    """Opting out with ``exclude_special_tokens_in_text=False`` excludes nothing from free text."""
+
+    structural_tag = get_model_structural_tag(
+        model, tools=tools, reasoning=True, exclude_special_tokens_in_text=False
+    )
+    assert all(excludes == [] for excludes in _collect_excludes(structural_tag))
+    # The less-restrictive grammar must still build.
+    xgr.Grammar.from_structural_tag(structural_tag)
+
+
+@pytest.mark.parametrize("flag", [False, True])
+def test_exclude_special_tokens_in_text_harmony_is_no_op(flag):
+    """Harmony has no special tokens to exclude, so the flag never adds excludes."""
+
+    structural_tag = get_model_structural_tag(
+        "harmony", tools=make_tools(["search"]), exclude_special_tokens_in_text=flag
+    )
+    assert all(excludes == [] for excludes in _collect_excludes(structural_tag))
+
+
+def test_exclude_special_tokens_in_text_passed_to_specific_function():
+    """The flag also reaches the model-specific builders directly via kwargs."""
+
+    tools = [FunctionToolParam(function={"name": "search", "parameters": SIMPLE_SCHEMA})]
+
+    off = get_qwen_3_structural_tag(tools=tools, exclude_special_tokens_in_text=False)
+    assert all(excludes == [] for excludes in _collect_excludes(off))
+
+    on = get_qwen_3_structural_tag(tools=tools, exclude_special_tokens_in_text=True)
+    flat = [token for excludes in _collect_excludes(on) for token in excludes]
+    assert "<think>" in flat
+    assert "</think>" in flat
 
 
 @pytest.mark.parametrize(
@@ -746,12 +830,14 @@ def test_strict_or_missing_parameters(
     format_type: str, instance: str, is_accepted: bool, tool: Dict[str, Any]
 ):
     """strict=False or missing 'parameters' should still accept/reject instances correctly."""
-    if format_type == "harmony":
-        tools = [tool]
-        stag = get_model_structural_tag(format_type, tools=tools, reasoning=False)
-    else:
-        tools = [tool]
-        stag = get_model_structural_tag(format_type, tools=tools, reasoning=False)
+    tools = [tool]
+    # Special-token exclusion (on by default) is what makes markers appearing
+    # outside their required wrapper (e.g. a bare Kimi <|tool_call_begin|>
+    # without the tool-calls section) get rejected; passed explicitly here to
+    # make the dependency clear.
+    stag = get_model_structural_tag(
+        format_type, tools=tools, reasoning=False, exclude_special_tokens_in_text=True
+    )
 
     check_stag_with_instance(stag, instance, is_accepted)
 


### PR DESCRIPTION
This PR provides a new parameter `exclude_special_tokens_in_text` to control whether the special tokens will be excluded during the triggered format and the reasoning part. When it's `False`, the behavior is consistent with the current main branch, and the behavior will change when it's `True`. Default is `True` now.