### PR TITLE
fix: reject unsupported overlapping `oneOf` schemas

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -116,6 +116,10 @@ std::string AnyOfSpec::ToString() const {
   return "AnyOfSpec{options.size()=" + std::to_string(options.size()) + "}";
 }
 
+std::string OneOfSpec::ToString() const {
+  return "OneOfSpec{options.size()=" + std::to_string(options.size()) + "}";
+}
+
 std::string AllOfSpec::ToString() const {
   return "AllOfSpec{schemas.size()=" + std::to_string(schemas.size()) + "}";
 }
@@ -154,6 +158,178 @@ bool HasMultipleInRange(int64_t start, int64_t end, int64_t multiple_of) {
   for (int64_t value = start; value <= end; ++value) {
     if (IsMultipleOf(value, multiple_of)) return true;
     if (value == std::numeric_limits<int64_t>::max()) break;
+  }
+  return false;
+}
+
+constexpr const char* kUnsupportedOneOfMessage =
+    "oneOf with overlapping or non-provably-disjoint branches is not supported; use anyOf for "
+    "union semantics or add a discriminator";
+
+bool IsSchemaAnnotationKey(const std::string& key) {
+  static const std::unordered_set<std::string> kAnnotationKeys = {
+      "title",
+      "default",
+      "description",
+      "examples",
+      "deprecated",
+      "readOnly",
+      "writeOnly",
+      "$comment",
+      "$schema",
+  };
+  return kAnnotationKeys.count(key) != 0;
+}
+
+bool HasOnlyKeys(
+    const picojson::object& schema, const std::unordered_set<std::string>& allowed_keys
+) {
+  for (const auto& [key, _] : schema) {
+    if (allowed_keys.count(key) == 0 && !IsSchemaAnnotationKey(key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IsSupportedJSONType(const std::string& type) {
+  static const std::unordered_set<std::string> kTypes = {
+      "null",
+      "boolean",
+      "object",
+      "array",
+      "number",
+      "string",
+      "integer",
+  };
+  return kTypes.count(type) != 0;
+}
+
+bool NormalizeTypeSet(
+    const picojson::value& type_value, std::unordered_set<std::string>* type_set
+) {
+  if (type_value.is<std::string>()) {
+    const auto& type = type_value.get<std::string>();
+    if (!IsSupportedJSONType(type)) {
+      return false;
+    }
+    type_set->insert(type);
+    return true;
+  }
+  if (!type_value.is<picojson::array>()) {
+    return false;
+  }
+
+  const auto& type_array = type_value.get<picojson::array>();
+  if (type_array.empty()) {
+    return false;
+  }
+  for (const auto& item : type_array) {
+    if (!item.is<std::string>()) {
+      return false;
+    }
+    const auto& type = item.get<std::string>();
+    if (!IsSupportedJSONType(type)) {
+      return false;
+    }
+    type_set->insert(type);
+  }
+  return true;
+}
+
+bool IsNumericValue(const picojson::value& value) {
+  return value.is<int64_t>() || value.is<double>();
+}
+
+long double GetNumericValue(const picojson::value& value) {
+  if (value.is<int64_t>()) {
+    return static_cast<long double>(value.get<int64_t>());
+  }
+  return static_cast<long double>(value.get<double>());
+}
+
+bool IsIntegerValue(const picojson::value& value) {
+  if (value.is<int64_t>()) {
+    return true;
+  }
+  if (!value.is<double>()) {
+    return false;
+  }
+  double number = value.get<double>();
+  return std::isfinite(number) && std::floor(number) == number;
+}
+
+bool JSONValuesEqual(const picojson::value& lhs, const picojson::value& rhs) {
+  if (IsNumericValue(lhs) && IsNumericValue(rhs)) {
+    return GetNumericValue(lhs) == GetNumericValue(rhs);
+  }
+  if (lhs.is<picojson::null>() || rhs.is<picojson::null>()) {
+    return lhs.is<picojson::null>() && rhs.is<picojson::null>();
+  }
+  if (lhs.is<bool>() || rhs.is<bool>()) {
+    return lhs.is<bool>() && rhs.is<bool>() && lhs.get<bool>() == rhs.get<bool>();
+  }
+  if (lhs.is<std::string>() || rhs.is<std::string>()) {
+    return lhs.is<std::string>() && rhs.is<std::string>() &&
+           lhs.get<std::string>() == rhs.get<std::string>();
+  }
+  if (lhs.is<picojson::array>() || rhs.is<picojson::array>()) {
+    if (!lhs.is<picojson::array>() || !rhs.is<picojson::array>()) {
+      return false;
+    }
+    const auto& lhs_array = lhs.get<picojson::array>();
+    const auto& rhs_array = rhs.get<picojson::array>();
+    if (lhs_array.size() != rhs_array.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < lhs_array.size(); ++i) {
+      if (!JSONValuesEqual(lhs_array[i], rhs_array[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  if (lhs.is<picojson::object>() || rhs.is<picojson::object>()) {
+    if (!lhs.is<picojson::object>() || !rhs.is<picojson::object>()) {
+      return false;
+    }
+    const auto& lhs_object = lhs.get<picojson::object>();
+    const auto& rhs_object = rhs.get<picojson::object>();
+    if (lhs_object.size() != rhs_object.size()) {
+      return false;
+    }
+    for (const auto& [key, lhs_value] : lhs_object) {
+      auto rhs_it = rhs_object.find(key);
+      if (rhs_it == rhs_object.end() || !JSONValuesEqual(lhs_value, rhs_it->second)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return lhs.serialize() == rhs.serialize();
+}
+
+bool ValueMatchesType(const picojson::value& value, const std::string& type) {
+  if (type == "null") {
+    return value.is<picojson::null>();
+  }
+  if (type == "boolean") {
+    return value.is<bool>();
+  }
+  if (type == "string") {
+    return value.is<std::string>();
+  }
+  if (type == "integer") {
+    return IsIntegerValue(value);
+  }
+  if (type == "number") {
+    return IsNumericValue(value);
+  }
+  if (type == "array") {
+    return value.is<picojson::array>();
+  }
+  if (type == "object") {
+    return value.is<picojson::object>();
   }
   return false;
 }
@@ -221,6 +397,272 @@ std::string JoinRegexAlternatives(const std::vector<std::string>& alternatives) 
   return result;
 }
 
+bool TypeSetsOverlap(
+    const std::unordered_set<std::string>& lhs, const std::unordered_set<std::string>& rhs
+) {
+  for (const auto& lhs_type : lhs) {
+    for (const auto& rhs_type : rhs) {
+      if (lhs_type == rhs_type) {
+        return true;
+      }
+      if ((lhs_type == "integer" || lhs_type == "number") &&
+          (rhs_type == "integer" || rhs_type == "number")) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool FiniteValuesOverlap(
+    const std::vector<picojson::value>& lhs, const std::vector<picojson::value>& rhs
+) {
+  for (const auto& lhs_value : lhs) {
+    for (const auto& rhs_value : rhs) {
+      if (JSONValuesEqual(lhs_value, rhs_value)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool FiniteValuesOverlapTypeSet(
+    const std::vector<picojson::value>& values, const std::unordered_set<std::string>& type_set
+) {
+  for (const auto& value : values) {
+    for (const auto& type : type_set) {
+      if (ValueMatchesType(value, type)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool TryGetFiniteValues(
+    const picojson::object& schema, std::vector<picojson::value>* values, bool require_pure_schema
+) {
+  if (schema.count("const")) {
+    if (require_pure_schema && !HasOnlyKeys(schema, {"const"})) {
+      return false;
+    }
+    values->push_back(schema.at("const"));
+    return true;
+  }
+  if (schema.count("enum")) {
+    if (require_pure_schema && !HasOnlyKeys(schema, {"enum"})) {
+      return false;
+    }
+    if (!schema.at("enum").is<picojson::array>()) {
+      return false;
+    }
+    const auto& enum_values = schema.at("enum").get<picojson::array>();
+    if (enum_values.empty()) {
+      return false;
+    }
+    values->insert(values->end(), enum_values.begin(), enum_values.end());
+    return true;
+  }
+  return false;
+}
+
+struct OneOfArmProof {
+  enum class Kind { kTypeSet, kFiniteValues };
+
+  Kind kind;
+  std::unordered_set<std::string> type_set;
+  std::vector<picojson::value> finite_values;
+};
+
+std::optional<OneOfArmProof> ClassifyTypeOrFiniteOneOfArm(const picojson::value& option) {
+  if (!option.is<picojson::object>()) {
+    return std::nullopt;
+  }
+  const auto& schema = option.get<picojson::object>();
+
+  if (schema.count("$ref") || schema.count("anyOf") || schema.count("allOf") ||
+      schema.count("oneOf")) {
+    return std::nullopt;
+  }
+
+  std::vector<picojson::value> finite_values;
+  if (TryGetFiniteValues(schema, &finite_values, true)) {
+    OneOfArmProof proof;
+    proof.kind = OneOfArmProof::Kind::kFiniteValues;
+    proof.finite_values = std::move(finite_values);
+    return proof;
+  }
+
+  if (!schema.count("type") || !HasOnlyKeys(schema, {"type"})) {
+    return std::nullopt;
+  }
+
+  std::unordered_set<std::string> type_set;
+  if (!NormalizeTypeSet(schema.at("type"), &type_set)) {
+    return std::nullopt;
+  }
+  if (type_set.count("object")) {
+    return std::nullopt;
+  }
+
+  OneOfArmProof proof;
+  proof.kind = OneOfArmProof::Kind::kTypeSet;
+  proof.type_set = std::move(type_set);
+  return proof;
+}
+
+bool OneOfArmProofsAreDisjoint(const OneOfArmProof& lhs, const OneOfArmProof& rhs) {
+  if (lhs.kind == OneOfArmProof::Kind::kTypeSet && rhs.kind == OneOfArmProof::Kind::kTypeSet) {
+    return !TypeSetsOverlap(lhs.type_set, rhs.type_set);
+  }
+  if (lhs.kind == OneOfArmProof::Kind::kFiniteValues &&
+      rhs.kind == OneOfArmProof::Kind::kFiniteValues) {
+    return !FiniteValuesOverlap(lhs.finite_values, rhs.finite_values);
+  }
+  if (lhs.kind == OneOfArmProof::Kind::kFiniteValues && rhs.kind == OneOfArmProof::Kind::kTypeSet) {
+    return !FiniteValuesOverlapTypeSet(lhs.finite_values, rhs.type_set);
+  }
+  return !FiniteValuesOverlapTypeSet(rhs.finite_values, lhs.type_set);
+}
+
+std::optional<std::vector<picojson::value>> GetDiscriminatorValues(
+    const picojson::value& option, const std::string& discriminator_key
+) {
+  if (!option.is<picojson::object>()) {
+    return std::nullopt;
+  }
+  const auto& schema = option.get<picojson::object>();
+  if (schema.count("$ref") || schema.count("anyOf") || schema.count("allOf") ||
+      schema.count("oneOf")) {
+    return std::nullopt;
+  }
+  if (!schema.count("type") || !schema.at("type").is<std::string>() ||
+      schema.at("type").get<std::string>() != "object") {
+    return std::nullopt;
+  }
+  if (!schema.count("required") || !schema.at("required").is<picojson::array>()) {
+    return std::nullopt;
+  }
+
+  bool requires_discriminator = false;
+  for (const auto& required_key : schema.at("required").get<picojson::array>()) {
+    if (!required_key.is<std::string>()) {
+      return std::nullopt;
+    }
+    if (required_key.get<std::string>() == discriminator_key) {
+      requires_discriminator = true;
+    }
+  }
+  if (!requires_discriminator) {
+    return std::nullopt;
+  }
+
+  if (!schema.count("properties") || !schema.at("properties").is<picojson::object>()) {
+    return std::nullopt;
+  }
+  const auto& properties = schema.at("properties").get<picojson::object>();
+  auto property_it = properties.find(discriminator_key);
+  if (property_it == properties.end() || !property_it->second.is<picojson::object>()) {
+    return std::nullopt;
+  }
+
+  std::vector<picojson::value> values;
+  if (!TryGetFiniteValues(property_it->second.get<picojson::object>(), &values, true)) {
+    return std::nullopt;
+  }
+  return values;
+}
+
+std::vector<std::string> GetDiscriminatorCandidates(const picojson::value& option) {
+  std::vector<std::string> candidates;
+  if (!option.is<picojson::object>()) {
+    return candidates;
+  }
+  const auto& schema = option.get<picojson::object>();
+  if (!schema.count("required") || !schema.at("required").is<picojson::array>() ||
+      !schema.count("properties") || !schema.at("properties").is<picojson::object>()) {
+    return candidates;
+  }
+  const auto& properties = schema.at("properties").get<picojson::object>();
+  for (const auto& required_key : schema.at("required").get<picojson::array>()) {
+    if (!required_key.is<std::string>()) {
+      continue;
+    }
+    const auto& key = required_key.get<std::string>();
+    auto property_it = properties.find(key);
+    if (property_it == properties.end() || !property_it->second.is<picojson::object>()) {
+      continue;
+    }
+    std::vector<picojson::value> values;
+    if (TryGetFiniteValues(property_it->second.get<picojson::object>(), &values, true)) {
+      candidates.push_back(key);
+    }
+  }
+  return candidates;
+}
+
+bool TryProveStrictDiscriminatorOneOf(const picojson::array& options) {
+  if (options.empty()) {
+    return false;
+  }
+
+  for (const auto& discriminator_key : GetDiscriminatorCandidates(options.front())) {
+    std::vector<std::vector<picojson::value>> branch_values;
+    bool all_branches_have_key = true;
+    for (const auto& option : options) {
+      auto values = GetDiscriminatorValues(option, discriminator_key);
+      if (!values.has_value()) {
+        all_branches_have_key = false;
+        break;
+      }
+      branch_values.push_back(std::move(values.value()));
+    }
+    if (!all_branches_have_key) {
+      continue;
+    }
+
+    bool pairwise_disjoint = true;
+    for (size_t i = 0; i < branch_values.size() && pairwise_disjoint; ++i) {
+      for (size_t j = i + 1; j < branch_values.size(); ++j) {
+        if (FiniteValuesOverlap(branch_values[i], branch_values[j])) {
+          pairwise_disjoint = false;
+          break;
+        }
+      }
+    }
+    if (pairwise_disjoint) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool TryProveTypeOrFiniteOneOf(const picojson::array& options) {
+  std::vector<OneOfArmProof> proofs;
+  proofs.reserve(options.size());
+  for (const auto& option : options) {
+    auto proof = ClassifyTypeOrFiniteOneOfArm(option);
+    if (!proof.has_value()) {
+      return false;
+    }
+    proofs.push_back(std::move(proof.value()));
+  }
+
+  for (size_t i = 0; i < proofs.size(); ++i) {
+    for (size_t j = i + 1; j < proofs.size(); ++j) {
+      if (!OneOfArmProofsAreDisjoint(proofs[i], proofs[j])) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool TryProvePairwiseDisjointOneOf(const picojson::array& options) {
+  return TryProveStrictDiscriminatorOneOf(options) || TryProveTypeOrFiniteOneOf(options);
+}
+
 /*!
  * \brief Parser for JSON Schema, converts JSON Schema to SchemaSpec intermediate representation.
  */
@@ -259,6 +701,7 @@ class SchemaParser {
   Result<EnumSpec, SchemaError> ParseEnum(const picojson::object& schema);
   Result<RefSpec, SchemaError> ParseRef(const picojson::object& schema);
   Result<AnyOfSpec, SchemaError> ParseAnyOf(const picojson::object& schema);
+  Result<OneOfSpec, SchemaError> ParseOneOf(const picojson::object& schema);
   Result<AllOfSpec, SchemaError> ParseAllOf(const picojson::object& schema);
   Result<TypeArraySpec, SchemaError> ParseTypeArray(
       const picojson::object& schema, const std::string& rule_name_hint
@@ -385,10 +828,14 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
     auto enum_result = ParseEnum(schema_obj);
     if (enum_result.IsErr()) return ResultErr(std::move(enum_result).UnwrapErr());
     result = SchemaSpec::Make(std::move(enum_result).Unwrap(), cache_key, rule_name_hint);
-  } else if (schema_obj.count("anyOf") || schema_obj.count("oneOf")) {
+  } else if (schema_obj.count("anyOf")) {
     auto anyof_result = ParseAnyOf(schema_obj);
     if (anyof_result.IsErr()) return ResultErr(std::move(anyof_result).UnwrapErr());
     result = SchemaSpec::Make(std::move(anyof_result).Unwrap(), cache_key, rule_name_hint);
+  } else if (schema_obj.count("oneOf")) {
+    auto oneof_result = ParseOneOf(schema_obj);
+    if (oneof_result.IsErr()) return ResultErr(std::move(oneof_result).UnwrapErr());
+    result = SchemaSpec::Make(std::move(oneof_result).Unwrap(), cache_key, rule_name_hint);
   } else if (schema_obj.count("allOf")) {
     auto allof_result = ParseAllOf(schema_obj);
     if (allof_result.IsErr()) return ResultErr(std::move(allof_result).UnwrapErr());
@@ -1050,19 +1497,38 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::ResolveRef(
 
 Result<AnyOfSpec, SchemaError> SchemaParser::ParseAnyOf(const picojson::object& schema) {
   AnyOfSpec spec;
-  auto anyof_key = schema.count("anyOf") ? "anyOf" : "oneOf";
-  if (!schema.at(anyof_key).is<picojson::array>()) {
-    return ResultErr<SchemaError>(
-        SchemaErrorType::kInvalidSchema, std::string(anyof_key) + " must be an array"
-    );
+  if (!schema.at("anyOf").is<picojson::array>()) {
+    return ResultErr<SchemaError>(SchemaErrorType::kInvalidSchema, "anyOf must be an array");
   }
   int idx = 0;
-  for (const auto& option : schema.at(anyof_key).get<picojson::array>()) {
+  for (const auto& option : schema.at("anyOf").get<picojson::array>()) {
     auto option_result = Parse(option, "case_" + std::to_string(idx));
     if (option_result.IsErr()) return ResultErr(std::move(option_result).UnwrapErr());
     spec.options.push_back(std::move(option_result).Unwrap());
     ++idx;
   }
+  return ResultOk(std::move(spec));
+}
+
+Result<OneOfSpec, SchemaError> SchemaParser::ParseOneOf(const picojson::object& schema) {
+  OneOfSpec spec;
+  if (!schema.at("oneOf").is<picojson::array>()) {
+    return ResultErr<SchemaError>(SchemaErrorType::kInvalidSchema, "oneOf must be an array");
+  }
+
+  const auto& options = schema.at("oneOf").get<picojson::array>();
+  int idx = 0;
+  for (const auto& option : options) {
+    auto option_result = Parse(option, "case_" + std::to_string(idx));
+    if (option_result.IsErr()) return ResultErr(std::move(option_result).UnwrapErr());
+    spec.options.push_back(std::move(option_result).Unwrap());
+    ++idx;
+  }
+
+  if (!TryProvePairwiseDisjointOneOf(options)) {
+    return ResultErr<SchemaError>(SchemaErrorType::kUnsupportedSchema, kUnsupportedOneOfMessage);
+  }
+
   return ResultOk(std::move(spec));
 }
 
@@ -1554,6 +2020,8 @@ std::string JSONSchemaConverter::GenerateFromSpec(
           return GenerateRef(s, rule_name_hint);
         } else if constexpr (std::is_same_v<T, AnyOfSpec>) {
           return GenerateAnyOf(s, rule_name_hint);
+        } else if constexpr (std::is_same_v<T, OneOfSpec>) {
+          return GenerateOneOf(s, rule_name_hint);
         } else if constexpr (std::is_same_v<T, AllOfSpec>) {
           return GenerateAllOf(s, rule_name_hint);
         } else if constexpr (std::is_same_v<T, TypeArraySpec>) {
@@ -2522,6 +2990,19 @@ std::string JSONSchemaConverter::GenerateRef(const RefSpec& spec, const std::str
 
 std::string JSONSchemaConverter::GenerateAnyOf(
     const AnyOfSpec& spec, const std::string& rule_name
+) {
+  std::string result = "";
+  for (size_t i = 0; i < spec.options.size(); ++i) {
+    if (i != 0) {
+      result += " | ";
+    }
+    result += CreateRule(spec.options[i], rule_name + "_case_" + std::to_string(i));
+  }
+  return result;
+}
+
+std::string JSONSchemaConverter::GenerateOneOf(
+    const OneOfSpec& spec, const std::string& rule_name
 ) {
   std::string result = "";
   for (size_t i = 0; i < spec.options.size(); ++i) {

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -163,8 +163,8 @@ bool HasMultipleInRange(int64_t start, int64_t end, int64_t multiple_of) {
 }
 
 constexpr const char* kUnsupportedOneOfMessage =
-    "oneOf with overlapping or non-provably-disjoint branches is not supported; use anyOf for "
-    "union semantics or add a discriminator";
+    "oneOf with overlapping or non-provably-disjoint branches cannot be represented exactly; "
+    "falling back to anyOf semantics";
 
 bool IsSchemaAnnotationKey(const std::string& key) {
   static const std::unordered_set<std::string> kAnnotationKeys = {
@@ -694,7 +694,9 @@ class SchemaParser {
   Result<ConstSpec, SchemaError> ParseConst(const picojson::object& schema);
   Result<EnumSpec, SchemaError> ParseEnum(const picojson::object& schema);
   Result<RefSpec, SchemaError> ParseRef(const picojson::object& schema);
-  Result<AnyOfSpec, SchemaError> ParseAnyOf(const picojson::object& schema);
+  Result<AnyOfSpec, SchemaError> ParseAnyOf(
+      const picojson::object& schema, const std::string& keyword
+  );
   Result<OneOfSpec, SchemaError> ParseOneOf(const picojson::object& schema);
   Result<AllOfSpec, SchemaError> ParseAllOf(const picojson::object& schema);
   Result<TypeArraySpec, SchemaError> ParseTypeArray(
@@ -823,13 +825,22 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
     if (enum_result.IsErr()) return ResultErr(std::move(enum_result).UnwrapErr());
     result = SchemaSpec::Make(std::move(enum_result).Unwrap(), cache_key, rule_name_hint);
   } else if (schema_obj.count("anyOf")) {
-    auto anyof_result = ParseAnyOf(schema_obj);
+    auto anyof_result = ParseAnyOf(schema_obj, "anyOf");
     if (anyof_result.IsErr()) return ResultErr(std::move(anyof_result).UnwrapErr());
     result = SchemaSpec::Make(std::move(anyof_result).Unwrap(), cache_key, rule_name_hint);
   } else if (schema_obj.count("oneOf")) {
     auto oneof_result = ParseOneOf(schema_obj);
-    if (oneof_result.IsErr()) return ResultErr(std::move(oneof_result).UnwrapErr());
-    result = SchemaSpec::Make(std::move(oneof_result).Unwrap(), cache_key, rule_name_hint);
+    if (oneof_result.IsErr()) {
+      if (oneof_result.ErrRef().Type() != SchemaErrorType::kUnsupportedSchema) {
+        return ResultErr(std::move(oneof_result).UnwrapErr());
+      }
+      XGRAMMAR_LOG(WARNING) << oneof_result.ErrRef().what();
+      auto anyof_result = ParseAnyOf(schema_obj, "oneOf");
+      if (anyof_result.IsErr()) return ResultErr(std::move(anyof_result).UnwrapErr());
+      result = SchemaSpec::Make(std::move(anyof_result).Unwrap(), cache_key, rule_name_hint);
+    } else {
+      result = SchemaSpec::Make(std::move(oneof_result).Unwrap(), cache_key, rule_name_hint);
+    }
   } else if (schema_obj.count("allOf")) {
     auto allof_result = ParseAllOf(schema_obj);
     if (allof_result.IsErr()) return ResultErr(std::move(allof_result).UnwrapErr());
@@ -1489,13 +1500,15 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::ResolveRef(
   return ResultOk(resolved);
 }
 
-Result<AnyOfSpec, SchemaError> SchemaParser::ParseAnyOf(const picojson::object& schema) {
+Result<AnyOfSpec, SchemaError> SchemaParser::ParseAnyOf(
+    const picojson::object& schema, const std::string& keyword
+) {
   AnyOfSpec spec;
-  if (!schema.at("anyOf").is<picojson::array>()) {
-    return ResultErr<SchemaError>(SchemaErrorType::kInvalidSchema, "anyOf must be an array");
+  if (!schema.at(keyword).is<picojson::array>()) {
+    return ResultErr<SchemaError>(SchemaErrorType::kInvalidSchema, keyword + " must be an array");
   }
   int idx = 0;
-  for (const auto& option : schema.at("anyOf").get<picojson::array>()) {
+  for (const auto& option : schema.at(keyword).get<picojson::array>()) {
     auto option_result = Parse(option, "case_" + std::to_string(idx));
     if (option_result.IsErr()) return ResultErr(std::move(option_result).UnwrapErr());
     spec.options.push_back(std::move(option_result).Unwrap());

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -241,13 +241,6 @@ bool IsNumericValue(const picojson::value& value) {
   return value.is<int64_t>() || value.is<double>();
 }
 
-long double GetNumericValue(const picojson::value& value) {
-  if (value.is<int64_t>()) {
-    return static_cast<long double>(value.get<int64_t>());
-  }
-  return static_cast<long double>(value.get<double>());
-}
-
 bool IsIntegerValue(const picojson::value& value) {
   if (value.is<int64_t>()) {
     return true;
@@ -259,9 +252,15 @@ bool IsIntegerValue(const picojson::value& value) {
   return std::isfinite(number) && std::floor(number) == number;
 }
 
-bool JSONValuesEqual(const picojson::value& lhs, const picojson::value& rhs) {
-  if (IsNumericValue(lhs) && IsNumericValue(rhs)) {
-    return GetNumericValue(lhs) == GetNumericValue(rhs);
+bool JSONValuesMayOverlap(const picojson::value& lhs, const picojson::value& rhs) {
+  if (IsNumericValue(lhs) || IsNumericValue(rhs)) {
+    if (!IsNumericValue(lhs) || !IsNumericValue(rhs)) {
+      return false;
+    }
+    if (lhs.is<int64_t>() && rhs.is<int64_t>()) {
+      return lhs.get<int64_t>() == rhs.get<int64_t>();
+    }
+    return true;
   }
   if (lhs.is<picojson::null>() || rhs.is<picojson::null>()) {
     return lhs.is<picojson::null>() && rhs.is<picojson::null>();
@@ -283,7 +282,7 @@ bool JSONValuesEqual(const picojson::value& lhs, const picojson::value& rhs) {
       return false;
     }
     for (size_t i = 0; i < lhs_array.size(); ++i) {
-      if (!JSONValuesEqual(lhs_array[i], rhs_array[i])) {
+      if (!JSONValuesMayOverlap(lhs_array[i], rhs_array[i])) {
         return false;
       }
     }
@@ -300,7 +299,7 @@ bool JSONValuesEqual(const picojson::value& lhs, const picojson::value& rhs) {
     }
     for (const auto& [key, lhs_value] : lhs_object) {
       auto rhs_it = rhs_object.find(key);
-      if (rhs_it == rhs_object.end() || !JSONValuesEqual(lhs_value, rhs_it->second)) {
+      if (rhs_it == rhs_object.end() || !JSONValuesMayOverlap(lhs_value, rhs_it->second)) {
         return false;
       }
     }
@@ -419,7 +418,7 @@ bool FiniteValuesOverlap(
 ) {
   for (const auto& lhs_value : lhs) {
     for (const auto& rhs_value : rhs) {
-      if (JSONValuesEqual(lhs_value, rhs_value)) {
+      if (JSONValuesMayOverlap(lhs_value, rhs_value)) {
         return true;
       }
     }
@@ -431,6 +430,9 @@ bool FiniteValuesOverlapTypeSet(
     const std::vector<picojson::value>& values, const std::unordered_set<std::string>& type_set
 ) {
   for (const auto& value : values) {
+    if (IsNumericValue(value) && (type_set.count("integer") || type_set.count("number"))) {
+      return true;
+    }
     for (const auto& type : type_set) {
       if (ValueMatchesType(value, type)) {
         return true;
@@ -1517,6 +1519,10 @@ Result<OneOfSpec, SchemaError> SchemaParser::ParseOneOf(const picojson::object& 
   }
 
   const auto& options = schema.at("oneOf").get<picojson::array>();
+  if (options.empty()) {
+    return ResultErr<SchemaError>(SchemaErrorType::kUnsupportedSchema, kUnsupportedOneOfMessage);
+  }
+
   int idx = 0;
   for (const auto& option : options) {
     auto option_result = Parse(option, "case_" + std::to_string(idx));

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -442,20 +442,12 @@ bool FiniteValuesOverlapTypeSet(
   return false;
 }
 
-bool TryGetFiniteValues(
-    const picojson::object& schema, std::vector<picojson::value>* values, bool require_pure_schema
-) {
+bool TryGetFiniteValues(const picojson::object& schema, std::vector<picojson::value>* values) {
   if (schema.count("const")) {
-    if (require_pure_schema && !HasOnlyKeys(schema, {"const"})) {
-      return false;
-    }
     values->push_back(schema.at("const"));
     return true;
   }
   if (schema.count("enum")) {
-    if (require_pure_schema && !HasOnlyKeys(schema, {"enum"})) {
-      return false;
-    }
     if (!schema.at("enum").is<picojson::array>()) {
       return false;
     }
@@ -489,7 +481,7 @@ std::optional<OneOfArmProof> ClassifyTypeOrFiniteOneOfArm(const picojson::value&
   }
 
   std::vector<picojson::value> finite_values;
-  if (TryGetFiniteValues(schema, &finite_values, true)) {
+  if (TryGetFiniteValues(schema, &finite_values)) {
     OneOfArmProof proof;
     proof.kind = OneOfArmProof::Kind::kFiniteValues;
     proof.finite_values = std::move(finite_values);
@@ -570,7 +562,7 @@ std::optional<std::vector<picojson::value>> GetDiscriminatorValues(
   }
 
   std::vector<picojson::value> values;
-  if (!TryGetFiniteValues(property_it->second.get<picojson::object>(), &values, true)) {
+  if (!TryGetFiniteValues(property_it->second.get<picojson::object>(), &values)) {
     return std::nullopt;
   }
   return values;
@@ -597,7 +589,7 @@ std::vector<std::string> GetDiscriminatorCandidates(const picojson::value& optio
       continue;
     }
     std::vector<picojson::value> values;
-    if (TryGetFiniteValues(property_it->second.get<picojson::object>(), &values, true)) {
+    if (TryGetFiniteValues(property_it->second.get<picojson::object>(), &values)) {
       candidates.push_back(key);
     }
   }

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -133,6 +133,12 @@ struct AnyOfSpec {
   std::string ToString() const;
 };
 
+struct OneOfSpec {
+  std::vector<SchemaSpecPtr> options;
+
+  std::string ToString() const;
+};
+
 struct AllOfSpec {
   std::vector<SchemaSpecPtr> schemas;
 
@@ -160,6 +166,7 @@ using SchemaSpecVariant = std::variant<
     EnumSpec,
     RefSpec,
     AnyOfSpec,
+    OneOfSpec,
     AllOfSpec,
     TypeArraySpec>;
 
@@ -300,6 +307,7 @@ class JSONSchemaConverter {
   virtual std::string GenerateEnum(const EnumSpec& spec, const std::string& rule_name);
   virtual std::string GenerateRef(const RefSpec& spec, const std::string& rule_name);
   virtual std::string GenerateAnyOf(const AnyOfSpec& spec, const std::string& rule_name);
+  virtual std::string GenerateOneOf(const OneOfSpec& spec, const std::string& rule_name);
   virtual std::string GenerateAllOf(const AllOfSpec& spec, const std::string& rule_name);
   virtual std::string GenerateTypeArray(const TypeArraySpec& spec, const std::string& rule_name);
 

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -790,17 +790,23 @@ def test_anyof_oneof():
 
 
 def test_oneof_unsupported_overlap_fails_closed():
-    def assert_oneof_unsupported(schema: Dict[str, Any]):
+    def assert_oneof_unsupported(schema: Union[Dict[str, Any], str]):
         with pytest.raises(Exception) as e:
             xgr.Grammar.from_json_schema(schema, any_whitespace=False)
         assert "oneOf with overlapping or non-provably-disjoint branches is not supported" in str(
             e.value
         )
 
+    assert_oneof_unsupported({"oneOf": []})
     assert_oneof_unsupported({"oneOf": [{"type": "integer"}, {"type": "number"}]})
     assert_oneof_unsupported({"oneOf": [{"type": ["integer", "string"]}, {"type": "number"}]})
     assert_oneof_unsupported({"oneOf": [{"type": "integer"}, {}]})
     assert_oneof_unsupported({"oneOf": [{"const": 1}, {"const": 1.0}]})
+    assert_oneof_unsupported('{"oneOf":[{"const":9007199254740993},{"const":9007199254740993.0}]}')
+    assert_oneof_unsupported('{"oneOf":[{"const":1.5},{"const":2.5}]}')
+    assert_oneof_unsupported(
+        '{"oneOf":[{"enum":[9007199254740993]},{"enum":[9007199254740993.0]}]}'
+    )
     assert_oneof_unsupported({"oneOf": [{"enum": [1, "hello", 2]}, {"type": "integer"}]})
     assert_oneof_unsupported(
         {
@@ -832,6 +838,12 @@ def test_oneof_disjoint_cases():
     check_schema_with_instance(schema, '"cat"', any_whitespace=False)
     check_schema_with_instance(schema, '"dog"', any_whitespace=False)
     check_schema_with_instance(schema, '"fish"', is_accepted=False, any_whitespace=False)
+
+    schema = '{"oneOf":[{"const":9007199254740992},{"const":9007199254740993}]}'
+    grammar = xgr.Grammar.from_json_schema(schema, any_whitespace=False)
+    assert _is_grammar_accept_string(grammar, "9007199254740992")
+    assert _is_grammar_accept_string(grammar, "9007199254740993")
+    assert not _is_grammar_accept_string(grammar, "9007199254740994")
 
     schema = {
         "oneOf": [

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -805,27 +805,16 @@ def test_oneof_unsupported_overlap_warns_and_falls_back(capfd):
             assert not _is_grammar_accept_string(grammar, instance)
 
     assert_oneof_falls_back(
-        {"oneOf": [{"type": "integer"}, {"type": "number"}]},
-        ["1", "1.5"],
-        ['"x"'],
+        {"oneOf": [{"type": "integer"}, {"type": "number"}]}, ["1", "1.5"], ['"x"']
     )
     assert_oneof_falls_back(
-        {"oneOf": [{"type": ["integer", "string"]}, {"type": "number"}]},
-        ["1", '"x"', "1.5"],
+        {"oneOf": [{"type": ["integer", "string"]}, {"type": "number"}]}, ["1", '"x"', "1.5"]
     )
     assert_oneof_falls_back({"oneOf": [{"type": "integer"}, {}]}, ["1", "true"])
     assert_oneof_falls_back({"oneOf": [{"const": 1}, {"const": 1.0}]}, ["1"])
-    assert_oneof_falls_back(
-        '{"oneOf":[{"const":9007199254740993},{"const":9007199254740993.0}]}'
-    )
-    assert_oneof_falls_back(
-        '{"oneOf":[{"const":1.5},{"const":2.5}]}',
-        ["1.5", "2.5"],
-        ["3.5"],
-    )
-    assert_oneof_falls_back(
-        '{"oneOf":[{"enum":[9007199254740993]},{"enum":[9007199254740993.0]}]}'
-    )
+    assert_oneof_falls_back('{"oneOf":[{"const":9007199254740993},{"const":9007199254740993.0}]}')
+    assert_oneof_falls_back('{"oneOf":[{"const":1.5},{"const":2.5}]}', ["1.5", "2.5"], ["3.5"])
+    assert_oneof_falls_back('{"oneOf":[{"enum":[9007199254740993]},{"enum":[9007199254740993.0]}]}')
     assert_oneof_falls_back({"oneOf": [{"enum": [1, "hello", 2]}, {"type": "integer"}]}, ["1", "3"])
     assert_oneof_falls_back(
         {
@@ -845,7 +834,10 @@ def test_oneof_unsupported_overlap_warns_and_falls_back(capfd):
         ["1", "1.5", '"x"'],
     )
     assert_oneof_falls_back(
-        {"oneOf": [{"type": "integer"}, {"$ref": "#/$defs/x"}], "$defs": {"x": {"type": "integer"}}},
+        {
+            "oneOf": [{"type": "integer"}, {"$ref": "#/$defs/x"}],
+            "$defs": {"x": {"type": "integer"}},
+        },
         ["1"],
     )
 

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -789,26 +789,45 @@ def test_anyof_oneof():
     check_schema_with_instance(schema, schema_rejected, is_accepted=False, any_whitespace=False)
 
 
-def test_oneof_unsupported_overlap_fails_closed():
-    def assert_oneof_unsupported(schema: Union[Dict[str, Any], str]):
-        with pytest.raises(Exception) as e:
-            xgr.Grammar.from_json_schema(schema, any_whitespace=False)
-        assert "oneOf with overlapping or non-provably-disjoint branches is not supported" in str(
-            e.value
-        )
+def test_oneof_unsupported_overlap_warns_and_falls_back(capfd):
+    def assert_oneof_falls_back(
+        schema: Union[Dict[str, Any], str],
+        accepted_instances: Optional[List[str]] = None,
+        rejected_instances: Optional[List[str]] = None,
+    ):
+        schema_input = schema if isinstance(schema, str) else json.dumps(schema)
+        grammar = xgr.Grammar.from_json_schema(schema_input, any_whitespace=False)
+        captured = capfd.readouterr()
+        assert "falling back to anyOf semantics" in captured.err
+        for instance in accepted_instances or []:
+            assert _is_grammar_accept_string(grammar, instance)
+        for instance in rejected_instances or []:
+            assert not _is_grammar_accept_string(grammar, instance)
 
-    assert_oneof_unsupported({"oneOf": []})
-    assert_oneof_unsupported({"oneOf": [{"type": "integer"}, {"type": "number"}]})
-    assert_oneof_unsupported({"oneOf": [{"type": ["integer", "string"]}, {"type": "number"}]})
-    assert_oneof_unsupported({"oneOf": [{"type": "integer"}, {}]})
-    assert_oneof_unsupported({"oneOf": [{"const": 1}, {"const": 1.0}]})
-    assert_oneof_unsupported('{"oneOf":[{"const":9007199254740993},{"const":9007199254740993.0}]}')
-    assert_oneof_unsupported('{"oneOf":[{"const":1.5},{"const":2.5}]}')
-    assert_oneof_unsupported(
+    assert_oneof_falls_back(
+        {"oneOf": [{"type": "integer"}, {"type": "number"}]},
+        ["1", "1.5"],
+        ['"x"'],
+    )
+    assert_oneof_falls_back(
+        {"oneOf": [{"type": ["integer", "string"]}, {"type": "number"}]},
+        ["1", '"x"', "1.5"],
+    )
+    assert_oneof_falls_back({"oneOf": [{"type": "integer"}, {}]}, ["1", "true"])
+    assert_oneof_falls_back({"oneOf": [{"const": 1}, {"const": 1.0}]}, ["1"])
+    assert_oneof_falls_back(
+        '{"oneOf":[{"const":9007199254740993},{"const":9007199254740993.0}]}'
+    )
+    assert_oneof_falls_back(
+        '{"oneOf":[{"const":1.5},{"const":2.5}]}',
+        ["1.5", "2.5"],
+        ["3.5"],
+    )
+    assert_oneof_falls_back(
         '{"oneOf":[{"enum":[9007199254740993]},{"enum":[9007199254740993.0]}]}'
     )
-    assert_oneof_unsupported({"oneOf": [{"enum": [1, "hello", 2]}, {"type": "integer"}]})
-    assert_oneof_unsupported(
+    assert_oneof_falls_back({"oneOf": [{"enum": [1, "hello", 2]}, {"type": "integer"}]}, ["1", "3"])
+    assert_oneof_falls_back(
         {
             "oneOf": [
                 {"type": "object"},
@@ -818,13 +837,16 @@ def test_oneof_unsupported_overlap_fails_closed():
                     "properties": {"kind": {"const": "special"}},
                 },
             ]
-        }
+        },
+        ['{"kind": "special"}', "{}"],
     )
-    assert_oneof_unsupported(
-        {"oneOf": [{"type": "integer"}, {"anyOf": [{"type": "number"}, {"type": "string"}]}]}
+    assert_oneof_falls_back(
+        {"oneOf": [{"type": "integer"}, {"anyOf": [{"type": "number"}, {"type": "string"}]}]},
+        ["1", "1.5", '"x"'],
     )
-    assert_oneof_unsupported(
-        {"oneOf": [{"type": "integer"}, {"$ref": "#/$defs/x"}], "$defs": {"x": {"type": "integer"}}}
+    assert_oneof_falls_back(
+        {"oneOf": [{"type": "integer"}, {"$ref": "#/$defs/x"}], "$defs": {"x": {"type": "integer"}}},
+        ["1"],
     )
 
 

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -789,6 +789,67 @@ def test_anyof_oneof():
     check_schema_with_instance(schema, schema_rejected, is_accepted=False, any_whitespace=False)
 
 
+def test_oneof_unsupported_overlap_fails_closed():
+    def assert_oneof_unsupported(schema: Dict[str, Any]):
+        with pytest.raises(Exception) as e:
+            xgr.Grammar.from_json_schema(schema, any_whitespace=False)
+        assert "oneOf with overlapping or non-provably-disjoint branches is not supported" in str(
+            e.value
+        )
+
+    assert_oneof_unsupported({"oneOf": [{"type": "integer"}, {"type": "number"}]})
+    assert_oneof_unsupported({"oneOf": [{"type": ["integer", "string"]}, {"type": "number"}]})
+    assert_oneof_unsupported({"oneOf": [{"type": "integer"}, {}]})
+    assert_oneof_unsupported({"oneOf": [{"const": 1}, {"const": 1.0}]})
+    assert_oneof_unsupported({"oneOf": [{"enum": [1, "hello", 2]}, {"type": "integer"}]})
+    assert_oneof_unsupported(
+        {
+            "oneOf": [
+                {"type": "object"},
+                {
+                    "type": "object",
+                    "required": ["kind"],
+                    "properties": {"kind": {"const": "special"}},
+                },
+            ]
+        }
+    )
+    assert_oneof_unsupported(
+        {"oneOf": [{"type": "integer"}, {"anyOf": [{"type": "number"}, {"type": "string"}]}]}
+    )
+    assert_oneof_unsupported(
+        {"oneOf": [{"type": "integer"}, {"$ref": "#/$defs/x"}], "$defs": {"x": {"type": "integer"}}}
+    )
+
+
+def test_oneof_disjoint_cases():
+    schema = {"oneOf": [{"type": "string"}, {"type": "integer"}]}
+    check_schema_with_instance(schema, '"x"', any_whitespace=False)
+    check_schema_with_instance(schema, 1, any_whitespace=False)
+    check_schema_with_instance(schema, 1.5, is_accepted=False, any_whitespace=False)
+
+    schema = {"oneOf": [{"const": "cat"}, {"const": "dog"}]}
+    check_schema_with_instance(schema, '"cat"', any_whitespace=False)
+    check_schema_with_instance(schema, '"dog"', any_whitespace=False)
+    check_schema_with_instance(schema, '"fish"', is_accepted=False, any_whitespace=False)
+
+    schema = {
+        "oneOf": [
+            {"type": "object", "required": ["kind"], "properties": {"kind": {"const": "cat"}}},
+            {"type": "object", "required": ["kind"], "properties": {"kind": {"const": "dog"}}},
+        ]
+    }
+    check_schema_with_instance(schema, '{"kind": "cat"}', any_whitespace=False)
+    check_schema_with_instance(schema, '{"kind": "dog"}', any_whitespace=False)
+    check_schema_with_instance(schema, '{"kind": "fish"}', is_accepted=False, any_whitespace=False)
+
+
+def test_anyof_integer_number_unchanged():
+    schema = {"anyOf": [{"type": "integer"}, {"type": "number"}]}
+    check_schema_with_instance(schema, 1, any_whitespace=False)
+    check_schema_with_instance(schema, 1.5, any_whitespace=False)
+
+
 def test_alias():
     class MainModel(BaseModel):
         test: str = Field(..., alias="name")

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -816,6 +816,11 @@ def test_oneof_unsupported_overlap_warns_and_falls_back(capfd):
     assert_oneof_falls_back('{"oneOf":[{"const":1.5},{"const":2.5}]}', ["1.5", "2.5"], ["3.5"])
     assert_oneof_falls_back('{"oneOf":[{"enum":[9007199254740993]},{"enum":[9007199254740993.0]}]}')
     assert_oneof_falls_back({"oneOf": [{"enum": [1, "hello", 2]}, {"type": "integer"}]}, ["1", "3"])
+    # A non-integer numeric const is conservatively treated as possibly overlapping an
+    # integer-typed arm, so this disjoint schema still falls back to anyOf semantics.
+    assert_oneof_falls_back(
+        {"oneOf": [{"type": "integer"}, {"const": 1.5}]}, ["1", "1.5"], ["2.5", '"x"']
+    )
     assert_oneof_falls_back(
         {
             "oneOf": [
@@ -842,22 +847,38 @@ def test_oneof_unsupported_overlap_warns_and_falls_back(capfd):
     )
 
 
-def test_oneof_disjoint_cases():
+def test_oneof_disjoint_cases(capfd):
+    # A oneOf proven pairwise-disjoint must NOT emit the anyOf fallback warning. The generated
+    # grammar is identical to the fallback, so asserting the warning is absent is the only way to
+    # verify the disjointness prover actually fired.
+    def assert_no_fallback():
+        captured = capfd.readouterr()
+        assert "falling back to anyOf semantics" not in captured.err
+
     schema = {"oneOf": [{"type": "string"}, {"type": "integer"}]}
     check_schema_with_instance(schema, '"x"', any_whitespace=False)
     check_schema_with_instance(schema, 1, any_whitespace=False)
     check_schema_with_instance(schema, 1.5, is_accepted=False, any_whitespace=False)
+    assert_no_fallback()
 
     schema = {"oneOf": [{"const": "cat"}, {"const": "dog"}]}
     check_schema_with_instance(schema, '"cat"', any_whitespace=False)
     check_schema_with_instance(schema, '"dog"', any_whitespace=False)
     check_schema_with_instance(schema, '"fish"', is_accepted=False, any_whitespace=False)
+    assert_no_fallback()
+
+    schema = {"oneOf": [{"enum": ["a", "b"]}, {"enum": ["c", "d"]}]}
+    check_schema_with_instance(schema, '"a"', any_whitespace=False)
+    check_schema_with_instance(schema, '"d"', any_whitespace=False)
+    check_schema_with_instance(schema, '"e"', is_accepted=False, any_whitespace=False)
+    assert_no_fallback()
 
     schema = '{"oneOf":[{"const":9007199254740992},{"const":9007199254740993}]}'
     grammar = xgr.Grammar.from_json_schema(schema, any_whitespace=False)
     assert _is_grammar_accept_string(grammar, "9007199254740992")
     assert _is_grammar_accept_string(grammar, "9007199254740993")
     assert not _is_grammar_accept_string(grammar, "9007199254740994")
+    assert_no_fallback()
 
     schema = {
         "oneOf": [
@@ -868,6 +889,19 @@ def test_oneof_disjoint_cases():
     check_schema_with_instance(schema, '{"kind": "cat"}', any_whitespace=False)
     check_schema_with_instance(schema, '{"kind": "dog"}', any_whitespace=False)
     check_schema_with_instance(schema, '{"kind": "fish"}', is_accepted=False, any_whitespace=False)
+    assert_no_fallback()
+
+    # Numeric discriminator: exercises the discriminator prover with non-string const values.
+    schema = {
+        "oneOf": [
+            {"type": "object", "required": ["v"], "properties": {"v": {"const": 1}}},
+            {"type": "object", "required": ["v"], "properties": {"v": {"const": 2}}},
+        ]
+    }
+    check_schema_with_instance(schema, '{"v": 1}', any_whitespace=False)
+    check_schema_with_instance(schema, '{"v": 2}', any_whitespace=False)
+    check_schema_with_instance(schema, '{"v": 3}', is_accepted=False, any_whitespace=False)
+    assert_no_fallback()
 
 
 def test_anyof_integer_number_unchanged():


### PR DESCRIPTION
`oneOf` is compiled as `anyOf`, so a constrained grammar accepts values that match more than one branch. `ParseAnyOf` handles both keywords and emits a union, and `oneOf`'s exactly-one semantics are lost. `{"oneOf":[{"type":"integer"},{"type":"number"}]}` compiles and the matcher accepts `1`, which matches both branches and is invalid under `oneOf`.

Exactly-one is sound only when the branches are mutually exclusive, so this proves that before compiling. A new `OneOfSpec` carries the keyword, and a conservative prover checks pairwise disjointness. It proves a pair disjoint by primitive type-set (integer overlaps number), by exact `const`/`enum` value, or by a strict object discriminator where every branch requires the same key constrained to disjoint `const`/`enum`. When all pairs prove disjoint, the `oneOf` compiles as the existing union, which is then exact-one. Everything else fails closed with `kUnsupportedSchema` rather than emit an unsound grammar. That includes overlapping or non-provably-disjoint branches, `$ref`, nested composition, any-typed or loose-object branches, and an empty `oneOf`. Numeric `const` equality stays conservative. Two numbers prove distinct only when both are exact integers, so a precision-lossy case like a large integer against its float spelling fails closed instead of wrongly unioning.

This is the same sound-or-error direction as the `multipleOf` work in #670 and #661. `anyOf` is unchanged. Tests cover the disjoint cases that compile, the overlapping and composite cases that now error, and the numeric precision boundary.

Scope: this covers `type`, `const`, `enum`, and discriminator disjointness. General `oneOf` over overlapping branches needs grammar complement and is out of scope; failing closed is better than the current silent false-accept.
