### PR TITLE
feat: support max_tokens in AnyTokens/AnyTextFormat for think budget

### DIFF
--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -118,6 +118,14 @@ class CompiledGrammar::Impl {
   /*! \brief Mapping from the parser state to the adaptive token mask. */
   std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache> adaptive_token_mask_cache;
 
+  /*!
+   * \brief Rule id of the single bounded any_text region (a TagDispatch carrying max_tokens != -1),
+   * or -1 if the grammar has no token-budgeted region. v1 supports at most one such region.
+   */
+  int32_t bounded_tag_dispatch_rule_id = -1;
+  /*! \brief Token budget (max_tokens) of the bounded region, or -1 if none. */
+  int32_t bounded_tag_dispatch_max_tokens = -1;
+
   Grammar GetGrammar() const { return grammar; }
 
   TokenizerInfo GetTokenizerInfo() const { return tokenizer_info; }
@@ -139,7 +147,11 @@ XGRAMMAR_MEMBER_TABLE(
     "tokenizer_info",
     &CompiledGrammar::Impl::tokenizer_info,
     "adaptive_token_mask_cache",
-    &CompiledGrammar::Impl::adaptive_token_mask_cache
+    &CompiledGrammar::Impl::adaptive_token_mask_cache,
+    "bounded_tag_dispatch_rule_id",
+    &CompiledGrammar::Impl::bounded_tag_dispatch_rule_id,
+    "bounded_tag_dispatch_max_tokens",
+    &CompiledGrammar::Impl::bounded_tag_dispatch_max_tokens
 );
 
 }  // namespace xgrammar

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -356,6 +356,7 @@ void EarleyParser::Reset() {
   scanable_state_history_.PopBack(scanable_state_history_.size());
   is_completed_.clear();
   stop_token_is_accepted_ = false;
+  budget_exhausted_rule_id_ = -1;
   XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
   PushStateAndExpand(ParserState(
       grammar_->GetRootRuleId(),
@@ -883,6 +884,15 @@ void EarleyParser::AdvanceCharacterClassStar(
 void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
   XGRAMMAR_DCHECK(state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value());
   const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
+  // Token budget: if this is the bounded any_text region and its budget is exhausted, refuse to
+  // consume any more input bytes while at an accepting node. AdvanceFsm only ever produces
+  // CharRange successors, so returning here drops the loop's continuation; the region has already
+  // reported completable at this accepting node, so the parent's end-tag bytes remain the only
+  // scanable continuation. The IsEndState guard ensures we never strand the FSM mid-tag-prefix.
+  if (budget_exhausted_rule_id_ != -1 && state.rule_id == budget_exhausted_rule_id_ &&
+      current_fsm.GetFsm().IsEndState(state.element_id)) {
+    return;
+  }
   for (const auto& edge : current_fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
     if ((!edge.IsCharRange()) || ch < edge.min || ch > edge.max) {
       continue;

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -277,6 +277,14 @@ class EarleyParser {
   bool stop_token_is_accepted_ = false;
 
   /*!
+   * \brief When set to a rule id (>=0), a bounded any_text TagDispatch region whose token budget
+   * is exhausted: AdvanceFsm refuses to consume further input bytes for that rule while at an
+   * accepting node, forcing the region to complete (its end tag becomes the only continuation).
+   * -1 = no active budget. Set by the matcher before each Advance-driving step.
+   */
+  int32_t budget_exhausted_rule_id_ = -1;
+
+  /*!
    * \brief Check if the state has been added into the queue.
    * \param state The state to check.
    * \return True if in the vector, false otherwise.
@@ -479,6 +487,12 @@ class EarleyParser {
     }
     return latest_states;
   }
+
+  /*!
+   * \brief Set the bounded any_text rule whose token budget is exhausted (or -1 to clear). When
+   * set, AdvanceFsm stops consuming input for that rule at accepting nodes, forcing completion.
+   */
+  void SetBudgetExhaustedRule(int32_t rule_id) { budget_exhausted_rule_id_ = rule_id; }
 
   /*!
    * \brief Push one state to check if it can accept the token.

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -135,7 +135,7 @@ int32_t GrammarBuilder::AddChoices(const std::vector<int32_t>& choices) {
 
 int32_t GrammarBuilder::AddTagDispatch(const Grammar::Impl::TagDispatch& tag_dispatch) {
   std::vector<int32_t> data;
-  data.reserve(tag_dispatch.tag_rule_pairs.size() * 2 + 2);
+  data.reserve(tag_dispatch.tag_rule_pairs.size() * 2 + 3);
   for (const auto& [tag, rule_id] : tag_dispatch.tag_rule_pairs) {
     data.push_back(AddByteString(tag));
     data.push_back(rule_id);
@@ -146,6 +146,8 @@ int32_t GrammarBuilder::AddTagDispatch(const Grammar::Impl::TagDispatch& tag_dis
     exclude_str_expr_ids.push_back(AddByteString(exclude_str));
   }
   data.push_back(AddChoices(exclude_str_expr_ids));
+  // Trailing token budget (see TagDispatch::kTagDispatchExtraParameter layout).
+  data.push_back(tag_dispatch.max_tokens);
   return AddGrammarExpr(
       {GrammarExprType::kTagDispatch, data.data(), static_cast<int32_t>(data.size())}
   );

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -63,6 +63,18 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   AdaptiveTokenMask GetAdaptiveTokenMask(bool is_root_rule);
 
   /*!
+   * \brief Whether init_rule_id_ is a token-budgeted any_text region (a TagDispatch with
+   * max_tokens != -1). For such a rule the fast-accept paths are disabled so every candidate token
+   * is live-simulated at runtime, where the matcher's budget suppression in AdvanceFsm governs it.
+   */
+  bool IsBoundedRule() {
+    const auto& rule = grammar_->GetRule(init_rule_id_);
+    const auto& body = grammar_->GetGrammarExpr(rule.body_expr_id);
+    return body.type == Grammar::Impl::GrammarExprType::kTagDispatch &&
+           grammar_->GetTagDispatch(rule.body_expr_id).max_tokens != -1;
+  }
+
+  /*!
    * \brief Get the token mask for the given ParserState.
    * \param first_char_mask The first character mask.
    * \param is_root_rule Whether to consider the parent rule. If false, there will be
@@ -433,6 +445,13 @@ std::pair<bool, std::bitset<256>> GrammarMatcherForTokenMaskCache::GetSpeculativ
   // If the initial rule is a tag dispatch, we will check if it can achieve its initial state.
   const auto& rule = grammar_->GetRule(init_rule_id_);
   const auto& rule_body = grammar_->GetGrammarExpr(rule.body_expr_id);
+  // A token-budgeted TagDispatch must not use the speculative fast-accept: every candidate token
+  // has to be live-simulated at runtime so the budget suppression in AdvanceFsm can reject
+  // over-budget content tokens.
+  if (rule_body.type == GrammarExprType::kTagDispatch &&
+      grammar_->GetTagDispatch(rule.body_expr_id).max_tokens != -1) {
+    return {false, std::bitset<256>{}};
+  }
   if (rule_body.type == GrammarExprType::kTagDispatch) {
     std::bitset<256> speculative_mask;
     XGRAMMAR_DCHECK(grammar_->per_rule_fsms[init_rule_id_].has_value());
@@ -518,6 +537,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
 
   XGRAMMAR_DCHECK(init_rule_id_ != -1 && grammar_->per_rule_fsms[init_rule_id_].has_value());
   auto [speculative_calculation, speculative_mask] = GetSpeculativeCalculation();
+  const bool is_bounded_rule = IsBoundedRule();
 
   int prev_matched_size = 0;
   int last_rejected_range = 0;
@@ -637,12 +657,19 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       bool can_reach_end = tmp_can_reach_end_prefix_or_stack_.back();
 
       if (accepted) {
-        tmp_accepted_indices_.push_back(i);
+        // For a token-budgeted region, a token that advances the loop must stay UNCERTAIN so the
+        // runtime live-check (where the budget suppression applies) decides it, instead of being
+        // fast-accepted here (which would bypass the budget).
+        if (is_bounded_rule) {
+          tmp_uncertain_indices_.push_back(i);
+        } else {
+          tmp_accepted_indices_.push_back(i);
+        }
       } else if (can_reach_end && prev_matched_size > 0) {
         auto [lookahead_accepted, lookahead_completed] =
             IsTokenPassLookaheadAssertion(token, tmp_can_reach_end_stack_);
         if ((!is_root_rule) && lookahead_accepted) {
-          if (lookahead_completed || !is_exact_lookahead) {
+          if (lookahead_completed || !is_exact_lookahead || is_bounded_rule) {
             tmp_uncertain_indices_.push_back(i);
           } else {
             tmp_accepted_indices_.push_back(i);
@@ -790,9 +817,12 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   tmp_can_reach_end_stack_.push_back(false);
   tmp_can_reach_end_prefix_or_stack_.push_back(false);
 
-  // Try to get the crossing cache.
-  bool rule_level_cache_is_available =
-      rule_level_cache_.has_value() && grammar_->per_rule_fsm_hashes[init_rule_id_].has_value();
+  // Try to get the crossing cache. A token-budgeted region must NOT share the rule-level (FSM-hash)
+  // cache: its FSM is identical to an unbounded TagDispatch with the same excludes, so reuse would
+  // serve an unbounded (fast-accept) mask and silently bypass the budget.
+  bool rule_level_cache_is_available = rule_level_cache_.has_value() &&
+                                       grammar_->per_rule_fsm_hashes[init_rule_id_].has_value() &&
+                                       !IsBoundedRule();
   std::optional<uint64_t> fsm_hash = std::nullopt;
   int32_t new_state_id = -1;
   std::optional<AdaptiveTokenMask> crossing_cache = std::nullopt;
@@ -1055,6 +1085,24 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   }
   std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
   TagDispatchOptimization(compiled_grammar_impl, &tag_dispatch_rule_id_to_second_slicing_bitset);
+
+  // Detect the single bounded any_text region (a TagDispatch carrying max_tokens != -1) so the
+  // matcher can enforce its token budget. v1 supports at most one such region per grammar.
+  for (int32_t rule_id = 0; rule_id < compiled_grammar_impl->grammar->NumRules(); ++rule_id) {
+    const auto& rule = compiled_grammar_impl->grammar->GetRule(rule_id);
+    const auto& body = compiled_grammar_impl->grammar->GetGrammarExpr(rule.body_expr_id);
+    if (body.type != Grammar::Impl::GrammarExprType::kTagDispatch) {
+      continue;
+    }
+    auto td = compiled_grammar_impl->grammar->GetTagDispatch(rule.body_expr_id);
+    if (td.max_tokens < 0) {
+      continue;
+    }
+    XGRAMMAR_CHECK(compiled_grammar_impl->bounded_tag_dispatch_rule_id == -1)
+        << "Only a single bounded any_text region (max_tokens) is supported per grammar.";
+    compiled_grammar_impl->bounded_tag_dispatch_rule_id = rule_id;
+    compiled_grammar_impl->bounded_tag_dispatch_max_tokens = td.max_tokens;
+  }
 
   // If the compiler is cache-enabled, then we hash the grammars for crossing-grammar caching.
   if (rule_level_cache_.has_value()) {

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -90,6 +90,7 @@ class SubGrammarAdderImpl : public GrammarMutator {
     }
     new_tag_dispatch.loop_after_dispatch = old_tag_dispatch.loop_after_dispatch;
     new_tag_dispatch.excludes = old_tag_dispatch.excludes;
+    new_tag_dispatch.max_tokens = old_tag_dispatch.max_tokens;
     return builder_->AddTagDispatch(new_tag_dispatch);
   }
 

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -197,7 +197,14 @@ class Grammar::Impl {
     bool loop_after_dispatch;
     /*! \brief The strings that are excluded by the tag dispatch. */
     std::vector<std::string> excludes;
-    static const int kTagDispatchExtraParameter = 2;
+    /*!
+     * \brief Max number of whole tokens this tag dispatch may consume before it must complete;
+     * -1 = unbounded. Enforced by the matcher (token budget for a bounded any_text region).
+     */
+    int32_t max_tokens = -1;
+    // Trailing (non tag/rule-pair) parameters in the kTagDispatch grammar expr, in order:
+    //   [loop_after_dispatch, excludes_choices_id, max_tokens].
+    static const int kTagDispatchExtraParameter = 3;
   };
 
   /*! \brief Get the tag dispatch from the grammar expr. */
@@ -229,6 +236,9 @@ class Grammar::Impl {
     for (int j = 0; j < exclude_str_expr.size(); j++) {
       result.excludes.push_back(GetByteString(exclude_str_expr[j]));
     }
+
+    result.max_tokens =
+        grammar_expr[grammar_expr.size() - TagDispatch::kTagDispatchExtraParameter + 2];
     return result;
   }
 

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -461,6 +461,8 @@ class GrammarMatcher::Impl : public EarleyParser {
         tmp_accepted_bitset_(tokenizer_info_.GetVocabSize()) {
     XGRAMMAR_CHECK(!override_stop_tokens.has_value() || !override_stop_tokens->empty())
         << "The override_stop_tokens should not be empty";
+    bounded_rule_id_ = compiled_grammar_->bounded_tag_dispatch_rule_id;
+    bounded_max_tokens_ = compiled_grammar_->bounded_tag_dispatch_max_tokens;
   }
 
   bool AcceptToken(int32_t token_id, bool debug_print = false);
@@ -475,7 +477,12 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   bool IsTerminated() const;
 
-  void Reset() { EarleyParser::Reset(); }
+  void Reset() {
+    EarleyParser::Reset();
+    token_length_history.clear();
+    bounded_region_consumed_ = 0;
+    bounded_consumed_history_.clear();
+  }
 
   int GetMaxRollbackTokens() const { return -1; }
 
@@ -522,11 +529,46 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   std::string PrintBitmask(int32_t* bitmask_data_ptr, const TokenizerInfo& tokenizer_info);
 
+  /*!
+   * \brief Whether the parser currently sits inside the bounded any_text region (some live
+   * scanable state belongs to the budgeted TagDispatch rule).
+   */
+  bool InBoundedRegion() const {
+    if (bounded_rule_id_ < 0) {
+      return false;
+    }
+    for (const auto& s : GetLatestScanableStates()) {
+      if (s.rule_id == bounded_rule_id_) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /*! \brief Push one in-region token-count delta, kept in lockstep with token_length_history. */
+  void PushBoundedDelta(int delta) {
+    bounded_consumed_history_.push_back(delta);
+    bounded_region_consumed_ += delta;
+  }
+
+  /*! \brief Tell the parser whether the bounded region's budget is exhausted (drives AdvanceFsm).
+   */
+  void RefreshBudgetSuppression() {
+    const bool exhausted = bounded_rule_id_ >= 0 && bounded_region_consumed_ >= bounded_max_tokens_;
+    SetBudgetExhaustedRule(exhausted ? bounded_rule_id_ : -1);
+  }
+
   CompiledGrammar compiled_grammar_;
   TokenizerInfo tokenizer_info_;
   std::vector<int> stop_token_ids_;
   bool terminate_without_stop_token_;
   std::deque<int> token_length_history;
+  // Token budget for the single bounded any_text region (-1 = none). bounded_region_consumed_
+  // counts content tokens; bounded_consumed_history_ mirrors token_length_history for rollback.
+  int32_t bounded_rule_id_ = -1;
+  int32_t bounded_max_tokens_ = -1;
+  int bounded_region_consumed_ = 0;
+  std::deque<int> bounded_consumed_history_;
 
   // Temporary data for FillNextTokenBitmask. They are stored here to avoid repeated allocation.
   DynamicBitset tmp_accepted_bitset_;
@@ -593,6 +635,7 @@ bool GrammarMatcher::Impl::AcceptStopToken() {
   }
   XGRAMMAR_DCHECK(!stop_token_is_accepted_);
   token_length_history.push_back(0);
+  PushBoundedDelta(0);  // stop token never counts toward the region budget
   stop_token_is_accepted_ = true;
   return true;
 }
@@ -619,6 +662,12 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
                           << tokenizer_info_.GetVocabSize() << "). Rejecting the token.";
     return false;
   }
+
+  // Token budget: snapshot whether the parser is inside the bounded any_text region before this
+  // token, and tell the parser to suppress further loop consumption if the budget is exhausted (so
+  // the byte/atomic advances below obey the same rule the mask advertised).
+  const bool in_region_before = InBoundedRegion();
+  RefreshBudgetSuppression();
 
   if (debug_print) {
     std::string states_str;
@@ -689,8 +738,10 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     PopLastStates(pos);
     AdvanceAtomicToken(token_id, debug_print);
     token_length_history.push_back(1);
+    PushBoundedDelta(in_region_before ? 1 : 0);
   } else if (byte_path_success && !atomic_success) {
     token_length_history.push_back(token.size());
+    PushBoundedDelta(in_region_before ? 1 : 0);
   } else {
     // Both paths succeeded — merge atomic token states into byte path
     if (token.empty()) {
@@ -699,6 +750,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
       rule_id_to_completable_states_.PushBack(atomic_completable);
       is_completed_.push_back(atomic_completed);
       token_length_history.push_back(1);
+      PushBoundedDelta(in_region_before ? 1 : 0);
     } else {
       auto byte_states = GetLatestScanableStates();
       std::vector<ParserState> merged = byte_states;
@@ -730,6 +782,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
       rule_id_to_completable_states_.PushBack(merged_completable);
       is_completed_.push_back(byte_completed || atomic_completed);
       token_length_history.push_back(token.size());
+      PushBoundedDelta(in_region_before ? 1 : 0);
     }
   }
 
@@ -769,6 +822,9 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
     ++accepted_cnt;
   }
   token_length_history.push_back(input_str.size());
+  // AcceptString is used for forced/jump-forward continuations, which do not occur inside the
+  // open-ended bounded region; push 0 to keep the rollback ledgers in lockstep.
+  PushBoundedDelta(0);
 
   if (debug_print) {
     XGRAMMAR_LOG(INFO) << "String \"" << EscapeString(input_str) << "\" is accepted.";
@@ -812,6 +868,10 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
   XGRAMMAR_CHECK(!IsStopTokenAccepted())
       << "GrammarMatcher has terminated after accepting the stop token, but is trying to "
          "find the next token mask";
+  // Token budget: if the bounded region is exhausted, the parser must suppress further loop
+  // consumption so the per-candidate live walk below rejects over-budget content tokens, leaving
+  // only the region's end tag valid.
+  RefreshBudgetSuppression();
   int32_t* bitmask_data_ptr =
       CheckAndGetBitmaskPtr(*next_token_bitmask, tokenizer_info_.GetVocabSize(), index);
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
@@ -1028,6 +1088,11 @@ void GrammarMatcher::Impl::Rollback(int num_tokens) {
     int steps = token_length_history.back();
     PopLastStates(steps);
     token_length_history.pop_back();
+    // Keep the bounded-region counter in lockstep with the rollback ledger.
+    if (!bounded_consumed_history_.empty()) {
+      bounded_region_consumed_ -= bounded_consumed_history_.back();
+      bounded_consumed_history_.pop_back();
+    }
     --num_tokens;
   }
 }

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -199,6 +199,9 @@ picojson::value AnyTokensFormat::ToJSON() const {
   picojson::object obj;
   obj["type"] = picojson::value(type);
   obj["exclude_tokens"] = IntOrStringVectorToJSONArray(exclude_tokens);
+  if (max_tokens.has_value()) {
+    obj["max_tokens"] = picojson::value(static_cast<double>(max_tokens.value()));
+  }
   return picojson::value(std::move(obj));
 }
 
@@ -994,7 +997,26 @@ Result<AnyTokensFormat, ISTError> StructuralTagParser::ParseAnyTokensFormat(
     }
     exclude_tokens = std::move(parsed).Unwrap();
   }
-  return ResultOk<AnyTokensFormat>(std::move(exclude_tokens));
+  std::optional<int> max_tokens = std::nullopt;
+  auto mt_it = obj.find("max_tokens");
+  if (mt_it != obj.end() && !mt_it->second.is<picojson::null>()) {
+    // A present-but-non-numeric / out-of-range max_tokens is an error rather than being silently
+    // ignored (which would degrade the budget to "unbounded"). Range-check the double before
+    // casting to int to avoid the UB of static_cast<int> on an out-of-range value.
+    if (!mt_it->second.is<double>()) {
+      return ResultErr<ISTError>("max_tokens in any_tokens must be a non-negative integer or null."
+      );
+    }
+    double raw = mt_it->second.get<double>();
+    if (raw < 0 || raw > static_cast<double>(std::numeric_limits<int>::max()) ||
+        raw != std::floor(raw)) {
+      return ResultErr<ISTError>(
+          "max_tokens in any_tokens must be a non-negative integer in [0, INT_MAX]."
+      );
+    }
+    max_tokens = static_cast<int>(raw);
+  }
+  return ResultOk<AnyTokensFormat>(std::move(exclude_tokens), max_tokens);
 }
 
 Result<TokenTriggeredTagsFormat, ISTError> StructuralTagParser::ParseTokenTriggeredTagsFormat(
@@ -2251,6 +2273,12 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const AnyTokensFor
   int exclude_seq = grammar_builder_.AddSequence({exclude_expr});
   int exclude_choices = grammar_builder_.AddChoices({exclude_seq});
   int inner_rule = grammar_builder_.AddRuleWithHint("any_tokens_inner", exclude_choices);
+  // Each `inner_rule` matches exactly one token, so when max_tokens is set we bound the
+  // repetition to at most max_tokens, giving an exact token-count budget.
+  if (format.max_tokens.has_value()) {
+    int repeat_expr = grammar_builder_.AddRepeat(inner_rule, 0, format.max_tokens.value());
+    return ResultOk(grammar_builder_.AddRuleWithHint("any_tokens", repeat_expr));
+  }
   auto inner_ref = grammar_builder_.AddRuleRef(inner_rule);
   auto star_rule_id = grammar_builder_.AddEmptyRuleWithHint("any_tokens");
   auto star_ref = grammar_builder_.AddRuleRef(star_rule_id);

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -128,6 +128,9 @@ picojson::value AnyTextFormat::ToJSON() const {
   obj["type"] = picojson::value(type);
   obj["excludes"] = StringVectorToJSONArray(excludes);
   obj["detected_end_strs"] = StringVectorToJSONArray(detected_end_strs_);
+  if (max_tokens != -1) {
+    obj["max_tokens"] = picojson::value(static_cast<double>(max_tokens));
+  }
   return picojson::value(std::move(obj));
 }
 
@@ -576,14 +579,40 @@ Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
   );
 }
 
+// Reads an optional non-negative integer "max_tokens" field. Returns -1 if absent or null
+// (unbounded). A present-but-invalid value is an error rather than silently unbounded.
+static Result<int32_t, ISTError> ParseAnyTextMaxTokens(const picojson::object& obj) {
+  auto it = obj.find("max_tokens");
+  if (it == obj.end() || it->second.is<picojson::null>()) {
+    return ResultOk<int32_t>(-1);
+  }
+  if (!it->second.is<double>()) {
+    return ResultErr<ISTError>("max_tokens in any_text must be a non-negative integer or null.");
+  }
+  double raw = it->second.get<double>();
+  if (raw < 0 || raw > static_cast<double>(std::numeric_limits<int>::max()) ||
+      raw != std::floor(raw)) {
+    return ResultErr<ISTError>(
+        "max_tokens in any_text must be a non-negative integer in [0, INT_MAX]."
+    );
+  }
+  return ResultOk<int32_t>(static_cast<int32_t>(raw));
+}
+
 Result<AnyTextFormat, ISTError> StructuralTagParser::ParseAnyTextFormat(const picojson::object& obj
 ) {
+  auto mt = ParseAnyTextMaxTokens(obj);
+  if (mt.IsErr()) {
+    return ResultErr<ISTError>(std::move(mt).UnwrapErr());
+  }
+  int32_t max_tokens = std::move(mt).Unwrap();
+
   auto excluded_strs_it = obj.find("excludes");
   if (excluded_strs_it == obj.end()) {
     if ((obj.find("type") == obj.end())) {
       return ResultErr<ISTError>("Any text format should not have any fields other than type");
     }
-    return ResultOk<AnyTextFormat>(std::vector<std::string>{});
+    return ResultOk<AnyTextFormat>(std::vector<std::string>{}, max_tokens);
   }
   if (!excluded_strs_it->second.is<picojson::array>()) {
     return ResultErr<ISTError>("AnyText format's excluded_strs field must be an array");
@@ -597,7 +626,7 @@ Result<AnyTextFormat, ISTError> StructuralTagParser::ParseAnyTextFormat(const pi
     }
     excluded_strs.push_back(excluded_str.get<std::string>());
   }
-  return ResultOk<AnyTextFormat>(std::move(excluded_strs));
+  return ResultOk<AnyTextFormat>(std::move(excluded_strs), max_tokens);
 }
 
 Result<GrammarFormat, ISTError> StructuralTagParser::ParseGrammarFormat(const picojson::object& obj
@@ -1911,9 +1940,15 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const AnyTextForma
       all_excludes.push_back(s);
     }
   }
-  if (!all_excludes.empty()) {
-    auto tag_dispatch_expr =
-        grammar_builder_.AddTagDispatch(Grammar::Impl::TagDispatch{{}, false, all_excludes});
+  if (!all_excludes.empty() || format.max_tokens != -1) {
+    // With excludes, or with a token budget, the region is a TagDispatch (an Aho-Corasick scan).
+    // The token budget is carried on the TagDispatch and enforced by the matcher: once max_tokens
+    // content tokens are consumed the region is forced to complete (its end tag becomes the only
+    // continuation). An empty exclude set is fine (matches any text). This is the path used even
+    // for a budget without excludes, so the single enforcement mechanism covers both.
+    auto tag_dispatch_expr = grammar_builder_.AddTagDispatch(
+        Grammar::Impl::TagDispatch{{}, false, all_excludes, format.max_tokens}
+    );
     return ResultOk(grammar_builder_.AddRuleWithHint("any_text", tag_dispatch_expr));
   } else {
     auto any_text_expr = grammar_builder_.AddCharacterClassStar({{0, 0x10FFFF}}, false);

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -119,7 +119,11 @@ struct RegexFormat {
 struct AnyTextFormat {
   static constexpr const char* type = "any_text";
   std::vector<std::string> excludes;
-  AnyTextFormat(std::vector<std::string> excluded_strs) : excludes(std::move(excluded_strs)) {}
+  // Max number of whole tokens this region may consume; -1 = unbounded. Enforced atomically at
+  // token granularity by the matcher (the region is forced to end once the budget is reached).
+  int32_t max_tokens = -1;
+  AnyTextFormat(std::vector<std::string> excluded_strs, int32_t max_tokens = -1)
+      : excludes(std::move(excluded_strs)), max_tokens(max_tokens) {}
   picojson::value ToJSON() const;
 
  private:

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -163,8 +163,14 @@ struct ExcludeTokenFormat {
 struct AnyTokensFormat {
   static constexpr const char* type = "any_tokens";
   std::vector<std::variant<int32_t, std::string>> exclude_tokens;
-  AnyTokensFormat(std::vector<std::variant<int32_t, std::string>> exclude_tokens)
-      : exclude_tokens(std::move(exclude_tokens)) {}
+  // If set, match at most max_tokens tokens (each excluding exclude_tokens), giving an exact
+  // token-count budget. If std::nullopt, the number of tokens is unbounded.
+  std::optional<int> max_tokens = std::nullopt;
+  AnyTokensFormat(
+      std::vector<std::variant<int32_t, std::string>> exclude_tokens,
+      std::optional<int> max_tokens = std::nullopt
+  )
+      : exclude_tokens(std::move(exclude_tokens)), max_tokens(max_tokens) {}
   picojson::value ToJSON() const;
 
  private:

--- a/docs/structural_tag/structural_tag_api.md
+++ b/docs/structural_tag/structural_tag_api.md
@@ -264,6 +264,7 @@ Matches arbitrary text.
 | Field | Type | Default |
 | --- | --- | --- |
 | `excludes` | `string[]` | `[]` |
+| `max_tokens` | `int \| null` | `null` |
 
 - **Use it when**: the content should remain free-form until some enclosing boundary is reached
 
@@ -276,6 +277,26 @@ Matches arbitrary text.
 
 When `any_text` appears inside a string-level `tag`, the enclosing end string is automatically
 treated as a stop condition.
+
+`max_tokens` (default `null`) caps how many **whole tokens** this region may consume. When set to a
+non-negative integer `N`, at most `N` tokens are matched and then the region is forced to end —
+i.e. its enclosing end tag (the next element after the region) becomes the only valid
+continuation, **not** the EOS/stop token. Because the limit is enforced at the token level by the
+matcher, it composes with **multi-token / multi-character `excludes`** (e.g. a `</think>` end
+marker that spans several tokens), which a token-level `any_tokens` budget cannot express. This
+gives, for example, a token budget on a reasoning/think section:
+
+```json
+{
+    "type": "tag",
+    "begin": "<think>",
+    "content": {"type": "any_text", "excludes": ["</think>"], "max_tokens": 256},
+    "end": "</think>"
+}
+```
+
+The budget is atomic at token granularity (the last admitted token is never split). The current
+implementation supports a single token-bounded `any_text` region per grammar.
 
 ### Composition Formats
 

--- a/docs/structural_tag/structural_tag_api.md
+++ b/docs/structural_tag/structural_tag_api.md
@@ -640,6 +640,7 @@ Matches zero or more tokens, excluding those in `exclude_tokens`.
 | Field | Type | Default |
 | --- | --- | --- |
 | `exclude_tokens` | `(int \| string)[]` | `[]` |
+| `max_tokens` | `int \| null` | `null` |
 
 - **Use it when**: content should remain unconstrained until a token-level boundary is reached
 
@@ -648,6 +649,18 @@ Matches zero or more tokens, excluding those in `exclude_tokens`.
 ```
 
 Semantically, `any_tokens` is equivalent to `star(exclude_token(...))`.
+
+`max_tokens` (default `null`) caps how many tokens this format may consume. When set to a
+non-negative integer `N`, the region matches **at most** `N` tokens (each of which still excludes
+the values in `exclude_tokens`), giving an exact token-count budget; when `null`, there is no
+limit. This is useful for bounding an otherwise-unlimited region, e.g. a token budget on a
+think/reasoning section:
+
+```json
+{"type": "any_tokens", "exclude_tokens": ["<|eos|>"], "max_tokens": 256}
+```
+
+With `max_tokens` set, `any_tokens` is equivalent to `repeat(exclude_token(...), min=0, max=N)`.
 
 #### `token_triggered_tags`
 

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -36,6 +36,7 @@ def get_model_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
 ) -> StructuralTag:
     r"""Get a structural tag for a model's reasoning and tool-call output format.
 
@@ -207,6 +208,14 @@ def get_model_structural_tag(
         emit in bad cases that would otherwise blow up grammar
         compilation/matching. Default: ``None``.
 
+    reasoning_max_tokens : Optional[int]
+        Optional token budget for the reasoning (think) span. When set to a
+        non-negative integer, a reasoning-capable model's think content is
+        bounded to at most this many tokens before the closing think marker is
+        forced -- i.e. a "think budget". ``None`` (default) leaves the reasoning
+        length unbounded. Has no effect for non-reasoning models or when
+        ``reasoning`` is ``False``.
+
     Notes
     -----
     If a tool's ``parameters`` field is omitted or ``None``, its generated
@@ -241,6 +250,7 @@ def get_model_structural_tag(
         any_order=any_order,
         exclude_special_tokens=exclude_special_tokens,
         max_whitespace_cnt=max_whitespace_cnt,
+        reasoning_max_tokens=reasoning_max_tokens,
     )
 
 
@@ -528,6 +538,7 @@ def get_llama_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Llama style structural tag format.
@@ -639,6 +650,7 @@ def get_kimi_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Kimi-K2 style structural tag format.
@@ -779,7 +791,9 @@ def get_kimi_structural_tag(
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
+    prefix_tag = TagFormat(
+        begin="", content=AnyTextFormat(max_tokens=reasoning_max_tokens), end=THINK_TAG_END
+    )
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
 
@@ -792,6 +806,7 @@ def get_deepseek_r1_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-R1 style structural tag format.
@@ -888,7 +903,9 @@ def get_deepseek_r1_structural_tag(
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
+    prefix_tag = TagFormat(
+        begin="", content=AnyTextFormat(max_tokens=reasoning_max_tokens), end=THINK_TAG_END
+    )
 
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
@@ -902,6 +919,7 @@ def get_deepseek_v3_1_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V3.1 style structural tag format.
@@ -996,7 +1014,9 @@ def get_deepseek_v3_1_structural_tag(
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
+    prefix_tag = TagFormat(
+        begin="", content=AnyTextFormat(max_tokens=reasoning_max_tokens), end=THINK_TAG_END
+    )
 
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
@@ -1011,6 +1031,7 @@ def get_qwen_3_5_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Qwen XML tool-call structural tag format.
@@ -1120,7 +1141,9 @@ def get_qwen_3_5_structural_tag(
 
     prefix_tag = SequenceFormat(
         elements=[
-            TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END),
+            TagFormat(
+                begin="", content=AnyTextFormat(max_tokens=reasoning_max_tokens), end=THINK_TAG_END
+            ),
             ConstStringFormat(value=THINK_SUFFIX),
         ]
     )
@@ -1140,6 +1163,7 @@ def get_qwen_3_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Qwen3 style structural tag format.
@@ -1245,7 +1269,9 @@ def get_qwen_3_structural_tag(
 
     prefix_tag = SequenceFormat(
         elements=[
-            TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END),
+            TagFormat(
+                begin="", content=AnyTextFormat(max_tokens=reasoning_max_tokens), end=THINK_TAG_END
+            ),
             ConstStringFormat(value=THINK_SUFFIX),
         ]
     )
@@ -1261,6 +1287,7 @@ def get_harmony_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get harmony(gpt-oss) style structural tag format.
@@ -1382,7 +1409,11 @@ def get_harmony_structural_tag(
         assert len(tags) > 0
 
     if reasoning:
-        analysis_tag = TagFormat(begin=ANALYSIS_BEGIN, content=AnyTextFormat(), end=FINAL_END)
+        analysis_tag = TagFormat(
+            begin=ANALYSIS_BEGIN,
+            content=AnyTextFormat(max_tokens=reasoning_max_tokens),
+            end=FINAL_END,
+        )
         tags.append(analysis_tag)
 
     tags_with_separator = TagsWithSeparatorFormat(tags=tags, separator=TAG_SEPARATOR)
@@ -1398,6 +1429,7 @@ def get_deepseek_v3_2_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V3.2 style structural tag format.
@@ -1518,7 +1550,9 @@ def get_deepseek_v3_2_structural_tag(
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
+    prefix_tag = TagFormat(
+        begin="", content=AnyTextFormat(max_tokens=reasoning_max_tokens), end=THINK_TAG_END
+    )
 
     sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
     return StructuralTag(format=sequence_format)
@@ -1533,6 +1567,7 @@ def get_minimax_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get MiniMax-M2.5 style structural tag format.
@@ -1650,7 +1685,9 @@ def get_minimax_structural_tag(
         )
 
     if reasoning:
-        think_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
+        think_tag = TagFormat(
+            begin="", content=AnyTextFormat(max_tokens=reasoning_max_tokens), end=THINK_TAG_END
+        )
     else:
         think_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
     return StructuralTag(
@@ -1669,6 +1706,7 @@ def get_glm_4_7_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get GLM-4.7/GLM-5 style structural tag format.
@@ -1788,7 +1826,10 @@ def get_glm_4_7_structural_tag(
 
     prefix_tag = TagFormat(
         begin="",
-        content=AnyTextFormat(excludes=_text_excludes(exclude_special_tokens, REASONING_EXCLUDES)),
+        content=AnyTextFormat(
+            excludes=_text_excludes(exclude_special_tokens, REASONING_EXCLUDES),
+            max_tokens=reasoning_max_tokens,
+        ),
         end=THINK_TAG_END,
     )
 
@@ -1806,6 +1847,7 @@ def _get_gemma_4_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get Gemma 4 style structural tag format.
@@ -1919,7 +1961,11 @@ def _get_gemma_4_structural_tag(
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
+    prefix_tag = TagFormat(
+        begin=THINK_TAG_BEGIN,
+        content=AnyTextFormat(max_tokens=reasoning_max_tokens),
+        end=THINK_TAG_END,
+    )
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
 
@@ -1932,6 +1978,7 @@ def get_deepseek_v4_structural_tag(
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
+    reasoning_max_tokens: Optional[int] = None,
     **kwargs: Any,
 ) -> StructuralTag:
     """Get DeepSeek-V4 style structural tag format.
@@ -2050,7 +2097,9 @@ def get_deepseek_v4_structural_tag(
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
+    prefix_tag = TagFormat(
+        begin="", content=AnyTextFormat(max_tokens=reasoning_max_tokens), end=THINK_TAG_END
+    )
 
     sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
     return StructuralTag(format=sequence_format)

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -60,6 +60,13 @@ class AnyTextFormat(BaseModel):
     excludes: List[str] = []
     """List of strings that should not appear in the matched text."""
 
+    max_tokens: Optional[int] = Field(default=None, ge=0)
+    """Maximum number of whole tokens this region may match. If None, unbounded. When set, at most
+    max_tokens tokens are matched and then the region is forced to end (e.g. its end tag becomes
+    the only valid continuation) -- a token budget that composes with multi-token/string
+    ``excludes``. Enforced atomically at token granularity. v1 supports a single bounded any_text
+    region per grammar."""
+
 
 class TokenFormat(BaseModel):
     """A format that matches a single token by ID or string representation."""

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -90,6 +90,11 @@ class AnyTokensFormat(BaseModel):
     exclude_tokens: List[Union[int, str]] = []
     """List of token IDs or strings to exclude."""
 
+    max_tokens: Optional[int] = Field(default=None, ge=0)
+    """Maximum number of tokens to match. If None, there is no limit. If set, at most
+    max_tokens tokens are matched (each excluding the tokens in exclude_tokens), giving an
+    exact token-count budget. It must be a non-negative integer."""
+
 
 class GrammarFormat(BaseModel):
     """A format that matches an ebnf grammar."""

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -25,7 +25,7 @@ from xgrammar.builtin_structural_tag import (
     normalize_tool_choice,
 )
 from xgrammar.openai_tool_call_schema import BuiltinToolParam, FunctionToolParam
-from xgrammar.structural_tag import JSONSchemaFormat, StructuralTag, TagFormat
+from xgrammar.structural_tag import AnyTextFormat, JSONSchemaFormat, StructuralTag, TagFormat
 from xgrammar.testing import _is_grammar_accept_string
 
 
@@ -1405,3 +1405,88 @@ def test_get_model_structural_tag_max_whitespace_cnt_propagates():
     )
     assert nodes_bounded
     assert all(n.max_whitespace_cnt == 2 for n in nodes_bounded)
+
+
+# ---------- Test: reasoning_max_tokens (think budget) ----------
+
+# Reasoning models whose think span is closed by one of these markers.
+_THINK_REGION_ENDS = {"</think>", "<channel|>"}
+
+# Registered reasoning models whose think region is a ``</think>``-terminated tag.
+_REASONING_MODELS = [
+    "deepseek_r1",
+    "deepseek_v3_1",
+    "deepseek_v3_2",
+    "deepseek_v4",
+    "qwen_3",
+    "qwen_3_5",
+    "kimi",
+    "minimax",
+    "glm_4_7",
+]
+
+
+def _collect_anytext_max_tokens(structural_tag: StructuralTag) -> List[Optional[int]]:
+    """Collect ``max_tokens`` from every nested AnyTextFormat node."""
+
+    return [
+        format_obj.max_tokens
+        for format_obj in _walk_structural_format(structural_tag.format)
+        if isinstance(format_obj, AnyTextFormat)
+    ]
+
+
+def _collect_think_region_max_tokens(structural_tag: StructuralTag) -> List[Optional[int]]:
+    """``max_tokens`` of the AnyText content nested inside a reasoning/think tag."""
+
+    return [
+        format_obj.content.max_tokens
+        for format_obj in _walk_structural_format(structural_tag.format)
+        if isinstance(format_obj, TagFormat)
+        and format_obj.end in _THINK_REGION_ENDS
+        and isinstance(format_obj.content, AnyTextFormat)
+    ]
+
+
+@pytest.mark.parametrize("model", _REASONING_MODELS)
+def test_reasoning_max_tokens_bounds_think_region(model: str):
+    """``reasoning_max_tokens`` bounds the think region only; nothing else gets a budget."""
+    st = get_model_structural_tag(model, tools=None, reasoning_max_tokens=8)
+    think = _collect_think_region_max_tokens(st)
+    all_max_tokens = _collect_anytext_max_tokens(st)
+    assert think and all(mt == 8 for mt in think)
+    # Only the think region(s) carry the budget; e.g. the free text after </think> stays unbounded.
+    assert all_max_tokens.count(8) == len(think)
+    assert all(mt in (8, None) for mt in all_max_tokens)
+
+
+@pytest.mark.parametrize("model", _REASONING_MODELS + ["harmony", "llama"])
+def test_reasoning_max_tokens_defaults_to_unbounded(model: str):
+    """Without ``reasoning_max_tokens`` every AnyText region stays unbounded (unchanged)."""
+    st = get_model_structural_tag(model, tools=None)
+    assert all(mt is None for mt in _collect_anytext_max_tokens(st))
+
+
+def test_reasoning_max_tokens_harmony_bounds_analysis_only():
+    """For harmony only the analysis (reasoning) channel is budgeted, not the final channel."""
+    st = get_model_structural_tag("harmony", tools=None, reasoning_max_tokens=8)
+    max_tokens = _collect_anytext_max_tokens(st)
+    assert max_tokens.count(8) == 1
+    assert max_tokens.count(None) >= 1
+
+
+def test_reasoning_max_tokens_ignored_without_reasoning():
+    """A think budget has no effect when reasoning is off or the model has no reasoning part."""
+    st = get_model_structural_tag(
+        "deepseek_r1", tools=None, reasoning=False, reasoning_max_tokens=8
+    )
+    assert all(mt is None for mt in _collect_anytext_max_tokens(st))
+    # Llama has no reasoning part: it accepts the argument and ignores it.
+    st_llama = get_model_structural_tag("llama", tools=None, reasoning_max_tokens=8)
+    assert all(mt is None for mt in _collect_anytext_max_tokens(st_llama))
+
+
+def test_reasoning_max_tokens_compiles_to_grammar():
+    """A think-budgeted structural tag still compiles to a grammar."""
+    st = get_model_structural_tag("deepseek_r1", tools=None, reasoning_max_tokens=4)
+    assert xgr.Grammar.from_structural_tag(st) is not None

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -542,5 +542,114 @@ def test_tag_dispatch_perf(ebnf, input_str):
     print(f"Accept token: avg={statistics.mean(flat_accept):.2f} us, max={max(flat_accept):.2f} us")
 
 
+# ---------- any_text max_tokens (token budget) ----------
+
+# Synthetic vocab where the end tag "</think>" spans MULTIPLE tokens ("</" + "think>"), which is
+# exactly the case a byte-level any_text token budget must handle (AnyTokensFormat cannot, since
+# its excludes are single tokens).
+_TB_VOCAB = ["<think>", "a", "b", "</", "think>", "c", "<eos>"]
+_TB_B, _TB_A, _TB_BB, _TB_E1, _TB_E2, _TB_C, _TB_EOS = 0, 1, 2, 3, 4, 5, 6
+
+
+def _think_budget_compiled(max_tokens, *, cache_enabled=True, compiler=None):
+    tokenizer_info = xgr.TokenizerInfo(_TB_VOCAB, stop_token_ids=[_TB_EOS])
+    compiler = compiler or xgr.GrammarCompiler(tokenizer_info, cache_enabled=cache_enabled)
+    content = {"type": "any_text", "excludes": ["</think>"]}
+    if max_tokens is not None:
+        content["max_tokens"] = max_tokens
+    stag = {
+        "type": "structural_tag",
+        "format": {"type": "tag", "begin": "<think>", "content": content, "end": "</think>"},
+    }
+    return compiler, compiler.compile_structural_tag(stag)
+
+
+def _accepts(compiled, tokens):
+    matcher = xgr.GrammarMatcher(compiled)
+    for t in tokens:
+        if not matcher.accept_token(t):
+            return False
+    return matcher.is_completed()
+
+
+def _allowed(compiled, prefix, token):
+    matcher = xgr.GrammarMatcher(compiled)
+    for t in prefix:
+        assert matcher.accept_token(t)
+    return matcher.accept_token(token)
+
+
+def test_any_text_max_tokens_forces_end_tag_not_eos():
+    """After N content tokens the bounded region is forced to END: only the (multi-token) end tag
+    is valid, content is rejected, and EOS is NOT allowed (we force the end tag, not a stop)."""
+    _, cg = _think_budget_compiled(2)
+    B, A, BB, E1, E2, C, EOS = _TB_B, _TB_A, _TB_BB, _TB_E1, _TB_E2, _TB_C, _TB_EOS
+    assert _accepts(cg, [B, A, BB, E1, E2])  # 2 content tokens + end -> complete
+    assert _accepts(cg, [B, A, E1, E2])  # 1 content token
+    assert _accepts(cg, [B, E1, E2])  # 0 content tokens
+    assert not _accepts(cg, [B, A, BB, C, E1, E2])  # 3 content tokens exceeds budget
+    # at the budget, content is rejected but the end tag is allowed; EOS is not (region not done)
+    assert _allowed(cg, [B, A, BB], E1) is True
+    assert _allowed(cg, [B, A, BB], A) is False
+    assert _allowed(cg, [B, A, BB], EOS) is False
+
+
+def test_any_text_max_tokens_zero_forces_immediate_end():
+    _, cg = _think_budget_compiled(0)
+    B, A, E1, E2 = _TB_B, _TB_A, _TB_E1, _TB_E2
+    assert _accepts(cg, [B, E1, E2])
+    assert _allowed(cg, [B], A) is False
+    assert _allowed(cg, [B], E1) is True
+
+
+def test_any_text_max_tokens_rollback_restores_budget():
+    _, cg = _think_budget_compiled(2)
+    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
+    matcher = xgr.GrammarMatcher(cg)
+    assert matcher.accept_token(B)
+    assert matcher.accept_token(A)
+    assert matcher.accept_token(BB)  # budget full
+    assert not matcher.accept_token(C)  # over budget
+    matcher.rollback(1)  # undo one content token
+    assert matcher.accept_token(C)  # budget restored: one content token allowed again
+    assert not matcher.accept_token(A)  # full again
+    assert matcher.accept_token(E1) and matcher.accept_token(E2)
+    assert matcher.is_completed()
+
+
+def test_any_text_max_tokens_cache_no_staleness():
+    """A bounded region must not reuse an unbounded region's cached fast-accept mask even when
+    their FSMs (excludes) are identical and they are compiled by the same cache-enabled compiler."""
+    tokenizer_info = xgr.TokenizerInfo(_TB_VOCAB, stop_token_ids=[_TB_EOS])
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=True)
+    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
+    # compile the UNBOUNDED variant first to populate the FSM-hash cache
+    _, cg_unbounded = _think_budget_compiled(None, compiler=compiler)
+    assert _accepts(cg_unbounded, [B, A, BB, C, A, E1, E2])  # 5 content tokens, no budget
+    # now the bounded variant (same excludes/FSM) must still enforce
+    _, cg_bounded = _think_budget_compiled(2, compiler=compiler)
+    assert _allowed(cg_bounded, [B, A, BB], A) is False
+    assert not _accepts(cg_bounded, [B, A, BB, C, E1, E2])
+    assert _accepts(cg_bounded, [B, A, BB, E1, E2])
+
+
+def test_any_text_unbounded_no_regression():
+    _, cg = _think_budget_compiled(None)
+    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
+    # without a budget the region accepts arbitrarily many content tokens
+    assert _accepts(cg, [B, A, BB, C, A, BB, C, E1, E2])
+
+
+def test_any_text_max_tokens_fork_independent():
+    _, cg = _think_budget_compiled(2)
+    B, A, BB, C = _TB_B, _TB_A, _TB_BB, _TB_C
+    matcher = xgr.GrammarMatcher(cg)
+    assert matcher.accept_token(B) and matcher.accept_token(A)  # 1 content used
+    child = matcher.fork()
+    assert child.accept_token(BB)  # child uses its 2nd
+    assert not child.accept_token(C)  # child exhausted
+    assert matcher.accept_token(BB)  # parent budget independent, still has its 2nd
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -7,6 +7,7 @@ from transformers import AutoTokenizer
 
 import xgrammar as xgr
 from xgrammar.structural_tag import (
+    AnyTextFormat,
     AnyTokensFormat,
     JSONSchemaFormat,
     SequenceFormat,
@@ -4504,6 +4505,44 @@ def test_structural_tag_max_whitespace_cnt_compile_cache():
     g_bounded = compiler.compile_structural_tag(_ws_stag(max_whitespace_cnt=2)).grammar
     assert _is_grammar_accept_string(g_unbounded, _ws_instance(5))
     assert not _is_grammar_accept_string(g_bounded, _ws_instance(5))
+
+
+def test_any_text_max_tokens_builds_tag_dispatch():
+    """A bounded any_text (with or without excludes) compiles to a TagDispatch that carries the
+    budget; the budget itself is enforced by the matcher (see test_grammar_matcher_structural_tag).
+    """
+    for fmt in (
+        {"type": "any_text", "excludes": ["</think>"], "max_tokens": 4},
+        {"type": "any_text", "max_tokens": 4},  # no excludes, but bounded -> still a TagDispatch
+    ):
+        grammar_str = str(
+            xgr.Grammar.from_structural_tag({"type": "structural_tag", "format": fmt})
+        )
+        assert "TagDispatch" in grammar_str
+    # unbounded no-excludes stays a plain character-class star (no regression)
+    assert "[\\0-\\U0010ffff]*" in str(
+        xgr.Grammar.from_structural_tag({"type": "structural_tag", "format": {"type": "any_text"}})
+    )
+
+
+def test_any_text_max_tokens_model_roundtrip():
+    model = AnyTextFormat(excludes=["</think>"], max_tokens=8)
+    assert model.model_dump()["max_tokens"] == 8
+    assert AnyTextFormat.model_validate_json(model.model_dump_json()).max_tokens == 8
+    # unset -> None (unbounded), distinct from 0
+    assert AnyTextFormat(excludes=["</think>"]).model_dump()["max_tokens"] is None
+
+
+@pytest.mark.parametrize("bad", [-1, "2", 2.5, 10**12])
+def test_any_text_max_tokens_invalid_raises(bad):
+    stag = {"type": "structural_tag", "format": {"type": "any_text", "max_tokens": bad}}
+    with pytest.raises(Exception):
+        xgr.Grammar.from_structural_tag(stag)
+
+
+def test_any_text_max_tokens_negative_rejected_by_pydantic():
+    with pytest.raises(Exception):
+        AnyTextFormat(excludes=["</think>"], max_tokens=-1)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -6,7 +6,13 @@ import pytest
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
-from xgrammar.structural_tag import JSONSchemaFormat, SequenceFormat, StructuralTag, TagFormat
+from xgrammar.structural_tag import (
+    AnyTokensFormat,
+    JSONSchemaFormat,
+    SequenceFormat,
+    StructuralTag,
+    TagFormat,
+)
 from xgrammar.testing import _is_grammar_accept_string
 
 
@@ -3580,6 +3586,289 @@ any_tokens ::= ("" | (any_tokens_inner any_tokens))
 root ::= ((any_tokens))
 """,
     )
+
+
+def test_any_tokens_format_max_tokens():
+    """max_tokens bounds the per-token star to {0, N} (an exact token-count budget)."""
+    check_stag_with_grammar(
+        {"type": "any_tokens", "exclude_tokens": [5, 10], "max_tokens": 3},
+        r"""any_tokens_inner ::= ((ExcludeToken(5, 10)))
+any_tokens ::= ((any_tokens_inner{0, 3}))
+root ::= ((any_tokens))
+""",
+    )
+
+
+def test_any_tokens_format_max_tokens_enforced():
+    """End-to-end: max_tokens=N accepts at most N tokens (each excluding exclude_tokens),
+    then the section must end. Each token counts exactly once."""
+    # raw vocab: a=0, b=1, c=2, X=3
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c", "X"])
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+    spec = {
+        "type": "structural_tag",
+        "format": {
+            "type": "sequence",
+            "elements": [
+                {"type": "any_tokens", "exclude_tokens": ["X"], "max_tokens": 2},
+                {"type": "const_string", "value": "X"},
+            ],
+        },
+    }
+    compiled = compiler.compile_structural_tag(spec)
+    A, B, C, X = 0, 1, 2, 3
+
+    def accepts(tokens):
+        matcher = xgr.GrammarMatcher(compiled)
+        for token_id in tokens:
+            if not matcher.accept_token(token_id):
+                return False
+        return matcher.is_completed()
+
+    assert accepts([X])  # 0 budget tokens, then end
+    assert accepts([A, X])  # 1 budget token
+    assert accepts([A, B, X])  # 2 budget tokens (budget full), then end
+    assert not accepts([A, B, C])  # 3rd budget token exceeds max_tokens -> rejected
+    assert not accepts([A, B, C, X])
+
+
+def test_any_tokens_format_max_tokens_zero_grammar():
+    """max_tokens=0 produces a {0, 0} repetition (zero tokens), distinct from the unbounded star."""
+    check_stag_with_grammar(
+        {"type": "any_tokens", "exclude_tokens": [5], "max_tokens": 0},
+        r"""any_tokens_inner ::= ((ExcludeToken(5)))
+any_tokens ::= ((any_tokens_inner{0, 0}))
+root ::= ((any_tokens))
+""",
+    )
+
+
+def test_any_tokens_format_max_tokens_one_grammar():
+    """Boundary max_tokens=1 produces {0, 1} (optional single token)."""
+    check_stag_with_grammar(
+        {"type": "any_tokens", "exclude_tokens": [5], "max_tokens": 1},
+        r"""any_tokens_inner ::= ((ExcludeToken(5)))
+any_tokens ::= ((any_tokens_inner{0, 1}))
+root ::= ((any_tokens))
+""",
+    )
+
+
+def test_any_tokens_format_max_tokens_no_exclude_tokens_grammar():
+    """max_tokens applies even with an empty exclude set (ExcludeToken())."""
+    check_stag_with_grammar(
+        {"type": "any_tokens", "max_tokens": 2},
+        r"""any_tokens_inner ::= ((ExcludeToken()))
+any_tokens ::= ((any_tokens_inner{0, 2}))
+root ::= ((any_tokens))
+""",
+    )
+
+
+def _any_tokens_budget_accepts(max_tokens, exclude_tokens, vocab, prefix_end="X"):
+    """Helper: compile [any_tokens(exclude_tokens, max_tokens), const_string(prefix_end)] and
+    return an accepts(token_ids) closure."""
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+    spec = {
+        "type": "structural_tag",
+        "format": {
+            "type": "sequence",
+            "elements": [
+                {"type": "any_tokens", "exclude_tokens": exclude_tokens, "max_tokens": max_tokens},
+                {"type": "const_string", "value": prefix_end},
+            ],
+        },
+    }
+    compiled = compiler.compile_structural_tag(spec)
+
+    def accepts(token_ids):
+        matcher = xgr.GrammarMatcher(compiled)
+        for token_id in token_ids:
+            if not matcher.accept_token(token_id):
+                return False
+        return matcher.is_completed()
+
+    return accepts
+
+
+def test_any_tokens_format_max_tokens_zero_enforced():
+    """max_tokens=0: no budget token may be consumed; only the immediate end is valid."""
+    accepts = _any_tokens_budget_accepts(0, ["X"], ["a", "b", "X"])
+    A, _, X = 0, 1, 2
+    assert accepts([X])
+    assert not accepts([A, X])
+    assert not accepts([A])
+
+
+def test_any_tokens_format_max_tokens_one_enforced():
+    """max_tokens=1: zero or exactly one budget token, then forced end."""
+    accepts = _any_tokens_budget_accepts(1, ["X"], ["a", "b", "X"])
+    A, B, X = 0, 1, 2
+    assert accepts([X])
+    assert accepts([A, X])
+    assert not accepts([A, B, X])
+    assert not accepts([A, B])
+
+
+def test_any_tokens_format_max_tokens_with_exclude_tokens_enforced():
+    """max_tokens AND exclude_tokens both enforced: excluded token rejected mid-budget; each
+    non-excluded token counts against the budget."""
+    accepts = _any_tokens_budget_accepts(3, ["c"], ["a", "b", "c", "X"])
+    A, B, C, X = 0, 1, 2, 3
+    assert accepts([A, B, X])  # 2 of 3 budget, c never used
+    assert accepts([A, B, A, X])  # 3 budget tokens, none excluded
+    assert not accepts([A, C, X])  # C excluded mid-budget
+    assert not accepts([A, B, A, A, X])  # 4th budget token exceeds max_tokens
+
+
+def test_any_tokens_format_max_tokens_negative_raises_in_grammar():
+    """A negative max_tokens (as a JSON integer in a dict) is rejected at grammar build."""
+    stag = {
+        "type": "structural_tag",
+        "format": {"type": "any_tokens", "exclude_tokens": [5], "max_tokens": -1},
+    }
+    with pytest.raises(Exception, match="non-negative integer"):
+        xgr.Grammar.from_structural_tag(stag)
+
+
+def test_any_tokens_format_max_tokens_non_numeric_raises():
+    """A present-but-non-numeric max_tokens is an error, not silently treated as unbounded."""
+    stag = {
+        "type": "structural_tag",
+        "format": {"type": "any_tokens", "exclude_tokens": [5], "max_tokens": "2"},
+    }
+    with pytest.raises(Exception, match="non-negative integer"):
+        xgr.Grammar.from_structural_tag(stag)
+
+
+def test_any_tokens_format_max_tokens_overflow_raises():
+    """A max_tokens above INT_MAX is rejected rather than silently truncated."""
+    stag = {"type": "structural_tag", "format": {"type": "any_tokens", "max_tokens": 10**12}}
+    with pytest.raises(Exception, match="non-negative integer"):
+        xgr.Grammar.from_structural_tag(stag)
+
+
+def test_any_tokens_format_max_tokens_negative_rejected_by_pydantic():
+    """The pydantic model rejects a negative max_tokens at construction (defense in depth)."""
+    with pytest.raises(Exception):
+        AnyTokensFormat(exclude_tokens=[5], max_tokens=-1)
+
+
+def test_any_tokens_format_max_tokens_roundtrip_json():
+    """Round-trip through the pydantic model preserves max_tokens and exclude_tokens."""
+    m = AnyTokensFormat(exclude_tokens=[5, 10], max_tokens=3)
+    dumped = m.model_dump()
+    assert dumped["max_tokens"] == 3 and dumped["exclude_tokens"] == [5, 10]
+    m2 = AnyTokensFormat.model_validate_json(m.model_dump_json())
+    assert m2.max_tokens == 3 and m2.exclude_tokens == [5, 10]
+    # the re-serialized form recompiles to the same {0, 3} grammar
+    check_stag_with_grammar(
+        {"type": "any_tokens", "exclude_tokens": [5, 10], "max_tokens": 3},
+        r"""any_tokens_inner ::= ((ExcludeToken(5, 10)))
+any_tokens ::= ((any_tokens_inner{0, 3}))
+root ::= ((any_tokens))
+""",
+    )
+
+
+def test_any_tokens_format_max_tokens_none_uses_unbounded_star():
+    """When max_tokens is unset it serializes as None and the grammar uses the unbounded star
+    (NOT the {0, N} form), distinguishing it from max_tokens=0."""
+    m = AnyTokensFormat(exclude_tokens=[5])
+    assert m.model_dump()["max_tokens"] is None
+    check_stag_with_grammar(
+        {"type": "any_tokens", "exclude_tokens": [5]},
+        r"""any_tokens_inner ::= ((ExcludeToken(5)))
+any_tokens ::= ("" | (any_tokens_inner any_tokens))
+root ::= ((any_tokens))
+""",
+    )
+
+
+def test_any_tokens_max_tokens_inside_tag_grammar():
+    """Think-style: AnyTokensFormat with max_tokens nested in a TagFormat with token begin/end.
+    The parent end token is auto-detected and folded into ExcludeToken while {0, N} is preserved."""
+    check_stag_with_grammar(
+        {
+            "type": "tag",
+            "begin": {"type": "token", "token": 1},
+            "content": {"type": "any_tokens", "exclude_tokens": [5], "max_tokens": 3},
+            "end": {"type": "token", "token": 99},
+        },
+        r"""any_tokens_inner ::= ((ExcludeToken(5, 99)))
+any_tokens ::= ((any_tokens_inner{0, 3}))
+tag ::= ((Token(1) any_tokens Token(99)))
+root ::= ((tag))
+""",
+    )
+
+
+def test_any_tokens_max_tokens_inside_tag_enforced():
+    """Think-style enforcement: end reachable after 0..N content tokens (early end allowed),
+    end forced once the budget is reached, and content cannot exceed N tokens."""
+    # vocab: B=0 (begin), x=1 (content), y=2 (content), E=3 (end)
+    tokenizer_info = xgr.TokenizerInfo(["<b>", "x", "y", "</e>"])
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+    spec = {
+        "type": "structural_tag",
+        "format": {
+            "type": "tag",
+            "begin": {"type": "token", "token": 0},
+            "content": {"type": "any_tokens", "exclude_tokens": [], "max_tokens": 3},
+            "end": {"type": "token", "token": 3},
+        },
+    }
+    compiled = compiler.compile_structural_tag(spec)
+    B, X, E = 0, 1, 3
+
+    def accepts(token_ids):
+        matcher = xgr.GrammarMatcher(compiled)
+        for token_id in token_ids:
+            if not matcher.accept_token(token_id):
+                return False
+        return matcher.is_completed()
+
+    assert accepts([B, E])  # 0 content tokens
+    assert accepts([B, X, E])  # 1 content token
+    assert accepts([B, X, X, X, E])  # exactly N=3 content tokens
+    assert not accepts([B, X, X, X, X, E])  # 4 content tokens > N
+
+    # end is FORCED once budget is reached
+    matcher = xgr.GrammarMatcher(compiled)
+    assert matcher.accept_token(B)
+    for _ in range(3):
+        assert matcher.accept_token(X)
+    assert not matcher.accept_token(X)  # 4th content token rejected
+    assert matcher.accept_token(E)  # only the end is allowed
+    assert matcher.is_completed()
+
+
+def test_any_tokens_max_tokens_zero_inside_tag_forces_immediate_end():
+    """max_tokens=0 inside a begin/end tag forces the end token immediately after begin."""
+    tokenizer_info = xgr.TokenizerInfo(["<b>", "x", "</e>"])
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+    spec = {
+        "type": "structural_tag",
+        "format": {
+            "type": "tag",
+            "begin": {"type": "token", "token": 0},
+            "content": {"type": "any_tokens", "exclude_tokens": [], "max_tokens": 0},
+            "end": {"type": "token", "token": 2},
+        },
+    }
+    compiled = compiler.compile_structural_tag(spec)
+    B, X, E = 0, 1, 2
+
+    def accepts(token_ids):
+        matcher = xgr.GrammarMatcher(compiled)
+        for token_id in token_ids:
+            if not matcher.accept_token(token_id):
+                return False
+        return matcher.is_completed()
+
+    assert accepts([B, E])
+    assert not accepts([B, X, E])
 
 
 def test_any_tokens_detects_end_from_parent_tag():


### PR DESCRIPTION
## Support `max_tokens` in structural-tag free-form regions (think budget)

### Purpose
Enable a **think budget**: cap how many tokens a model may spend inside an unbounded region of a structural tag (e.g. a `<think>…</think>` reasoning span). Today `any_text` / `any_tokens` regions are unbounded, so there is no way to limit the length of a thinking/free-form segment. This PR adds an optional per-region token budget that the grammar enforces directly.

### What's changed
- **`AnyTokensFormat`**: add an optional `max_tokens` that bounds the number of tokens the region may emit.
- **`AnyTextFormat`**: add an optional `max_tokens` budget. It is plumbed onto the `AnyTextFormat` and carried through the `TagDispatch`, and the matcher enforces it by forcing the bounded region to end once `max_tokens` is reached.
- `max_tokens` is **opt-in**: unset means unbounded (unchanged behavior). It is validated as a non-negative integer and round-trips through the pydantic models and JSON (de)serialization.

### Behavior
- A bounded `any_text` (with or without `excludes`) compiles to a `TagDispatch` that carries the budget; an unbounded, no-excludes `any_text` still lowers to a plain character-class star (no regression).

### Tests
Added converter- and matcher-level tests covering: TagDispatch construction for bounded regions, the unbounded no-regression path, budget enforcement at the matcher, model/JSON round-trips, and invalid-value rejection.