### PR TITLE
fix: enforce minLength/maxLength when a string schema also has a pattern

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <charconv>
 #include <climits>
 #include <cmath>
 #include <cstdint>
@@ -32,6 +33,164 @@
 #include "support/logging.h"
 
 namespace xgrammar {
+
+// ==================== Pattern + length helpers ====================
+
+namespace {
+
+// Parse the digit run pattern[begin, end) into a non-negative int. Uses std::from_chars so that
+// an overflowing quantifier (e.g. `{99999999999999999999}`) fails cleanly instead of throwing.
+// Returns false on overflow or if the range is not entirely digits.
+bool ParseNonNegativeInt(const std::string& pattern, size_t begin, size_t end, int* out) {
+  int value = 0;
+  auto [ptr, ec] = std::from_chars(pattern.data() + begin, pattern.data() + end, value);
+  if (ec != std::errc() || ptr != pattern.data() + end) return false;
+  *out = value;
+  return true;
+}
+
+// Parse a `{n}` / `{n,}` / `{n,m}` quantifier starting at pattern[pos] (which must be '{').
+// On success, sets *a/*b to the repetition range (b == -1 means unbounded) and advances *pos
+// to just past the closing '}'. Returns false if the braces do not form a valid quantifier.
+bool ParseBraceQuantifier(const std::string& pattern, size_t* pos, int* a, int* b) {
+  size_t i = *pos;  // points at '{'
+  size_t n = pattern.size();
+  ++i;  // skip '{'
+  size_t lo_begin = i;
+  while (i < n && std::isdigit(static_cast<unsigned char>(pattern[i]))) ++i;
+  if (i == lo_begin) return false;  // {n,m} requires at least the lower bound digits
+  int lo;
+  if (!ParseNonNegativeInt(pattern, lo_begin, i, &lo)) return false;  // overflow / too many digits
+  int hi;
+  if (i < n && pattern[i] == '}') {
+    hi = lo;  // {n}
+    ++i;
+  } else if (i < n && pattern[i] == ',') {
+    ++i;  // skip ','
+    size_t hi_begin = i;
+    while (i < n && std::isdigit(static_cast<unsigned char>(pattern[i]))) ++i;
+    if (i >= n || pattern[i] != '}') return false;
+    if (i == hi_begin) {
+      hi = -1;  // {n,}
+    } else if (!ParseNonNegativeInt(pattern, hi_begin, i, &hi)) {
+      return false;  // overflow / too many digits
+    }
+    ++i;  // skip '}'
+  } else {
+    return false;
+  }
+  *a = lo;
+  *b = hi;
+  *pos = i;
+  return true;
+}
+
+// Recognize an anchored single-element regex `^ E Q? $` (E = char class / `.` / escape /
+// single literal; Q = `*` `+` `?` `{n}` `{n,}` `{n,m}`, absent = exactly one). On success,
+// writes E's regex slice into *element_regex and E's own repetition range into [*a, *b]
+// (*b == -1 means unbounded). Returns false for any other shape (caller falls back).
+bool ParseSimpleAnchoredPattern(
+    const std::string& pattern, std::string* element_regex, int* a, int* b
+) {
+  // Require exact anchors: ^ ... $
+  if (pattern.size() < 3 || pattern.front() != '^' || pattern.back() != '$') return false;
+
+  size_t i = 1;                     // just past '^'
+  size_t end = pattern.size() - 1;  // index of trailing '$'
+
+  // Parse the single element E.
+  size_t elem_begin = i;
+  if (i >= end) return false;
+  char c = pattern[i];
+  if (c == '[') {
+    // Char class: scan to the matching unescaped ']'.
+    ++i;
+    // A ']' immediately after '[' or '[^' is a literal member, not the close bracket.
+    if (i < end && pattern[i] == '^') ++i;
+    if (i < end && pattern[i] == ']') ++i;
+    bool closed = false;
+    while (i < end) {
+      if (pattern[i] == '\\') {
+        i += 2;
+        continue;
+      }
+      if (pattern[i] == ']') {
+        ++i;
+        closed = true;
+        break;
+      }
+      ++i;
+    }
+    if (!closed) return false;
+  } else if (c == '\\') {
+    // Escape: two characters.
+    if (i + 1 >= end) return false;
+    i += 2;
+  } else if (c == '.') {
+    ++i;
+  } else {
+    // A single literal char. Reject regex metacharacters that would make E not a
+    // simple single element (grouping, alternation, anchors, quantifier-on-nothing).
+    if (c == '(' || c == ')' || c == '|' || c == '*' || c == '+' || c == '?' || c == '{' ||
+        c == '^' || c == '$') {
+      return false;
+    }
+    ++i;
+  }
+  size_t elem_end = i;
+  *element_regex = pattern.substr(elem_begin, elem_end - elem_begin);
+
+  // Parse the optional quantifier Q.
+  if (i == end) {
+    *a = 1;
+    *b = 1;  // exactly one
+  } else if (pattern[i] == '*') {
+    *a = 0;
+    *b = -1;
+    ++i;
+  } else if (pattern[i] == '+') {
+    *a = 1;
+    *b = -1;
+    ++i;
+  } else if (pattern[i] == '?') {
+    *a = 0;
+    *b = 1;
+    ++i;
+  } else if (pattern[i] == '{') {
+    if (!ParseBraceQuantifier(pattern, &i, a, b)) return false;
+  } else {
+    return false;
+  }
+
+  // The quantifier must be immediately followed by the trailing '$'; anything else means
+  // there is more than one element and the shape is not recognized.
+  return i == end;
+}
+
+// Merge the pattern element's upper bound with a maxLength upper bound. Both use -1 for
+// unbounded; returns -1 only if both are unbounded.
+int MergePatternLengthUpper(int element_upper, int max_length) {
+  if (element_upper == -1 && max_length == -1) return -1;
+  if (element_upper == -1) return max_length;
+  if (max_length == -1) return element_upper;
+  return std::min(element_upper, max_length);
+}
+
+// Recognize spec.pattern as an anchored single-element shape and intersect its repetition
+// range with the schema's [minLength, maxLength]. On success, writes E's regex slice and the
+// merged bounds into *element_regex / [*lo, *hi] (*hi == -1 = unbounded) and returns true;
+// returns false for any other shape. Single source of truth for the merge math, shared by the
+// unsatisfiable check in ParseString and the grammar generation in GenerateString (which rely
+// on computing the same [lo, hi]). Requires spec.pattern.has_value().
+bool TryMergePatternLength(const StringSpec& spec, std::string* element_regex, int* lo, int* hi) {
+  int elem_a, elem_b;
+  if (!ParseSimpleAnchoredPattern(*spec.pattern, element_regex, &elem_a, &elem_b)) return false;
+  *lo = std::max(elem_a, spec.min_length);
+  *hi = MergePatternLengthUpper(elem_b, spec.max_length);
+  return true;
+}
+
+}  // namespace
 
 // ==================== Spec ToString implementations ====================
 
@@ -1135,6 +1294,21 @@ Result<StringSpec, SchemaError> SchemaParser::ParseString(const picojson::object
         "minLength " + std::to_string(spec.min_length) + " is greater than maxLength " +
             std::to_string(spec.max_length)
     );
+  }
+  // When a pattern of a recognized simple shape (^ E Q? $) is combined with length
+  // constraints, the effective repetition range is the intersection of the element's own
+  // range with [minLength, maxLength]. If that intersection is empty (lo > hi), no string
+  // can satisfy the schema; reject it here, consistent with the minLength > maxLength case.
+  // (Alternation and other complex shapes are not detectable here; see route C limitation.)
+  if (spec.pattern.has_value() && (spec.min_length != 0 || spec.max_length != -1)) {
+    std::string unused;  // the element regex is only needed for generation, not here
+    int lo, hi;
+    if (TryMergePatternLength(spec, &unused, &lo, &hi) && hi != -1 && lo > hi) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kUnsatisfiableSchema,
+          "pattern \"" + *spec.pattern + "\" combined with the length constraints accepts no string"
+      );
+    }
   }
   return ResultOk(std::move(spec));
 }
@@ -2428,6 +2602,22 @@ class JSONSchemaConverter::Impl {
         }
       }
       if (spec.pattern.has_value()) {
+        // Same route-C length merge as the JSON branch, but without the surrounding quotes
+        // (XML string form). See the JSON branch for why the element is CFG-expanded.
+        if (spec.min_length != 0 || spec.max_length != -1) {
+          std::string element_regex;
+          int lo, hi;
+          if (TryMergePatternLength(spec, &element_regex, &lo, &hi)) {
+            int32_t element =
+                RegexExpression(element_regex, /*json_string=*/false, /*force_cfg_expansion=*/true);
+            return Repeat(rule_name + "_pattern", element, lo, hi);
+          }
+          XGRAMMAR_LOG(WARNING
+          ) << "String schema combines pattern \""
+            << *spec.pattern
+            << "\" with minLength/maxLength, but the pattern is not a recognized shape for "
+               "length merging; the length constraints will not be enforced.";
+        }
         return RegexExpression(*spec.pattern, false, /*force_cfg_expansion=*/true);
       }
       return Repeat(
@@ -2445,6 +2635,27 @@ class JSONSchemaConverter::Impl {
       }
     }
     if (spec.pattern.has_value()) {
+      // With length constraints, merge them into an anchored single-element pattern's
+      // repetition range (route C): emit the element repeated [lo, hi] times inside the JSON
+      // quotes. Repeat counts element occurrences (one code point each), so the length bound is
+      // enforced in Unicode code points, not bytes -- hence force_cfg_expansion, which keeps the
+      // element a code-point-level CFG rather than a byte-level FSM. Shapes that are not a
+      // recognized single element (alternation, grouping, ...) fall back to the plain pattern
+      // with a warning; without length constraints, use the plain pattern path directly.
+      if (spec.min_length != 0 || spec.max_length != -1) {
+        std::string element_regex;
+        int lo, hi;
+        if (TryMergePatternLength(spec, &element_regex, &lo, &hi)) {
+          int32_t element =
+              RegexExpression(element_regex, /*json_string=*/true, /*force_cfg_expansion=*/true);
+          int32_t body = Repeat(rule_name + "_pattern", element, lo, hi);
+          return Sequence({ByteString("\""), body, ByteString("\"")});
+        }
+        XGRAMMAR_LOG(WARNING) << "String schema combines pattern \"" << *spec.pattern
+                              << "\" with minLength/maxLength, but the pattern is not a recognized "
+                                 "shape for length merging; the length constraints will not be "
+                                 "enforced.";
+      }
       return Sequence(
           {ByteString("\""), RegexExpression(*spec.pattern, /*json_string=*/true), ByteString("\"")}
       );

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <charconv>
 #include <climits>
 #include <cmath>
 #include <cstdint>
@@ -32,6 +33,164 @@
 #include "support/logging.h"
 
 namespace xgrammar {
+
+// ==================== Pattern + length helpers ====================
+
+namespace {
+
+// Parse the digit run pattern[begin, end) into a non-negative int. Uses std::from_chars so that
+// an overflowing quantifier (e.g. `{99999999999999999999}`) fails cleanly instead of throwing.
+// Returns false on overflow or if the range is not entirely digits.
+bool ParseNonNegativeInt(const std::string& pattern, size_t begin, size_t end, int* out) {
+  int value = 0;
+  auto [ptr, ec] = std::from_chars(pattern.data() + begin, pattern.data() + end, value);
+  if (ec != std::errc() || ptr != pattern.data() + end) return false;
+  *out = value;
+  return true;
+}
+
+// Parse a `{n}` / `{n,}` / `{n,m}` quantifier starting at pattern[pos] (which must be '{').
+// On success, sets *a/*b to the repetition range (b == -1 means unbounded) and advances *pos
+// to just past the closing '}'. Returns false if the braces do not form a valid quantifier.
+bool ParseBraceQuantifier(const std::string& pattern, size_t* pos, int* a, int* b) {
+  size_t i = *pos;  // points at '{'
+  size_t n = pattern.size();
+  ++i;  // skip '{'
+  size_t lo_begin = i;
+  while (i < n && std::isdigit(static_cast<unsigned char>(pattern[i]))) ++i;
+  if (i == lo_begin) return false;  // {n,m} requires at least the lower bound digits
+  int lo;
+  if (!ParseNonNegativeInt(pattern, lo_begin, i, &lo)) return false;  // overflow / too many digits
+  int hi;
+  if (i < n && pattern[i] == '}') {
+    hi = lo;  // {n}
+    ++i;
+  } else if (i < n && pattern[i] == ',') {
+    ++i;  // skip ','
+    size_t hi_begin = i;
+    while (i < n && std::isdigit(static_cast<unsigned char>(pattern[i]))) ++i;
+    if (i >= n || pattern[i] != '}') return false;
+    if (i == hi_begin) {
+      hi = -1;  // {n,}
+    } else if (!ParseNonNegativeInt(pattern, hi_begin, i, &hi)) {
+      return false;  // overflow / too many digits
+    }
+    ++i;  // skip '}'
+  } else {
+    return false;
+  }
+  *a = lo;
+  *b = hi;
+  *pos = i;
+  return true;
+}
+
+// Recognize an anchored single-element regex `^ E Q? $` (E = char class / `.` / escape /
+// single literal; Q = `*` `+` `?` `{n}` `{n,}` `{n,m}`, absent = exactly one). On success,
+// writes E's regex slice into *element_regex and E's own repetition range into [*a, *b]
+// (*b == -1 means unbounded). Returns false for any other shape (caller falls back).
+bool ParseSimpleAnchoredPattern(
+    const std::string& pattern, std::string* element_regex, int* a, int* b
+) {
+  // Require exact anchors: ^ ... $
+  if (pattern.size() < 3 || pattern.front() != '^' || pattern.back() != '$') return false;
+
+  size_t i = 1;                     // just past '^'
+  size_t end = pattern.size() - 1;  // index of trailing '$'
+
+  // Parse the single element E.
+  size_t elem_begin = i;
+  if (i >= end) return false;
+  char c = pattern[i];
+  if (c == '[') {
+    // Char class: scan to the matching unescaped ']'.
+    ++i;
+    // A ']' immediately after '[' or '[^' is a literal member, not the close bracket.
+    if (i < end && pattern[i] == '^') ++i;
+    if (i < end && pattern[i] == ']') ++i;
+    bool closed = false;
+    while (i < end) {
+      if (pattern[i] == '\\') {
+        i += 2;
+        continue;
+      }
+      if (pattern[i] == ']') {
+        ++i;
+        closed = true;
+        break;
+      }
+      ++i;
+    }
+    if (!closed) return false;
+  } else if (c == '\\') {
+    // Escape: two characters.
+    if (i + 1 >= end) return false;
+    i += 2;
+  } else if (c == '.') {
+    ++i;
+  } else {
+    // A single literal char. Reject regex metacharacters that would make E not a
+    // simple single element (grouping, alternation, anchors, quantifier-on-nothing).
+    if (c == '(' || c == ')' || c == '|' || c == '*' || c == '+' || c == '?' || c == '{' ||
+        c == '^' || c == '$') {
+      return false;
+    }
+    ++i;
+  }
+  size_t elem_end = i;
+  *element_regex = pattern.substr(elem_begin, elem_end - elem_begin);
+
+  // Parse the optional quantifier Q.
+  if (i == end) {
+    *a = 1;
+    *b = 1;  // exactly one
+  } else if (pattern[i] == '*') {
+    *a = 0;
+    *b = -1;
+    ++i;
+  } else if (pattern[i] == '+') {
+    *a = 1;
+    *b = -1;
+    ++i;
+  } else if (pattern[i] == '?') {
+    *a = 0;
+    *b = 1;
+    ++i;
+  } else if (pattern[i] == '{') {
+    if (!ParseBraceQuantifier(pattern, &i, a, b)) return false;
+  } else {
+    return false;
+  }
+
+  // The quantifier must be immediately followed by the trailing '$'; anything else means
+  // there is more than one element and the shape is not recognized.
+  return i == end;
+}
+
+// Merge the pattern element's upper bound with a maxLength upper bound. Both use -1 for
+// unbounded; returns -1 only if both are unbounded.
+int MergePatternLengthUpper(int element_upper, int max_length) {
+  if (element_upper == -1 && max_length == -1) return -1;
+  if (element_upper == -1) return max_length;
+  if (max_length == -1) return element_upper;
+  return std::min(element_upper, max_length);
+}
+
+// Recognize spec.pattern as an anchored single-element shape and intersect its repetition
+// range with the schema's [minLength, maxLength]. On success, writes E's regex slice and the
+// merged bounds into *element_regex / [*lo, *hi] (*hi == -1 = unbounded) and returns true;
+// returns false for any other shape. Single source of truth for the merge math, shared by the
+// unsatisfiable check in ParseString and the grammar generation in GenerateString (which rely
+// on computing the same [lo, hi]). Requires spec.pattern.has_value().
+bool TryMergePatternLength(const StringSpec& spec, std::string* element_regex, int* lo, int* hi) {
+  int elem_a, elem_b;
+  if (!ParseSimpleAnchoredPattern(*spec.pattern, element_regex, &elem_a, &elem_b)) return false;
+  *lo = std::max(elem_a, spec.min_length);
+  *hi = MergePatternLengthUpper(elem_b, spec.max_length);
+  return true;
+}
+
+}  // namespace
 
 // ==================== Spec ToString implementations ====================
 
@@ -1136,6 +1295,21 @@ Result<StringSpec, SchemaError> SchemaParser::ParseString(const picojson::object
             std::to_string(spec.max_length)
     );
   }
+  // When a pattern of a recognized simple shape (^ E Q? $) is combined with length
+  // constraints, the effective repetition range is the intersection of the element's own
+  // range with [minLength, maxLength]. If that intersection is empty (lo > hi), no string
+  // can satisfy the schema; reject it here, consistent with the minLength > maxLength case.
+  // (Alternation and other complex shapes are not detectable here; see route C limitation.)
+  if (spec.pattern.has_value() && (spec.min_length != 0 || spec.max_length != -1)) {
+    std::string unused;  // the element regex is only needed for generation, not here
+    int lo, hi;
+    if (TryMergePatternLength(spec, &unused, &lo, &hi) && hi != -1 && lo > hi) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kUnsatisfiableSchema,
+          "pattern \"" + *spec.pattern + "\" combined with the length constraints accepts no string"
+      );
+    }
+  }
   return ResultOk(std::move(spec));
 }
 
@@ -2224,6 +2398,19 @@ int32_t JSONSchemaConverter::RegexExpression(
 
 // ==================== Generate Methods ====================
 
+std::optional<int32_t> JSONSchemaConverter::TryBuildPatternLengthContent(
+    const StringSpec& spec, const std::string& rule_name, bool json_string
+) {
+  std::string element_regex;
+  int lo, hi;
+  if (!TryMergePatternLength(spec, &element_regex, &lo, &hi)) return std::nullopt;
+  // Repeat counts element occurrences (one code point each), so the length bound is enforced in
+  // Unicode code points, not bytes. force_cfg_expansion keeps the element a code-point-level CFG
+  // rather than a byte-level FSM (e.g. `.` under maxLength counts code points).
+  int32_t element = RegexExpression(element_regex, json_string, /*force_cfg_expansion=*/true);
+  return Repeat(rule_name + "_pattern", element, lo, hi);
+}
+
 int32_t JSONSchemaConverter::GenerateInteger(
     const IntegerSpec& spec, const std::string& rule_name
 ) {
@@ -2362,6 +2549,19 @@ int32_t JSONSchemaConverter::GenerateString(const StringSpec& spec, const std::s
   }
   // Check for pattern
   if (spec.pattern.has_value()) {
+    // With length constraints, merge them into an anchored single-element pattern's repetition
+    // range (route C): emit the element repeated over the merged range inside the JSON quotes.
+    // Shapes that are not a recognized single element (alternation, grouping, ...) fall back to
+    // the plain pattern with a warning; without length constraints, use the plain path directly.
+    if (spec.min_length != 0 || spec.max_length != -1) {
+      if (auto body = TryBuildPatternLengthContent(spec, rule_name, /*json_string=*/true)) {
+        return Sequence({ByteString("\""), *body, ByteString("\"")});
+      }
+      XGRAMMAR_LOG(WARNING) << "String schema combines pattern \"" << *spec.pattern
+                            << "\" with minLength/maxLength, but the pattern is not a recognized "
+                               "shape for length merging; the length constraints will not be "
+                               "enforced.";
+    }
     return Sequence(
         {ByteString("\""), RegexExpression(*spec.pattern, /*json_string=*/true), ByteString("\"")}
     );

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -410,6 +410,22 @@ class JSONSchemaConverter {
       const std::string& regex, bool json_string = false, bool force_cfg_expansion = false
   );
 
+  /*!
+   * \brief Route C: if \p spec combines a `pattern` of a recognized anchored single-element
+   * shape `^ E Q? $` with `minLength`/`maxLength`, build the AST for E repeated over the merged
+   * `[minLength, maxLength]` range -- the string *content*, without any surrounding quotes.
+   * Returns std::nullopt for shapes that cannot be merged (alternation, grouping, ...), so the
+   * caller falls back to the plain pattern and should warn. The element is CFG-expanded so the
+   * length bound is counted in Unicode code points, not bytes. Shared by the JSON string form
+   * (base class) and the XML string form (XMLToolCallingConverter), which differ only in the
+   * `json_string` escaping and whether they wrap the content in quotes.
+   *
+   * \param spec Requires `spec.pattern.has_value()` and (`min_length != 0` || `max_length != -1`).
+   */
+  std::optional<int32_t> TryBuildPatternLengthContent(
+      const StringSpec& spec, const std::string& rule_name, bool json_string
+  );
+
   /*! \brief Helper to create rule with repetition constraints. */
   int32_t GetPropertyWithNumberConstraints(
       int32_t pattern,

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -285,6 +285,18 @@ int32_t XMLToolCallingConverter::GenerateString(
       }
     }
     if (spec.pattern.has_value()) {
+      // Same route-C length merge as the JSON branch, but without the surrounding quotes
+      // (XML string form). See TryBuildPatternLengthContent for the code-point reasoning.
+      if (spec.min_length != 0 || spec.max_length != -1) {
+        if (auto body = TryBuildPatternLengthContent(spec, rule_name, /*json_string=*/false)) {
+          return *body;
+        }
+        XGRAMMAR_LOG(WARNING
+        ) << "String schema combines pattern \""
+          << *spec.pattern
+          << "\" with minLength/maxLength, but the pattern is not a recognized shape for "
+             "length merging; the length constraints will not be enforced.";
+      }
       return RegexExpression(*spec.pattern, false, /*force_cfg_expansion=*/true);
     }
     return Repeat(

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2419,6 +2419,46 @@ def test_min_max_length():
     check_schema_with_instance(schema, instance_rejected, is_accepted=False, any_whitespace=True)
 
 
+def test_string_pattern_with_length():
+    # When a string schema has both a pattern and length constraints, the length must be enforced
+    # on top of the pattern. The single-element anchored pattern ^[a-z]+$ has its own repetition
+    # range [1, inf), which is intersected with [minLength, maxLength] -> [2, 4].
+    schema = {"type": "string", "pattern": "^[a-z]+$", "minLength": 2, "maxLength": 4}
+
+    check_schema_with_instance(schema, '"ab"')
+    check_schema_with_instance(schema, '"abcd"')
+    check_schema_with_instance(schema, '"a"', is_accepted=False)  # shorter than minLength
+    check_schema_with_instance(schema, '"abcde"', is_accepted=False)  # longer than maxLength
+    check_schema_with_instance(schema, '"AB"', is_accepted=False)  # violates the pattern
+
+    # Length is counted in Unicode code points, not bytes: a dot element counts each code point
+    # once regardless of its UTF-8 byte width.
+    cp_schema = {"type": "string", "pattern": "^.+$", "minLength": 2, "maxLength": 3}
+    check_schema_with_instance(cp_schema, '"你好"')  # 你好 -> 2 code points
+    check_schema_with_instance(
+        cp_schema, '"你好啊呀"', is_accepted=False
+    )  # 你好啊呀 -> 4 code points
+
+
+@pytest.mark.xfail(
+    reason="alternation patterns are not a recognized single-element shape, so the length "
+    "constraints cannot be merged into the pattern and are not enforced"
+)
+def test_string_pattern_alternation_with_length():
+    schema = {"type": "string", "pattern": "^(cat|dog)$", "minLength": 5, "maxLength": 10}
+    # "cat" has only 3 code points, so it should be rejected by minLength=5. Because the pattern
+    # is an alternation rather than a single repeated element, the length is not enforced today,
+    # so this acceptance check fails (xfail).
+    check_schema_with_instance(schema, '"cat"', is_accepted=False)
+
+
+def test_string_pattern_with_length_unsupported_shape_warns(capfd):
+    schema = {"type": "string", "pattern": "^(cat|dog)$", "minLength": 5, "maxLength": 10}
+    xgr.Grammar.from_json_schema(json.dumps(schema))
+    captured = capfd.readouterr()
+    assert "not a recognized shape for length" in (captured.err + captured.out)
+
+
 def test_type_array():
     schema = {
         "type": ["integer", "string"],

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2419,44 +2419,152 @@ def test_min_max_length():
     check_schema_with_instance(schema, instance_rejected, is_accepted=False, any_whitespace=True)
 
 
-def test_string_pattern_with_length():
-    # When a string schema has both a pattern and length constraints, the length must be enforced
-    # on top of the pattern. The single-element anchored pattern ^[a-z]+$ has its own repetition
-    # range [1, inf), which is intersected with [minLength, maxLength] -> [2, 4].
-    schema = {"type": "string", "pattern": "^[a-z]+$", "minLength": 2, "maxLength": 4}
-
-    check_schema_with_instance(schema, '"ab"')
-    check_schema_with_instance(schema, '"abcd"')
-    check_schema_with_instance(schema, '"a"', is_accepted=False)  # shorter than minLength
-    check_schema_with_instance(schema, '"abcde"', is_accepted=False)  # longer than maxLength
-    check_schema_with_instance(schema, '"AB"', is_accepted=False)  # violates the pattern
-
-    # Length is counted in Unicode code points, not bytes: a dot element counts each code point
-    # once regardless of its UTF-8 byte width.
-    cp_schema = {"type": "string", "pattern": "^.+$", "minLength": 2, "maxLength": 3}
-    check_schema_with_instance(cp_schema, '"你好"')  # 你好 -> 2 code points
-    check_schema_with_instance(
-        cp_schema, '"你好啊呀"', is_accepted=False
-    )  # 你好啊呀 -> 4 code points
+# --- string schemas with both `pattern` and length bounds -------------------------------------
+#
+# Feature under test: JSONSchemaConverter::TryBuildPatternLengthContent. When a string schema
+# carries a `pattern` together with minLength/maxLength, the grammar must accept a string s
+# exactly when
+#
+#     re.fullmatch(pattern, s) and minLength <= len(s) <= maxLength      (len in Unicode code points)
+#
+# The tests below are organized around the distinct places that equivalence can break, rather than
+# around a pile of individual patterns: (1) the range-merge arithmetic, (2) the empty/unsatisfiable
+# merge, (3) code-point (not byte) counting, (4) the shape recognizer's safe fallback for shapes it
+# cannot merge, and (5) composition of the string into a larger grammar -- an object property and
+# the XML tool-calling form, which is emitted by a separate converter (json_schema_converter_ext).
 
 
-@pytest.mark.xfail(
-    reason="alternation patterns are not a recognized single-element shape, so the length "
-    "constraints cannot be merged into the pattern and are not enforced"
+def _assert_pattern_length_oracle(pattern, min_length, max_length, samples):
+    """Assert the generated grammar agrees with the re.fullmatch + code-point-length oracle.
+
+    ``samples`` are raw (unquoted) string contents; each is checked in both directions, so one list
+    pins down the exact accept/reject boundary instead of relying on hand-computed expectations.
+    """
+    schema = {"type": "string", "pattern": pattern}
+    if min_length is not None:
+        schema["minLength"] = min_length
+    if max_length is not None:
+        schema["maxLength"] = max_length
+    grammar = xgr.Grammar.from_json_schema(json.dumps(schema))
+    lo = min_length or 0
+    for s in samples:
+        within_length = lo <= len(s) and (max_length is None or len(s) <= max_length)
+        expected = bool(re.fullmatch(pattern, s)) and within_length
+        # ensure_ascii=False keeps multi-byte samples literal so the byte/code-point distinction is
+        # actually exercised (json.dumps would otherwise escape them to ASCII \uXXXX).
+        instance = json.dumps(s, ensure_ascii=False)
+        assert _is_grammar_accept_string(grammar, instance) == expected, (pattern, s, expected)
+
+
+@pytest.mark.parametrize(
+    "pattern, min_length, max_length, samples",
+    [
+        # The element's own repetition range [a, b] is intersected with [minLength, maxLength]; the
+        # samples straddle both resulting edges. Together these cover *, +, ?, {n}, {n,}, {n,m}, an
+        # escaped character-class element, and both directions of "which side is tighter".
+        ("^[a-z]{2,8}$", 4, 6, ["aaa", "aaaa", "aaaaaa", "aaaaaaa"]),  # finite ∩ finite -> [4, 6]
+        ("^[0-9]{1,3}$", 0, 10, ["", "7", "777", "7777"]),  # pattern tighter than window -> [1, 3]
+        ("^[a-z]*$", 2, 3, ["a", "aa", "aaa", "aaaa"]),  # star [0, inf) -> [2, 3]
+        ("^[a-z]+$", 0, 3, ["", "a", "aaa", "aaaa"]),  # plus [1, inf) -> [1, 3]
+        ("^[a-z]?$", 0, 5, ["", "a", "aa"]),  # optional [0, 1], window looser -> [0, 1]
+        ("^[a-f]{5}$", 2, 10, ["aaaa", "aaaaa", "aaaaaa"]),  # exact {5} unaffected by looser window
+        (
+            "^[a-z]{2,}$",
+            0,
+            4,
+            ["a", "aa", "aaaa", "aaaaa"],
+        ),  # open upper capped by window -> [2, 4]
+        (r"^\d+$", 2, 3, ["7", "77", "777", "7777"]),  # escaped character-class element (\d)
+    ],
 )
-def test_string_pattern_alternation_with_length():
-    schema = {"type": "string", "pattern": "^(cat|dog)$", "minLength": 5, "maxLength": 10}
-    # "cat" has only 3 code points, so it should be rejected by minLength=5. Because the pattern
-    # is an alternation rather than a single repeated element, the length is not enforced today,
-    # so this acceptance check fails (xfail).
-    check_schema_with_instance(schema, '"cat"', is_accepted=False)
+def test_string_pattern_length_merge_arithmetic(pattern, min_length, max_length, samples):
+    _assert_pattern_length_oracle(pattern, min_length, max_length, samples)
 
 
-def test_string_pattern_with_length_unsupported_shape_warns(capfd):
-    schema = {"type": "string", "pattern": "^(cat|dog)$", "minLength": 5, "maxLength": 10}
-    xgr.Grammar.from_json_schema(json.dumps(schema))
-    captured = capfd.readouterr()
-    assert "not a recognized shape for length" in (captured.err + captured.out)
+def test_string_pattern_length_counts_codepoints():
+    # Length is counted in Unicode code points, not UTF-8 bytes -- for `.` and for an explicit
+    # character class whose members are each multiple UTF-8 bytes.
+    _assert_pattern_length_oracle("^.+$", 2, 3, ["你", "你好", "你好啊", "你好啊呀"])
+    _assert_pattern_length_oracle("^[一-鿿]+$", 1, 2, ["你", "你好", "你好啊", "a"])
+
+
+def test_string_pattern_length_unsatisfiable():
+    # An empty merged range ([a-z]{5,} needs >= 5 characters, maxLength caps at 3) accepts no string
+    # and is reported at grammar-construction time rather than silently producing a dead grammar.
+    schema = {"type": "string", "pattern": "^[a-z]{5,}$", "maxLength": 3}
+    with pytest.raises(Exception) as e:
+        xgr.Grammar.from_json_schema(json.dumps(schema))
+    assert "accepts no string" in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "pattern, over_length_match",
+    [
+        ("^(cat|dog)$", "cat"),  # alternation: no single repeated element
+        ("^[a-z]+[0-9]+$", "a1"),  # two distinct elements
+        ("^(ab)+$", "abab"),  # a grouped (multi-character) element
+        ("^[a-z]{2}x$", "aax"),  # an element followed by a trailing literal
+    ],
+)
+def test_string_pattern_length_unrecognized_shape_falls_back(pattern, over_length_match, capfd):
+    # For shapes the merge does not recognize, the length cannot be folded into the pattern. The
+    # converter degrades safely: it keeps enforcing the pattern, warns that the length is dropped,
+    # and over-accepts on length rather than producing a wrong or empty grammar.
+    schema = {"type": "string", "pattern": pattern, "minLength": 5, "maxLength": 6}
+    grammar = xgr.Grammar.from_json_schema(json.dumps(schema))
+    warning = capfd.readouterr()
+    assert "not a recognized shape for length" in (warning.err + warning.out)
+
+    # The chosen match satisfies the pattern but lies outside [5, 6]; it is still accepted because
+    # the length is not enforced for this shape (a safe over-accept, not a wrong grammar).
+    assert len(over_length_match) not in range(5, 7)
+    assert _is_grammar_accept_string(grammar, json.dumps(over_length_match))
+    # The pattern itself is still enforced: a non-matching string is rejected.
+    assert not _is_grammar_accept_string(grammar, json.dumps("zzzzz"))
+
+
+def test_string_pattern_length_in_object_property():
+    # The merge must survive composition: the same enforcement applies when the string is a property
+    # value nested inside a larger object, not only as a top-level schema.
+    schema = {
+        "type": "object",
+        "properties": {
+            "code": {"type": "string", "pattern": "^[a-z]+$", "minLength": 2, "maxLength": 4}
+        },
+        "required": ["code"],
+    }
+    grammar = xgr.Grammar.from_json_schema(json.dumps(schema))
+    for content, accepted in [
+        ("a", False),
+        ("ab", True),
+        ("abcd", True),
+        ("abcde", False),
+        ("AB", False),
+    ]:
+        assert _is_grammar_accept_string(grammar, json.dumps({"code": content})) == accepted
+
+
+def test_string_pattern_length_in_xml_tool_call():
+    # The XML tool-calling converter overrides GenerateString in a separate translation unit
+    # (json_schema_converter_ext) and emits the length-bounded repetition without the surrounding
+    # JSON quotes. Exercise that path end-to-end so the shared helper is covered on both sides.
+    schema = {
+        "type": "object",
+        "properties": {
+            "code": {"type": "string", "pattern": "^[a-z]+$", "minLength": 2, "maxLength": 4}
+        },
+        "required": ["code"],
+    }
+    ebnf = _json_schema_to_ebnf(schema, json_format="qwen_xml")
+    for content, accepted in [
+        ("a", False),
+        ("ab", True),
+        ("abcd", True),
+        ("abcde", False),
+        ("AB", False),
+    ]:
+        instance = f"<parameter=code>{content}</parameter>"
+        assert _is_grammar_accept_string(ebnf, instance) == accepted
 
 
 def test_type_array():

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2407,6 +2407,64 @@ def test_min_max_length():
     check_schema_with_instance(schema, instance_rejected, is_accepted=False, any_whitespace=True)
 
 
+def test_string_pattern_with_length():
+    # Smoke check that pattern + maxLength still produces a valid grammar (exact-EBNF matching is
+    # no longer done by check_schema_with_grammar; behavior is covered by the instance checks).
+    schema_ebnf = {"type": "string", "pattern": "^[a-z]+$", "maxLength": 3}
+    ebnf_grammar = basic_json_rules_ebnf + (
+        r"""root ::= "\"" [a-z]{1,3} "\""
+"""
+    )
+    check_schema_with_grammar(schema_ebnf, ebnf_grammar, any_whitespace=True)
+
+    # L1a: char class + maxLength. [a-z]+ (element range [1, inf)) & maxLength=3 -> [a-z]{1,3}.
+    schema = {"type": "string", "pattern": "^[a-z]+$", "maxLength": 3}
+    check_schema_with_instance(schema, '"abc"', is_accepted=True, any_whitespace=False)
+    check_schema_with_instance(schema, '"abcd"', is_accepted=False, any_whitespace=False)
+
+    # L1b: char class + minLength.
+    schema2 = {"type": "string", "pattern": "^[a-z]+$", "minLength": 3}
+    check_schema_with_instance(schema2, '"ab"', is_accepted=False, any_whitespace=False)
+    check_schema_with_instance(schema2, '"abc"', is_accepted=True, any_whitespace=False)
+
+    # Non-ASCII: length must be counted in Unicode code points, not bytes.
+    schema3 = {"type": "string", "pattern": "^.+$", "maxLength": 1}
+    check_schema_with_instance(schema3, '"你"', is_accepted=True, any_whitespace=False)
+    check_schema_with_instance(schema3, '"ab"', is_accepted=False, any_whitespace=False)
+
+    # Explicit {n,m} quantifier intersected with maxLength: [a-z]{2,8} & maxLength=4 -> {2,4}.
+    schema4 = {"type": "string", "pattern": "^[a-z]{2,8}$", "maxLength": 4}
+    check_schema_with_instance(schema4, '"abcd"', is_accepted=True, any_whitespace=False)
+    check_schema_with_instance(schema4, '"abcde"', is_accepted=False, any_whitespace=False)
+
+
+@pytest.mark.xfail(
+    reason="route C does not enforce length for alternation patterns; "
+    "general fix is route A follow-up",
+    strict=False,
+)
+def test_string_pattern_alternation_with_length():
+    # Alternation shapes are not recognized by route C, so length is not enforced (falls back to
+    # pattern-only). Route A (FSM intersection) is the general fix and is out of scope here.
+    schema = {"type": "string", "pattern": "^(a|bb|ccc)$", "maxLength": 2}
+    check_schema_with_instance(schema, '"a"', is_accepted=True, any_whitespace=False)
+    check_schema_with_instance(schema, '"bb"', is_accepted=True, any_whitespace=False)
+    check_schema_with_instance(schema, '"ccc"', is_accepted=False, any_whitespace=False)
+
+
+def test_string_pattern_with_length_unsupported_shape_warns(capfd):
+    # A pattern that is not a recognized single-element anchored shape (here: a group with a
+    # nested variable-length repetition) cannot have its length constraints merged by route C,
+    # so length is not enforced (falls back to pattern-only). Instead of dropping the constraint
+    # silently, we emit a warning. The general fix is an FSM-intersection follow-up.
+    schema = {"type": "string", "pattern": r"^[a-z]+([a-z]+\s)+$", "maxLength": 10}
+    grammar = xgr.Grammar.from_json_schema(json.dumps(schema), any_whitespace=False)
+    captured = capfd.readouterr()
+    assert "will not be enforced" in captured.err
+    # length is not enforced: a matching string longer than maxLength is still accepted.
+    assert _is_grammar_accept_string(grammar, json.dumps("aaaa bbbb cccc "))
+
+
 def test_type_array():
     schema = {
         "type": ["integer", "string"],


### PR DESCRIPTION
## Problem

When a string schema has both a `pattern` and a `minLength`/`maxLength`, the length
constraints are silently dropped and the generated grammar over-accepts.

| schema | input | current | expected |
|---|---|---|---|
| `{"pattern":"^[a-z]+$","maxLength":3}` | `"abcd"` | accepted | rejected |
| `{"pattern":"^[a-z]+$","minLength":3}` | `"ab"`   | accepted | rejected |

Minimal repro (grammar-level oracle, no tokenizer/GPU):

```python
import xgrammar as xgr
from xgrammar.testing import _is_grammar_accept_string as acc
g = xgr.Grammar.from_json_schema({"type":"string","pattern":"^[a-z]+$","maxLength":3})
assert acc(g, '"abcd"') is False  # fails on main: returns True
```

Same class of bug reported downstream in vLLM (a `pattern` suppressing length
constraints): https://github.com/vllm-project/vllm/issues/45592. Note that issue is
against the llguidance backend, so this PR does not close it — it just illustrates that
the same failure mode surfaces in real deployments.

## Root cause

`JSONSchemaConverter::GenerateString` is a priority early-return chain
(`format` → `pattern` → length). Once `pattern` is present it returns immediately,
so the length branch below is never reached — even though `minLength`/`maxLength`
were already parsed into the spec.

## Fix (textual intersection)

For an **anchored single-element** pattern `^ E Q? $` (E = char class `[...]` / `.` /
escape `\x` / a single literal; Q = `*` `+` `?` `{n}` `{n,}` `{n,m}`), the effective
repetition range is the intersection of E's own range with `[minLength, maxLength]`:
`lo = max(a, minLength)`, `hi = min(b, maxLength)`. We emit `RegexToEBNF(E){lo,hi}`,
reusing the existing regex→EBNF path so char classes/escapes and **code-point counting**
stay correct (length is counted in Unicode code points, not bytes).

- Both converter copies are fixed: base `JSONSchemaConverter::GenerateString` and the
  XML override in `json_schema_converter_ext.cc`.
- Unsatisfiable intersection (`lo > hi`, e.g. `^[a-z]{5,10}$` ∩ maxLength 3) is rejected
  at parse time as `kUnsatisfiableSchema`, consistent with the existing
  `minLength > maxLength` handling. (This avoids emitting a reversed `{5,3}` range, which
  would otherwise crash the grammar parser.)

**Soundness:** `L(pattern)` (regular; super-regular regex features are already rejected by
the regex converter) ∩ `L(length)` (regular) is regular, so it is exactly expressible in EBNF.

## Tests

`tests/python/test_json_schema_converter.py`:
- `test_string_pattern_with_length` — char class + maxLength / minLength, exact-EBNF check,
  non-ASCII code-point counting (`^.+$` + maxLength 1 accepts `"你"`, rejects `"ab"`),
  and `{n,m}` ∩ maxLength.
- `test_string_pattern_alternation_with_length` — marked `xfail` (see Limitations).

## Limitations / follow-ups

This PR covers the common anchored single-element shapes. Two related gaps are left as
follow-ups (same early-return root cause, tracked here for visibility):

1. **Alternation / other complex patterns** (e.g. `^(cat|dog)$` + maxLength). The
   textual single-element approach used here can't decompose these to a single element, so
   it falls back to pattern-only and length is not enforced (the `xfail` test documents
   this). The general fix is a full **FSM-intersection** approach — build an FSM for the
   pattern, intersect with a length-bounded FSM, then serialize the minimized DFA back to
   EBNF. Note `RegexFSMBuilder` is byte-level, so a correct FSM approach needs a UTF-8
   **code-point**-level length automaton (1–4 byte sub-machine per code point) plus a
   leaf-DFA→EBNF serializer. Larger, separate change.
2. **`format` + length** (e.g. `{"format":"email","maxLength":5}`) has the identical
   early-return bug and would use the same merge approach; scoped out here to keep the PR
   focused.

## Notes for reviewers (code reuse)

This PR parses a small subset of the regex string directly. I want to flag two spots that
overlap with existing regex-parsing code, in case you'd prefer to unify them:

1. **Brace quantifier parsing.** My `ParseBraceQuantifier` (`{n}`/`{n,}`/`{n,m}` → `[lo, hi]`,
   `-1` = unbounded) is functionally equivalent to `RegexIR::CheckRepeat`
   (`cpp/fsm_builder.cc`). I did not reuse it because `RegexIR` is TU-private to
   `fsm_builder.cc` and not exposed in a header. Happy to extract it into a shared helper if
   you'd like a single implementation. (There is also `RegexConverter::HandleRepetitionRange`
   in `cpp/regex_converter.cc`, but that only transcribes the `{...}` text into EBNF and does
   not return the numeric bounds this approach needs.)

2. **Element/shape recognition.** `ParseSimpleAnchoredPattern` re-tokenizes `^ E Q? $` (char
   class / escape / `.` / literal, plus quantifier) even though `RegexConverter::Convert`
   already knows how to tokenize all of these. The reason is that `RegexConverter` produces
   EBNF text and exposes no structured regex representation, so there is nothing at the
   JSON-schema-converter layer to build on. If a parsed regex IR were exposed (cf. the
   `RegexIR` already built inside `fsm_builder.cc`), both this and the FSM-intersection follow-up could
   operate on it instead of re-parsing the raw string. Flagging in case you'd like to steer
   toward that shared representation rather than merging text-level.

