### PR TITLE
feat: support Gemma tool calling format with <|"|> string delimiters 

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1659,6 +1659,16 @@ std::string JSONSchemaConverter::FormatOtherProperty(
   return key_pattern + " " + colon_pattern_ + " " + value_rule;
 }
 
+std::string JSONSchemaConverter::FormatPatternKey(const std::string& pattern) {
+  return "\"\\\"\"" + RegexToEBNF(pattern, false) + "\"\\\"\"";
+}
+
+std::string JSONSchemaConverter::CreatePropertyNamesKeyRule(
+    const SchemaSpecPtr& property_names, const std::string& rule_name_hint
+) {
+  return CreateRule(property_names, rule_name_hint);
+}
+
 std::string JSONSchemaConverter::GetPropertyWithNumberConstraints(
     const std::string& pattern, int min_properties, int max_properties, int already_repeated_times
 ) {
@@ -2133,8 +2143,7 @@ std::string JSONSchemaConverter::GenerateObject(
       for (size_t i = 0; i < spec.pattern_properties.size(); ++i) {
         const auto& pp = spec.pattern_properties[i];
         std::string value = CreateRule(pp.schema, rule_name + "_pp_" + std::to_string(i));
-        std::string pp_single = "\"\\\"\"" + RegexToEBNF(pp.pattern, false) + "\"\\\"\" " +
-                                colon_pattern_ + " " + value;
+        std::string pp_single = FormatPatternKey(pp.pattern) + " " + colon_pattern_ + " " + value;
         if (i != 0) pp_body += " | ";
         pp_body += pp_single;
       }
@@ -2156,7 +2165,7 @@ std::string JSONSchemaConverter::GenerateObject(
       // propertyNames constrains keys of additional properties.
       // Only apply when additional properties are allowed — when additionalProperties
       // is false, no extra keys beyond named properties should be permitted.
-      auto key_pattern = CreateRule(spec.property_names, rule_name + "_name");
+      auto key_pattern = CreatePropertyNamesKeyRule(spec.property_names, rule_name + "_name");
       std::string val_rule = CreateRule(effective_additional, rule_name + "_" + effective_suffix);
       pp_override = key_pattern + " " + colon_pattern_ + " " + val_rule;
       effective_suffix = "pn";
@@ -2183,8 +2192,8 @@ std::string JSONSchemaConverter::GenerateObject(
         for (size_t i = 0; i < spec.pattern_properties.size(); ++i) {
           const auto& pp = spec.pattern_properties[i];
           std::string value = CreateRule(pp.schema, rule_name + "_prop_" + std::to_string(i));
-          std::string property_pattern = "\"\\\"\"" + RegexToEBNF(pp.pattern, false) + "\"\\\"\" " +
-                                         colon_pattern_ + " " + value;
+          std::string property_pattern =
+              FormatPatternKey(pp.pattern) + " " + colon_pattern_ + " " + value;
           if (i != 0) {
             property_rule_body += " | ";
           }
@@ -2192,7 +2201,7 @@ std::string JSONSchemaConverter::GenerateObject(
         }
         property_rule_body += ")";
       } else {
-        auto key_pattern = CreateRule(spec.property_names, rule_name + "_name");
+        auto key_pattern = CreatePropertyNamesKeyRule(spec.property_names, rule_name + "_name");
         property_rule_body +=
             beg_seq + " " + key_pattern + " " + colon_pattern_ + " " + GetBasicAnyRuleName() + ")";
       }

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1198,7 +1198,7 @@ void JSONSchemaConverter::AddBasicRules() {
   // basic_string - cache_key matches SchemaParser::ComputeCacheKey for {"type": "string"}
   constexpr const char* kStringCacheKey = "{\"type\":\"string\"}";
   auto str_spec = SchemaSpec::Make(StringSpec{}, kStringCacheKey, kBasicString);
-  std::string str_body = "[\"] " + kBasicStringSub;
+  std::string str_body = GenerateString(std::get<StringSpec>(str_spec->spec), kBasicString);
   ebnf_script_creator_.AddRule(kBasicString, str_body);
   AddCache(kStringCacheKey, kBasicString);
 
@@ -3327,6 +3327,7 @@ std::optional<JSONFormat> JSONFormatFromString(const std::string& format) {
       {"minimax_xml", JSONFormat::kMiniMaxXML},
       {"deepseek_xml", JSONFormat::kDeepSeekXML},
       {"glm_xml", JSONFormat::kGlmXML},
+      {"gemma", JSONFormat::kGemma},
   };
   auto it = kNameToFormat.find(format);
   if (it == kNameToFormat.end()) {
@@ -3407,6 +3408,12 @@ std::string JSONSchemaToEBNF(
           ref_resolver,
           json_format,
           any_order
+      );
+      return converter.Convert(spec);
+    }
+    case JSONFormat::kGemma: {
+      GemmaToolCallingConverter converter(
+          indent, separators, any_whitespace, max_whitespace_cnt, ref_resolver, any_order
       );
       return converter.Convert(spec);
     }

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -324,6 +324,16 @@ class JSONSchemaConverter {
       const std::string& rule_name_suffix
   );
 
+  /*! \brief Format an object key constrained by a regex (patternProperties).
+   * Override for formats whose keys are not JSON-quoted. */
+  virtual std::string FormatPatternKey(const std::string& pattern);
+
+  /*! \brief Build the key pattern for propertyNames-constrained keys.
+   * Override for formats whose keys are not JSON strings. */
+  virtual std::string CreatePropertyNamesKeyRule(
+      const SchemaSpecPtr& property_names, const std::string& rule_name_hint
+  );
+
   /*! \brief Get the basic string rule name. Override for different formats. */
   virtual std::string GetKeyPattern() const;
 

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -188,6 +188,7 @@ enum class JSONFormat : int {
   kMiniMaxXML = 2,
   kDeepSeekXML = 3,
   kGlmXML = 4,
+  kGemma = 5,
 };
 
 /*!

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -304,6 +304,7 @@ std::optional<std::string> XMLToolCallingConverter::GetCache(const std::string& 
 const std::string GemmaToolCallingConverter::kStringDelim = "<|\"|>";
 const std::string GemmaToolCallingConverter::kGemmaStringContent = "gemma_string_content";
 const std::string GemmaToolCallingConverter::kGemmaVariableName = "gemma_variable_name";
+const std::string GemmaToolCallingConverter::kGemmaBoundedChar = "gemma_bounded_char";
 
 GemmaToolCallingConverter::GemmaToolCallingConverter(
     std::optional<int> indent,
@@ -326,6 +327,19 @@ void GemmaToolCallingConverter::AddBasicRules() {
           "))"
   );
   ebnf_script_creator_.AddRule(kGemmaVariableName, "[a-zA-Z_] [a-zA-Z0-9_]*");
+  // A single string-content character for length-constrained strings: any character
+  // except a '<' that starts the <|"|> delimiter. Since lookahead assertions cannot
+  // contain choices, each "the following text diverges from the delimiter at position
+  // k" case is a separate rule.
+  ebnf_script_creator_.AddRule(kGemmaBoundedChar + "_lt1", "\"<\" (= [^|])");
+  ebnf_script_creator_.AddRule(kGemmaBoundedChar + "_lt2", "\"<\" (= \"|\" [^\\\"])");
+  ebnf_script_creator_.AddRule(kGemmaBoundedChar + "_lt3", "\"<\" (= \"|\\\"\" [^|])");
+  ebnf_script_creator_.AddRule(kGemmaBoundedChar + "_lt4", "\"<\" (= \"|\\\"|\" [^>])");
+  ebnf_script_creator_.AddRule(
+      kGemmaBoundedChar,
+      "[^<] | " + kGemmaBoundedChar + "_lt1 | " + kGemmaBoundedChar + "_lt2 | " +
+          kGemmaBoundedChar + "_lt3 | " + kGemmaBoundedChar + "_lt4"
+  );
   // The base implementation builds all basic rules through the virtual Generate* methods,
   // so basic_string / basic_any / basic_object etc. all come out in Gemma format.
   JSONSchemaConverter::AddBasicRules();
@@ -336,6 +350,11 @@ std::string GemmaToolCallingConverter::GenerateString(
 ) {
   std::string delim = EBNFScriptCreator::Str(kStringDelim);
 
+  // NOTE: for the format/pattern branches the regex is emitted verbatim between the
+  // delimiters. A permissive pattern (e.g. ".*") can therefore generate text containing
+  // the <|"|> delimiter itself, which closes the string early for downstream parsers.
+  // Intersecting an arbitrary regex with "does not contain the delimiter" is not
+  // supported; keep patterns restrictive (the builtin formats are all safe).
   if (spec.format.has_value()) {
     auto regex_pattern = JSONFormatToRegexPattern(*spec.format);
     if (regex_pattern.has_value()) {
@@ -348,9 +367,9 @@ std::string GemmaToolCallingConverter::GenerateString(
   }
 
   if (spec.min_length != 0 || spec.max_length != -1) {
-    // Exclude '<' so the multi-character delimiter can never appear inside the
-    // length-constrained content.
-    std::string char_pattern = "[^<]";
+    // kGemmaBoundedChar consumes exactly one character and forbids only a '<' that
+    // starts the <|"|> delimiter, so repetition counts stay exact while the string
+    // terminator remains unambiguous.
     std::string repetition;
     if (spec.max_length == -1) {
       repetition = "{" + std::to_string(spec.min_length) + ",}";
@@ -358,7 +377,7 @@ std::string GemmaToolCallingConverter::GenerateString(
       repetition =
           "{" + std::to_string(spec.min_length) + "," + std::to_string(spec.max_length) + "}";
     }
-    return delim + " " + char_pattern + repetition + " " + delim;
+    return delim + " " + kGemmaBoundedChar + repetition + " " + delim;
   }
 
   return delim + " " + kGemmaStringContent + " " + delim;
@@ -402,6 +421,17 @@ std::string GemmaToolCallingConverter::GemmaValueToEBNFLiteral(const std::string
   std::string err = picojson::parse(value, json_value);
   XGRAMMAR_CHECK(err.empty()) << "Failed to parse JSON value: " << err
                               << ". The JSON string is: " << json_value;
+  if (!value.is<std::string>() && !value.is<picojson::object>() && !value.is<picojson::array>()) {
+    // Scalars (numbers, booleans, null) are identical in Gemma and JSON form. Keep the
+    // original literal text: round-tripping numbers through picojson's double storage
+    // would lose precision for large integers and change formatting (e.g. 1.0 -> 1).
+    std::string trimmed = json_value;
+    trimmed.erase(0, trimmed.find_first_not_of(" \n\t\r"));
+    trimmed.erase(trimmed.find_last_not_of(" \n\t\r") + 1);
+    return EBNFScriptCreator::Str(trimmed);
+  }
+  // Strings, objects and arrays must be re-serialized into Gemma form. Note: numbers
+  // nested inside objects/arrays still go through picojson and may lose precision.
   return EBNFScriptCreator::Str(GemmaSerializeJSON(value));
 }
 
@@ -438,6 +468,25 @@ std::string GemmaToolCallingConverter::GetKeyPatternExcluding(
 ) {
   // The trie-based exclusion in the base class is built for JSON-quoted keys; Gemma keys
   // are bare identifiers, so fall back to the plain key pattern.
+  return GetKeyPattern();
+}
+
+std::string GemmaToolCallingConverter::FormatPatternKey(const std::string& pattern) {
+  // Gemma keys are unquoted; emit the bare pattern. Note the sglang parser reads keys up
+  // to the first ':', so patterns whose language contains ':' cannot round-trip.
+  return "(" + RegexToEBNF(pattern, false) + ")";
+}
+
+std::string GemmaToolCallingConverter::CreatePropertyNamesKeyRule(
+    const SchemaSpecPtr& property_names, const std::string& rule_name_hint
+) {
+  // Gemma keys are bare identifiers, not <|"|>-delimited strings. Constrain by the
+  // propertyNames pattern when one is given; otherwise fall back to the identifier rule.
+  if (auto* str_spec = std::get_if<StringSpec>(&property_names->spec)) {
+    if (str_spec->pattern.has_value()) {
+      return "(" + RegexToEBNF(*str_spec->pattern, false) + ")";
+    }
+  }
   return GetKeyPattern();
 }
 

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -299,4 +299,146 @@ std::optional<std::string> XMLToolCallingConverter::GetCache(const std::string& 
   return rule_cache_manager_.GetCache(key, nested_object_level_ > 1);
 }
 
+// ==================== GemmaToolCallingConverter ====================
+
+const std::string GemmaToolCallingConverter::kStringDelim = "<|\"|>";
+const std::string GemmaToolCallingConverter::kGemmaStringContent = "gemma_string_content";
+const std::string GemmaToolCallingConverter::kGemmaVariableName = "gemma_variable_name";
+
+GemmaToolCallingConverter::GemmaToolCallingConverter(
+    std::optional<int> indent,
+    std::optional<std::pair<std::string, std::string>> separators,
+    bool any_whitespace,
+    std::optional<int> max_whitespace_cnt,
+    RefResolver ref_resolver,
+    bool any_order
+)
+    : JSONSchemaConverter(
+          indent, separators, any_whitespace, max_whitespace_cnt, ref_resolver, any_order
+      ) {}
+
+void GemmaToolCallingConverter::AddBasicRules() {
+  // Any text not containing the string delimiter. The enclosing rules terminate it with
+  // the delimiter itself, so the boundary is unambiguous.
+  ebnf_script_creator_.AddRule(
+      kGemmaStringContent,
+      "TagDispatch(loop_after_dispatch=false,excludes=(" + EBNFScriptCreator::Str(kStringDelim) +
+          "))"
+  );
+  ebnf_script_creator_.AddRule(kGemmaVariableName, "[a-zA-Z_] [a-zA-Z0-9_]*");
+  // The base implementation builds all basic rules through the virtual Generate* methods,
+  // so basic_string / basic_any / basic_object etc. all come out in Gemma format.
+  JSONSchemaConverter::AddBasicRules();
+}
+
+std::string GemmaToolCallingConverter::GenerateString(
+    const StringSpec& spec, const std::string& rule_name
+) {
+  std::string delim = EBNFScriptCreator::Str(kStringDelim);
+
+  if (spec.format.has_value()) {
+    auto regex_pattern = JSONFormatToRegexPattern(*spec.format);
+    if (regex_pattern.has_value()) {
+      return delim + " " + RegexToEBNF(regex_pattern.value(), false) + " " + delim;
+    }
+  }
+
+  if (spec.pattern.has_value()) {
+    return delim + " " + RegexToEBNF(*spec.pattern, false) + " " + delim;
+  }
+
+  if (spec.min_length != 0 || spec.max_length != -1) {
+    // Exclude '<' so the multi-character delimiter can never appear inside the
+    // length-constrained content.
+    std::string char_pattern = "[^<]";
+    std::string repetition;
+    if (spec.max_length == -1) {
+      repetition = "{" + std::to_string(spec.min_length) + ",}";
+    } else {
+      repetition =
+          "{" + std::to_string(spec.min_length) + "," + std::to_string(spec.max_length) + "}";
+    }
+    return delim + " " + char_pattern + repetition + " " + delim;
+  }
+
+  return delim + " " + kGemmaStringContent + " " + delim;
+}
+
+std::string GemmaToolCallingConverter::GemmaSerializeJSON(const picojson::value& value) {
+  if (value.is<std::string>()) {
+    // Gemma strings have no escape sequences; the raw content is emitted between delimiters.
+    return kStringDelim + value.get<std::string>() + kStringDelim;
+  }
+  if (value.is<picojson::object>()) {
+    const auto& obj = value.get<picojson::object>();
+    std::string result = "{";
+    bool first = true;
+    for (const auto& [key, val] : obj) {
+      if (!first) {
+        result += ",";
+      }
+      first = false;
+      result += key + ":" + GemmaSerializeJSON(val);
+    }
+    return result + "}";
+  }
+  if (value.is<picojson::array>()) {
+    const auto& arr = value.get<picojson::array>();
+    std::string result = "[";
+    for (size_t i = 0; i < arr.size(); ++i) {
+      if (i != 0) {
+        result += ",";
+      }
+      result += GemmaSerializeJSON(arr[i]);
+    }
+    return result + "]";
+  }
+  // Numbers, booleans and null keep their JSON serialization.
+  return value.serialize();
+}
+
+std::string GemmaToolCallingConverter::GemmaValueToEBNFLiteral(const std::string& json_value) {
+  picojson::value value;
+  std::string err = picojson::parse(value, json_value);
+  XGRAMMAR_CHECK(err.empty()) << "Failed to parse JSON value: " << err
+                              << ". The JSON string is: " << json_value;
+  return EBNFScriptCreator::Str(GemmaSerializeJSON(value));
+}
+
+std::string GemmaToolCallingConverter::GenerateConst(
+    const ConstSpec& spec, const std::string& rule_name
+) {
+  return GemmaValueToEBNFLiteral(spec.json_value);
+}
+
+std::string GemmaToolCallingConverter::GenerateEnum(
+    const EnumSpec& spec, const std::string& rule_name
+) {
+  XGRAMMAR_DCHECK(!spec.json_values.empty())
+      << "GenerateEnum called with empty enum spec for rule: " << rule_name;
+  std::string result;
+  for (size_t i = 0; i < spec.json_values.size(); ++i) {
+    if (i != 0) {
+      result += " | ";
+    }
+    result += "(" + GemmaValueToEBNFLiteral(spec.json_values[i]) + ")";
+  }
+  return result;
+}
+
+std::string GemmaToolCallingConverter::FormatPropertyKey(const std::string& key) {
+  // Keys are unquoted in Gemma format.
+  return EBNFScriptCreator::Str(key);
+}
+
+std::string GemmaToolCallingConverter::GetKeyPattern() const { return kGemmaVariableName; }
+
+std::string GemmaToolCallingConverter::GetKeyPatternExcluding(
+    const std::vector<ObjectSpec::Property>& properties, const std::string& rule_name
+) {
+  // The trie-based exclusion in the base class is built for JSON-quoted keys; Gemma keys
+  // are bare identifiers, so fall back to the plain key pattern.
+  return GetKeyPattern();
+}
+
 }  // namespace xgrammar

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -301,7 +301,7 @@ std::optional<std::string> XMLToolCallingConverter::GetCache(const std::string& 
 
 // ==================== GemmaToolCallingConverter ====================
 
-const std::string GemmaToolCallingConverter::kStringDelim = "<|\"|>";
+const std::string GemmaToolCallingConverter::kGemmaStringDelim = "<|\"|>";
 const std::string GemmaToolCallingConverter::kGemmaStringContent = "gemma_string_content";
 const std::string GemmaToolCallingConverter::kGemmaVariableName = "gemma_variable_name";
 const std::string GemmaToolCallingConverter::kGemmaBoundedChar = "gemma_bounded_char";
@@ -323,8 +323,8 @@ void GemmaToolCallingConverter::AddBasicRules() {
   // the delimiter itself, so the boundary is unambiguous.
   ebnf_script_creator_.AddRule(
       kGemmaStringContent,
-      "TagDispatch(loop_after_dispatch=false,excludes=(" + EBNFScriptCreator::Str(kStringDelim) +
-          "))"
+      "TagDispatch(loop_after_dispatch=false,excludes=(" +
+          EBNFScriptCreator::Str(kGemmaStringDelim) + "))"
   );
   ebnf_script_creator_.AddRule(kGemmaVariableName, "[a-zA-Z_] [a-zA-Z0-9_]*");
   // A single string-content character for length-constrained strings: any character
@@ -348,13 +348,13 @@ void GemmaToolCallingConverter::AddBasicRules() {
 std::string GemmaToolCallingConverter::GenerateString(
     const StringSpec& spec, const std::string& rule_name
 ) {
-  std::string delim = EBNFScriptCreator::Str(kStringDelim);
+  std::string delim = EBNFScriptCreator::Str(kGemmaStringDelim);
 
   // NOTE: for the format/pattern branches the regex is emitted verbatim between the
   // delimiters. A permissive pattern (e.g. ".*") can therefore generate text containing
   // the <|"|> delimiter itself, which closes the string early for downstream parsers.
   // Intersecting an arbitrary regex with "does not contain the delimiter" is not
-  // supported; keep patterns restrictive (the builtin formats are all safe).
+  // supported; keep patterns restrictive.
   if (spec.format.has_value()) {
     auto regex_pattern = JSONFormatToRegexPattern(*spec.format);
     if (regex_pattern.has_value()) {
@@ -367,9 +367,7 @@ std::string GemmaToolCallingConverter::GenerateString(
   }
 
   if (spec.min_length != 0 || spec.max_length != -1) {
-    // kGemmaBoundedChar consumes exactly one character and forbids only a '<' that
-    // starts the <|"|> delimiter, so repetition counts stay exact while the string
-    // terminator remains unambiguous.
+    // Count repetitions of kGemmaBoundedChar so min/max length are enforced per character.
     std::string repetition;
     if (spec.max_length == -1) {
       repetition = "{" + std::to_string(spec.min_length) + ",}";
@@ -383,10 +381,10 @@ std::string GemmaToolCallingConverter::GenerateString(
   return delim + " " + kGemmaStringContent + " " + delim;
 }
 
-std::string GemmaToolCallingConverter::GemmaSerializeJSON(const picojson::value& value) {
+std::string GemmaToolCallingConverter::SerializeJSON(const picojson::value& value) {
   if (value.is<std::string>()) {
     // Gemma strings have no escape sequences; the raw content is emitted between delimiters.
-    return kStringDelim + value.get<std::string>() + kStringDelim;
+    return kGemmaStringDelim + value.get<std::string>() + kGemmaStringDelim;
   }
   if (value.is<picojson::object>()) {
     const auto& obj = value.get<picojson::object>();
@@ -397,7 +395,7 @@ std::string GemmaToolCallingConverter::GemmaSerializeJSON(const picojson::value&
         result += ",";
       }
       first = false;
-      result += key + ":" + GemmaSerializeJSON(val);
+      result += key + ":" + SerializeJSON(val);
     }
     return result + "}";
   }
@@ -408,7 +406,7 @@ std::string GemmaToolCallingConverter::GemmaSerializeJSON(const picojson::value&
       if (i != 0) {
         result += ",";
       }
-      result += GemmaSerializeJSON(arr[i]);
+      result += SerializeJSON(arr[i]);
     }
     return result + "]";
   }
@@ -416,7 +414,7 @@ std::string GemmaToolCallingConverter::GemmaSerializeJSON(const picojson::value&
   return value.serialize();
 }
 
-std::string GemmaToolCallingConverter::GemmaValueToEBNFLiteral(const std::string& json_value) {
+std::string GemmaToolCallingConverter::ValueToEBNFLiteral(const std::string& json_value) {
   picojson::value value;
   std::string err = picojson::parse(value, json_value);
   XGRAMMAR_CHECK(err.empty()) << "Failed to parse JSON value: " << err
@@ -432,13 +430,13 @@ std::string GemmaToolCallingConverter::GemmaValueToEBNFLiteral(const std::string
   }
   // Strings, objects and arrays must be re-serialized into Gemma form. Note: numbers
   // nested inside objects/arrays still go through picojson and may lose precision.
-  return EBNFScriptCreator::Str(GemmaSerializeJSON(value));
+  return EBNFScriptCreator::Str(SerializeJSON(value));
 }
 
 std::string GemmaToolCallingConverter::GenerateConst(
     const ConstSpec& spec, const std::string& rule_name
 ) {
-  return GemmaValueToEBNFLiteral(spec.json_value);
+  return ValueToEBNFLiteral(spec.json_value);
 }
 
 std::string GemmaToolCallingConverter::GenerateEnum(
@@ -451,7 +449,7 @@ std::string GemmaToolCallingConverter::GenerateEnum(
     if (i != 0) {
       result += " | ";
     }
-    result += "(" + GemmaValueToEBNFLiteral(spec.json_values[i]) + ")";
+    result += "(" + ValueToEBNFLiteral(spec.json_values[i]) + ")";
   }
   return result;
 }
@@ -472,8 +470,8 @@ std::string GemmaToolCallingConverter::GetKeyPatternExcluding(
 }
 
 std::string GemmaToolCallingConverter::FormatPatternKey(const std::string& pattern) {
-  // Gemma keys are unquoted; emit the bare pattern. Note the sglang parser reads keys up
-  // to the first ':', so patterns whose language contains ':' cannot round-trip.
+  // Gemma keys are unquoted; emit the bare pattern. A pattern whose language contains
+  // ':' is ambiguous against the key/value separator and cannot round-trip.
   return "(" + RegexToEBNF(pattern, false) + ")";
 }
 

--- a/cpp/json_schema_converter_ext.h
+++ b/cpp/json_schema_converter_ext.h
@@ -96,6 +96,54 @@ class XMLToolCallingConverter : public JSONSchemaConverter {
   const XMLWrapper xml_wrapper_;
 };
 
+/*!
+ * \brief Converter for Gemma Tool Calling format.
+ *
+ * This converter generates EBNF where the whole value space (all nesting levels)
+ * uses Gemma's custom format instead of JSON:
+ * - Object keys are unquoted: {key:value,key2:value2}
+ * - Strings are delimited by <|"|> instead of ", with no escape sequences:
+ *   <|"|>any text<|"|>
+ * - Numbers, booleans, arrays and objects otherwise follow JSON syntax.
+ */
+class GemmaToolCallingConverter : public JSONSchemaConverter {
+ public:
+  GemmaToolCallingConverter(
+      std::optional<int> indent,
+      std::optional<std::pair<std::string, std::string>> separators,
+      bool any_whitespace,
+      std::optional<int> max_whitespace_cnt,
+      RefResolver ref_resolver = nullptr,
+      bool any_order = false
+  );
+
+ protected:
+  std::string GenerateString(const StringSpec& spec, const std::string& rule_name) override;
+  std::string GenerateConst(const ConstSpec& spec, const std::string& rule_name) override;
+  std::string GenerateEnum(const EnumSpec& spec, const std::string& rule_name) override;
+
+  std::string FormatPropertyKey(const std::string& key) override;
+  std::string GetKeyPattern() const override;
+  std::string GetKeyPatternExcluding(
+      const std::vector<ObjectSpec::Property>& properties, const std::string& rule_name
+  ) override;
+
+  void AddBasicRules() override;
+
+ private:
+  // The Gemma string delimiter that replaces the JSON double quote.
+  static const std::string kStringDelim;
+  // Rule matching any text that does not contain the string delimiter.
+  static const std::string kGemmaStringContent;
+  // Rule matching an unquoted property key.
+  static const std::string kGemmaVariableName;
+
+  /*! \brief Serialize a JSON value into Gemma's tool call argument format. */
+  static std::string GemmaSerializeJSON(const picojson::value& value);
+  /*! \brief Parse a JSON-serialized value and return its Gemma serialization as an EBNF literal. */
+  static std::string GemmaValueToEBNFLiteral(const std::string& json_value);
+};
+
 }  // namespace xgrammar
 
 #endif  // XGRAMMAR_JSON_SCHEMA_CONVERTER_EXT_H_

--- a/cpp/json_schema_converter_ext.h
+++ b/cpp/json_schema_converter_ext.h
@@ -127,6 +127,10 @@ class GemmaToolCallingConverter : public JSONSchemaConverter {
   std::string GetKeyPatternExcluding(
       const std::vector<ObjectSpec::Property>& properties, const std::string& rule_name
   ) override;
+  std::string FormatPatternKey(const std::string& pattern) override;
+  std::string CreatePropertyNamesKeyRule(
+      const SchemaSpecPtr& property_names, const std::string& rule_name_hint
+  ) override;
 
   void AddBasicRules() override;
 
@@ -137,6 +141,9 @@ class GemmaToolCallingConverter : public JSONSchemaConverter {
   static const std::string kGemmaStringContent;
   // Rule matching an unquoted property key.
   static const std::string kGemmaVariableName;
+  // Rule matching exactly one character that cannot start the string delimiter.
+  // Used for length-constrained strings where repetition counts must stay exact.
+  static const std::string kGemmaBoundedChar;
 
   /*! \brief Serialize a JSON value into Gemma's tool call argument format. */
   static std::string GemmaSerializeJSON(const picojson::value& value);

--- a/cpp/json_schema_converter_ext.h
+++ b/cpp/json_schema_converter_ext.h
@@ -1,7 +1,7 @@
 /*!
  *  Copyright (c) 2024 by Contributors
  * \file xgrammar/json_schema_converter_ext.h
- * \brief Extended format converters for JSON Schema, including XML Tool Calling format.
+ * \brief Extended tool-calling format converters for JSON Schema (XML styles, Gemma).
  */
 
 #ifndef XGRAMMAR_JSON_SCHEMA_CONVERTER_EXT_H_
@@ -136,7 +136,7 @@ class GemmaToolCallingConverter : public JSONSchemaConverter {
 
  private:
   // The Gemma string delimiter that replaces the JSON double quote.
-  static const std::string kStringDelim;
+  static const std::string kGemmaStringDelim;
   // Rule matching any text that does not contain the string delimiter.
   static const std::string kGemmaStringContent;
   // Rule matching an unquoted property key.
@@ -146,9 +146,9 @@ class GemmaToolCallingConverter : public JSONSchemaConverter {
   static const std::string kGemmaBoundedChar;
 
   /*! \brief Serialize a JSON value into Gemma's tool call argument format. */
-  static std::string GemmaSerializeJSON(const picojson::value& value);
+  static std::string SerializeJSON(const picojson::value& value);
   /*! \brief Parse a JSON-serialized value and return its Gemma serialization as an EBNF literal. */
-  static std::string GemmaValueToEBNFLiteral(const std::string& json_value);
+  static std::string ValueToEBNFLiteral(const std::string& json_value);
 };
 
 }  // namespace xgrammar

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -543,10 +543,10 @@ Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
     if (it != obj.end() && it->second.is<std::string>()) {
       style = it->second.get<std::string>();
       if (style != "json" && style != "qwen_xml" && style != "minimax_xml" &&
-          style != "deepseek_xml" && style != "glm_xml") {
+          style != "deepseek_xml" && style != "glm_xml" && style != "gemma") {
         return ResultErr<ISTError>(
-            "style must be \"json\", \"qwen_xml\", \"minimax_xml\", \"deepseek_xml\", or "
-            "\"glm_xml\""
+            "style must be \"json\", \"qwen_xml\", \"minimax_xml\", \"deepseek_xml\", "
+            "\"glm_xml\", or \"gemma\""
         );
       }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ Homepage = "https://xgrammar.mlc.ai/"
 GitHub = "https://github.com/mlc-ai/xgrammar"
 
 [project.optional-dependencies]
-test = ["huggingface-hub[cli]", "protobuf", "pytest", "sentencepiece", "tiktoken"]
+test = ["huggingface-hub[cli]", "jinja2", "protobuf", "pytest", "sentencepiece", "tiktoken"]
 metal = [
   # transformers >=5.13 breaks `import mlx_lm`.
   "mlx-lm; platform_system == 'Darwin' and platform_machine == 'arm64'",

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -1847,7 +1847,10 @@ def get_gemma_4_structural_tag(
     TOOL_CALL_TRIGGER = "<|tool_call>"
     THINK_TAG_BEGIN = "<|channel>thought\n"
     THINK_TAG_END = "<channel|>"
-    GEMMA4_EXCLUDE_TOKENS = ["<|channel>", "<channel|>"]
+    # Besides the reasoning-channel markers, exclude the tool-response opener: Gemma 4
+    # otherwise reliably starts fabricating a <|tool_response>...  itself right after
+    # finishing a tool call instead of stopping.
+    GEMMA4_EXCLUDE_TOKENS = ["<|channel>", "<channel|>", "<|tool_response>"]
 
     tools = tools or []
     builtin_tools = builtin_tools or []

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -1826,8 +1826,9 @@ def get_gemma_4_structural_tag(
       ``function`` object containing ``name`` and ``parameters`` fields.
     - ``reasoning``: whether to enable reasoning mode. If ``False``, the
       reasoning channel is omitted.
-    - ``tool_choice``: ``"auto"`` or ``"required"``. ``"required"`` forces at
-      least one tool call.
+    - ``tool_choice``: ``"auto"``, ``"required"``, or ``"forced"``. ``"required"``
+      forces at least one tool call; ``"forced"`` forces exactly the single
+      resolved tool.
 
     Supported models:
 
@@ -1847,9 +1848,8 @@ def get_gemma_4_structural_tag(
     TOOL_CALL_TRIGGER = "<|tool_call>"
     THINK_TAG_BEGIN = "<|channel>thought\n"
     THINK_TAG_END = "<channel|>"
-    # Do NOT exclude <|tool_response> here: per the Gemma 4 prompt-formatting spec, the
-    # model emits <|tool_response> right after a tool call as its halt signal, and the
-    # inference engine is expected to register it as an additional stop sequence.
+    # <|tool_response> is deliberately not excluded: the model emits it as its halt
+    # signal after a tool call, so it must be handled as a stop sequence, not blocked.
     GEMMA4_EXCLUDE_TOKENS = ["<|channel>", "<channel|>"]
 
     tools = tools or []
@@ -1923,7 +1923,13 @@ def get_gemma_4_structural_tag(
     if not reasoning:
         return StructuralTag(format=suffix_tag)
 
-    prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
+    prefix_tag = TagFormat(
+        begin=THINK_TAG_BEGIN,
+        content=AnyTextFormat(
+            excludes=_text_excludes(exclude_special_tokens, GEMMA4_EXCLUDE_TOKENS)
+        ),
+        end=THINK_TAG_END,
+    )
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
 

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -1847,10 +1847,10 @@ def get_gemma_4_structural_tag(
     TOOL_CALL_TRIGGER = "<|tool_call>"
     THINK_TAG_BEGIN = "<|channel>thought\n"
     THINK_TAG_END = "<channel|>"
-    # Besides the reasoning-channel markers, exclude the tool-response opener: Gemma 4
-    # otherwise reliably starts fabricating a <|tool_response>...  itself right after
-    # finishing a tool call instead of stopping.
-    GEMMA4_EXCLUDE_TOKENS = ["<|channel>", "<channel|>", "<|tool_response>"]
+    # Do NOT exclude <|tool_response> here: per the Gemma 4 prompt-formatting spec, the
+    # model emits <|tool_response> right after a tool call as its halt signal, and the
+    # inference engine is expected to register it as an additional stop sequence.
+    GEMMA4_EXCLUDE_TOKENS = ["<|channel>", "<channel|>"]
 
     tools = tools or []
     builtin_tools = builtin_tools or []

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -1795,10 +1795,8 @@ def get_glm_4_7_structural_tag(
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
 
-# TODO: We are dropping Gemma support because its parameter format is special and not supported
-# yet: the string are wrapped by <|"|> instead of ". We will support it later and get it back.
-# @register_model_structural_tag("gemma_4")
-def _get_gemma_4_structural_tag(
+@register_model_structural_tag("gemma_4")
+def get_gemma_4_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
@@ -1864,6 +1862,7 @@ def _get_gemma_4_structural_tag(
                     begin=TOOL_CALL_BEGIN_PREFIX + name,
                     content=JSONSchemaFormat(
                         json_schema=parameters,
+                        style="gemma",
                         any_order=any_order,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),
@@ -1890,6 +1889,7 @@ def _get_gemma_4_structural_tag(
             begin=TOOL_CALL_BEGIN_PREFIX + function.name,
             content=JSONSchemaFormat(
                 json_schema=_get_function_parameters(function),
+                style="gemma",
                 any_order=any_order,
                 max_whitespace_cnt=max_whitespace_cnt,
             ),
@@ -1907,6 +1907,7 @@ def _get_gemma_4_structural_tag(
                     begin=TOOL_CALL_BEGIN_PREFIX + name,
                     content=JSONSchemaFormat(
                         json_schema=parameters,
+                        style="gemma",
                         any_order=any_order,
                         max_whitespace_cnt=max_whitespace_cnt,
                     ),

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -1850,7 +1850,9 @@ def get_gemma_4_structural_tag(
     THINK_TAG_END = "<channel|>"
     # <|tool_response> is deliberately not excluded: the model emits it as its halt
     # signal after a tool call, so it must be handled as a stop sequence, not blocked.
-    GEMMA4_EXCLUDE_TOKENS = ["<|channel>", "<channel|>"]
+    # <|tool_call> is excluded so the model cannot start a tool call inside the thought
+    # channel, whose content is free-form text and not constrained by the tool-call grammar.
+    GEMMA4_EXCLUDE_TOKENS = ["<|channel>", "<channel|>", "<|tool_call>"]
 
     tools = tools or []
     builtin_tools = builtin_tools or []

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -1850,9 +1850,13 @@ def get_gemma_4_structural_tag(
     THINK_TAG_END = "<channel|>"
     # <|tool_response> is deliberately not excluded: the model emits it as its halt
     # signal after a tool call, so it must be handled as a stop sequence, not blocked.
-    # <|tool_call> is excluded so the model cannot start a tool call inside the thought
-    # channel, whose content is free-form text and not constrained by the tool-call grammar.
-    GEMMA4_EXCLUDE_TOKENS = ["<|channel>", "<channel|>", "<|tool_call>"]
+    # The triggered free text must NOT exclude <|tool_call>: it is the trigger, and
+    # excluding it would block the dispatch into the tool-call tags entirely.
+    TEXT_EXCLUDES = ["<|channel>", "<channel|>"]
+    # <|tool_call> is excluded from the thought channel (and from free text when no
+    # tools are available) so the model cannot start a tool call there: that content
+    # is free-form text and not constrained by the tool-call grammar.
+    REASONING_EXCLUDES = TEXT_EXCLUDES + [TOOL_CALL_TRIGGER]
 
     tools = tools or []
     builtin_tools = builtin_tools or []
@@ -1879,11 +1883,11 @@ def get_gemma_4_structural_tag(
             suffix_tag = TriggeredTagsFormat(
                 triggers=[TOOL_CALL_TRIGGER],
                 tags=tags,
-                excludes=_text_excludes(exclude_special_tokens, GEMMA4_EXCLUDE_TOKENS),
+                excludes=_text_excludes(exclude_special_tokens, TEXT_EXCLUDES),
             )
         else:
             suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens, GEMMA4_EXCLUDE_TOKENS)
+                excludes=_text_excludes(exclude_special_tokens, REASONING_EXCLUDES)
             )
 
     elif tool_choice == "forced":
@@ -1927,9 +1931,7 @@ def get_gemma_4_structural_tag(
 
     prefix_tag = TagFormat(
         begin=THINK_TAG_BEGIN,
-        content=AnyTextFormat(
-            excludes=_text_excludes(exclude_special_tokens, GEMMA4_EXCLUDE_TOKENS)
-        ),
+        content=AnyTextFormat(excludes=_text_excludes(exclude_special_tokens, REASONING_EXCLUDES)),
         end=THINK_TAG_END,
     )
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -31,11 +31,13 @@ class JSONSchemaFormat(BaseModel):
     """The type of the format."""
     json_schema: Union[bool, Dict[str, Any]]
     """The JSON schema."""
-    style: Literal["json", "qwen_xml", "minimax_xml", "deepseek_xml", "glm_xml"] = "json"
+    style: Literal["json", "qwen_xml", "minimax_xml", "deepseek_xml", "glm_xml", "gemma"] = "json"
     """How to parse the content. Valid values: \"json\" (standard JSON), \"qwen_xml\" (Qwen XML:
     <parameter=key>value</parameter>), \"minimax_xml\" (MiniMax XML: <parameter name=\"key\">value</parameter>),
     \"deepseek_xml\" (DeepSeek XML(DeepSeek-v3.2): <{dsml_token}parameter name=\"key\" string=\"true|false\">value</{dsml_token}parameter>),
-    \"glm_xml\" (GLM XML: <arg_key>key</arg_key><arg_value>value</arg_value>)."""
+    \"glm_xml\" (GLM XML: <arg_key>key</arg_key><arg_value>value</arg_value>),
+    \"gemma\" (Gemma: {key:<|\"|>string value<|\"|>,key2:123}; unquoted keys and <|\"|>-delimited
+    strings)."""
     any_order: bool = False
     """Whether object properties may appear in any order.
 

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -24,7 +24,9 @@ def _json_schema_to_ebnf(
     separators: Optional[Tuple[str, str]] = None,
     max_whitespace_cnt: Optional[int] = None,
     strict_mode: bool = True,
-    json_format: Literal["json", "qwen_xml", "minimax_xml", "deepseek_xml", "glm_xml"] = "json",
+    json_format: Literal[
+        "json", "qwen_xml", "minimax_xml", "deepseek_xml", "glm_xml", "gemma"
+    ] = "json",
     any_order: bool = False,
 ) -> str:
     """Convert JSON schema string to BNF grammar string. For test purposes.
@@ -58,8 +60,9 @@ def _json_schema_to_ebnf(
 
     json_format : str, default: "json"
         The root format of the generated grammar. One of "json", "qwen_xml", "minimax_xml",
-        "deepseek_xml", "glm_xml". Formats other than "json" generate an XML-style root object
-        for tool calling, while the inner values remain JSON-style.
+        "deepseek_xml", "glm_xml", "gemma". Formats other than "json" generate a tool-calling
+        root object; the XML formats keep JSON-style inner values, while "gemma" uses Gemma's
+        unquoted-key, <|"|>-delimited-string format throughout.
 
     Returns
     -------

--- a/tests/python/chat_template_gemma4_31b_it.jinja
+++ b/tests/python/chat_template_gemma4_31b_it.jinja
@@ -1,0 +1,390 @@
+{#
+  Template: Google Gemma 4 Canonical Chat Template
+  Author: Google Gemma Engineering Team
+  Published: 2026-07-09
+  Context: Fixed tool-calling loops, turn closures, and thinking content-ordering.
+#}
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is none -%}
+        {{- 'null' -}}
+    {%- elif argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{#- ===== SETUP ===== -#}
+{%- set ns = namespace(prev_message_type=None, prev_non_tool_role=None) -%}
+{%- set loop_messages = messages -%}
+{%- set enable_thinking = enable_thinking | default(false) -%}
+{%- set preserve_thinking = preserve_thinking | default(false) -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if enable_thinking or tools or (messages and messages[0]['role'] in ['system', 'developer']) -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages and messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is sequence -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation using tracked state — O(1) instead of O(n) backward scan -#}
+    {%- set continue_same_model_turn = (role == 'model' and ns.prev_non_tool_role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- set thinking_gate = (loop.index0 > ns_turn.last_user_idx) or (preserve_thinking and message.get('tool_calls')) -%}
+    {%- if thinking_text and thinking_gate -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message.get('tool_calls') -%}
+                {%- for tool_call in message.get('tool_calls') -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is none -%}
+                    {%- else -%}
+                        {{- raise_exception(
+                            "chat_template: tool_calls[].function.arguments must be a "
+                            "JSON object (mapping), not a string. Deserialize arguments "
+                            "before passing to the template."
+                        ) -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message.get('tool_responses') -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown', true), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') or 'unknown') -%}
+                        {%- for tc in message.get('tool_calls') -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') in ['image', 'image_url'] -%}
+                                    {{- '<|image|>' -}}
+                                {%- elif part.get('type') in ['audio', 'input_audio'] -%}
+                                    {{- '<|audio|>' -}}
+                                {%- elif part.get('type') == 'video' -%}
+                                    {{- '<|video|>' -}}
+                                {%- endif -%}
+                            {%- endfor -%}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message.get('content') is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message.get('content') is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item.get('type') == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item.get('type') in ['image', 'image_url'] -%}
+                        {{- '<|image|>' -}}
+                    {%- elif item.get('type') in ['audio', 'input_audio'] -%}
+                        {{- '<|audio|>' -}}
+                    {%- elif item.get('type') == 'video' -%}
+                        {{- '<|video|>' -}}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {{- captured_content -}}
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {#- Forward-scan: find next non-tool message role for continuation detection -#}
+        {%- set next_nt = namespace(role=None, found=false) -%}
+        {%- for j in range(loop.index0 + 1, loop_messages | length) -%}
+            {%- if not next_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set next_nt.role = loop_messages[j]['role'] -%}
+                    {%- set next_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {%- set continues_into_next = (
+            role == 'model'
+            and next_nt.role == 'assistant'
+            and (not message.get('tool_calls') or ns_tr_out.flag)
+        ) -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif continues_into_next -%}
+        {%- elif not (ns_tr_out.flag and not has_content and not next_nt.found) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+
+    {#- Track previous non-tool role for next iteration (avoids O(n) backward scan) -#}
+    {%- set ns.prev_non_tool_role = message['role'] -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+        {%- if not enable_thinking -%}
+            {{- '<|channel>thought\n<channel|>' -}}
+        {%- endif -%}
+    {%- elif ns.prev_message_type == 'tool_response' and enable_thinking -%}
+        {{- '<|channel>thought\n' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/tests/python/chat_template_gemma4_e2b_it.jinja
+++ b/tests/python/chat_template_gemma4_e2b_it.jinja
@@ -1,0 +1,386 @@
+{#
+  Template: Google Gemma 4 Canonical Chat Template
+  Author: Google Gemma Engineering Team
+  Published: 2026-07-09
+  Context: Fixed tool-calling loops, turn closures, and thinking content-ordering.
+#}
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is none -%}
+        {{- 'null' -}}
+    {%- elif argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{#- ===== SETUP ===== -#}
+{%- set ns = namespace(prev_message_type=None, prev_non_tool_role=None) -%}
+{%- set loop_messages = messages -%}
+{%- set enable_thinking = enable_thinking | default(false) -%}
+{%- set preserve_thinking = preserve_thinking | default(false) -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if enable_thinking or tools or (messages and messages[0]['role'] in ['system', 'developer']) -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages and messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is sequence -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation using tracked state — O(1) instead of O(n) backward scan -#}
+    {%- set continue_same_model_turn = (role == 'model' and ns.prev_non_tool_role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- set thinking_gate = (loop.index0 > ns_turn.last_user_idx) or (preserve_thinking and message.get('tool_calls')) -%}
+    {%- if thinking_text and thinking_gate -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message.get('tool_calls') -%}
+                {%- for tool_call in message.get('tool_calls') -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is none -%}
+                    {%- else -%}
+                        {{- raise_exception(
+                            "chat_template: tool_calls[].function.arguments must be a "
+                            "JSON object (mapping), not a string. Deserialize arguments "
+                            "before passing to the template."
+                        ) -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message.get('tool_responses') -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown', true), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') or 'unknown') -%}
+                        {%- for tc in message.get('tool_calls') -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') in ['image', 'image_url'] -%}
+                                    {{- '<|image|>' -}}
+                                {%- elif part.get('type') in ['audio', 'input_audio'] -%}
+                                    {{- '<|audio|>' -}}
+                                {%- elif part.get('type') == 'video' -%}
+                                    {{- '<|video|>' -}}
+                                {%- endif -%}
+                            {%- endfor -%}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message.get('content') is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message.get('content') is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item.get('type') == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item.get('type') in ['image', 'image_url'] -%}
+                        {{- '<|image|>' -}}
+                    {%- elif item.get('type') in ['audio', 'input_audio'] -%}
+                        {{- '<|audio|>' -}}
+                    {%- elif item.get('type') == 'video' -%}
+                        {{- '<|video|>' -}}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {{- captured_content -}}
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {#- Forward-scan: find next non-tool message role for continuation detection -#}
+        {%- set next_nt = namespace(role=None, found=false) -%}
+        {%- for j in range(loop.index0 + 1, loop_messages | length) -%}
+            {%- if not next_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set next_nt.role = loop_messages[j]['role'] -%}
+                    {%- set next_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {%- set continues_into_next = (
+            role == 'model'
+            and next_nt.role == 'assistant'
+            and (not message.get('tool_calls') or ns_tr_out.flag)
+        ) -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif continues_into_next -%}
+        {%- elif not (ns_tr_out.flag and not has_content and not next_nt.found) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+
+    {#- Track previous non-tool role for next iteration (avoids O(n) backward scan) -#}
+    {%- set ns.prev_non_tool_role = message['role'] -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+    {%- elif ns.prev_message_type == 'tool_response' and enable_thinking -%}
+        {{- '<|channel>thought\n' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/tests/python/encoding_gemma4.py
+++ b/tests/python/encoding_gemma4.py
@@ -19,8 +19,8 @@ thought block in the generation prompt when thinking is disabled.
 
 To refresh after an upstream template update::
 
-    huggingface-cli download google/gemma-4-E2B-it chat_template.jinja
-    huggingface-cli download google/gemma-4-31B-it chat_template.jinja
+    hf download google/gemma-4-E2B-it chat_template.jinja
+    hf download google/gemma-4-31B-it chat_template.jinja
 
 then copy the files over the vendored ones and re-run
 ``test_gemma_4_vendored_template_matches_official``.

--- a/tests/python/encoding_gemma4.py
+++ b/tests/python/encoding_gemma4.py
@@ -1,0 +1,92 @@
+"""Render Gemma-4 chat-template outputs without transformers.
+
+Renders the official Gemma-4 chat templates with a jinja2 environment that
+mirrors transformers' ``_compile_jinja_template``, so the output is
+byte-identical to ``tokenizer.apply_chat_template``. This lets the alignment
+test exercise Gemma-4 on any transformers version: loading the Gemma-4
+tokenizer itself requires transformers >= 5.5, while this repo pins < 5.
+
+Vendored templates (byte-exact copies of ``chat_template.jinja``, published
+2026-07-09):
+
+- ``chat_template_gemma4_e2b_it.jinja`` from google/gemma-4-E2B-it,
+  snapshot 179516f0c449474fdc46f08f30ead5b11e178497
+- ``chat_template_gemma4_31b_it.jinja`` from google/gemma-4-31B-it,
+  snapshot b9ea41a2887d8607f594846523f94c6cc75ac8a4
+
+The two templates are identical except that the 31B one pre-renders an empty
+thought block in the generation prompt when thinking is disabled.
+
+To refresh after an upstream template update::
+
+    huggingface-cli download google/gemma-4-E2B-it chat_template.jinja
+    huggingface-cli download google/gemma-4-31B-it chat_template.jinja
+
+then copy the files over the vendored ones and re-run
+``test_gemma_4_vendored_template_matches_official``.
+"""
+
+import os
+from functools import lru_cache
+
+import jinja2
+import jinja2.ext
+from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+_TEMPLATE_FILES = {
+    "gemma4_e2b": "chat_template_gemma4_e2b_it.jinja",
+    "gemma4_31b": "chat_template_gemma4_31b_it.jinja",
+}
+
+
+def _raise_exception(message):
+    raise jinja2.exceptions.TemplateError(message)
+
+
+@lru_cache(maxsize=None)
+def _load_template(variant):
+    # Mirrors transformers' _compile_jinja_template environment so rendering
+    # is byte-identical to tokenizer.apply_chat_template.
+    env = ImmutableSandboxedEnvironment(
+        trim_blocks=True, lstrip_blocks=True, extensions=[jinja2.ext.loopcontrols]
+    )
+    env.globals["raise_exception"] = _raise_exception
+    path = os.path.join(os.path.dirname(__file__), _TEMPLATE_FILES[variant])
+    with open(path, encoding="utf-8") as f:
+        return env.from_string(f.read())
+
+
+class GemmaTemplateRenderer:
+    """Drop-in stand-in for the Gemma-4 tokenizer in the alignment test.
+
+    Only implements the ``apply_chat_template`` surface the test uses
+    (``tokenize=False``), plus the ``eos_token`` attribute ``strip_eos``
+    may read.
+    """
+
+    bos_token = "<bos>"
+    eos_token = None
+
+    def __init__(self, variant):
+        if variant not in _TEMPLATE_FILES:
+            raise ValueError(f"Unknown gemma-4 template variant: {variant}")
+        self.variant = variant
+
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=False,
+        tools=None,
+        add_generation_prompt=False,
+        enable_thinking=False,
+        **kwargs,
+    ):
+        assert tokenize is False, "GemmaTemplateRenderer only supports tokenize=False"
+        return _load_template(self.variant).render(
+            messages=messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            enable_thinking=enable_thinking,
+            bos_token=self.bos_token,
+            **kwargs,
+        )

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -178,6 +178,13 @@ def _collect_json_schema_nodes(structural_tag: StructuralTag) -> List[JSONSchema
     ]
 
 
+def _bitmask_allows(bitmask: Any, token_id: int) -> bool:
+    """Return whether the token is allowed by a bitmask from fill_next_token_bitmask."""
+
+    word = int(bitmask[0][token_id // 32].item())
+    return (word >> (token_id % 32)) & 1 == 1
+
+
 # ---------- Shared tool definitions ----------
 
 SIMPLE_SCHEMA = {"type": "object", "properties": {"q": {"type": "string"}}}
@@ -1357,6 +1364,41 @@ def test_any_order_default_is_false():
     assert _collect_any_order_flags(structural_tag) == [False]
 
 
+def test_any_order_reordered_arguments_accepted_only_when_enabled():
+    """End-to-end: reordered tool-call arguments are accepted only when any_order=True."""
+    tools = [
+        {
+            "function": {
+                "name": "fn",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"a": {"type": "integer"}, "b": {"type": "string"}},
+                    "required": ["a", "b"],
+                    "additionalProperties": False,
+                },
+            }
+        }
+    ]
+    forced = {"type": "function", "function": {"name": "fn"}}
+    ordered = '<tool_call>\n{"name": "fn", "arguments": {"a": 1, "b": "x"}}\n</tool_call>'
+    reordered = '<tool_call>\n{"name": "fn", "arguments": {"b": "x", "a": 1}}\n</tool_call>'
+
+    st_ordered = get_model_structural_tag(
+        "qwen_3", tools=tools, tool_choice=forced, reasoning=False
+    )
+    check_stag_with_instance(st_ordered, ordered, True)
+    check_stag_with_instance(st_ordered, reordered, False)
+
+    st_any_order = get_model_structural_tag(
+        "qwen_3", tools=tools, tool_choice=forced, reasoning=False, any_order=True
+    )
+    check_stag_with_instance(st_any_order, ordered, True)
+    check_stag_with_instance(st_any_order, reordered, True)
+
+
+# ---------- Test: gemma_4 token-level matching ----------
+
+
 def test_gemma_4_single_token_delimiter_walk():
     """Gemma-4's <|"|> / <|tool_call> markers are single tokens in the real tokenizer.
 
@@ -1423,43 +1465,6 @@ def test_gemma_4_single_token_delimiter_walk():
     # After a complete call the grammar reaches an accept state: EOS must be allowed.
     matcher.fill_next_token_bitmask(bitmask)
     assert _bitmask_allows(bitmask, vocab.index("<eos>"))
-
-
-def _bitmask_allows(bitmask, token_id: int) -> bool:
-    word = int(bitmask[0][token_id // 32].item())
-    return (word >> (token_id % 32)) & 1 == 1
-
-
-def test_any_order_reordered_arguments_accepted_only_when_enabled():
-    """End-to-end: reordered tool-call arguments are accepted only when any_order=True."""
-    tools = [
-        {
-            "function": {
-                "name": "fn",
-                "parameters": {
-                    "type": "object",
-                    "properties": {"a": {"type": "integer"}, "b": {"type": "string"}},
-                    "required": ["a", "b"],
-                    "additionalProperties": False,
-                },
-            }
-        }
-    ]
-    forced = {"type": "function", "function": {"name": "fn"}}
-    ordered = '<tool_call>\n{"name": "fn", "arguments": {"a": 1, "b": "x"}}\n</tool_call>'
-    reordered = '<tool_call>\n{"name": "fn", "arguments": {"b": "x", "a": 1}}\n</tool_call>'
-
-    st_ordered = get_model_structural_tag(
-        "qwen_3", tools=tools, tool_choice=forced, reasoning=False
-    )
-    check_stag_with_instance(st_ordered, ordered, True)
-    check_stag_with_instance(st_ordered, reordered, False)
-
-    st_any_order = get_model_structural_tag(
-        "qwen_3", tools=tools, tool_choice=forced, reasoning=False, any_order=True
-    )
-    check_stag_with_instance(st_any_order, ordered, True)
-    check_stag_with_instance(st_any_order, reordered, True)
 
 
 # ---------- Test: max_whitespace_cnt propagation ----------

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -13,6 +13,7 @@ from xgrammar.builtin_structural_tag import (
     get_deepseek_v3_1_structural_tag,
     get_deepseek_v3_2_structural_tag,
     get_deepseek_v4_structural_tag,
+    get_gemma_4_structural_tag,
     get_glm_4_7_structural_tag,
     get_harmony_structural_tag,
     get_kimi_structural_tag,
@@ -592,6 +593,7 @@ def test_kimi_auto_requires_tool_calls_section():
         get_deepseek_v4_structural_tag,
         get_minimax_structural_tag,
         get_glm_4_7_structural_tag,
+        get_gemma_4_structural_tag,
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -1357,6 +1357,79 @@ def test_any_order_default_is_false():
     assert _collect_any_order_flags(structural_tag) == [False]
 
 
+def test_gemma_4_single_token_delimiter_walk():
+    """Gemma-4's <|"|> / <|tool_call> markers are single tokens in the real tokenizer.
+
+    Compile the gemma_4 tag against a TokenizerInfo where each marker is one vocab
+    entry (as in google/gemma-4 tokenizers) and walk a full tool call token by token,
+    so literal-vs-token matching is covered beyond byte-level string tests.
+    """
+    vocab = [
+        "<|tool_call>",
+        "<tool_call|>",
+        '<|"|>',
+        "<|channel>",
+        "<channel|>",
+        "call",
+        ":",
+        "get_weather",
+        "{",
+        "}",
+        "city",
+        "Seoul",
+        "<eos>",
+    ]
+    tokenizer_info = xgr.TokenizerInfo(
+        vocab, xgr.VocabType.RAW, stop_token_ids=[vocab.index("<eos>")]
+    )
+    tools = [
+        FunctionToolParam(
+            function={
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            }
+        )
+    ]
+    structural_tag = get_gemma_4_structural_tag(
+        tools=tools, builtin_tools=[], tool_choice="required", reasoning=False
+    )
+    compiler = xgr.GrammarCompiler(tokenizer_info)
+    matcher = xgr.GrammarMatcher(compiler.compile_structural_tag(structural_tag))
+
+    token_walk = [
+        "<|tool_call>",
+        "call",
+        ":",
+        "get_weather",
+        "{",
+        "city",
+        ":",
+        '<|"|>',
+        "Seoul",
+        '<|"|>',
+        "}",
+        "<tool_call|>",
+    ]
+    bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    for piece in token_walk:
+        matcher.fill_next_token_bitmask(bitmask)
+        token_id = vocab.index(piece)
+        assert _bitmask_allows(bitmask, token_id), f"bitmask disallows {piece!r}"
+        assert matcher.accept_token(token_id), f"matcher rejected {piece!r}"
+    # After a complete call the grammar reaches an accept state: EOS must be allowed.
+    matcher.fill_next_token_bitmask(bitmask)
+    assert _bitmask_allows(bitmask, vocab.index("<eos>"))
+
+
+def _bitmask_allows(bitmask, token_id: int) -> bool:
+    word = int(bitmask[0][token_id // 32].item())
+    return (word >> (token_id % 32)) & 1 == 1
+
+
 def test_any_order_reordered_arguments_accepted_only_when_enabled():
     """End-to-end: reordered tool-call arguments are accepted only when any_order=True."""
     tools = [

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -871,7 +871,7 @@ InstanceCase = Tuple[Dict[str, Any], List[str], bool, List[bool]]
 
 def run_instance_case(format_type: str, case: InstanceCase):
     """Run one instance test case (accept/reject per instance string)."""
-    (input_dict, instances, reasoning, expected_accept_per_instance) = case
+    input_dict, instances, reasoning, expected_accept_per_instance = case
     kwargs = _input_dict_to_get_stag_kwargs(format_type, input_dict)
     kwargs["reasoning"] = reasoning
     stag = get_model_structural_tag(**kwargs)
@@ -1465,6 +1465,34 @@ def test_gemma_4_single_token_delimiter_walk():
     # After a complete call the grammar reaches an accept state: EOS must be allowed.
     matcher.fill_next_token_bitmask(bitmask)
     assert _bitmask_allows(bitmask, vocab.index("<eos>"))
+
+
+def test_gemma_4_auto_tool_call_trigger_dispatches():
+    """gemma_4 "auto" dispatches on <|tool_call> while the thought channel blocks it.
+
+    Regression test: the thought-channel exclude list (which blocks <|tool_call>)
+    was also applied to the triggered free text, where <|tool_call> is the trigger.
+    Excluding the trigger removed the dispatch path, so every auto tool call was
+    rejected.
+    """
+    structural_tag = get_model_structural_tag(
+        "gemma_4", tools=make_tools(["get_weather"]), reasoning=True
+    )
+
+    check_stag_with_instance(
+        structural_tag,
+        "<|channel>thought\nLet me check the weather.\n<channel|>"
+        '<|tool_call>call:get_weather{q:<|"|>Seoul<|"|>}<tool_call|>',
+        True,
+    )
+    # <|tool_call> must stay blocked inside the thought channel.
+    check_stag_with_instance(
+        structural_tag, "<|channel>thought\nmaybe <|tool_call> here\n<channel|>done", False
+    )
+    # In free text, <|tool_call> is only valid as the start of a well-formed call.
+    check_stag_with_instance(
+        structural_tag, "<|channel>thought\nok\n<channel|>text <|tool_call> not a call", False
+    )
 
 
 # ---------- Test: max_whitespace_cnt propagation ----------

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -65,8 +65,7 @@ PARALLEL_TOOL_SCENARIOS = [(2, "auto", 2), (2, "required", 2)]
 # (stag_key, model_id, reasoning, template_kwargs)
 # Excluded:
 #   - Llama-4: pythonic tool call format, needs separate structural tag
-#   - gemma_4: grammar is supported (style="gemma"), but template alignment is not
-#     yet verified against a released Gemma-4 chat template
+#   - gemma_4: template alignment not verified against a released Gemma-4 chat template
 #   - deepseek_r1 thinking=True: template drops <think> in history rendering,
 #     prompt diff extraction doesn't work
 #   - Kimi-K2-Thinking thinking=False: model always outputs <think></think>,

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -115,8 +115,9 @@ SKIP_EMPTY_REASONING = {
 
 # Templates that render the thought channel in history only alongside tool calls;
 # text-only reasoning outputs cannot be reconstructed via prompt diff, so those
-# scenarios are skipped.
-SKIP_REASONING_WITHOUT_TOOL_CALLS = {"ENCODER:gemma4_e2b", "ENCODER:gemma4_31b"}
+# scenarios are skipped. (The pre-2026-07-09 gemma-4 templates needed this; the
+# vendored templates render the thought channel for text-only messages too.)
+SKIP_REASONING_WITHOUT_TOOL_CALLS = set()
 
 # Templates that pre-render an empty thought block in the generation prompt when
 # thinking is disabled; history rendering omits it, so it is stripped before diffing.

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -115,8 +115,7 @@ SKIP_EMPTY_REASONING = {
 
 # Templates that render the thought channel in history only alongside tool calls;
 # text-only reasoning outputs cannot be reconstructed via prompt diff, so those
-# scenarios are skipped. (The pre-2026-07-09 gemma-4 templates needed this; the
-# vendored templates render the thought channel for text-only messages too.)
+# scenarios are skipped.
 SKIP_REASONING_WITHOUT_TOOL_CALLS = set()
 
 # Templates that pre-render an empty thought block in the generation prompt when

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -460,11 +460,11 @@ def test_gemma_4_vendored_template_matches_official(variant):
         for messages in ([USER_MSG], [USER_MSG, assistant_tool_calls], [USER_MSG, assistant_text]):
             for tools in (None, [TOOL_A], [TOOL_A, TOOL_B]):
                 for add_generation_prompt in (True, False):
-                    kwargs = dict(
-                        tools=tools,
-                        add_generation_prompt=add_generation_prompt,
-                        enable_thinking=enable_thinking,
-                    )
+                    kwargs = {
+                        "tools": tools,
+                        "add_generation_prompt": add_generation_prompt,
+                        "enable_thinking": enable_thinking,
+                    }
                     official = tokenizer.apply_chat_template(messages, tokenize=False, **kwargs)
                     vendored = renderer.apply_chat_template(messages, tokenize=False, **kwargs)
                     assert official == vendored, (

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -65,7 +65,8 @@ PARALLEL_TOOL_SCENARIOS = [(2, "auto", 2), (2, "required", 2)]
 # (stag_key, model_id, reasoning, template_kwargs)
 # Excluded:
 #   - Llama-4: pythonic tool call format, needs separate structural tag
-#   - gemma_4: tool calls use <|"|> quoting, not JSON
+#   - gemma_4: grammar is supported (style="gemma"), but template alignment is not
+#     yet verified against a released Gemma-4 chat template
 #   - deepseek_r1 thinking=True: template drops <think> in history rendering,
 #     prompt diff extraction doesn't work
 #   - Kimi-K2-Thinking thinking=False: model always outputs <think></think>,

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -1,9 +1,12 @@
 """Validate builtin structural tags against official chat templates.
 
-Uses tokenizer.apply_chat_template (or encoding scripts for DeepSeek V3.2/V4)
-to render model outputs, then checks that xgrammar structural tag grammars
-accept them. Requires encoding_dsv32.py and encoding_dsv4.py in the same
-directory.
+Uses tokenizer.apply_chat_template (or local encoders for DeepSeek V3.2/V4
+and Gemma-4) to render model outputs, then checks that xgrammar structural
+tag grammars accept them. Requires encoding_dsv32.py, encoding_dsv4.py and
+encoding_gemma4.py in the same directory.
+
+ENCODER: model ids render without transformers, so those cases run in
+tokenless environments and are not marked hf_token_required.
 """
 
 import json
@@ -95,10 +98,10 @@ MODEL_CONFIGS = [
     ("glm_4_7", "zai-org/GLM-4.7-Flash", False, {"enable_thinking": False}),
     ("deepseek_v4", "ENCODER:dsv4", True, {"thinking_mode": "thinking"}),
     ("deepseek_v4", "ENCODER:dsv4", False, {"thinking_mode": "chat"}),
-    ("gemma_4", "google/gemma-4-E2B-it", True, {"enable_thinking": True}),
-    ("gemma_4", "google/gemma-4-E2B-it", False, {"enable_thinking": False}),
-    ("gemma_4", "google/gemma-4-31B-it", True, {"enable_thinking": True}),
-    ("gemma_4", "google/gemma-4-31B-it", False, {"enable_thinking": False}),
+    ("gemma_4", "ENCODER:gemma4_e2b", True, {"enable_thinking": True}),
+    ("gemma_4", "ENCODER:gemma4_e2b", False, {"enable_thinking": False}),
+    ("gemma_4", "ENCODER:gemma4_31b", True, {"enable_thinking": True}),
+    ("gemma_4", "ENCODER:gemma4_31b", False, {"enable_thinking": False}),
 ]
 
 # DeepSeek V3.2 encoder rejects empty reasoning + no tool calls. Gemma-4 templates
@@ -106,18 +109,18 @@ MODEL_CONFIGS = [
 SKIP_EMPTY_REASONING = {
     "ENCODER:dsv32",
     "MiniMaxAI/MiniMax-M2.5",
-    "google/gemma-4-E2B-it",
-    "google/gemma-4-31B-it",
+    "ENCODER:gemma4_e2b",
+    "ENCODER:gemma4_31b",
 }
 
 # Templates that render the thought channel in history only alongside tool calls;
 # text-only reasoning outputs cannot be reconstructed via prompt diff, so those
 # scenarios are skipped.
-SKIP_REASONING_WITHOUT_TOOL_CALLS = {"google/gemma-4-E2B-it", "google/gemma-4-31B-it"}
+SKIP_REASONING_WITHOUT_TOOL_CALLS = {"ENCODER:gemma4_e2b", "ENCODER:gemma4_31b"}
 
 # Templates that pre-render an empty thought block in the generation prompt when
 # thinking is disabled; history rendering omits it, so it is stripped before diffing.
-PRERENDERED_EMPTY_THOUGHT_MODELS = {"google/gemma-4-31B-it"}
+PRERENDERED_EMPTY_THOUGHT_MODELS = {"ENCODER:gemma4_31b"}
 PRERENDERED_EMPTY_THOUGHT = "<|channel>thought\n<channel|>"
 
 # Models where tool call format in template doesn't match structural tag.
@@ -159,6 +162,11 @@ EOS_SUFFIXES = {
 
 @lru_cache(maxsize=None)
 def load_tokenizer(model_id):
+    if model_id.startswith("ENCODER:gemma4"):
+        from encoding_gemma4 import GemmaTemplateRenderer
+
+        return GemmaTemplateRenderer(model_id.split(":")[1])
+
     from transformers import AutoTokenizer
 
     return AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
@@ -295,9 +303,11 @@ def extract_output_encoder(encoder_name, stag_key, assistant_msg, tools, templat
 
 
 def extract_model_output(stag_key, model_id, assistant_msg, tools, template_kwargs):
-    if model_id.startswith("ENCODER:"):
-        encoder_name = model_id.split(":")[1]
+    encoder_name = model_id.split(":")[1] if model_id.startswith("ENCODER:") else None
+    if encoder_name in ("dsv32", "dsv4"):
         return extract_output_encoder(encoder_name, stag_key, assistant_msg, tools, template_kwargs)
+    # gemma4_* encoders mimic apply_chat_template, so they reuse the tokenizer
+    # path (prompt diff, prerendered-thought stripping, EOS stripping).
     return extract_output_tokenizer(model_id, stag_key, assistant_msg, tools, template_kwargs)
 
 
@@ -361,7 +371,16 @@ def generate_test_cases():
                         num_tool_calls,
                     )
                 )
-    return cases
+    # ENCODER: cases render locally without transformers or a HF token, so
+    # only tokenizer-based cases carry the hf_token_required marker.
+    return [
+        pytest.param(
+            case,
+            id=case_id(case),
+            marks=[] if case[1].startswith("ENCODER:") else [pytest.mark.hf_token_required],
+        )
+        for case in cases
+    ]
 
 
 def case_id(case):
@@ -388,8 +407,7 @@ def case_id(case):
 TEST_CASES = generate_test_cases()
 
 
-@pytest.mark.hf_token_required
-@pytest.mark.parametrize("case", TEST_CASES, ids=[case_id(c) for c in TEST_CASES])
+@pytest.mark.parametrize("case", TEST_CASES)
 def test_reasoning_stag(case):
     (
         stag_key,
@@ -406,6 +424,54 @@ def test_reasoning_stag(case):
     assistant_msg = make_assistant_msg(stag_key, reasoning_content, num_tool_calls)
     model_output = extract_model_output(stag_key, model_id, assistant_msg, tools, template_kwargs)
     validate_output(stag_key, tools, tool_choice, reasoning, model_output)
+
+
+# Official model ids for the vendored gemma-4 templates (drift guard below).
+GEMMA4_OFFICIAL_MODELS = {
+    "gemma4_e2b": "google/gemma-4-E2B-it",
+    "gemma4_31b": "google/gemma-4-31B-it",
+}
+
+
+@pytest.mark.hf_token_required
+@pytest.mark.parametrize("variant", sorted(GEMMA4_OFFICIAL_MODELS))
+def test_gemma_4_vendored_template_matches_official(variant):
+    """The vendored gemma-4 templates must render exactly like the official ones.
+
+    Guards against upstream chat-template updates drifting from the vendored
+    copies used by the ENCODER:gemma4_* cases. Loading the official tokenizer
+    requires transformers >= 5.5 (gemma-4 support), so this only runs where
+    that is available.
+    """
+    import transformers
+
+    major, minor = (int(p) for p in transformers.__version__.split(".")[:2])
+    if (major, minor) < (5, 5):
+        pytest.skip("gemma-4 tokenizer requires transformers >= 5.5")
+
+    from encoding_gemma4 import GemmaTemplateRenderer
+
+    tokenizer = load_tokenizer(GEMMA4_OFFICIAL_MODELS[variant])
+    renderer = GemmaTemplateRenderer(variant)
+
+    assistant_tool_calls = make_assistant_msg("gemma_4", REASONING_CONTENT, 2)
+    assistant_text = make_assistant_msg("gemma_4", None, 0)
+    for enable_thinking in (True, False):
+        for messages in ([USER_MSG], [USER_MSG, assistant_tool_calls], [USER_MSG, assistant_text]):
+            for tools in (None, [TOOL_A], [TOOL_A, TOOL_B]):
+                for add_generation_prompt in (True, False):
+                    kwargs = dict(
+                        tools=tools,
+                        add_generation_prompt=add_generation_prompt,
+                        enable_thinking=enable_thinking,
+                    )
+                    official = tokenizer.apply_chat_template(messages, tokenize=False, **kwargs)
+                    vendored = renderer.apply_chat_template(messages, tokenize=False, **kwargs)
+                    assert official == vendored, (
+                        f"Vendored template drifted (enable_thinking={enable_thinking}, "
+                        f"messages={len(messages)}, tools={len(tools or [])}, "
+                        f"add_generation_prompt={add_generation_prompt})"
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -65,7 +65,6 @@ PARALLEL_TOOL_SCENARIOS = [(2, "auto", 2), (2, "required", 2)]
 # (stag_key, model_id, reasoning, template_kwargs)
 # Excluded:
 #   - Llama-4: pythonic tool call format, needs separate structural tag
-#   - gemma_4: template alignment not verified against a released Gemma-4 chat template
 #   - deepseek_r1 thinking=True: template drops <think> in history rendering,
 #     prompt diff extraction doesn't work
 #   - Kimi-K2-Thinking thinking=False: model always outputs <think></think>,
@@ -96,10 +95,30 @@ MODEL_CONFIGS = [
     ("glm_4_7", "zai-org/GLM-4.7-Flash", False, {"enable_thinking": False}),
     ("deepseek_v4", "ENCODER:dsv4", True, {"thinking_mode": "thinking"}),
     ("deepseek_v4", "ENCODER:dsv4", False, {"thinking_mode": "chat"}),
+    ("gemma_4", "google/gemma-4-E2B-it", True, {"enable_thinking": True}),
+    ("gemma_4", "google/gemma-4-E2B-it", False, {"enable_thinking": False}),
+    ("gemma_4", "google/gemma-4-31B-it", True, {"enable_thinking": True}),
+    ("gemma_4", "google/gemma-4-31B-it", False, {"enable_thinking": False}),
 ]
 
-# DeepSeek V3.2 encoder rejects empty reasoning + no tool calls.
-SKIP_EMPTY_REASONING = {"ENCODER:dsv32", "MiniMaxAI/MiniMax-M2.5"}
+# DeepSeek V3.2 encoder rejects empty reasoning + no tool calls. Gemma-4 templates
+# drop the thought channel entirely when reasoning content is empty.
+SKIP_EMPTY_REASONING = {
+    "ENCODER:dsv32",
+    "MiniMaxAI/MiniMax-M2.5",
+    "google/gemma-4-E2B-it",
+    "google/gemma-4-31B-it",
+}
+
+# Templates that render the thought channel in history only alongside tool calls;
+# text-only reasoning outputs cannot be reconstructed via prompt diff, so those
+# scenarios are skipped.
+SKIP_REASONING_WITHOUT_TOOL_CALLS = {"google/gemma-4-E2B-it", "google/gemma-4-31B-it"}
+
+# Templates that pre-render an empty thought block in the generation prompt when
+# thinking is disabled; history rendering omits it, so it is stripped before diffing.
+PRERENDERED_EMPTY_THOUGHT_MODELS = {"google/gemma-4-31B-it"}
+PRERENDERED_EMPTY_THOUGHT = "<|channel>thought\n<channel|>"
 
 # Models where tool call format in template doesn't match structural tag.
 SKIP_TOOLS = set()
@@ -133,6 +152,8 @@ EOS_SUFFIXES = {
     "glm_4_7": [],
     "deepseek_v3_2": ["<｜end▁of▁sentence｜>"],
     "deepseek_v4": ["<｜end▁of▁sentence｜>"],
+    # <|tool_response> is the halt signal the template appends after a tool call.
+    "gemma_4": ["<turn|>", "<|tool_response>"],
 }
 
 
@@ -216,6 +237,9 @@ def extract_output_tokenizer(model_id, stag_key, assistant_msg, tools, template_
         [USER_MSG, assistant_msg], add_generation_prompt=False, **kwargs
     )
 
+    if model_id in PRERENDERED_EMPTY_THOUGHT_MODELS and not full.startswith(prompt):
+        prompt = prompt.removesuffix(PRERENDERED_EMPTY_THOUGHT)
+
     if model_id in STRIP_THINK_MODELS and assistant_msg.get("reasoning_content") is not None:
         if not full.startswith(prompt):
             base = prompt.removesuffix("<think>\n").removesuffix("<think>")
@@ -295,6 +319,8 @@ def generate_test_cases():
             if num_tools > 0 and model_id in SKIP_TOOLS:
                 continue
             if num_tool_calls > 1 and model_id in SKIP_PARALLEL_TOOLS:
+                continue
+            if reasoning and num_tool_calls == 0 and model_id in SKIP_REASONING_WITHOUT_TOOL_CALLS:
                 continue
             if reasoning:
                 cases.append(

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -1543,7 +1543,7 @@ def test_gemma_const_scalar_preserves_literal():
     # Large integers must not be rounded through double re-serialization.
     big = 10000000000000001
     schema = {"type": "object", "properties": {"v": {"const": big}}, "required": ["v"]}
-    ebnf_grammar = _gemma_tool_calling_to_ebnf(schema)
+    ebnf_grammar = _json_schema_to_ebnf(schema, json_format="gemma")
     assert _is_grammar_accept_string(ebnf_grammar, "{v:%d}" % big)
     assert not _is_grammar_accept_string(ebnf_grammar, "{v:%d}" % (big - 1))
 
@@ -1555,7 +1555,7 @@ def test_gemma_const_nested_value():
         "properties": {"cfg": {"const": {"tags": ["a", 3, True]}}},
         "required": ["cfg"],
     }
-    ebnf_grammar = _gemma_tool_calling_to_ebnf(schema)
+    ebnf_grammar = _json_schema_to_ebnf(schema, json_format="gemma")
     assert _is_grammar_accept_string(ebnf_grammar, '{cfg:{tags:[<|"|>a<|"|>,3,true]}}')
     assert not _is_grammar_accept_string(ebnf_grammar, '{cfg:{"tags":["a",3,true]}}')
 

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -1360,5 +1360,132 @@ def test_true_schema():
     assert not _is_grammar_accept_string(ebnf_grammar, "anything")
 
 
+# ---------- Gemma tool calling (json_format="gemma") ----------
+# Format: {key:<|"|>string value<|"|>,key2:123} — unquoted keys, <|"|>-delimited strings
+
+
+def _check_gemma_grammar(schema: dict, instance: str, accepted: bool):
+    ebnf_grammar = _json_schema_to_ebnf(schema, json_format="gemma")
+    check_grammar_with_instance(ebnf_grammar, instance, accepted)
+
+
+gemma_string_schema_input_str_accepted = (
+    ('{name:<|"|>Bob<|"|>,age:100}', True),
+    ('{name:<|"|>Bob <html lang="en"> & "quotes"<|"|>,age:100}', True),
+    ('{name:<|"|>Bob<|"|>, age: 100}', True),
+    ('{name:<|"|><|"|>,age:0}', True),
+    # JSON-style quoting must be rejected
+    ('{name:"Bob",age:100}', False),
+    ('{"name":<|"|>Bob<|"|>,age:100}', False),
+    # The delimiter cannot appear inside the string content
+    ('{name:<|"|>Bo<|"|>b<|"|>,age:100}', False),
+    # Missing required property / unclosed brace
+    ('{name:<|"|>Bob<|"|>}', False),
+    ('{name:<|"|>Bob<|"|>,age:100', False),
+)
+
+
+@pytest.mark.parametrize("input_str, accepted", gemma_string_schema_input_str_accepted)
+def test_gemma_string_schema(input_str: str, accepted: bool):
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+        "required": ["name", "age"],
+    }
+    _check_gemma_grammar(schema, input_str, accepted)
+
+
+gemma_value_types_input_str_accepted = (
+    ("{count:42,ratio:3.14,flag:true}", True),
+    ("{count:-7,ratio:1e-3,flag:false}", True),
+    ("{count:42,ratio:3.14,flag:True}", False),
+    ('{count:<|"|>42<|"|>,ratio:3.14,flag:true}', False),
+)
+
+
+@pytest.mark.parametrize("input_str, accepted", gemma_value_types_input_str_accepted)
+def test_gemma_value_types(input_str: str, accepted: bool):
+    schema = {
+        "type": "object",
+        "properties": {
+            "count": {"type": "integer"},
+            "ratio": {"type": "number"},
+            "flag": {"type": "boolean"},
+        },
+        "required": ["count", "ratio", "flag"],
+    }
+    _check_gemma_grammar(schema, input_str, accepted)
+
+
+gemma_nested_schema_input_str_accepted = (
+    ('{tags:[<|"|>a<|"|>,<|"|>b<|"|>],info:{city:<|"|>Seoul<|"|>}}', True),
+    ("{tags:[],info:{}}", False),  # city is required
+    ('{tags:[],info:{city:<|"|>Seoul<|"|>}}', True),
+    ('{tags:["a"],info:{city:<|"|>Seoul<|"|>}}', False),
+    ('{tags:[<|"|>a<|"|>],info:{"city":<|"|>Seoul<|"|>}}', False),
+)
+
+
+@pytest.mark.parametrize("input_str, accepted", gemma_nested_schema_input_str_accepted)
+def test_gemma_nested_schema(input_str: str, accepted: bool):
+    schema = {
+        "type": "object",
+        "properties": {
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "info": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+        "required": ["tags", "info"],
+    }
+    _check_gemma_grammar(schema, input_str, accepted)
+
+
+gemma_enum_schema_input_str_accepted = (
+    ('{unit:<|"|>celsius<|"|>}', True),
+    ('{unit:<|"|>fahrenheit<|"|>}', True),
+    ('{unit:<|"|>kelvin<|"|>}', False),
+    ('{unit:"celsius"}', False),
+)
+
+
+@pytest.mark.parametrize("input_str, accepted", gemma_enum_schema_input_str_accepted)
+def test_gemma_enum_schema(input_str: str, accepted: bool):
+    schema = {
+        "type": "object",
+        "properties": {"unit": {"enum": ["celsius", "fahrenheit"]}},
+        "required": ["unit"],
+    }
+    _check_gemma_grammar(schema, input_str, accepted)
+
+
+gemma_additional_properties_input_str_accepted = (
+    ('{name:<|"|>Bob<|"|>,extra:5}', True),
+    ('{name:<|"|>Bob<|"|>}', True),
+    ('{name:<|"|>Bob<|"|>,123bad:5}', False),
+    ('{name:<|"|>Bob<|"|>,extra:<|"|>5<|"|>}', False),
+)
+
+
+@pytest.mark.parametrize("input_str, accepted", gemma_additional_properties_input_str_accepted)
+def test_gemma_additional_properties_schema(input_str: str, accepted: bool):
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+        "additionalProperties": {"type": "integer"},
+    }
+    _check_gemma_grammar(schema, input_str, accepted)
+
+
+def test_gemma_empty_schema():
+    schema = {"type": "object", "properties": {}}
+    ebnf_grammar = _json_schema_to_ebnf(schema, json_format="gemma")
+    assert _is_grammar_accept_string(ebnf_grammar, "{}")
+    assert not _is_grammar_accept_string(ebnf_grammar, "")
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -1487,5 +1487,78 @@ def test_gemma_empty_schema():
     assert not _is_grammar_accept_string(ebnf_grammar, "")
 
 
+gemma_pattern_properties_input_str_accepted = (
+    ("{x_a:1}", True),
+    ("{x_a:1,x_b:2}", True),
+    ('{"x_a":1}', False),  # JSON-quoted keys must be rejected
+    ("{y_a:1}", False),  # key does not match the pattern
+)
+
+
+@pytest.mark.parametrize("input_str, accepted", gemma_pattern_properties_input_str_accepted)
+def test_gemma_pattern_properties_schema(input_str: str, accepted: bool):
+    schema = {"type": "object", "patternProperties": {"^x_[a-z]+$": {"type": "integer"}}}
+    _check_gemma_grammar(schema, input_str, accepted)
+
+
+gemma_property_names_input_str_accepted = (
+    ("{abc:1}", True),
+    ('{<|"|>abc<|"|>:1}', False),  # delimited keys must be rejected
+    ("{ABC:1}", False),  # key does not match propertyNames pattern
+)
+
+
+@pytest.mark.parametrize("input_str, accepted", gemma_property_names_input_str_accepted)
+def test_gemma_property_names_schema(input_str: str, accepted: bool):
+    schema = {
+        "type": "object",
+        "propertyNames": {"pattern": "^[a-z]+$"},
+        "additionalProperties": {"type": "integer"},
+    }
+    _check_gemma_grammar(schema, input_str, accepted)
+
+
+gemma_length_bound_input_str_accepted = (
+    ('{s:<|"|>ab<|"|>}', True),
+    ('{s:<|"|>a<b<|"|>}', True),  # lone '<' is allowed in bounded strings
+    ('{s:<|"|>ab<<|"|>}', True),  # '<' as the last content character
+    ('{s:<|"|>한글날<|"|>}', True),  # repetition counts codepoints, not bytes
+    ('{s:<|"|>a<|"|>}', False),  # below minLength
+    ('{s:<|"|>abcdef<|"|>}', False),  # above maxLength
+    ('{s:<|"|>ab<|"|>cd<|"|>}', False),  # embedded delimiter
+)
+
+
+@pytest.mark.parametrize("input_str, accepted", gemma_length_bound_input_str_accepted)
+def test_gemma_length_bound_string_schema(input_str: str, accepted: bool):
+    schema = {
+        "type": "object",
+        "properties": {"s": {"type": "string", "minLength": 2, "maxLength": 5}},
+        "required": ["s"],
+    }
+    _check_gemma_grammar(schema, input_str, accepted)
+
+
+def test_gemma_const_scalar_preserves_literal():
+    # Large integers must not be rounded through double re-serialization.
+    big = 10000000000000001
+    schema = {"type": "object", "properties": {"v": {"const": big}}, "required": ["v"]}
+    ebnf_grammar = _gemma_tool_calling_to_ebnf(schema)
+    assert _is_grammar_accept_string(ebnf_grammar, "{v:%d}" % big)
+    assert not _is_grammar_accept_string(ebnf_grammar, "{v:%d}" % (big - 1))
+
+
+def test_gemma_const_nested_value():
+    # A single-key object avoids depending on the serializer's key ordering.
+    schema = {
+        "type": "object",
+        "properties": {"cfg": {"const": {"tags": ["a", 3, True]}}},
+        "required": ["cfg"],
+    }
+    ebnf_grammar = _gemma_tool_calling_to_ebnf(schema)
+    assert _is_grammar_accept_string(ebnf_grammar, '{cfg:{tags:[<|"|>a<|"|>,3,true]}}')
+    assert not _is_grammar_accept_string(ebnf_grammar, '{cfg:{"tags":["a",3,true]}}')
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -2599,7 +2599,7 @@ json_format_error_test_data = [
     ),
     (
         '{"type": "structural_tag", "format": {"type": "json_schema", "json_schema": {"type": "string"}, "style": "not_string"}}',
-        'style must be "json", "qwen_xml", "minimax_xml", "deepseek_xml", or "glm_xml"',
+        'style must be "json", "qwen_xml", "minimax_xml", "deepseek_xml", "glm_xml", or "gemma"',
     ),
     # RepeatFormat Errors - illegal min/max
     (


### PR DESCRIPTION
## Summary
- Add a new `"gemma"` JSON-schema style that emits Gemma 4's tool-call argument format: unquoted keys and `<|"|>`-delimited strings with no escape sequences
- Re-enable the `gemma_4` builtin structural tag (auto/required/forced tool choice, `<|channel>thought` reasoning prefix)
- Validate against the released Gemma-4 chat templates in the alignment test, plus token-level matcher tests

## Why
The `gemma_4` builtin structural tag existed but was unregistered because Gemma 4's argument format could not be expressed by the existing converters: strings are wrapped in the single special token `<|"|>` instead of JSON quotes (making `{`, `}`, `,` and `"` literal inside strings), and object keys are unquoted. Engines therefore fall back to unconstrained decoding for Gemma 4 tool calls. Measured on `gemma-4-E2B-it`, unconstrained generation fails to stop at the tool-call boundary in 11–12 of 12 adversarial runs and never emits the required thought channel, while constrained decoding with this converter is correct in all runs.

The implementation was written against these two references:
- Official Gemma 4 prompt-formatting spec: https://ai.google.dev/gemma/docs/core/prompt-formatting-gemma4
- Released chat template: https://huggingface.co/google/gemma-4-E2B-it/blob/main/chat_template.jinja

## Known limitations

- **`pattern`/`format` strings can leak the delimiter.** The regex is emitted verbatim between the `<|"|>` delimiters, so a permissive pattern (e.g. `.*`) can generate text containing the delimiter itself, which closes the string early for downstream parsers. Intersecting an arbitrary regex with "does not contain the delimiter" is not supported; keep such patterns restrictive.
- **Key patterns containing `:` cannot round-trip.** Gemma keys are unquoted, so a `patternProperties`/`propertyNames` pattern whose language contains `:` is ambiguous against the key/value separator.