### PR TITLE
fix: fix the returned type of serialzation.

### DIFF
--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -57,7 +57,7 @@ class CompiledGrammar(XGRObject):
         json_string : str
             The JSON string.
         """
-        return self._handle.serialize_json()
+        return str(self._handle.serialize_json())
 
     @staticmethod
     def deserialize_json(json_str: str, tokenizer_info: TokenizerInfo) -> "CompiledGrammar":

--- a/python/xgrammar/config.py
+++ b/python/xgrammar/config.py
@@ -61,4 +61,4 @@ def get_serialization_version() -> str:
     serialization_version : str
         The serialization version number.
     """
-    return _core.config.get_serialization_version()
+    return str(_core.config.get_serialization_version())

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -149,7 +149,7 @@ class Grammar(XGRObject):
         grammar_string : str
             The BNF grammar string.
         """
-        return self._handle.to_string()
+        return str(self._handle.to_string())
 
     @staticmethod
     def from_ebnf(ebnf_string: str, *, root_rule_name: str = "root") -> "Grammar":
@@ -405,7 +405,7 @@ class Grammar(XGRObject):
         json_string : str
             The JSON string.
         """
-        return self._handle.serialize_json()
+        return str(self._handle.serialize_json())
 
     @staticmethod
     def deserialize_json(json_string: str) -> "Grammar":

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -390,7 +390,7 @@ class GrammarMatcher(XGRObject):
         jump_forward_string : str
             The jump-forward string.
         """
-        return self._handle.find_jump_forward_string()
+        return str(self._handle.find_jump_forward_string())
 
     def rollback(self, num_tokens: int = 1) -> None:
         """Rollback the matcher to a previous state by several tokens.
@@ -476,7 +476,7 @@ class GrammarMatcher(XGRObject):
         internal_state : str
             The internal state of the matcher.
         """
-        return self._handle._debug_print_internal_state()
+        return str(self._handle._debug_print_internal_state())
 
 
 class BatchGrammarMatcher(XGRObject):

--- a/python/xgrammar/tokenizer_info.py
+++ b/python/xgrammar/tokenizer_info.py
@@ -388,7 +388,7 @@ class TokenizerInfo(XGRObject):
     def dump_metadata(self) -> str:
         """Dump the metadata of the tokenizer to a json string. It can be used to construct the
         tokenizer info from the vocabulary and the metadata string."""
-        return self._handle.dump_metadata()
+        return str(self._handle.dump_metadata())
 
     @staticmethod
     def from_vocab_and_metadata(
@@ -432,7 +432,7 @@ class TokenizerInfo(XGRObject):
         json_string : str
             The JSON string.
         """
-        return self._handle.serialize_json()
+        return str(self._handle.serialize_json())
 
     @staticmethod
     def deserialize_json(json_string: str) -> "TokenizerInfo":

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import json
+import subprocess
 import sys
+import textwrap
 from typing import Any, List, Tuple
 
 import pytest
@@ -368,6 +370,41 @@ def test_serialize_grammar_utf8():
     assert _is_grammar_accept_string(recovered_grammar, "你好")
     assert _is_grammar_accept_string(recovered_grammar, "hello")
     assert _is_grammar_accept_string(recovered_grammar, "\n")
+
+
+def test_serialized_output_survives_pickle():
+    """Pickling serialized output must not crash (regression for the diskcache segfault).
+
+    Run in a subprocess so a regression shows up as a non-zero return code instead of
+    segfaulting the whole pytest session.
+    """
+    script = textwrap.dedent(
+        """
+        import pickle
+        import xgrammar as xgr
+
+        grammar = xgr.Grammar.from_ebnf('root ::= "a"')
+        tokenizer_info = xgr.TokenizerInfo(
+            ["a", "b"], vocab_type=xgr.VocabType.BYTE_FALLBACK, vocab_size=2
+        )
+        compiled_grammar = xgr.GrammarCompiler(tokenizer_info).compile_grammar(grammar)
+
+        values = [
+            xgr.get_serialization_version(),
+            grammar.serialize_json(),
+            tokenizer_info.serialize_json(),
+            compiled_grammar.serialize_json(),
+        ]
+        for value in values:
+            assert pickle.loads(pickle.dumps(value)) == value
+        print("PICKLE_OK")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=300
+    )
+    assert result.returncode == 0, f"returncode={result.returncode}\n{result.stderr[-2000:]}"
+    assert "PICKLE_OK" in result.stdout
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As reported in #664, this PR fixes the serialization issue. The root reason is that tvm-ffi returns an `ffi::string`, which will be broken when being pickled. This PR fixes the issue by explicitly converting the return value to str.