### PR TITLE
[ROCm] Use a 2D launch for the Triton bitmask kernel

### DIFF
--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
@@ -67,7 +67,9 @@ def apply_token_bitmask_inplace_kernel(
         vocab_mask = offsets < vocab_size
         packed_bitmask_mask = bitmask_offsets < bitmask_strides
         packed_bitmask = tl.load(
-            bitmask_ptr + batch_id * bitmask_strides + bitmask_offsets, packed_bitmask_mask
+            bitmask_ptr + batch_id * bitmask_strides + bitmask_offsets,
+            mask=packed_bitmask_mask,
+            other=0,
         )
         bitmask = ((packed_bitmask[:, None] >> (tl.arange(0, 32)[None, :])) & 1) == 0
         bitmask = bitmask.reshape(BLOCK_SIZE)
@@ -75,6 +77,38 @@ def apply_token_bitmask_inplace_kernel(
         tl.store(
             logits_ptr + batch_id * logits_strides + offsets, -float("inf"), vocab_mask & bitmask
         )
+
+
+@triton.jit
+def apply_token_bitmask_inplace_rocm_kernel(
+    logits_ptr,
+    bitmask_ptr,
+    indices_ptr,
+    num_rows,
+    vocab_size,
+    logits_strides,
+    bitmask_strides,
+    BLOCK_SIZE: tl.constexpr,
+):
+    block_id = tl.program_id(0)
+    row_id = tl.program_id(1)
+    block_offset = block_id * BLOCK_SIZE
+    batch_id = row_id if indices_ptr is None else tl.load(indices_ptr + row_id)
+    offsets = block_offset + tl.arange(0, BLOCK_SIZE)
+    bitmask_offsets = block_offset // 32 + tl.arange(0, BLOCK_SIZE // 32)
+    vocab_mask = offsets < vocab_size
+    packed_bitmask_mask = bitmask_offsets < bitmask_strides
+    packed_bitmask = tl.load(
+        bitmask_ptr + batch_id * bitmask_strides + bitmask_offsets,
+        mask=packed_bitmask_mask,
+        other=0,
+    )
+    bitmask = ((packed_bitmask[:, None] >> (tl.arange(0, 32)[None, :])) & 1) == 0
+    bitmask = bitmask.reshape(BLOCK_SIZE)
+
+    tl.store(
+        logits_ptr + batch_id * logits_strides + offsets, -float("inf"), vocab_mask & bitmask
+    )
 
 
 def apply_token_bitmask_inplace_triton(
@@ -86,8 +120,9 @@ def apply_token_bitmask_inplace_triton(
     NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
     BLOCK_SIZE = 4096
 
-    arch = torch.cuda.get_device_properties(0).gcnArchName
-    if torch.version.hip is not None and "gfx1" not in arch:
+    is_rocm = torch.version.hip is not None
+    arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
+    if is_rocm and "gfx1" not in arch:
         # For AMD GPUs (non-Navi)
         WARP_SIZE = 64
     else:
@@ -112,18 +147,32 @@ def apply_token_bitmask_inplace_triton(
             indices_cpu = torch.tensor(indices, dtype=torch.int32)
             indices = indices_cpu.to(device=logits.device, non_blocking=True)
 
-    grid = (NUM_SMS,)
-
-    apply_token_bitmask_inplace_kernel[grid](
-        logits,
-        bitmask,
-        indices,
-        num_rows,
-        vocab_size,
-        logits.stride()[0],
-        bitmask.stride()[0],
-        NUM_SMS,
-        BLOCK_SIZE,
-        num_warps=BLOCK_SIZE // WARP_SIZE // (16 // logits.element_size()),
-        num_stages=3,
-    )
+    if is_rocm:
+        grid = (triton.cdiv(vocab_size, BLOCK_SIZE), num_rows)
+        apply_token_bitmask_inplace_rocm_kernel[grid](
+            logits,
+            bitmask,
+            indices,
+            num_rows,
+            vocab_size,
+            logits.stride()[0],
+            bitmask.stride()[0],
+            BLOCK_SIZE,
+            num_warps=BLOCK_SIZE // WARP_SIZE // (16 // logits.element_size()),
+            num_stages=3,
+        )
+    else:
+        grid = (NUM_SMS,)
+        apply_token_bitmask_inplace_kernel[grid](
+            logits,
+            bitmask,
+            indices,
+            num_rows,
+            vocab_size,
+            logits.stride()[0],
+            bitmask.stride()[0],
+            NUM_SMS,
+            BLOCK_SIZE,
+            num_warps=BLOCK_SIZE // WARP_SIZE // (16 // logits.element_size()),
+            num_stages=3,
+        )

--- a/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
+++ b/python/xgrammar/kernels/apply_token_bitmask_inplace_triton.py
@@ -84,7 +84,6 @@ def apply_token_bitmask_inplace_rocm_kernel(
     logits_ptr,
     bitmask_ptr,
     indices_ptr,
-    num_rows,
     vocab_size,
     logits_strides,
     bitmask_strides,
@@ -117,11 +116,12 @@ def apply_token_bitmask_inplace_triton(
     vocab_size: Optional[int] = None,
     indices: Optional[Union[List[int], torch.Tensor]] = None,
 ):
-    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    device_props = torch.cuda.get_device_properties(logits.device)
+    NUM_SMS = device_props.multi_processor_count
     BLOCK_SIZE = 4096
 
     is_rocm = torch.version.hip is not None
-    arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
+    arch = getattr(device_props, "gcnArchName", "")
     if is_rocm and "gfx1" not in arch:
         # For AMD GPUs (non-Navi)
         WARP_SIZE = 64
@@ -147,13 +147,15 @@ def apply_token_bitmask_inplace_triton(
             indices_cpu = torch.tensor(indices, dtype=torch.int32)
             indices = indices_cpu.to(device=logits.device, non_blocking=True)
 
+    if num_rows == 0 or vocab_size == 0:
+        return
+
     if is_rocm:
         grid = (triton.cdiv(vocab_size, BLOCK_SIZE), num_rows)
         apply_token_bitmask_inplace_rocm_kernel[grid](
             logits,
             bitmask,
             indices,
-            num_rows,
             vocab_size,
             logits.stride()[0],
             bitmask.stride()[0],

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -365,6 +365,28 @@ def test_apply_token_bitmask_inplace_indices(
         torch.testing.assert_close(logits, logits_expected)
 
 
+@pytest.mark.parametrize("case", ("empty_indices", "zero_vocab"))
+def test_apply_token_bitmask_inplace_triton_empty_work(case: str):
+    if not _is_cuda_available:
+        pytest.skip(reason="CUDA is not installed")
+
+    kernel = get_apply_token_bitmask_kernel("triton")
+
+    if case == "empty_indices":
+        logits = torch.randn((2, 64), dtype=torch.float32, device="cuda")
+        bitmask = torch.zeros((2, 2), dtype=torch.int32, device="cuda")
+        expected = logits.clone()
+        kernel(logits, bitmask, indices=[])
+    else:
+        logits = torch.empty((2, 0), dtype=torch.float32, device="cuda")
+        bitmask = torch.empty((2, 0), dtype=torch.int32, device="cuda")
+        expected = logits.clone()
+        kernel(logits, bitmask, vocab_size=0)
+
+    torch.cuda.synchronize()
+    torch.testing.assert_close(logits, expected)
+
+
 def test_bitmask_to_boolmask():
     # 0xFFFF0000, 0x0000FFFF
     bitmask = torch.tensor([[-65536, 65535]], dtype=torch.int32)


### PR DESCRIPTION
This PR changes only the ROCm path of `apply_token_bitmask_inplace_triton.py`. CUDA keeps the existing persistent launch. The current ROCm path uses a persistent 1D grid and loops over work with `tl.range(..., NUM_SMS)`. This patch switches ROCm to a regular 2D launch where each Triton program handles one `(vocab block, row)` pair. The motivation is an intermittent ROCm HSA exception we are seeing through vLLM structured-output inference. The failing vLLM logs consistently show this kernel being JITed shortly before the crash:

```text
Triton kernel JIT compilation during inference: apply_token_bitmask_inplace_kernel
HSA_STATUS_ERROR_EXCEPTION ... code: 0x1016
```

Filed an issue regarding this here:
- https://github.com/mlc-ai/xgrammar/issues/678

I could not reduce this to a standalone xgrammar crash. A direct xgrammar stress script using the same Qwen-shaped tensors did not fail locally. So I would not describe this as a proven xgrammar-only bug fix. The reason I think the PR still makes sense is that it removes the ROCm persistent-loop kernel shape from the suspect path, keeps the behavior unchanged, and did not show a performance regression on MI300.

I compared installed `xgrammar==0.2.1` against this patched source module across 480 GPU-timed cases. The benchmark measures only the in-place bitmask application after logits and bitmasks are already on GPU.

| Slice | Cases | Median delta vs installed |
|---|---:|---:|
| All cases | 480 | `-0.0039 ms` |
| Full-row cases | 300 | `-0.0039 ms` |
| Sparse-index cases | 180 | `-0.0039 ms` |
| Qwen vocab `151936` | 120 | `-0.0039 ms` |

On this MI300 setup, I do not see a steady-state performance regression. The patched ROCm path was slightly faster in this sweep, but the main takeaway is that the launch-shape change is behavior-preserving and performance-neutral for the cases tested.
