### PR TITLE
fix: handle negative zero float ranges

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2875,6 +2875,8 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
           }
         }
       }
+    } else if (isStartNegative) {
+      parts.push_back(std::to_string(startInt) + "\\.0{1," + std::to_string(precision) + "}");
     }
 
     if (startInt < INT64_MAX - 1) {
@@ -2930,6 +2932,8 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
           }
         }
       }
+    } else if (!isEndNegative) {
+      parts.push_back(std::to_string(endInt) + "\\.0{1," + std::to_string(precision) + "}");
     }
 
     if (endInt > INT64_MIN + 1) {
@@ -2963,6 +2967,10 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
         std::string intRangeRegex = GenerateRangeRegex(startInt + 1, endInt - 1);
         intRangeRegex = intRangeRegex.substr(1, intRangeRegex.length() - 2);
         parts.push_back(intRangeRegex + "(\\.\\d{1," + std::to_string(precision) + "})?");
+      }
+
+      if (start.value() < 0.0 && end.value() > 0.0) {
+        parts.push_back("-0\\.\\d{1," + std::to_string(precision) + "}");
       }
 
       if (startFrac > 0.0) {
@@ -3008,6 +3016,8 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
             }
           }
         }
+      } else if (isStartNegative) {
+        parts.push_back(std::to_string(startInt) + "\\.0{1," + std::to_string(precision) + "}");
       } else {
         parts.push_back(std::to_string(startInt) + "\\.\\d{1," + std::to_string(precision) + "}");
       }
@@ -3054,8 +3064,10 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
             }
           }
         }
-      } else {
+      } else if (isEndNegative) {
         parts.push_back(std::to_string(endInt) + "\\.\\d{1," + std::to_string(precision) + "}");
+      } else {
+        parts.push_back(std::to_string(endInt) + "\\.0{1," + std::to_string(precision) + "}");
       }
     }
   }

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2969,7 +2969,7 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
         parts.push_back(intRangeRegex + "(\\.\\d{1," + std::to_string(precision) + "})?");
       }
 
-      if (start.value() < 0.0 && end.value() > 0.0) {
+      if (start.value() <= -1.0 && end.value() > 0.0) {
         parts.push_back("-0\\.\\d{1," + std::to_string(precision) + "}");
       }
 
@@ -3070,6 +3070,11 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
         parts.push_back(std::to_string(endInt) + "\\.0{1," + std::to_string(precision) + "}");
       }
     }
+  }
+
+  if (start && startInt == -1 && startFrac > 0.0) {
+    const std::string negative_zero_wildcard = "-0\\.\\d{1," + std::to_string(precision) + "}";
+    parts.erase(std::remove(parts.begin(), parts.end(), negative_zero_wildcard), parts.end());
   }
 
   std::ostringstream result;

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2940,10 +2940,14 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
       parts.push_back(std::to_string(endInt) + "\\.\\d{1," + std::to_string(precision) + "}");
     }
 
-    if (endInt > INT64_MIN + 1) {
-      std::string intRangeRegex = GenerateRangeRegex(std::nullopt, endInt - 1);
+    int64_t intRangeEnd = endFrac > 0.0 && endInt < 0 ? endInt : endInt - 1;
+    if (intRangeEnd > INT64_MIN) {
+      std::string intRangeRegex = GenerateRangeRegex(std::nullopt, intRangeEnd);
       intRangeRegex = intRangeRegex.substr(1, intRangeRegex.length() - 2);
       parts.push_back(intRangeRegex + "(\\.\\d{1," + std::to_string(precision) + "})?");
+    }
+    if (endFrac > 0.0 && endInt >= 0) {
+      parts.push_back(std::to_string(endInt));
     }
   } else if (start && end) {
     if (startInt == endInt) {
@@ -2957,6 +2961,9 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
         if (startStr != endStr) {
           parts.push_back(EscapeDotForRegex(endStr));
         }
+        if (start.value() <= 0.0 && end.value() >= 0.0) {
+          parts.push_back("0\\.0{1," + std::to_string(precision) + "}");
+        }
       }
     } else {
       std::string startStr = FormatFloat(start.value(), precision);
@@ -2967,10 +2974,17 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
         parts.push_back(EscapeDotForRegex(endStr));
       }
 
-      if (endInt > startInt + 1) {
-        std::string intRangeRegex = GenerateRangeRegex(startInt + 1, endInt - 1);
+      int64_t intRangeEnd = endFrac > 0.0 && endInt < 0 ? endInt : endInt - 1;
+      if (intRangeEnd > startInt) {
+        std::string intRangeRegex = GenerateRangeRegex(startInt + 1, intRangeEnd);
         intRangeRegex = intRangeRegex.substr(1, intRangeRegex.length() - 2);
         parts.push_back(intRangeRegex + "(\\.\\d{1," + std::to_string(precision) + "})?");
+      }
+      if ((startInt + 1 > 0 || intRangeEnd < 0) && start.value() <= 0.0 && end.value() >= 0.0) {
+        parts.push_back("0\\.0{1," + std::to_string(precision) + "}");
+      }
+      if (endFrac > 0.0 && endInt >= 0 && static_cast<double>(endInt) >= start.value()) {
+        parts.push_back(std::to_string(endInt));
       }
 
       if (start.value() <= -1.0 && end.value() > 0.0) {

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2656,7 +2656,7 @@ std::string JSONSchemaConverter::GenerateRangeRegex(
 
       if (len == 1) {
         parts.push_back(MakePatternForDigitRange(start_str[0], '9', 0));
-        parts.push_back("[1-9]\\d*");
+        parts.push_back("[1-9]\\d+");
       } else {
         parts.push_back(start_str);
 
@@ -2696,7 +2696,7 @@ std::string JSONSchemaConverter::GenerateRangeRegex(
 
       if (len == 1) {
         parts.push_back("-" + MakePatternForDigitRange(end_str[0], '9', 0));
-        parts.push_back("-[1-9]\\d*");
+        parts.push_back("-[1-9]\\d+");
       } else {
         parts.push_back(std::to_string(end.value()));
 
@@ -2877,6 +2877,8 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
       }
     } else if (isStartNegative) {
       parts.push_back(std::to_string(startInt) + "\\.0{1," + std::to_string(precision) + "}");
+    } else {
+      parts.push_back(std::to_string(startInt) + "\\.\\d{1," + std::to_string(precision) + "}");
     }
 
     if (startInt < INT64_MAX - 1) {
@@ -2934,6 +2936,8 @@ std::string JSONSchemaConverter::GenerateFloatRangeRegex(
       }
     } else if (!isEndNegative) {
       parts.push_back(std::to_string(endInt) + "\\.0{1," + std::to_string(precision) + "}");
+    } else {
+      parts.push_back(std::to_string(endInt) + "\\.\\d{1," + std::to_string(precision) + "}");
     }
 
     if (endInt > INT64_MIN + 1) {

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -1612,7 +1612,7 @@ def test_generate_range_regex():
 
     # Unbounded ranges (None cases)
     assert _generate_range_regex(None, None) == r"^-?\d+$"
-    assert _generate_range_regex(5, None) == r"^([5-9]|[1-9]\d*)$"
+    assert _generate_range_regex(5, None) == r"^([5-9]|[1-9]\d+)$"
     assert _generate_range_regex(None, 0) == r"^(-[1-9]\d*|0)$"
 
     # Medium range
@@ -2267,12 +2267,12 @@ def test_generate_float_regex():
 
     assert (
         _generate_float_regex(0.5, None)
-        == r"^(0\.5|0\.6\d{0,5}|0\.7\d{0,5}|0\.8\d{0,5}|0\.9\d{0,5}|([1-9]|[1-9]\d*)(\.\d{1,6})?)$"
+        == r"^(0\.5|0\.6\d{0,5}|0\.7\d{0,5}|0\.8\d{0,5}|0\.9\d{0,5}|([1-9]|[1-9]\d+)(\.\d{1,6})?)$"
     )
 
     assert (
         _generate_float_regex(None, -1.5)
-        == r"^(-1\.5|-1\.6\d{0,5}|-1\.7\d{0,5}|-1\.8\d{0,5}|-1\.9\d{0,5}|(-[3-9]|-[1-9]\d*)(\.\d{1,6})?)$"
+        == r"^(-1\.5|-1\.6\d{0,5}|-1\.7\d{0,5}|-1\.8\d{0,5}|-1\.9\d{0,5}|(-[3-9]|-[1-9]\d+)(\.\d{1,6})?)$"
     )
 
     assert _generate_float_regex(None, None) == r"^-?\d+(\.\d{1,6})?$"
@@ -2312,6 +2312,23 @@ def test_generate_float_regex_cross_zero_accepts_negative_zero_decimal():
     check_schema_with_instance(near_zero_schema, "-0.1")
     check_schema_with_instance(near_zero_schema, "-0.5")
     check_schema_with_instance(near_zero_schema, "-0.9", is_accepted=False)
+
+
+def test_generate_float_regex_one_sided_integer_boundaries():
+    minimum_regex = re.compile(_generate_float_regex(4.0, None))
+    assert minimum_regex.fullmatch("4.1") is not None
+    assert minimum_regex.fullmatch("4.999999") is not None
+    assert minimum_regex.fullmatch("3.999999") is None
+
+    maximum_regex = re.compile(_generate_float_regex(None, -4.0))
+    assert maximum_regex.fullmatch("-4.1") is not None
+    assert maximum_regex.fullmatch("-4.999999") is not None
+    assert maximum_regex.fullmatch("-3.999999") is None
+
+    check_schema_with_instance({"type": "number", "minimum": 4.0}, "4.1")
+    check_schema_with_instance({"type": "number", "minimum": 4.0}, "3.9", is_accepted=False)
+    check_schema_with_instance({"type": "number", "maximum": -4.0}, "-4.1")
+    check_schema_with_instance({"type": "number", "maximum": -4.0}, "-3.9", is_accepted=False)
 
 
 def test_float_minimum_no_wildcard_in_grammar():

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2257,12 +2257,12 @@ def test_generate_float_regex():
 
     assert (
         _generate_float_regex(1.5, 5.75)
-        == r"^(1\.5|5\.75|(([2-4]))(\.\d{1,6})?|1\.6\d{0,5}|1\.7\d{0,5}|1\.8\d{0,5}|1\.9\d{0,5}|5\.0\d{0,5}|5\.1\d{0,5}|5\.2\d{0,5}|5\.3\d{0,5}|5\.4\d{0,5}|5\.5\d{0,5}|5\.6\d{0,5}|5\.70\d{0,4}|5\.71\d{0,4}|5\.72\d{0,4}|5\.73\d{0,4}|5\.74\d{0,4})$"
+        == r"^(1\.5|5\.75|(([2-4]))(\.\d{1,6})?|5|1\.6\d{0,5}|1\.7\d{0,5}|1\.8\d{0,5}|1\.9\d{0,5}|5\.0\d{0,5}|5\.1\d{0,5}|5\.2\d{0,5}|5\.3\d{0,5}|5\.4\d{0,5}|5\.5\d{0,5}|5\.6\d{0,5}|5\.70\d{0,4}|5\.71\d{0,4}|5\.72\d{0,4}|5\.73\d{0,4}|5\.74\d{0,4})$"
     )
 
     assert (
         _generate_float_regex(-3.14, 2.71828)
-        == r"^(-3\.14|2\.71828|(-([1-3])|0|(1))(\.\d{1,6})?|-0\.\d{1,6}|-3\.0\d{0,5}|-3\.10\d{0,4}|-3\.11\d{0,4}|-3\.12\d{0,4}|-3\.13\d{0,4}|2\.0\d{0,5}|2\.1\d{0,5}|2\.2\d{0,5}|2\.3\d{0,5}|2\.4\d{0,5}|2\.5\d{0,5}|2\.6\d{0,5}|2\.70\d{0,4}|2\.710\d{0,3}|2\.711\d{0,3}|2\.712\d{0,3}|2\.713\d{0,3}|2\.714\d{0,3}|2\.715\d{0,3}|2\.716\d{0,3}|2\.717\d{0,3}|2\.7180\d{0,2}|2\.7181\d{0,2}|2\.71820\d{0,1}|2\.71821\d{0,1}|2\.71822\d{0,1}|2\.71823\d{0,1}|2\.71824\d{0,1}|2\.71825\d{0,1}|2\.71826\d{0,1}|2\.71827\d{0,1})$"
+        == r"^(-3\.14|2\.71828|(-([1-3])|0|(1))(\.\d{1,6})?|2|-0\.\d{1,6}|-3\.0\d{0,5}|-3\.10\d{0,4}|-3\.11\d{0,4}|-3\.12\d{0,4}|-3\.13\d{0,4}|2\.0\d{0,5}|2\.1\d{0,5}|2\.2\d{0,5}|2\.3\d{0,5}|2\.4\d{0,5}|2\.5\d{0,5}|2\.6\d{0,5}|2\.70\d{0,4}|2\.710\d{0,3}|2\.711\d{0,3}|2\.712\d{0,3}|2\.713\d{0,3}|2\.714\d{0,3}|2\.715\d{0,3}|2\.716\d{0,3}|2\.717\d{0,3}|2\.7180\d{0,2}|2\.7181\d{0,2}|2\.71820\d{0,1}|2\.71821\d{0,1}|2\.71822\d{0,1}|2\.71823\d{0,1}|2\.71824\d{0,1}|2\.71825\d{0,1}|2\.71826\d{0,1}|2\.71827\d{0,1})$"
     )
 
     assert (
@@ -2272,7 +2272,7 @@ def test_generate_float_regex():
 
     assert (
         _generate_float_regex(None, -1.5)
-        == r"^(-1\.5|-1\.6\d{0,5}|-1\.7\d{0,5}|-1\.8\d{0,5}|-1\.9\d{0,5}|(-[3-9]|-[1-9]\d+)(\.\d{1,6})?)$"
+        == r"^(-1\.5|-1\.6\d{0,5}|-1\.7\d{0,5}|-1\.8\d{0,5}|-1\.9\d{0,5}|(-[2-9]|-[1-9]\d+)(\.\d{1,6})?)$"
     )
 
     assert _generate_float_regex(None, None) == r"^-?\d+(\.\d{1,6})?$"
@@ -2285,7 +2285,7 @@ def test_generate_float_regex():
 
     assert (
         _generate_float_regex(-0.000001, 0.000001)
-        == r"^(-0\.000001|0\.000001|-0\.000000\d{0,0}|0\.000000\d{0,0})$"
+        == r"^(-0\.000001|0\.000001|0\.0{1,6}|0|-0\.000000\d{0,0}|0\.000000\d{0,0})$"
     )
 
 
@@ -2329,6 +2329,23 @@ def test_generate_float_regex_one_sided_integer_boundaries():
     check_schema_with_instance({"type": "number", "minimum": 4.0}, "3.9", is_accepted=False)
     check_schema_with_instance({"type": "number", "maximum": -4.0}, "-4.1")
     check_schema_with_instance({"type": "number", "maximum": -4.0}, "-3.9", is_accepted=False)
+
+
+def test_generate_float_regex_fractional_upper_bound_includes_floor_integer():
+    positive_regex = re.compile(_generate_float_regex(1.5, 5.75))
+    assert positive_regex.fullmatch("5") is not None
+    assert positive_regex.fullmatch("5.75") is not None
+    assert positive_regex.fullmatch("6") is None
+
+    negative_regex = re.compile(_generate_float_regex(None, -1.5))
+    assert negative_regex.fullmatch("-2") is not None
+    assert negative_regex.fullmatch("-2.0") is not None
+    assert negative_regex.fullmatch("-1") is None
+
+    mixed_regex = re.compile(_generate_float_regex(-3.14, 2.71828))
+    assert mixed_regex.fullmatch("2") is not None
+    assert mixed_regex.fullmatch("2.71828") is not None
+    assert mixed_regex.fullmatch("3") is None
 
 
 def test_float_minimum_no_wildcard_in_grammar():

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -1,4 +1,5 @@
 import json
+import re
 import sys
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
@@ -2252,7 +2253,7 @@ def test_primitive_type_object():
 
 
 def test_generate_float_regex():
-    assert _generate_float_regex(1.0, 5.0) == r"^(1|5|(([2-4]))(\.\d{1,6})?|1\.\d{1,6}|5\.\d{1,6})$"
+    assert _generate_float_regex(1.0, 5.0) == r"^(1|5|(([2-4]))(\.\d{1,6})?|1\.\d{1,6}|5\.0{1,6})$"
 
     assert (
         _generate_float_regex(1.5, 5.75)
@@ -2261,7 +2262,7 @@ def test_generate_float_regex():
 
     assert (
         _generate_float_regex(-3.14, 2.71828)
-        == r"^(-3\.14|2\.71828|(-([1-3])|0|(1))(\.\d{1,6})?|-3\.0\d{0,5}|-3\.10\d{0,4}|-3\.11\d{0,4}|-3\.12\d{0,4}|-3\.13\d{0,4}|2\.0\d{0,5}|2\.1\d{0,5}|2\.2\d{0,5}|2\.3\d{0,5}|2\.4\d{0,5}|2\.5\d{0,5}|2\.6\d{0,5}|2\.70\d{0,4}|2\.710\d{0,3}|2\.711\d{0,3}|2\.712\d{0,3}|2\.713\d{0,3}|2\.714\d{0,3}|2\.715\d{0,3}|2\.716\d{0,3}|2\.717\d{0,3}|2\.7180\d{0,2}|2\.7181\d{0,2}|2\.71820\d{0,1}|2\.71821\d{0,1}|2\.71822\d{0,1}|2\.71823\d{0,1}|2\.71824\d{0,1}|2\.71825\d{0,1}|2\.71826\d{0,1}|2\.71827\d{0,1})$"
+        == r"^(-3\.14|2\.71828|(-([1-3])|0|(1))(\.\d{1,6})?|-0\.\d{1,6}|-3\.0\d{0,5}|-3\.10\d{0,4}|-3\.11\d{0,4}|-3\.12\d{0,4}|-3\.13\d{0,4}|2\.0\d{0,5}|2\.1\d{0,5}|2\.2\d{0,5}|2\.3\d{0,5}|2\.4\d{0,5}|2\.5\d{0,5}|2\.6\d{0,5}|2\.70\d{0,4}|2\.710\d{0,3}|2\.711\d{0,3}|2\.712\d{0,3}|2\.713\d{0,3}|2\.714\d{0,3}|2\.715\d{0,3}|2\.716\d{0,3}|2\.717\d{0,3}|2\.7180\d{0,2}|2\.7181\d{0,2}|2\.71820\d{0,1}|2\.71821\d{0,1}|2\.71822\d{0,1}|2\.71823\d{0,1}|2\.71824\d{0,1}|2\.71825\d{0,1}|2\.71826\d{0,1}|2\.71827\d{0,1})$"
     )
 
     assert (
@@ -2284,8 +2285,23 @@ def test_generate_float_regex():
 
     assert (
         _generate_float_regex(-0.000001, 0.000001)
-        == r"^(-0\.000001|0\.000001|-0\.000000\d{0,0}|0\.000000\d{0,0})$"
+        == r"^(-0\.000001|0\.000001|-0\.\d{1,6}|-0\.000000\d{0,0}|0\.000000\d{0,0})$"
     )
+
+
+def test_generate_float_regex_cross_zero_accepts_negative_zero_decimal():
+    regex = re.compile(_generate_float_regex(-4.0, 4.0))
+    for value in ("-0.1", "-0.5", "-0.999999"):
+        assert regex.fullmatch(value) is not None
+    assert regex.fullmatch("-0") is None
+    assert regex.fullmatch("-4.1") is None
+    assert regex.fullmatch("4.1") is None
+
+    schema = {"type": "number", "minimum": -4.0, "maximum": 4.0}
+    check_schema_with_instance(schema, "-0.5")
+    check_schema_with_instance(schema, "-0.1")
+    check_schema_with_instance(schema, "-4.1", is_accepted=False)
+    check_schema_with_instance(schema, "4.1", is_accepted=False)
 
 
 def test_float_minimum_no_wildcard_in_grammar():

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2285,7 +2285,7 @@ def test_generate_float_regex():
 
     assert (
         _generate_float_regex(-0.000001, 0.000001)
-        == r"^(-0\.000001|0\.000001|-0\.\d{1,6}|-0\.000000\d{0,0}|0\.000000\d{0,0})$"
+        == r"^(-0\.000001|0\.000001|-0\.000000\d{0,0}|0\.000000\d{0,0})$"
     )
 
 
@@ -2297,11 +2297,21 @@ def test_generate_float_regex_cross_zero_accepts_negative_zero_decimal():
     assert regex.fullmatch("-4.1") is None
     assert regex.fullmatch("4.1") is None
 
+    near_zero_regex = re.compile(_generate_float_regex(-0.5, 0.5))
+    assert near_zero_regex.fullmatch("-0.1") is not None
+    assert near_zero_regex.fullmatch("-0.5") is not None
+    assert near_zero_regex.fullmatch("-0.9") is None
+
     schema = {"type": "number", "minimum": -4.0, "maximum": 4.0}
     check_schema_with_instance(schema, "-0.5")
     check_schema_with_instance(schema, "-0.1")
     check_schema_with_instance(schema, "-4.1", is_accepted=False)
     check_schema_with_instance(schema, "4.1", is_accepted=False)
+
+    near_zero_schema = {"type": "number", "minimum": -0.5, "maximum": 0.5}
+    check_schema_with_instance(near_zero_schema, "-0.1")
+    check_schema_with_instance(near_zero_schema, "-0.5")
+    check_schema_with_instance(near_zero_schema, "-0.9", is_accepted=False)
 
 
 def test_float_minimum_no_wildcard_in_grammar():


### PR DESCRIPTION
## Summary
- allow JSON schema float ranges that cross zero to match negative-zero decimals such as `-0.5`
- keep one-sided integer boundaries tight so `minimum: 4.0` rejects `3.999999` and `maximum: -4.0` rejects `-3.999999`
- include the integer floor of fractional upper bounds, e.g. `5` for `[1.5, 5.75]` and `-2` for `(-inf, -1.5]`, without broadening tiny ranges like `[-0.000001, 0.000001]`

Fixes #662.

## Testing
- `PATH=/private/tmp/codex-pytools/bin:$PATH cmake --build build -j 10`
- `PATH=/private/tmp/codex-pytools/bin:$PATH .venv/bin/python -m pip install --no-build-isolation -e .`
- `PYTHONPATH=python .venv/bin/python -m pytest tests/python/test_json_schema_converter.py -q` (`326 passed`)
- `PYTHONPATH=python .venv/bin/python -m ruff check tests/python/test_json_schema_converter.py`
- `git diff --check`
- local regex spot-check for `(-inf, -1.5]`, `[-4, 4]`, `[4, inf)`, `[1.5, 5.75]`, and `[-0.000001, 0.000001]`

I used AI assistance to inspect the existing range-generation code and reviewed the final diff/tests before pushing.
