### PR TITLE
fix: fix the empty string in regex.

### DIFF
--- a/cpp/regex_converter.cc
+++ b/cpp/regex_converter.cc
@@ -326,10 +326,7 @@ std::string RegexConverter::Convert() {
       if (parenthesis_level_ == 0) {
         RaiseError("Unmatched ')'");
       }
-      // Special case: if the alternative right before ')' is empty (e.g. "(a|)"), emit an empty
-      // string so the group does not end with a bare '|'. We check the last emitted segment
-      // rather than the raw previous character so an all-anchor alternative like "(a|$)" is also
-      // covered. Note: an empty group "()" (last segment '(') is intentionally left as "( )".
+      // Empty alternative before ')' (e.g. "(a|)" or "(a|$)"): emit "" so it isn't a bare '|'.
       if (!result_ebnf_.empty() && result_ebnf_.back() == '|') {
         AddEBNFSegment("\"\"");
       }
@@ -362,10 +359,8 @@ std::string RegexConverter::Convert() {
       }
     } else if (*current_ == '|') {
       is_empty = false;
-      // If the alternative ending here is empty, emit an empty string so the result never
-      // contains a bare '|' with nothing on its left. This covers a leading empty alternative
-      // (result is empty, e.g. "^$|abc" after anchors are dropped), consecutive '|' ("a||b"),
-      // and an empty first alternative inside a group ("(|a)").
+      // Empty alternative before '|': emit "" so there's no bare '|' on the left.
+      // Covers leading ("^$|abc"), consecutive ("a||b") and group-start ("(|a)") cases.
       if (result_ebnf_.empty() || result_ebnf_.back() == '|' || result_ebnf_.back() == '(') {
         AddEBNFSegment("\"\"");
       }
@@ -388,7 +383,7 @@ std::string RegexConverter::Convert() {
   if (parenthesis_level_ != 0) {
     RaiseError("The parenthesis is not closed.");
   }
-  // Handle a trailing empty alternative, e.g. "abc|", so the result never ends with a bare '|'.
+  // Trailing empty alternative, e.g. "abc|": emit "" so it doesn't end with a bare '|'.
   if (!result_ebnf_.empty() && result_ebnf_.back() == '|') {
     AddEBNFSegment("\"\"");
   }

--- a/cpp/regex_converter.cc
+++ b/cpp/regex_converter.cc
@@ -326,8 +326,11 @@ std::string RegexConverter::Convert() {
       if (parenthesis_level_ == 0) {
         RaiseError("Unmatched ')'");
       }
-      // Special case: if the previous character is '|', add an empty string to the result.
-      if (current_ != start_ && current_[-1] == '|') {
+      // Special case: if the alternative right before ')' is empty (e.g. "(a|)"), emit an empty
+      // string so the group does not end with a bare '|'. We check the last emitted segment
+      // rather than the raw previous character so an all-anchor alternative like "(a|$)" is also
+      // covered. Note: an empty group "()" (last segment '(') is intentionally left as "( )".
+      if (!result_ebnf_.empty() && result_ebnf_.back() == '|') {
         AddEBNFSegment("\"\"");
       }
       --parenthesis_level_;
@@ -359,6 +362,13 @@ std::string RegexConverter::Convert() {
       }
     } else if (*current_ == '|') {
       is_empty = false;
+      // If the alternative ending here is empty, emit an empty string so the result never
+      // contains a bare '|' with nothing on its left. This covers a leading empty alternative
+      // (result is empty, e.g. "^$|abc" after anchors are dropped), consecutive '|' ("a||b"),
+      // and an empty first alternative inside a group ("(|a)").
+      if (result_ebnf_.empty() || result_ebnf_.back() == '|' || result_ebnf_.back() == '(') {
+        AddEBNFSegment("\"\"");
+      }
       AddEBNFSegment("|");
       ++current_;
     } else if (*current_ == '\\') {
@@ -377,6 +387,10 @@ std::string RegexConverter::Convert() {
   }
   if (parenthesis_level_ != 0) {
     RaiseError("The parenthesis is not closed.");
+  }
+  // Handle a trailing empty alternative, e.g. "abc|", so the result never ends with a bare '|'.
+  if (!result_ebnf_.empty() && result_ebnf_.back() == '|') {
+    AddEBNFSegment("\"\"");
   }
   if (is_empty) {
     AddEBNFSegment("\"\"");

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -940,7 +940,6 @@ deepseek_pattern_empty_leading_alternative_input_str_accepted = (
     # The "^$" branch allows an empty value.
     ('<｜DSML｜parameter name="url" string="true"></｜DSML｜parameter>', True),
     ('<｜DSML｜parameter name="url" string="true">http://x.com/</｜DSML｜parameter>', False),
-    ('<｜DSML｜parameter name="url" string="true">https://y.com/</｜DSML｜parameter>', False),
 )
 
 

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -935,6 +935,31 @@ root ::=  [ \n\t]* (("<｜DSML｜parameter name=\"name\" string=\"" ("true" | "f
     _check_deepseek_grammar(schema, expected_grammar, input_str, accepted)
 
 
+deepseek_pattern_empty_leading_alternative_input_str_accepted = (
+    ('<｜DSML｜parameter name="url" string="true">https://x.com/</｜DSML｜parameter>', True),
+    # The "^$" branch allows an empty value.
+    ('<｜DSML｜parameter name="url" string="true"></｜DSML｜parameter>', True),
+    ('<｜DSML｜parameter name="url" string="true">http://x.com/</｜DSML｜parameter>', False),
+    ('<｜DSML｜parameter name="url" string="true">https://y.com/</｜DSML｜parameter>', False),
+)
+
+
+@pytest.mark.parametrize(
+    "input_str, accepted", deepseek_pattern_empty_leading_alternative_input_str_accepted
+)
+def test_deepseek_pattern_empty_leading_alternative(input_str: str, accepted: bool):
+    # Regression: a pattern whose first alternative is empty ("^$|...") used to emit a bare
+    # leading '|' in the EBNF and crash the grammar parser on the deepseek_xml path.
+    schema = {
+        "type": "object",
+        "properties": {"url": {"type": "string", "pattern": "^$|^https://x\\.com/"}},
+        "required": ["url"],
+    }
+    ebnf_grammar = _deepseek_xml_tool_calling_to_ebnf(schema)
+    assert "root_prop_0 ::= |" not in str(ebnf_grammar)
+    check_grammar_with_instance(ebnf_grammar, input_str, accepted)
+
+
 deepseek_test_additional_properties_schema_input_str_accepted = (
     (
         '<｜DSML｜parameter name="name" string="true">Bob</｜DSML｜parameter><｜DSML｜parameter name="age" string="false">\t100\n</｜DSML｜parameter><｜DSML｜parameter name="location" string="true">New York</｜DSML｜parameter>',

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -948,15 +948,31 @@ deepseek_pattern_empty_leading_alternative_input_str_accepted = (
 )
 def test_deepseek_pattern_empty_leading_alternative(input_str: str, accepted: bool):
     # Regression: a pattern whose first alternative is empty ("^$|...") used to emit a bare
-    # leading '|' in the EBNF and crash the grammar parser on the deepseek_xml path.
+    # leading '|' (root_prop_0 ::= | ...) and crash the grammar parser on the deepseek_xml path.
+    # It must now be emitted as root_prop_0 ::= "" | ...
+    expected_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
+basic_string_sub ::= ("\"" | [^\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub) (= [ \n\t]* [,}\]:])
+basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
+basic_integer ::= ("0" | "-"? [1-9] [0-9]*)
+basic_number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
+basic_string ::= ["] basic_string_sub
+basic_boolean ::= "true" | "false"
+basic_null ::= "null"
+basic_array ::= (("[" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_any)* [ \n\t]* "]") | ("[" [ \n\t]* "]"))
+basic_object ::= ("{" [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any ([ \n\t]* "," [ \n\t]* basic_string [ \n\t]* ":" [ \n\t]* basic_any)* [ \n\t]* "}") | "{" [ \n\t]* "}"
+xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
+xml_any ::= xml_string | basic_array | basic_object
+xml_object ::= ( [ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>" ([ \n\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\t]* xml_any [ \n\t]* "</｜DSML｜parameter>")* [ \n\t]*) | [ \n\t]*
+xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
+root_prop_0 ::= "" | "h" "t" "t" "p" "s" ":" "/" "/" "x" "." "c" "o" "m" "/"
+root ::=  [ \n\t]* (("<｜DSML｜parameter name=\"url\" string=\"" ("true" | "false") "\">" [ \n\t]* root_prop_0 [ \n\t]* "</｜DSML｜parameter>" "")) [ \n\t]*
+"""
     schema = {
         "type": "object",
         "properties": {"url": {"type": "string", "pattern": "^$|^https://x\\.com/"}},
         "required": ["url"],
     }
-    ebnf_grammar = _deepseek_xml_tool_calling_to_ebnf(schema)
-    assert "root_prop_0 ::= |" not in str(ebnf_grammar)
-    check_grammar_with_instance(ebnf_grammar, input_str, accepted)
+    _check_deepseek_grammar(schema, expected_grammar, input_str, accepted)
 
 
 deepseek_test_additional_properties_schema_input_str_accepted = (

--- a/tests/python/test_regex_converter.py
+++ b/tests/python/test_regex_converter.py
@@ -367,50 +367,21 @@ def test_empty_alternative():
 
 
 def test_empty_alternative_positions():
-    # Leading empty alternative must not produce a bare leading '|'.
-    regex = "|a"
-    grammar_str = _regex_to_ebnf(regex)
-    assert grammar_str == 'root ::= "" | "a"\n'
-    assert _is_grammar_accept_string(grammar_str, "")
-    assert _is_grammar_accept_string(grammar_str, "a")
-    assert not _is_grammar_accept_string(grammar_str, "b")
+    # An empty alternative in any position must emit "" instead of a bare '|'.
+    expected = {
+        "a|": 'root ::= "a" | ""\n',  # trailing
+        "a||b": 'root ::= "a" | "" | "b"\n',  # consecutive
+        "(|a)": 'root ::= ( "" | "a" )\n',  # group start
+        "(a|$)": 'root ::= ( "a" | "" )\n',  # anchor collapses to empty before ')'
+    }
+    for regex, grammar_str in expected.items():
+        assert _regex_to_ebnf(regex) == grammar_str
 
-    # Trailing empty alternative must not produce a bare trailing '|'.
-    regex = "a|"
-    grammar_str = _regex_to_ebnf(regex)
-    assert grammar_str == 'root ::= "a" | ""\n'
-    assert _is_grammar_accept_string(grammar_str, "a")
-    assert _is_grammar_accept_string(grammar_str, "")
-
-    # Consecutive '|' (empty middle alternative).
-    regex = "a||b"
-    grammar_str = _regex_to_ebnf(regex)
-    assert grammar_str == 'root ::= "a" | "" | "b"\n'
-    assert _is_grammar_accept_string(grammar_str, "a")
-    assert _is_grammar_accept_string(grammar_str, "b")
-    assert _is_grammar_accept_string(grammar_str, "")
-
-    # Empty first alternative inside a group.
-    regex = "(|a)"
-    grammar_str = _regex_to_ebnf(regex)
-    assert grammar_str == 'root ::= ( "" | "a" )\n'
-    assert _is_grammar_accept_string(grammar_str, "")
-    assert _is_grammar_accept_string(grammar_str, "a")
-
-    # An all-anchor alternative collapses to empty; the dropped anchors must not leave a bare '|'.
-    # This is the deepseek_xml tool-calling crash from the bug report ("^$|^https://...").
-    regex = r"^$|^https://x\.com/"
-    grammar_str = _regex_to_ebnf(regex)
-    assert grammar_str.startswith('root ::= "" |')
+    # Bug report: a leading "^$" collapses to an empty first alternative ("^$|^https://...").
+    grammar_str = _regex_to_ebnf(r"^$|^https://x\.com/")
+    assert grammar_str == 'root ::= "" | "h" "t" "t" "p" "s" ":" "/" "/" "x" "." "c" "o" "m" "/"\n'
     assert _is_grammar_accept_string(grammar_str, "")
     assert _is_grammar_accept_string(grammar_str, "https://x.com/")
-
-    # An empty alternative produced by an anchor right before ')'.
-    regex = r"(a|$)"
-    grammar_str = _regex_to_ebnf(regex)
-    assert grammar_str == 'root ::= ( "a" | "" )\n'
-    assert _is_grammar_accept_string(grammar_str, "a")
-    assert _is_grammar_accept_string(grammar_str, "")
 
 
 def test_non_greedy_quantifier():

--- a/tests/python/test_regex_converter.py
+++ b/tests/python/test_regex_converter.py
@@ -366,6 +366,53 @@ def test_empty_alternative():
     assert not _is_grammar_accept_string(grammar_str, "abd")
 
 
+def test_empty_alternative_positions():
+    # Leading empty alternative must not produce a bare leading '|'.
+    regex = "|a"
+    grammar_str = _regex_to_ebnf(regex)
+    assert grammar_str == 'root ::= "" | "a"\n'
+    assert _is_grammar_accept_string(grammar_str, "")
+    assert _is_grammar_accept_string(grammar_str, "a")
+    assert not _is_grammar_accept_string(grammar_str, "b")
+
+    # Trailing empty alternative must not produce a bare trailing '|'.
+    regex = "a|"
+    grammar_str = _regex_to_ebnf(regex)
+    assert grammar_str == 'root ::= "a" | ""\n'
+    assert _is_grammar_accept_string(grammar_str, "a")
+    assert _is_grammar_accept_string(grammar_str, "")
+
+    # Consecutive '|' (empty middle alternative).
+    regex = "a||b"
+    grammar_str = _regex_to_ebnf(regex)
+    assert grammar_str == 'root ::= "a" | "" | "b"\n'
+    assert _is_grammar_accept_string(grammar_str, "a")
+    assert _is_grammar_accept_string(grammar_str, "b")
+    assert _is_grammar_accept_string(grammar_str, "")
+
+    # Empty first alternative inside a group.
+    regex = "(|a)"
+    grammar_str = _regex_to_ebnf(regex)
+    assert grammar_str == 'root ::= ( "" | "a" )\n'
+    assert _is_grammar_accept_string(grammar_str, "")
+    assert _is_grammar_accept_string(grammar_str, "a")
+
+    # An all-anchor alternative collapses to empty; the dropped anchors must not leave a bare '|'.
+    # This is the deepseek_xml tool-calling crash from the bug report ("^$|^https://...").
+    regex = r"^$|^https://x\.com/"
+    grammar_str = _regex_to_ebnf(regex)
+    assert grammar_str.startswith('root ::= "" |')
+    assert _is_grammar_accept_string(grammar_str, "")
+    assert _is_grammar_accept_string(grammar_str, "https://x.com/")
+
+    # An empty alternative produced by an anchor right before ')'.
+    regex = r"(a|$)"
+    grammar_str = _regex_to_ebnf(regex)
+    assert grammar_str == 'root ::= ( "a" | "" )\n'
+    assert _is_grammar_accept_string(grammar_str, "a")
+    assert _is_grammar_accept_string(grammar_str, "")
+
+
 def test_non_greedy_quantifier():
     regex = "a{1,3}?"
     grammar_str = _regex_to_ebnf(regex)


### PR DESCRIPTION
This PR fixes the empty string in regex generation as reported in #671.