### PR TITLE
fix: compile SequenceFormat/OrFormat under C++20

### DIFF
--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -126,6 +126,12 @@ picojson::value AnyTextFormat::ToJSON() const {
   return picojson::value(std::move(obj));
 }
 
+// These two constructors are defined here rather than inline because instantiating
+// vector<Format> against the still-incomplete Format variant is ill-formed under C++20.
+SequenceFormat::SequenceFormat(std::vector<Format> elements) : elements(std::move(elements)) {}
+
+OrFormat::OrFormat(std::vector<Format> elements) : elements(std::move(elements)) {}
+
 picojson::value SequenceFormat::ToJSON() const {
   picojson::object obj;
   obj["type"] = picojson::value(type);

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -170,7 +170,7 @@ struct AnyTokensFormat {
 struct SequenceFormat {
   static constexpr const char* type = "sequence";
   std::vector<Format> elements;
-  SequenceFormat(std::vector<Format> elements) : elements(std::move(elements)) {}
+  SequenceFormat(std::vector<Format> elements);
   picojson::value ToJSON() const;
 
  private:
@@ -183,7 +183,7 @@ struct SequenceFormat {
 struct OrFormat {
   static constexpr const char* type = "or";
   std::vector<Format> elements;
-  OrFormat(std::vector<Format> elements) : elements(std::move(elements)) {}
+  OrFormat(std::vector<Format> elements);
   picojson::value ToJSON() const;
 
  private:


### PR DESCRIPTION
This makes the code compile under C++20. Both structs hold their children by value as a std::vector<Format>, where Format is the variant that also contains these very structs. Under C++20, std::vector requires its element type to be complete at the point it's instantiated. When the constructors were defined inline in the header, they forced vector<Format> to be instantiated while Format (and the structs it references) was still being defined and therefore incomplete, which is ill-formed. Moving the definitions into the .cc delays that instantiation until everything is fully defined, so the build is happy again.

This stays backwards compatible with C++17. Verified by compiling structural_tag.cc under both -std=c++17 and -std=c++20