### PR TITLE
Fix: fix the ci.

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -83,7 +83,8 @@ jobs:
       - name: Install MLX
         if: matrix.os == 'macos-14' && !endsWith(matrix.python, 't')
         run: |
-          pip install mlx-lm
+          # transformers 5.13.0 breaks `import mlx_lm`.
+          pip install mlx-lm "transformers<5.13"
 
       - name: Run C++ tests
         run: |

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Install MLX
         if: matrix.os == 'macos-14' && !endsWith(matrix.python, 't')
         run: |
-          # transformers 5.13.0 breaks `import mlx_lm`.
+          # transformers >=5.13 breaks `import mlx_lm` (keep in sync with pyproject.toml [project.optional-dependencies].metal).
           pip install mlx-lm "transformers<5.13"
 
       - name: Run C++ tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,11 @@ GitHub = "https://github.com/mlc-ai/xgrammar"
 
 [project.optional-dependencies]
 test = ["huggingface-hub[cli]", "protobuf", "pytest", "sentencepiece", "tiktoken"]
-metal = ["mlx-lm; platform_system == 'Darwin' and platform_machine == 'arm64'"]
+metal = [
+  # transformers 5.13.0 breaks `import mlx_lm`.
+  "mlx-lm; platform_system == 'Darwin' and platform_machine == 'arm64'",
+  "transformers<5.13; platform_system == 'Darwin' and platform_machine == 'arm64'",
+]
 
 [build-system]
 requires = ["scikit-build-core>=0.10.0", "apache-tvm-ffi>=0.1.9"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ GitHub = "https://github.com/mlc-ai/xgrammar"
 [project.optional-dependencies]
 test = ["huggingface-hub[cli]", "protobuf", "pytest", "sentencepiece", "tiktoken"]
 metal = [
-  # transformers 5.13.0 breaks `import mlx_lm`.
+  # transformers >=5.13 breaks `import mlx_lm`.
   "mlx-lm; platform_system == 'Darwin' and platform_machine == 'arm64'",
   "transformers<5.13; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,16 +29,7 @@ Homepage = "https://xgrammar.mlc.ai/"
 GitHub = "https://github.com/mlc-ai/xgrammar"
 
 [project.optional-dependencies]
-test = [
-  "huggingface-hub[cli]",
-  "protobuf",
-  "pytest",
-  "sentencepiece",
-  "tiktoken",
-  # transformers==4.50.0 has error on MacOS.
-  # https://github.com/huggingface/transformers/issues/36906
-  "transformers<4.50.0; platform_system == 'Darwin'",
-]
+test = ["huggingface-hub[cli]", "protobuf", "pytest", "sentencepiece", "tiktoken"]
 metal = ["mlx-lm; platform_system == 'Darwin' and platform_machine == 'arm64'"]
 
 [build-system]


### PR DESCRIPTION
mlx-lm has a conflict with `transformers==5.13`. This PR pins the version of transformers to fix the cr and the build with mlx-lm.