### PR TITLE
[Refactor] Unify grammar AST construction in GrammarBuilder

### DIFF
--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "grammar_functor.h"
@@ -215,72 +216,82 @@ int32_t GrammarBuilder::AddExpr(
 int32_t GrammarBuilder::AddExprImpl(
     const GrammarExprSpec& spec, int32_t self_rule_id, const std::string& name_hint
 ) {
-  using Kind = GrammarExprSpec::Kind;
-  switch (spec.kind_) {
-    case Kind::kExprId:
-      XGRAMMAR_DCHECK(spec.id_ >= 0 && spec.id_ < NumGrammarExprs())
-          << "The grammar expr id " << spec.id_ << " is out of bound";
-      return spec.id_;
-    case Kind::kByteString:
-      return AddByteString(spec.str_);
-    case Kind::kCharacterClass:
-      return AddCharacterClass(spec.cc_elements_, spec.is_negative_);
-    case Kind::kCharacterClassStar:
-      return AddCharacterClassStar(spec.cc_elements_, spec.is_negative_);
-    case Kind::kEmptyStr:
-      return AddEmptyStr();
-    case Kind::kRuleRef:
-      return AddRuleRef(spec.id_);
-    case Kind::kSelfRef:
+  namespace gs = grammar_spec;
+
+  struct Visitor {
+    GrammarBuilder* builder;
+    int32_t self_rule_id;
+    const std::string& name_hint;
+
+    int32_t CheckedSelfRuleId() const {
       XGRAMMAR_CHECK(self_rule_id != -1)
           << "SelfRef is only allowed when the spec is materialized with a bound self rule id, "
              "e.g. through GrammarBuilder::AddRule";
-      return AddRuleRef(self_rule_id);
-    case Kind::kSequence: {
+      return self_rule_id;
+    }
+
+    int32_t operator()(const gs::ExprId& spec) const {
+      XGRAMMAR_DCHECK(spec.id >= 0 && spec.id < builder->NumGrammarExprs())
+          << "The grammar expr id " << spec.id << " is out of bound";
+      return spec.id;
+    }
+    int32_t operator()(const gs::ByteString& spec) const {
+      return builder->AddByteString(spec.str);
+    }
+    int32_t operator()(const gs::CharacterClass& spec) const {
+      return builder->AddCharacterClass(spec.elements, spec.is_negative);
+    }
+    int32_t operator()(const gs::CharacterClassStar& spec) const {
+      return builder->AddCharacterClassStar(spec.elements, spec.is_negative);
+    }
+    int32_t operator()(const gs::EmptyStr&) const { return builder->AddEmptyStr(); }
+    int32_t operator()(const gs::RuleRef& spec) const { return builder->AddRuleRef(spec.rule_id); }
+    int32_t operator()(const gs::SelfRef&) const {
+      return builder->AddRuleRef(CheckedSelfRuleId());
+    }
+    int32_t operator()(const gs::Token& spec) const { return builder->AddToken(spec.token_ids); }
+    int32_t operator()(const gs::ExcludeToken& spec) const {
+      return builder->AddExcludeToken(spec.token_ids);
+    }
+    int32_t operator()(const gs::TagDispatch& spec) const { return builder->AddTagDispatch(spec); }
+    int32_t operator()(const gs::TokenTagDispatch& spec) const {
+      return builder->AddTokenTagDispatch(spec);
+    }
+    int32_t operator()(const gs::Sequence& spec) const {
       std::vector<int32_t> element_ids;
-      element_ids.reserve(spec.children_.size());
-      for (const auto& child : spec.children_) {
-        element_ids.push_back(AddExprImpl(child, self_rule_id, name_hint));
+      element_ids.reserve(spec.elements.size());
+      for (const auto& element : spec.elements) {
+        element_ids.push_back(builder->AddExprImpl(element, self_rule_id, name_hint));
       }
-      return AddSequence(element_ids);
+      return builder->AddSequence(element_ids);
     }
-    case Kind::kChoices: {
+    int32_t operator()(const gs::Choices& spec) const {
       std::vector<int32_t> choice_ids;
-      choice_ids.reserve(spec.children_.size());
-      for (const auto& child : spec.children_) {
-        choice_ids.push_back(AddExprImpl(child, self_rule_id, name_hint));
+      choice_ids.reserve(spec.choices.size());
+      for (const auto& choice : spec.choices) {
+        choice_ids.push_back(builder->AddExprImpl(choice, self_rule_id, name_hint));
       }
-      return AddChoices(choice_ids);
+      return builder->AddChoices(choice_ids);
     }
-    case Kind::kRepeat: {
-      XGRAMMAR_DCHECK(spec.children_.size() == 1);
-      const auto& element = spec.children_[0];
-      if (element.kind_ == Kind::kRuleRef) {
-        return AddRepeat(element.id_, spec.min_repeat_count_, spec.max_repeat_count_);
+    int32_t operator()(const gs::Repeat& spec) const {
+      XGRAMMAR_DCHECK(spec.element.size() == 1);
+      const auto& element = spec.element[0];
+      if (auto* rule_ref = std::get_if<gs::RuleRef>(&element.value)) {
+        return builder->AddRepeat(rule_ref->rule_id, spec.min_repeat_count, spec.max_repeat_count);
       }
-      if (element.kind_ == Kind::kSelfRef) {
-        XGRAMMAR_CHECK(self_rule_id != -1)
-            << "SelfRef is only allowed when the spec is materialized with a bound self rule id, "
-               "e.g. through GrammarBuilder::AddRule";
-        return AddRepeat(self_rule_id, spec.min_repeat_count_, spec.max_repeat_count_);
+      if (std::holds_alternative<gs::SelfRef>(element.value)) {
+        return builder->AddRepeat(
+            CheckedSelfRuleId(), spec.min_repeat_count, spec.max_repeat_count
+        );
       }
-      auto element_expr_id = AddExprImpl(element, self_rule_id, name_hint);
-      return AddRepeatFromExpr(
-          name_hint, element_expr_id, spec.min_repeat_count_, spec.max_repeat_count_
+      auto element_expr_id = builder->AddExprImpl(element, self_rule_id, name_hint);
+      return builder->AddRepeatFromExpr(
+          name_hint, element_expr_id, spec.min_repeat_count, spec.max_repeat_count
       );
     }
-    case Kind::kToken:
-      return AddToken(spec.token_ids_);
-    case Kind::kExcludeToken:
-      return AddExcludeToken(spec.token_ids_);
-    case Kind::kTagDispatch:
-      return AddTagDispatch(*spec.tag_dispatch_);
-    case Kind::kTokenTagDispatch:
-      return AddTokenTagDispatch(*spec.token_tag_dispatch_);
-    default:
-      XGRAMMAR_LOG(FATAL) << "Unexpected spec kind: " << static_cast<int>(spec.kind_);
-      XGRAMMAR_UNREACHABLE();
-  }
+  };
+
+  return std::visit(Visitor{this, self_rule_id, name_hint}, spec.value);
 }
 
 int32_t GrammarBuilder::AddSubGrammar(const Grammar& sub_grammar) {

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "grammar_functor.h"
 #include "support/logging.h"
 
 namespace xgrammar {
@@ -25,18 +26,22 @@ GrammarBuilder::GrammarBuilder(const Grammar& grammar)
   }
 }
 
-Grammar GrammarBuilder::Get(const std::string& root_rule_name) {
+Grammar GrammarBuilder::Get(const std::string& root_rule_name, bool normalize) {
   int32_t root_rule_id = GetRuleId(root_rule_name);
   XGRAMMAR_CHECK(root_rule_id != -1)
       << "The root rule with name \"" << root_rule_name << "\" is not found.";
-  return Get(root_rule_id);
+  return Get(root_rule_id, normalize);
 }
 
-Grammar GrammarBuilder::Get(int32_t root_rule_id) {
+Grammar GrammarBuilder::Get(int32_t root_rule_id, bool normalize) {
   XGRAMMAR_CHECK(root_rule_id >= 0 && root_rule_id < static_cast<int32_t>(grammar_->rules_.size()))
       << "The root rule id " << root_rule_id << " is out of bound.";
   grammar_->root_rule_id_ = root_rule_id;
-  return Grammar(grammar_);
+  Grammar result(grammar_);
+  if (normalize) {
+    result = GrammarNormalizer::Apply(result);
+  }
+  return result;
 }
 
 int32_t GrammarBuilder::AddGrammarExpr(const GrammarExpr& grammar_expr) {
@@ -102,13 +107,13 @@ int32_t GrammarBuilder::AddEmptyStr() {
   return AddGrammarExpr({GrammarExprType::kEmptyStr, nullptr, 0});
 }
 
-int32_t GrammarBuilder::AddTokenSet(const std::vector<int32_t>& token_ids) {
+int32_t GrammarBuilder::AddToken(const std::vector<int32_t>& token_ids) {
   return AddGrammarExpr(
       {GrammarExprType::kToken, token_ids.data(), static_cast<int32_t>(token_ids.size())}
   );
 }
 
-int32_t GrammarBuilder::AddExcludeTokenSet(const std::vector<int32_t>& token_ids) {
+int32_t GrammarBuilder::AddExcludeToken(const std::vector<int32_t>& token_ids) {
   return AddGrammarExpr(
       {GrammarExprType::kExcludeToken, token_ids.data(), static_cast<int32_t>(token_ids.size())}
   );
@@ -177,6 +182,10 @@ int32_t GrammarBuilder::AddRepeat(
   return AddGrammarExpr({GrammarExprType::kRepeat, data.data(), static_cast<int32_t>(data.size())});
 }
 
+int32_t GrammarBuilder::AddRepeat(const Grammar::Impl::Repeat& repeat) {
+  return AddRepeat(repeat.rule_id, repeat.min_repeat_count, repeat.max_repeat_count);
+}
+
 int32_t GrammarBuilder::AddRepeatFromExpr(
     const std::string& cur_rule_name,
     int32_t grammar_expr_id,
@@ -191,6 +200,170 @@ int32_t GrammarBuilder::AddRepeatFromExpr(
     ref_rule_id = AddRule(GetNewRuleName(cur_rule_name), grammar_expr_id);
   }
   return AddRepeat(ref_rule_id, min_repeat_count, max_repeat_count);
+}
+
+int32_t GrammarBuilder::AddExpr(const GrammarExprSpec& spec, const std::string& name_hint) {
+  return AddExprImpl(spec, -1, name_hint);
+}
+
+int32_t GrammarBuilder::AddExpr(
+    const GrammarExprSpec& spec, int32_t self_rule_id, const std::string& name_hint
+) {
+  return AddExprImpl(spec, self_rule_id, name_hint);
+}
+
+int32_t GrammarBuilder::AddExprImpl(
+    const GrammarExprSpec& spec, int32_t self_rule_id, const std::string& name_hint
+) {
+  using Kind = GrammarExprSpec::Kind;
+  switch (spec.kind_) {
+    case Kind::kExprId:
+      XGRAMMAR_DCHECK(spec.id_ >= 0 && spec.id_ < NumGrammarExprs())
+          << "The grammar expr id " << spec.id_ << " is out of bound";
+      return spec.id_;
+    case Kind::kByteString:
+      return AddByteString(spec.str_);
+    case Kind::kCharacterClass:
+      return AddCharacterClass(spec.cc_elements_, spec.is_negative_);
+    case Kind::kCharacterClassStar:
+      return AddCharacterClassStar(spec.cc_elements_, spec.is_negative_);
+    case Kind::kEmptyStr:
+      return AddEmptyStr();
+    case Kind::kRuleRef:
+      return AddRuleRef(spec.id_);
+    case Kind::kSelfRef:
+      XGRAMMAR_CHECK(self_rule_id != -1)
+          << "SelfRef is only allowed when the spec is materialized with a bound self rule id, "
+             "e.g. through GrammarBuilder::AddRule";
+      return AddRuleRef(self_rule_id);
+    case Kind::kSequence: {
+      std::vector<int32_t> element_ids;
+      element_ids.reserve(spec.children_.size());
+      for (const auto& child : spec.children_) {
+        element_ids.push_back(AddExprImpl(child, self_rule_id, name_hint));
+      }
+      return AddSequence(element_ids);
+    }
+    case Kind::kChoices: {
+      std::vector<int32_t> choice_ids;
+      choice_ids.reserve(spec.children_.size());
+      for (const auto& child : spec.children_) {
+        choice_ids.push_back(AddExprImpl(child, self_rule_id, name_hint));
+      }
+      return AddChoices(choice_ids);
+    }
+    case Kind::kRepeat: {
+      XGRAMMAR_DCHECK(spec.children_.size() == 1);
+      const auto& element = spec.children_[0];
+      if (element.kind_ == Kind::kRuleRef) {
+        return AddRepeat(element.id_, spec.min_repeat_count_, spec.max_repeat_count_);
+      }
+      if (element.kind_ == Kind::kSelfRef) {
+        XGRAMMAR_CHECK(self_rule_id != -1)
+            << "SelfRef is only allowed when the spec is materialized with a bound self rule id, "
+               "e.g. through GrammarBuilder::AddRule";
+        return AddRepeat(self_rule_id, spec.min_repeat_count_, spec.max_repeat_count_);
+      }
+      auto element_expr_id = AddExprImpl(element, self_rule_id, name_hint);
+      return AddRepeatFromExpr(
+          name_hint, element_expr_id, spec.min_repeat_count_, spec.max_repeat_count_
+      );
+    }
+    case Kind::kToken:
+      return AddToken(spec.token_ids_);
+    case Kind::kExcludeToken:
+      return AddExcludeToken(spec.token_ids_);
+    case Kind::kTagDispatch:
+      return AddTagDispatch(*spec.tag_dispatch_);
+    case Kind::kTokenTagDispatch:
+      return AddTokenTagDispatch(*spec.token_tag_dispatch_);
+    default:
+      XGRAMMAR_LOG(FATAL) << "Unexpected spec kind: " << static_cast<int>(spec.kind_);
+      XGRAMMAR_UNREACHABLE();
+  }
+}
+
+int32_t GrammarBuilder::AddSubGrammar(const Grammar& sub_grammar) {
+  const Grammar::Impl& sub = *sub_grammar.operator->();
+  int32_t num_rules = sub.NumRules();
+  XGRAMMAR_CHECK(num_rules > 0) << "The sub grammar has no rules";
+
+  // Step 1. Allocate all rules first so rule references can be remapped.
+  std::vector<int32_t> new_rule_ids(num_rules);
+  for (int32_t i = 0; i < num_rules; ++i) {
+    new_rule_ids[i] = AddEmptyRule(GetNewRuleName(sub.GetRule(i).name));
+  }
+
+  // Step 2. Copy the rule bodies and lookahead assertions.
+  for (int32_t i = 0; i < num_rules; ++i) {
+    const auto& rule = sub.GetRule(i);
+    UpdateRuleBody(new_rule_ids[i], CopySubGrammarExpr(sub, rule.body_expr_id, new_rule_ids));
+    if (rule.lookahead_assertion_id != -1) {
+      UpdateLookaheadAssertion(
+          new_rule_ids[i], CopySubGrammarExpr(sub, rule.lookahead_assertion_id, new_rule_ids)
+      );
+      UpdateLookaheadExact(new_rule_ids[i], rule.is_exact_lookahead);
+    }
+  }
+  return new_rule_ids[sub.GetRootRuleId()];
+}
+
+int32_t GrammarBuilder::CopySubGrammarExpr(
+    const Grammar::Impl& sub_grammar,
+    int32_t grammar_expr_id,
+    const std::vector<int32_t>& new_rule_ids
+) {
+  auto expr = sub_grammar.GetGrammarExpr(grammar_expr_id);
+  switch (expr.type) {
+    // These exprs do not contain ids, so they can be copied verbatim.
+    case GrammarExprType::kByteString:
+    case GrammarExprType::kCharacterClass:
+    case GrammarExprType::kCharacterClassStar:
+    case GrammarExprType::kEmptyStr:
+    case GrammarExprType::kToken:
+    case GrammarExprType::kExcludeToken:
+      return AddGrammarExpr(expr);
+    case GrammarExprType::kRuleRef:
+      return AddRuleRef(new_rule_ids[sub_grammar.GetRuleRef(expr)]);
+    case GrammarExprType::kSequence: {
+      std::vector<int32_t> new_element_ids;
+      new_element_ids.reserve(expr.size());
+      for (auto element_id : sub_grammar.GetSequence(expr)) {
+        new_element_ids.push_back(CopySubGrammarExpr(sub_grammar, element_id, new_rule_ids));
+      }
+      return AddSequence(new_element_ids);
+    }
+    case GrammarExprType::kChoices: {
+      std::vector<int32_t> new_choice_ids;
+      new_choice_ids.reserve(expr.size());
+      for (auto choice_id : sub_grammar.GetChoices(expr)) {
+        new_choice_ids.push_back(CopySubGrammarExpr(sub_grammar, choice_id, new_rule_ids));
+      }
+      return AddChoices(new_choice_ids);
+    }
+    case GrammarExprType::kRepeat: {
+      auto repeat = sub_grammar.GetRepeat(expr);
+      repeat.rule_id = new_rule_ids[repeat.rule_id];
+      return AddRepeat(repeat);
+    }
+    case GrammarExprType::kTagDispatch: {
+      auto tag_dispatch = sub_grammar.GetTagDispatch(expr);
+      for (auto& [tag, rule_id] : tag_dispatch.tag_rule_pairs) {
+        rule_id = new_rule_ids[rule_id];
+      }
+      return AddTagDispatch(tag_dispatch);
+    }
+    case GrammarExprType::kTokenTagDispatch: {
+      auto token_tag_dispatch = sub_grammar.GetTokenTagDispatch(expr);
+      for (auto& [token_id, rule_id] : token_tag_dispatch.trigger_rule_pairs) {
+        rule_id = new_rule_ids[rule_id];
+      }
+      return AddTokenTagDispatch(token_tag_dispatch);
+    }
+    default:
+      XGRAMMAR_LOG(FATAL) << "Unexpected grammar expr type: " << static_cast<int>(expr.type);
+      XGRAMMAR_UNREACHABLE();
+  }
 }
 
 int32_t GrammarBuilder::NumGrammarExprs() const { return grammar_->NumGrammarExprs(); }
@@ -213,6 +386,17 @@ int32_t GrammarBuilder::AddRule(const std::string& name, int32_t body_expr_id) {
 
 int32_t GrammarBuilder::AddRuleWithHint(const std::string& name_hint, int32_t body_expr_id) {
   return AddRule({GetNewRuleName(name_hint), body_expr_id});
+}
+
+int32_t GrammarBuilder::AddRule(const std::string& name, const GrammarExprSpec& spec) {
+  // The rule is added first so that SelfRef in the spec can refer to it.
+  auto rule_id = AddEmptyRule(name);
+  UpdateRuleBody(rule_id, AddExprImpl(spec, rule_id, name));
+  return rule_id;
+}
+
+int32_t GrammarBuilder::AddRuleWithHint(const std::string& name_hint, const GrammarExprSpec& spec) {
+  return AddRule(GetNewRuleName(name_hint), spec);
 }
 
 int32_t GrammarBuilder::NumRules() const { return grammar_->NumRules(); }

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -10,8 +10,11 @@
 #include <xgrammar/xgrammar.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "grammar_impl.h"
@@ -20,7 +23,199 @@
 namespace xgrammar {
 
 /*!
- * \brief Helper class to build a BNF grammar.
+ * \brief A lightweight, nestable description of a grammar expression tree.
+ *
+ * A GrammarExprSpec is built with the static factory methods and can be nested arbitrarily:
+ *
+ * \code
+ * using Spec = GrammarExprSpec;
+ * auto spec = Spec::Choices(
+ *     Spec::Sequence(Spec::ByteString("abc"), Spec::RuleRef(other_rule_id)),
+ *     Spec::ByteString("def"),
+ *     Spec::Sequence(Spec::ByteString("ghi"), Spec::SelfRef())
+ * );
+ * int32_t rule_id = builder.AddRule("my_rule", spec);
+ * \endcode
+ *
+ * An int32_t (an already-added grammar expr id) converts implicitly to a GrammarExprSpec, so
+ * existing expr ids can be mixed with nested specs, e.g. Choices(id1, id2, Spec::EmptyStr()).
+ *
+ * SelfRef() refers to the rule currently being defined, and is only valid when the spec is
+ * materialized through GrammarBuilder::AddRule / AddRuleWithHint, or through an AddExpr overload
+ * that binds the self rule id explicitly.
+ *
+ * The spec is a build-time-only description: it is materialized into grammar exprs by
+ * GrammarBuilder, and can be discarded afterwards.
+ */
+class GrammarExprSpec {
+ public:
+  using CharacterClassElement = Grammar::Impl::CharacterClassElement;
+
+  /*! \brief Implicitly wraps an already-added grammar expr id. */
+  GrammarExprSpec(int32_t grammar_expr_id) : kind_(Kind::kExprId), id_(grammar_expr_id) {}
+
+  /*! \brief A byte string expr. Supports UTF-8 strings. */
+  static GrammarExprSpec ByteString(std::string str) {
+    GrammarExprSpec spec(Kind::kByteString);
+    spec.str_ = std::move(str);
+    return spec;
+  }
+
+  /*! \brief A character class expr, e.g. [a-z] or [^a-z]. */
+  static GrammarExprSpec CharacterClass(
+      std::vector<CharacterClassElement> elements, bool is_negative = false
+  ) {
+    GrammarExprSpec spec(Kind::kCharacterClass);
+    spec.cc_elements_ = std::move(elements);
+    spec.is_negative_ = is_negative;
+    return spec;
+  }
+
+  /*! \brief A character class star expr, e.g. [a-z]* or [^a-z]*. */
+  static GrammarExprSpec CharacterClassStar(
+      std::vector<CharacterClassElement> elements, bool is_negative = false
+  ) {
+    GrammarExprSpec spec(Kind::kCharacterClassStar);
+    spec.cc_elements_ = std::move(elements);
+    spec.is_negative_ = is_negative;
+    return spec;
+  }
+
+  /*! \brief An empty string expr. */
+  static GrammarExprSpec EmptyStr() { return GrammarExprSpec(Kind::kEmptyStr); }
+
+  /*! \brief A reference to the rule with the given id. */
+  static GrammarExprSpec RuleRef(int32_t rule_id) {
+    GrammarExprSpec spec(Kind::kRuleRef);
+    spec.id_ = rule_id;
+    return spec;
+  }
+
+  /*! \brief A reference to the rule currently being defined. Only valid when materialized with
+   * a bound self rule id. \sa GrammarBuilder::AddRule */
+  static GrammarExprSpec SelfRef() { return GrammarExprSpec(Kind::kSelfRef); }
+
+  /*! \brief A sequence expr. Elements are matched one after another. */
+  static GrammarExprSpec Sequence(std::vector<GrammarExprSpec> elements) {
+    GrammarExprSpec spec(Kind::kSequence);
+    spec.children_ = std::move(elements);
+    return spec;
+  }
+
+  /*! \brief A sequence expr from a variadic list of specs (or expr ids). */
+  template <
+      typename... Args,
+      typename = std::enable_if_t<(std::is_convertible_v<Args, GrammarExprSpec> && ...)>>
+  static GrammarExprSpec Sequence(Args&&... elements) {
+    return Sequence(MakeChildren(std::forward<Args>(elements)...));
+  }
+
+  /*! \brief A choices expr. Any one of the choices can be matched. */
+  static GrammarExprSpec Choices(std::vector<GrammarExprSpec> choices) {
+    GrammarExprSpec spec(Kind::kChoices);
+    spec.children_ = std::move(choices);
+    return spec;
+  }
+
+  /*! \brief A choices expr from a variadic list of specs (or expr ids). */
+  template <
+      typename... Args,
+      typename = std::enable_if_t<(std::is_convertible_v<Args, GrammarExprSpec> && ...)>>
+  static GrammarExprSpec Choices(Args&&... choices) {
+    return Choices(MakeChildren(std::forward<Args>(choices)...));
+  }
+
+  /*!
+   * \brief A repeat expr, matching the element between min_repeat_count and max_repeat_count
+   * times. If the element is not a rule reference, a new rule will be created to wrap it.
+   * \param max_repeat_count The maximum repeat count (inclusive), or -1 for unbounded.
+   */
+  static GrammarExprSpec Repeat(
+      GrammarExprSpec element, int32_t min_repeat_count, int32_t max_repeat_count
+  ) {
+    GrammarExprSpec spec(Kind::kRepeat);
+    spec.children_.push_back(std::move(element));
+    spec.min_repeat_count_ = min_repeat_count;
+    spec.max_repeat_count_ = max_repeat_count;
+    return spec;
+  }
+
+  /*! \brief A token expr (token-level matching). Any one of the tokens can be matched. */
+  static GrammarExprSpec Token(std::vector<int32_t> token_ids) {
+    GrammarExprSpec spec(Kind::kToken);
+    spec.token_ids_ = std::move(token_ids);
+    return spec;
+  }
+
+  /*! \brief An exclude token expr. Any token except the given ones can be matched. */
+  static GrammarExprSpec ExcludeToken(std::vector<int32_t> token_ids) {
+    GrammarExprSpec spec(Kind::kExcludeToken);
+    spec.token_ids_ = std::move(token_ids);
+    return spec;
+  }
+
+  /*! \brief A tag dispatch expr. The referenced rules must already exist in the builder. */
+  static GrammarExprSpec TagDispatch(Grammar::Impl::TagDispatch tag_dispatch) {
+    GrammarExprSpec spec(Kind::kTagDispatch);
+    spec.tag_dispatch_ = std::move(tag_dispatch);
+    return spec;
+  }
+
+  /*! \brief A token tag dispatch expr. The referenced rules must already exist in the builder. */
+  static GrammarExprSpec TokenTagDispatch(Grammar::Impl::TokenTagDispatch token_tag_dispatch) {
+    GrammarExprSpec spec(Kind::kTokenTagDispatch);
+    spec.token_tag_dispatch_ = std::move(token_tag_dispatch);
+    return spec;
+  }
+
+ private:
+  friend class GrammarBuilder;
+
+  enum class Kind : int32_t {
+    kExprId,
+    kByteString,
+    kCharacterClass,
+    kCharacterClassStar,
+    kEmptyStr,
+    kRuleRef,
+    kSelfRef,
+    kSequence,
+    kChoices,
+    kRepeat,
+    kToken,
+    kExcludeToken,
+    kTagDispatch,
+    kTokenTagDispatch,
+  };
+
+  explicit GrammarExprSpec(Kind kind) : kind_(kind) {}
+
+  template <typename... Args>
+  static std::vector<GrammarExprSpec> MakeChildren(Args&&... args) {
+    std::vector<GrammarExprSpec> children;
+    children.reserve(sizeof...(Args));
+    (children.push_back(GrammarExprSpec(std::forward<Args>(args))), ...);
+    return children;
+  }
+
+  Kind kind_;
+  /*! \brief The expr id for kExprId, or the rule id for kRuleRef. */
+  int32_t id_ = -1;
+  std::string str_;
+  bool is_negative_ = false;
+  std::vector<CharacterClassElement> cc_elements_;
+  std::vector<GrammarExprSpec> children_;
+  int32_t min_repeat_count_ = 0;
+  int32_t max_repeat_count_ = -1;
+  std::vector<int32_t> token_ids_;
+  std::optional<Grammar::Impl::TagDispatch> tag_dispatch_;
+  std::optional<Grammar::Impl::TokenTagDispatch> token_tag_dispatch_;
+};
+
+/*!
+ * \brief Helper class to build a BNF grammar. It is the unified entry for constructing the
+ * grammar AST: it can add single grammar exprs, materialize nested GrammarExprSpecs, add whole
+ * sub grammars, and normalize the result grammar on Get().
  */
 class GrammarBuilder {
  public:
@@ -28,13 +223,9 @@ class GrammarBuilder {
   using GrammarExprType = Grammar::Impl::GrammarExprType;
   using GrammarExpr = Grammar::Impl::GrammarExpr;
 
-  /*! \brief One element of a character class, containing a lower and a upper bound. Both bounds are
-   * inclusive.
-   */
-  struct CharacterClassElement {
-    int32_t lower;
-    int32_t upper;
-  };
+  /*! \brief One element of a character class, containing a lower and a upper bound. Both bounds
+   * are inclusive. */
+  using CharacterClassElement = Grammar::Impl::CharacterClassElement;
 
   /*! \brief Default constructor. Creates a new grammar object. */
   GrammarBuilder();
@@ -46,15 +237,19 @@ class GrammarBuilder {
    * \brief Get the result grammar. This function will also set the root rule to the rule with the
    * specified name. The rule should be already added to the grammar.
    * \param root_rule_name The name of the root rule. Default is "root".
+   * \param normalize If true, the grammar will be normalized (GrammarNormalizer) before being
+   * returned.
    */
-  Grammar Get(const std::string& root_rule_name = "root");
+  Grammar Get(const std::string& root_rule_name = "root", bool normalize = false);
 
   /*!
    * \brief Get the result grammar. This function will also set the root rule to the rule with
    * the specified id. The rule should be already added to the grammar.
    * \param root_rule_id The id of the root rule.
+   * \param normalize If true, the grammar will be normalized (GrammarNormalizer) before being
+   * returned.
    */
-  Grammar Get(int32_t root_rule_id);
+  Grammar Get(int32_t root_rule_id, bool normalize = false);
 
   /****************** GrammarExpr handling ******************/
 
@@ -96,10 +291,10 @@ class GrammarBuilder {
   int32_t AddEmptyStr();
 
   /*! \brief Add a GrammarExpr for kToken (token-level matching). */
-  int32_t AddTokenSet(const std::vector<int32_t>& token_ids);
+  int32_t AddToken(const std::vector<int32_t>& token_ids);
 
   /*! \brief Add a GrammarExpr for kExcludeToken (excluded token-level matching). */
-  int32_t AddExcludeTokenSet(const std::vector<int32_t>& token_ids);
+  int32_t AddExcludeToken(const std::vector<int32_t>& token_ids);
 
   /*! \brief Add a GrammarExpr for rule reference.*/
   int32_t AddRuleRef(int32_t rule_id);
@@ -121,6 +316,9 @@ class GrammarBuilder {
 
   int32_t AddRepeat(int32_t ref_rule_id, int32_t min_repeat_count, int32_t max_repeat_count);
 
+  /*! \brief Add a GrammarExpr for repeat from its typed representation. */
+  int32_t AddRepeat(const Grammar::Impl::Repeat& repeat);
+
   /*!
    * \brief Add a repeat GrammarExpr from an arbitrary grammar expression. If the expression is
    * not a rule reference, a new rule is created to wrap it.
@@ -134,6 +332,21 @@ class GrammarBuilder {
       int32_t grammar_expr_id,
       int32_t min_repeat_count,
       int32_t max_repeat_count
+  );
+
+  /*!
+   * \brief Materialize a nested GrammarExprSpec into grammar exprs and return the id of the
+   * top-level expr. SelfRef is not allowed in the spec.
+   * \param name_hint Name hint for auxiliary rules created during materialization (e.g. for
+   * Repeat elements).
+   */
+  int32_t AddExpr(const GrammarExprSpec& spec, const std::string& name_hint = "expr");
+
+  /*!
+   * \brief Materialize a nested GrammarExprSpec, with SelfRef bound to the given rule id.
+   */
+  int32_t AddExpr(
+      const GrammarExprSpec& spec, int32_t self_rule_id, const std::string& name_hint = "expr"
   );
 
   /*! \brief Get the number of grammar_exprs. */
@@ -150,6 +363,32 @@ class GrammarBuilder {
   int32_t AddRule(const std::string& name, int32_t body_expr_id);
 
   int32_t AddRuleWithHint(const std::string& name_hint, int32_t body_expr_id);
+
+  /*!
+   * \brief Add a new rule whose body is the materialization of the given GrammarExprSpec, and
+   * return the rule id. SelfRef in the spec refers to the rule being added, so recursive rules
+   * can be built in one call:
+   *
+   * \code
+   * // list ::= "" | item list
+   * builder.AddRule("list", Spec::Choices(
+   *     Spec::EmptyStr(),
+   *     Spec::Sequence(Spec::RuleRef(item_rule_id), Spec::SelfRef())
+   * ));
+   * \endcode
+   */
+  int32_t AddRule(const std::string& name, const GrammarExprSpec& spec);
+
+  /*! \brief Same as AddRule(name, spec), but the rule name is derived from the name hint. */
+  int32_t AddRuleWithHint(const std::string& name_hint, const GrammarExprSpec& spec);
+
+  /*!
+   * \brief Add all rules of another grammar into this builder. Rules are renamed on name
+   * conflicts, and all rule references (including those in tag dispatches and repeats) are
+   * remapped to the new rule ids.
+   * \return The new rule id of the sub grammar's root rule.
+   */
+  int32_t AddSubGrammar(const Grammar& sub_grammar);
 
   int32_t NumRules() const;
 
@@ -204,6 +443,23 @@ class GrammarBuilder {
   int32_t GetRuleId(const std::string& name) const;
 
  private:
+  /*!
+   * \brief Materialize a GrammarExprSpec into grammar exprs.
+   * \param self_rule_id The rule id SelfRef is bound to, or -1 if SelfRef is not allowed.
+   * \param name_hint Name hint for auxiliary rules created during materialization.
+   */
+  int32_t AddExprImpl(
+      const GrammarExprSpec& spec, int32_t self_rule_id, const std::string& name_hint
+  );
+
+  /*! \brief Recursively copy a grammar expr of another grammar into this builder, remapping
+   * rule ids with new_rule_ids. */
+  int32_t CopySubGrammarExpr(
+      const Grammar::Impl& sub_grammar,
+      int32_t grammar_expr_id,
+      const std::vector<int32_t>& new_rule_ids
+  );
+
   // Mutable pointer to the grammar object.
   std::shared_ptr<Grammar::Impl> grammar_;
   // Map from rule name to rule id.

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -10,11 +10,11 @@
 #include <xgrammar/xgrammar.h>
 
 #include <cstdint>
-#include <optional>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "grammar_impl.h"
@@ -23,194 +23,241 @@
 namespace xgrammar {
 
 /*!
- * \brief A lightweight, nestable description of a grammar expression tree.
+ * \brief Nestable build-time descriptions of grammar expression trees.
  *
- * A GrammarExprSpec is built with the static factory methods and can be nested arbitrarily:
+ * Every GrammarExprType has its own spec class with a trivial constructor that just stores its
+ * arguments. A spec tree can be nested arbitrarily and is materialized into grammar exprs by
+ * GrammarBuilder:
  *
  * \code
- * using Spec = GrammarExprSpec;
- * auto spec = Spec::Choices(
- *     Spec::Sequence(Spec::ByteString("abc"), Spec::RuleRef(other_rule_id)),
- *     Spec::ByteString("def"),
- *     Spec::Sequence(Spec::ByteString("ghi"), Spec::SelfRef())
- * );
- * int32_t rule_id = builder.AddRule("my_rule", spec);
+ * using namespace grammar_spec;
+ * int32_t rule_id = builder.AddRule("my_rule", Choices(
+ *     Sequence(ByteString("abc"), RuleRef(other_rule_id)),
+ *     ByteString("def"),
+ *     Sequence(ByteString("ghi"), SelfRef())
+ * ));
  * \endcode
  *
- * An int32_t (an already-added grammar expr id) converts implicitly to a GrammarExprSpec, so
- * existing expr ids can be mixed with nested specs, e.g. Choices(id1, id2, Spec::EmptyStr()).
+ * Any spec class (and int32_t, wrapping an already-added grammar expr id) converts implicitly
+ * to GrammarExprSpec, so existing expr ids can be mixed with nested specs, e.g.
+ * Choices(id1, id2, EmptyStr()).
  *
- * SelfRef() refers to the rule currently being defined, and is only valid when the spec is
+ * SelfRef refers to the rule currently being defined, and is only valid when the spec is
  * materialized through GrammarBuilder::AddRule / AddRuleWithHint, or through an AddExpr overload
  * that binds the self rule id explicitly.
  *
- * The spec is a build-time-only description: it is materialized into grammar exprs by
+ * The specs are build-time-only descriptions: they are materialized into grammar exprs by
  * GrammarBuilder, and can be discarded afterwards.
+ */
+namespace grammar_spec {
+
+class GrammarExprSpec;
+struct ExprId;
+struct ByteString;
+struct CharacterClass;
+struct CharacterClassStar;
+struct EmptyStr;
+struct RuleRef;
+struct SelfRef;
+struct Token;
+struct ExcludeToken;
+struct Sequence;
+struct Choices;
+struct Repeat;
+
+namespace detail {
+
+template <typename T, typename... Ts>
+inline constexpr bool is_one_of_v = (std::is_same_v<T, Ts> || ...);
+
+/*!
+ * \brief Whether T (after decay) can be used to construct a GrammarExprSpec: one of the spec
+ * classes, GrammarExprSpec itself, or an integral grammar expr id.
+ * \note This trait is spelled out as a type list instead of
+ * std::is_convertible<T, GrammarExprSpec>, because the latter would recursively instantiate
+ * itself through the converting constructors of GrammarExprSpec and Sequence/Choices/Repeat.
+ */
+template <typename T>
+inline constexpr bool is_spec_arg_v = is_one_of_v<
+                                          std::decay_t<T>,
+                                          GrammarExprSpec,
+                                          ExprId,
+                                          ByteString,
+                                          CharacterClass,
+                                          CharacterClassStar,
+                                          EmptyStr,
+                                          RuleRef,
+                                          SelfRef,
+                                          Token,
+                                          ExcludeToken,
+                                          Grammar::Impl::TagDispatch,
+                                          Grammar::Impl::TokenTagDispatch,
+                                          Sequence,
+                                          Choices,
+                                          Repeat> ||
+                                      std::is_integral_v<std::decay_t<T>>;
+
+}  // namespace detail
+
+/*! \brief Wraps an already-added grammar expr id. int32_t converts implicitly to it. */
+struct ExprId {
+  int32_t id;
+  ExprId(int32_t id) : id(id) {}
+};
+
+/*! \brief A byte string expr. Supports UTF-8 strings. */
+struct ByteString {
+  std::string str;
+  explicit ByteString(std::string str) : str(std::move(str)) {}
+};
+
+/*! \brief A character class expr, e.g. [a-z] or [^a-z]. */
+struct CharacterClass {
+  std::vector<Grammar::Impl::CharacterClassElement> elements;
+  bool is_negative;
+  explicit CharacterClass(
+      std::vector<Grammar::Impl::CharacterClassElement> elements, bool is_negative = false
+  )
+      : elements(std::move(elements)), is_negative(is_negative) {}
+};
+
+/*! \brief A character class star expr, e.g. [a-z]* or [^a-z]*. */
+struct CharacterClassStar {
+  std::vector<Grammar::Impl::CharacterClassElement> elements;
+  bool is_negative;
+  explicit CharacterClassStar(
+      std::vector<Grammar::Impl::CharacterClassElement> elements, bool is_negative = false
+  )
+      : elements(std::move(elements)), is_negative(is_negative) {}
+};
+
+/*! \brief An empty string expr. */
+struct EmptyStr {};
+
+/*! \brief A reference to the rule with the given id. */
+struct RuleRef {
+  int32_t rule_id;
+  explicit RuleRef(int32_t rule_id) : rule_id(rule_id) {}
+};
+
+/*! \brief A reference to the rule currently being defined. Only valid when materialized with a
+ * bound self rule id. \sa GrammarBuilder::AddRule */
+struct SelfRef {};
+
+/*! \brief A token expr (token-level matching). Any one of the tokens can be matched. */
+struct Token {
+  std::vector<int32_t> token_ids;
+  explicit Token(std::vector<int32_t> token_ids) : token_ids(std::move(token_ids)) {}
+};
+
+/*! \brief An exclude token expr. Any token except the given ones can be matched. */
+struct ExcludeToken {
+  std::vector<int32_t> token_ids;
+  explicit ExcludeToken(std::vector<int32_t> token_ids) : token_ids(std::move(token_ids)) {}
+};
+
+/*! \brief A tag dispatch expr, described by its typed representation. The referenced rules must
+ * already exist in the builder. */
+using TagDispatch = Grammar::Impl::TagDispatch;
+
+/*! \brief A token tag dispatch expr, described by its typed representation. The referenced rules
+ * must already exist in the builder. */
+using TokenTagDispatch = Grammar::Impl::TokenTagDispatch;
+
+/*! \brief A sequence expr. Elements are matched one after another. */
+struct Sequence {
+  std::vector<GrammarExprSpec> elements;
+
+  explicit Sequence(std::vector<GrammarExprSpec> elements) : elements(std::move(elements)) {}
+
+  /*! \brief Constructs from a variadic list of specs (or expr ids). */
+  template <
+      typename... Args,
+      typename = std::enable_if_t<
+          (detail::is_spec_arg_v<Args> && ...) &&
+          !(sizeof...(Args) == 1 && (std::is_same_v<std::decay_t<Args>, Sequence> && ...))>>
+  Sequence(Args&&... args) {
+    elements.reserve(sizeof...(Args));
+    (elements.emplace_back(std::forward<Args>(args)), ...);
+  }
+};
+
+/*! \brief A choices expr. Any one of the choices can be matched. */
+struct Choices {
+  std::vector<GrammarExprSpec> choices;
+
+  explicit Choices(std::vector<GrammarExprSpec> choices) : choices(std::move(choices)) {}
+
+  /*! \brief Constructs from a variadic list of specs (or expr ids). */
+  template <
+      typename... Args,
+      typename = std::enable_if_t<
+          (detail::is_spec_arg_v<Args> && ...) &&
+          !(sizeof...(Args) == 1 && (std::is_same_v<std::decay_t<Args>, Choices> && ...))>>
+  Choices(Args&&... args) {
+    choices.reserve(sizeof...(Args));
+    (choices.emplace_back(std::forward<Args>(args)), ...);
+  }
+};
+
+/*!
+ * \brief A repeat expr, matching the element between min_repeat_count and max_repeat_count
+ * times (max_repeat_count == -1 means unbounded). If the element is not a rule reference, a new
+ * rule will be created to wrap it on materialization.
+ */
+struct Repeat {
+  /*! \brief The repeated element. Stored in a vector because GrammarExprSpec is incomplete here;
+   * it always contains exactly one element. */
+  std::vector<GrammarExprSpec> element;
+  int32_t min_repeat_count;
+  int32_t max_repeat_count;
+
+  template <typename T, typename = std::enable_if_t<detail::is_spec_arg_v<T>>>
+  Repeat(T&& element, int32_t min_repeat_count, int32_t max_repeat_count)
+      : min_repeat_count(min_repeat_count), max_repeat_count(max_repeat_count) {
+    this->element.emplace_back(std::forward<T>(element));
+  }
+};
+
+/*!
+ * \brief The type-erased wrapper holding any of the spec classes. All spec classes and int32_t
+ * (an already-added grammar expr id) convert implicitly to it.
  */
 class GrammarExprSpec {
  public:
-  using CharacterClassElement = Grammar::Impl::CharacterClassElement;
+  using Variant = std::variant<
+      ExprId,
+      ByteString,
+      CharacterClass,
+      CharacterClassStar,
+      EmptyStr,
+      RuleRef,
+      SelfRef,
+      Token,
+      ExcludeToken,
+      TagDispatch,
+      TokenTagDispatch,
+      Sequence,
+      Choices,
+      Repeat>;
 
   /*! \brief Implicitly wraps an already-added grammar expr id. */
-  GrammarExprSpec(int32_t grammar_expr_id) : kind_(Kind::kExprId), id_(grammar_expr_id) {}
+  GrammarExprSpec(int32_t grammar_expr_id) : value(ExprId(grammar_expr_id)) {}
 
-  /*! \brief A byte string expr. Supports UTF-8 strings. */
-  static GrammarExprSpec ByteString(std::string str) {
-    GrammarExprSpec spec(Kind::kByteString);
-    spec.str_ = std::move(str);
-    return spec;
-  }
-
-  /*! \brief A character class expr, e.g. [a-z] or [^a-z]. */
-  static GrammarExprSpec CharacterClass(
-      std::vector<CharacterClassElement> elements, bool is_negative = false
-  ) {
-    GrammarExprSpec spec(Kind::kCharacterClass);
-    spec.cc_elements_ = std::move(elements);
-    spec.is_negative_ = is_negative;
-    return spec;
-  }
-
-  /*! \brief A character class star expr, e.g. [a-z]* or [^a-z]*. */
-  static GrammarExprSpec CharacterClassStar(
-      std::vector<CharacterClassElement> elements, bool is_negative = false
-  ) {
-    GrammarExprSpec spec(Kind::kCharacterClassStar);
-    spec.cc_elements_ = std::move(elements);
-    spec.is_negative_ = is_negative;
-    return spec;
-  }
-
-  /*! \brief An empty string expr. */
-  static GrammarExprSpec EmptyStr() { return GrammarExprSpec(Kind::kEmptyStr); }
-
-  /*! \brief A reference to the rule with the given id. */
-  static GrammarExprSpec RuleRef(int32_t rule_id) {
-    GrammarExprSpec spec(Kind::kRuleRef);
-    spec.id_ = rule_id;
-    return spec;
-  }
-
-  /*! \brief A reference to the rule currently being defined. Only valid when materialized with
-   * a bound self rule id. \sa GrammarBuilder::AddRule */
-  static GrammarExprSpec SelfRef() { return GrammarExprSpec(Kind::kSelfRef); }
-
-  /*! \brief A sequence expr. Elements are matched one after another. */
-  static GrammarExprSpec Sequence(std::vector<GrammarExprSpec> elements) {
-    GrammarExprSpec spec(Kind::kSequence);
-    spec.children_ = std::move(elements);
-    return spec;
-  }
-
-  /*! \brief A sequence expr from a variadic list of specs (or expr ids). */
+  /*! \brief Implicitly wraps any of the spec classes. */
   template <
-      typename... Args,
-      typename = std::enable_if_t<(std::is_convertible_v<Args, GrammarExprSpec> && ...)>>
-  static GrammarExprSpec Sequence(Args&&... elements) {
-    return Sequence(MakeChildren(std::forward<Args>(elements)...));
-  }
+      typename T,
+      typename = std::enable_if_t<
+          detail::is_spec_arg_v<T> && !std::is_same_v<std::decay_t<T>, GrammarExprSpec> &&
+          !std::is_integral_v<std::decay_t<T>>>>
+  GrammarExprSpec(T&& value) : value(std::forward<T>(value)) {}
 
-  /*! \brief A choices expr. Any one of the choices can be matched. */
-  static GrammarExprSpec Choices(std::vector<GrammarExprSpec> choices) {
-    GrammarExprSpec spec(Kind::kChoices);
-    spec.children_ = std::move(choices);
-    return spec;
-  }
-
-  /*! \brief A choices expr from a variadic list of specs (or expr ids). */
-  template <
-      typename... Args,
-      typename = std::enable_if_t<(std::is_convertible_v<Args, GrammarExprSpec> && ...)>>
-  static GrammarExprSpec Choices(Args&&... choices) {
-    return Choices(MakeChildren(std::forward<Args>(choices)...));
-  }
-
-  /*!
-   * \brief A repeat expr, matching the element between min_repeat_count and max_repeat_count
-   * times. If the element is not a rule reference, a new rule will be created to wrap it.
-   * \param max_repeat_count The maximum repeat count (inclusive), or -1 for unbounded.
-   */
-  static GrammarExprSpec Repeat(
-      GrammarExprSpec element, int32_t min_repeat_count, int32_t max_repeat_count
-  ) {
-    GrammarExprSpec spec(Kind::kRepeat);
-    spec.children_.push_back(std::move(element));
-    spec.min_repeat_count_ = min_repeat_count;
-    spec.max_repeat_count_ = max_repeat_count;
-    return spec;
-  }
-
-  /*! \brief A token expr (token-level matching). Any one of the tokens can be matched. */
-  static GrammarExprSpec Token(std::vector<int32_t> token_ids) {
-    GrammarExprSpec spec(Kind::kToken);
-    spec.token_ids_ = std::move(token_ids);
-    return spec;
-  }
-
-  /*! \brief An exclude token expr. Any token except the given ones can be matched. */
-  static GrammarExprSpec ExcludeToken(std::vector<int32_t> token_ids) {
-    GrammarExprSpec spec(Kind::kExcludeToken);
-    spec.token_ids_ = std::move(token_ids);
-    return spec;
-  }
-
-  /*! \brief A tag dispatch expr. The referenced rules must already exist in the builder. */
-  static GrammarExprSpec TagDispatch(Grammar::Impl::TagDispatch tag_dispatch) {
-    GrammarExprSpec spec(Kind::kTagDispatch);
-    spec.tag_dispatch_ = std::move(tag_dispatch);
-    return spec;
-  }
-
-  /*! \brief A token tag dispatch expr. The referenced rules must already exist in the builder. */
-  static GrammarExprSpec TokenTagDispatch(Grammar::Impl::TokenTagDispatch token_tag_dispatch) {
-    GrammarExprSpec spec(Kind::kTokenTagDispatch);
-    spec.token_tag_dispatch_ = std::move(token_tag_dispatch);
-    return spec;
-  }
-
- private:
-  friend class GrammarBuilder;
-
-  enum class Kind : int32_t {
-    kExprId,
-    kByteString,
-    kCharacterClass,
-    kCharacterClassStar,
-    kEmptyStr,
-    kRuleRef,
-    kSelfRef,
-    kSequence,
-    kChoices,
-    kRepeat,
-    kToken,
-    kExcludeToken,
-    kTagDispatch,
-    kTokenTagDispatch,
-  };
-
-  explicit GrammarExprSpec(Kind kind) : kind_(kind) {}
-
-  template <typename... Args>
-  static std::vector<GrammarExprSpec> MakeChildren(Args&&... args) {
-    std::vector<GrammarExprSpec> children;
-    children.reserve(sizeof...(Args));
-    (children.push_back(GrammarExprSpec(std::forward<Args>(args))), ...);
-    return children;
-  }
-
-  Kind kind_;
-  /*! \brief The expr id for kExprId, or the rule id for kRuleRef. */
-  int32_t id_ = -1;
-  std::string str_;
-  bool is_negative_ = false;
-  std::vector<CharacterClassElement> cc_elements_;
-  std::vector<GrammarExprSpec> children_;
-  int32_t min_repeat_count_ = 0;
-  int32_t max_repeat_count_ = -1;
-  std::vector<int32_t> token_ids_;
-  std::optional<Grammar::Impl::TagDispatch> tag_dispatch_;
-  std::optional<Grammar::Impl::TokenTagDispatch> token_tag_dispatch_;
+  Variant value;
 };
+
+}  // namespace grammar_spec
+
+using grammar_spec::GrammarExprSpec;
 
 /*!
  * \brief Helper class to build a BNF grammar. It is the unified entry for constructing the
@@ -370,10 +417,11 @@ class GrammarBuilder {
    * can be built in one call:
    *
    * \code
+   * using namespace grammar_spec;
    * // list ::= "" | item list
-   * builder.AddRule("list", Spec::Choices(
-   *     Spec::EmptyStr(),
-   *     Spec::Sequence(Spec::RuleRef(item_rule_id), Spec::SelfRef())
+   * builder.AddRule("list", Choices(
+   *     EmptyStr(),
+   *     Sequence(RuleRef(item_rule_id), SelfRef())
    * ));
    * \endcode
    */

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -34,154 +34,6 @@ namespace xgrammar {
 using GrammarExpr = Grammar::Impl::GrammarExpr;
 using ExprType = Grammar::Impl::GrammarExprType;
 
-/*************************** Impl of grammar constructors ***************************/
-
-/*!
- * \brief Base class for grammar mutators that add subgrammars.
- *
- * Provides functionality to visit a subgrammar and add its rules to the builder
- * while maintaining proper rule references and names.
- */
-class SubGrammarAdderImpl : public GrammarMutator {
- public:
-  SubGrammarAdderImpl() = default;
-
-  /*!
-   * \brief Visit a subgrammar and add the rules to the builder.
-   * \param grammar The subgrammar to visit.
-   * \return The new id of the root rule of this subgrammar.
-   */
-  int32_t ApplyWithBuilder(GrammarBuilder* builder, const Grammar& sub_grammar) {
-    InitGrammar(sub_grammar);
-    InitBuilder(builder);
-    new_rule_ids_names.reserve(base_grammar_->NumRules());
-    new_rule_ids_names.clear();
-    for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
-      auto new_name = builder_->GetNewRuleName(base_grammar_->GetRule(i).name);
-      auto new_id = builder_->AddEmptyRule(new_name);
-      new_rule_ids_names.emplace_back(new_id, new_name);
-    }
-    for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
-      auto rule = base_grammar_->GetRule(i);
-      cur_rule_name_ = new_rule_ids_names[i].second;
-      auto new_body_expr_id = VisitExpr(rule.body_expr_id);
-      builder_->UpdateRuleBody(new_rule_ids_names[i].first, new_body_expr_id);
-      auto new_lookahead_assertion_id = VisitLookaheadAssertion(rule.lookahead_assertion_id);
-      builder_->UpdateLookaheadAssertion(new_rule_ids_names[i].first, new_lookahead_assertion_id);
-    }
-    return new_rule_ids_names[base_grammar_->GetRootRuleId()].first;
-  }
-
-  int32_t VisitRuleRef(const GrammarExpr& grammar_expr) final {
-    return builder_->AddRuleRef(new_rule_ids_names[grammar_expr[0]].first);
-  }
-
-  int32_t VisitRepeat(const GrammarExpr& grammar_expr) final {
-    return builder_->AddRepeat(
-        new_rule_ids_names[grammar_expr[0]].first, grammar_expr[1], grammar_expr[2]
-    );
-  }
-
-  int32_t VisitTagDispatch(const GrammarExpr& grammar_expr) final {
-    Grammar::Impl::TagDispatch old_tag_dispatch = base_grammar_->GetTagDispatch(grammar_expr);
-    Grammar::Impl::TagDispatch new_tag_dispatch;
-    for (const auto& [trigger, rule_id] : old_tag_dispatch.tag_rule_pairs) {
-      new_tag_dispatch.tag_rule_pairs.emplace_back(trigger, new_rule_ids_names[rule_id].first);
-    }
-    new_tag_dispatch.loop_after_dispatch = old_tag_dispatch.loop_after_dispatch;
-    new_tag_dispatch.excludes = old_tag_dispatch.excludes;
-    return builder_->AddTagDispatch(new_tag_dispatch);
-  }
-
-  int32_t VisitTokenTagDispatch(const GrammarExpr& grammar_expr) final {
-    Grammar::Impl::TokenTagDispatch old_ttd = base_grammar_->GetTokenTagDispatch(grammar_expr);
-    Grammar::Impl::TokenTagDispatch new_ttd;
-    for (const auto& [token_id, rule_id] : old_ttd.trigger_rule_pairs) {
-      new_ttd.trigger_rule_pairs.emplace_back(token_id, new_rule_ids_names[rule_id].first);
-    }
-    new_ttd.loop_after_dispatch = old_ttd.loop_after_dispatch;
-    new_ttd.excludes = old_ttd.excludes;
-    return builder_->AddTokenTagDispatch(new_ttd);
-  }
-
-  std::vector<std::pair<int32_t, std::string>> new_rule_ids_names;
-};
-
-/*!
- * \brief Implementation of grammar union operation.
- *
- * Creates a new grammar that accepts strings from any of the input grammars.
- * The resulting grammar has a new root rule that chooses between the root rules
- * of all input grammars.
- */
-class GrammarUnionFunctorImpl : public GrammarMutator {
- public:
-  GrammarUnionFunctorImpl() = default;
-
-  Grammar Apply(const std::vector<Grammar>& grammars) {
-    InitGrammar();
-    InitBuilder();
-    auto root_rule_id = builder_->AddEmptyRule("root");
-
-    std::vector<int32_t> new_root_choices;
-    new_root_choices.reserve(grammars.size());
-
-    for (const auto& grammar : grammars) {
-      auto new_root_id_for_grammar = SubGrammarAdderImpl().ApplyWithBuilder(builder_, grammar);
-      auto new_rule_ref = builder_->AddRuleRef(new_root_id_for_grammar);
-      auto new_rule_ref_seq = builder_->AddSequence({new_rule_ref});
-      new_root_choices.push_back(new_rule_ref_seq);
-    }
-
-    builder_->UpdateRuleBody(root_rule_id, builder_->AddChoices(new_root_choices));
-    return builder_->Get(root_rule_id);
-  }
-
-  // Avoid hiding the original Apply(const Grammar&)
-  Grammar Apply(const Grammar& grammar) final {
-    XGRAMMAR_LOG(FATAL) << "Should not be called";
-    XGRAMMAR_UNREACHABLE();
-  }
-};
-
-/*!
- * \brief Implementation of grammar concatenation operation.
- *
- * Creates a new grammar that accepts strings that are concatenations of strings
- * from the input grammars in order. The resulting grammar has a new root rule
- * that concatenates the root rules of all input grammars.
- */
-class GrammarConcatFunctorImpl : public GrammarMutator {
- public:
-  GrammarConcatFunctorImpl() = default;
-
-  Grammar Apply(const std::vector<Grammar>& grammars) {
-    InitGrammar();
-    InitBuilder();
-    auto root_rule_id = builder_->AddEmptyRule("root");
-
-    std::vector<int32_t> new_root_sequence;
-    new_root_sequence.reserve(grammars.size());
-
-    for (const auto& grammar : grammars) {
-      auto new_root_id_for_grammar = SubGrammarAdderImpl().ApplyWithBuilder(builder_, grammar);
-      auto new_rule_ref = builder_->AddRuleRef(new_root_id_for_grammar);
-      new_root_sequence.push_back(new_rule_ref);
-    }
-
-    auto new_root_seq = builder_->AddSequence(new_root_sequence);
-    builder_->UpdateRuleBody(root_rule_id, builder_->AddChoices({new_root_seq}));
-
-    return builder_->Get(root_rule_id);
-  }
-
-  // Avoid hiding the original Apply(const Grammar&)
-  Grammar Apply(const Grammar& grammar) final {
-    XGRAMMAR_LOG(FATAL) << "Should not be called";
-    XGRAMMAR_UNREACHABLE();
-  }
-};
-
 /*************************** Impl of grammar normalizers ***************************/
 
 /*!
@@ -2655,18 +2507,36 @@ void RuleLevelCache::Impl::ClearCache() {
 
 size_t MemorySize(const RuleLevelCache& manager) { return MemorySize(manager.ImplPtr()); }
 
-/*************************** Forward grammar constructors to their impl ***************************/
+/*************************** Grammar constructors ***************************/
 
 Grammar GrammarUnionFunctor::Apply(const std::vector<Grammar>& grammars) {
-  return GrammarUnionFunctorImpl().Apply(grammars);
+  using Spec = GrammarExprSpec;
+  GrammarBuilder builder;
+  // Add the root rule first so it takes the name "root".
+  auto root_rule_id = builder.AddEmptyRule("root");
+  std::vector<Spec> choices;
+  choices.reserve(grammars.size());
+  for (const auto& grammar : grammars) {
+    choices.push_back(Spec::Sequence(Spec::RuleRef(builder.AddSubGrammar(grammar))));
+  }
+  builder.UpdateRuleBody(root_rule_id, builder.AddExpr(Spec::Choices(std::move(choices))));
+  return builder.Get(root_rule_id);
 }
 
 Grammar GrammarConcatFunctor::Apply(const std::vector<Grammar>& grammars) {
-  return GrammarConcatFunctorImpl().Apply(grammars);
-}
-
-int32_t SubGrammarAdder::Apply(GrammarBuilder* builder, const Grammar& sub_grammar) {
-  return SubGrammarAdderImpl().ApplyWithBuilder(builder, sub_grammar);
+  using Spec = GrammarExprSpec;
+  GrammarBuilder builder;
+  // Add the root rule first so it takes the name "root".
+  auto root_rule_id = builder.AddEmptyRule("root");
+  std::vector<Spec> sequence;
+  sequence.reserve(grammars.size());
+  for (const auto& grammar : grammars) {
+    sequence.push_back(Spec::RuleRef(builder.AddSubGrammar(grammar)));
+  }
+  builder.UpdateRuleBody(
+      root_rule_id, builder.AddExpr(Spec::Choices(Spec::Sequence(std::move(sequence))))
+  );
+  return builder.Get(root_rule_id);
 }
 
 /*************************** Forward grammar Normalizers to their impl ***************************/

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -2510,31 +2510,31 @@ size_t MemorySize(const RuleLevelCache& manager) { return MemorySize(manager.Imp
 /*************************** Grammar constructors ***************************/
 
 Grammar GrammarUnionFunctor::Apply(const std::vector<Grammar>& grammars) {
-  using Spec = GrammarExprSpec;
+  namespace gs = grammar_spec;
   GrammarBuilder builder;
   // Add the root rule first so it takes the name "root".
   auto root_rule_id = builder.AddEmptyRule("root");
-  std::vector<Spec> choices;
+  std::vector<GrammarExprSpec> choices;
   choices.reserve(grammars.size());
   for (const auto& grammar : grammars) {
-    choices.push_back(Spec::Sequence(Spec::RuleRef(builder.AddSubGrammar(grammar))));
+    choices.push_back(gs::Sequence(gs::RuleRef(builder.AddSubGrammar(grammar))));
   }
-  builder.UpdateRuleBody(root_rule_id, builder.AddExpr(Spec::Choices(std::move(choices))));
+  builder.UpdateRuleBody(root_rule_id, builder.AddExpr(gs::Choices(std::move(choices))));
   return builder.Get(root_rule_id);
 }
 
 Grammar GrammarConcatFunctor::Apply(const std::vector<Grammar>& grammars) {
-  using Spec = GrammarExprSpec;
+  namespace gs = grammar_spec;
   GrammarBuilder builder;
   // Add the root rule first so it takes the name "root".
   auto root_rule_id = builder.AddEmptyRule("root");
-  std::vector<Spec> sequence;
+  std::vector<GrammarExprSpec> sequence;
   sequence.reserve(grammars.size());
   for (const auto& grammar : grammars) {
-    sequence.push_back(Spec::RuleRef(builder.AddSubGrammar(grammar)));
+    sequence.push_back(gs::RuleRef(builder.AddSubGrammar(grammar)));
   }
   builder.UpdateRuleBody(
-      root_rule_id, builder.AddExpr(Spec::Choices(Spec::Sequence(std::move(sequence))))
+      root_rule_id, builder.AddExpr(gs::Choices(gs::Sequence(std::move(sequence))))
   );
   return builder.Get(root_rule_id);
 }

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -283,15 +283,6 @@ class GrammarConcatFunctor {
   static Grammar Apply(const std::vector<Grammar>& grammars);
 };
 
-/*!
- * \brief Add a sub grammar to the current builder. The return value
- * of Apply is the new rule id of the sub grammar's root rule.
- */
-class SubGrammarAdder {
- public:
-  static int32_t Apply(GrammarBuilder* builder, const Grammar& sub_grammar);
-};
-
 /*************************** Grammar Normalizer ***************************/
 
 /*!

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -172,24 +172,101 @@ class Grammar::Impl {
     return {type, data_ptr, data_len};
   }
 
-  /******************* GrammarExpr Getters *******************/
+  /******************* Typed representations of GrammarExprs *******************/
 
-  /*! \brief Get the string of the byte string grammar expr. */
-  std::string GetByteString(const GrammarExpr& grammar_expr) const {
-    std::string str;
-    str.reserve(grammar_expr.size());
-    for (int i = 0; i < grammar_expr.size(); ++i) {
-      str.push_back(static_cast<char>(static_cast<uint8_t>(grammar_expr[i])));
+  /*!
+   * \details Every composite GrammarExprType has a typed representation and a pair of const
+   * getters (one accepting a GrammarExpr, one accepting an expr id). GrammarBuilder provides
+   * symmetric Add* methods accepting the same representations.
+   *
+   * Performance notes: the typed representations are designed to be zero-cost. Most of them are
+   * non-owning views (pointer + length into the grammar buffer) or small trivially-copyable
+   * structs, so the getters never allocate. Owning containers are only created on demand via
+   * ToString()/ToVector(). The only exceptions are GetTagDispatch and GetTokenTagDispatch, which
+   * materialize vectors/strings; they should only be used on cold paths (compilation, printing,
+   * grammar transforms).
+   *
+   * Like GrammarExpr, the views point into the grammar buffer and are invalidated when new
+   * exprs are added to the grammar.
+   */
+
+  /*! \brief A non-owning view of a contiguous int32_t array in the grammar buffer, e.g. the
+   * sub-expr ids of a sequence/choices expr, or the token ids of a token expr. */
+  struct Int32Span {
+    const int32_t* data = nullptr;
+    int32_t data_len = 0;
+
+    int32_t size() const { return data_len; }
+    int32_t operator[](int i) const {
+      XGRAMMAR_DCHECK(i >= 0 && i < data_len) << "Index " << i << " is out of bound";
+      return data[i];
     }
-    return str;
-  }
+    const int32_t* begin() const { return data; }
+    const int32_t* end() const { return data + data_len; }
+    std::vector<int32_t> ToVector() const { return {data, data + data_len}; }
+  };
 
-  /*! \brief Get the string of the byte string grammar expr. */
-  std::string GetByteString(int32_t grammar_expr_id) const {
-    return GetByteString(GetGrammarExpr(grammar_expr_id));
-  }
+  /*! \brief A non-owning view of a byte string expr. Each element is a byte (0~255) stored as
+   * int32_t in the grammar buffer. */
+  struct ByteStringView {
+    const int32_t* data = nullptr;
+    int32_t data_len = 0;
 
-  /*! \brief The object representing a tag dispatch. */
+    int32_t size() const { return data_len; }
+    char operator[](int i) const {
+      XGRAMMAR_DCHECK(i >= 0 && i < data_len) << "Index " << i << " is out of bound";
+      return static_cast<char>(static_cast<uint8_t>(data[i]));
+    }
+    std::string ToString() const {
+      std::string str;
+      str.reserve(data_len);
+      for (int i = 0; i < data_len; ++i) {
+        str.push_back((*this)[i]);
+      }
+      return str;
+    }
+  };
+
+  /*! \brief One element of a character class: an inclusive range of unicode codepoints. */
+  struct CharacterClassElement {
+    int32_t lower;
+    int32_t upper;
+  };
+
+  /*! \brief A non-owning view of a character class (or character class star) expr. */
+  struct CharacterClassView {
+    bool is_negative = false;
+    /*! \brief The ranges, flattened as [lower0, upper0, lower1, upper1, ...]. */
+    const int32_t* ranges_data = nullptr;
+    int32_t num_ranges = 0;
+
+    int32_t size() const { return num_ranges; }
+    CharacterClassElement operator[](int i) const {
+      XGRAMMAR_DCHECK(i >= 0 && i < num_ranges) << "Index " << i << " is out of bound";
+      return {ranges_data[2 * i], ranges_data[2 * i + 1]};
+    }
+    std::vector<CharacterClassElement> ToVector() const {
+      std::vector<CharacterClassElement> result;
+      result.reserve(num_ranges);
+      for (int i = 0; i < num_ranges; ++i) {
+        result.push_back((*this)[i]);
+      }
+      return result;
+    }
+  };
+
+  /*! \brief The typed representation of a repeat expr. */
+  struct Repeat {
+    /*! \brief The id of the repeated rule. */
+    int32_t rule_id;
+    /*! \brief The minimum repeat count (inclusive). */
+    int32_t min_repeat_count;
+    /*! \brief The maximum repeat count (inclusive), or -1 for unbounded. */
+    int32_t max_repeat_count;
+  };
+
+  /*! \brief The typed representation of a tag dispatch. Owning: materialized by
+   * GetTagDispatch, so only use it on cold paths. */
   struct TagDispatch {
     /*! \brief The tag and rule id pairs. */
     std::vector<std::pair<std::string, int32_t>> tag_rule_pairs;
@@ -200,8 +277,106 @@ class Grammar::Impl {
     static const int kTagDispatchExtraParameter = 2;
   };
 
-  /*! \brief Get the tag dispatch from the grammar expr. */
-  TagDispatch GetTagDispatch(const GrammarExpr& grammar_expr) {
+  /*! \brief The typed representation of a token tag dispatch. Owning: materialized by
+   * GetTokenTagDispatch, so only use it on cold paths. */
+  struct TokenTagDispatch {
+    /*! \brief The trigger token id and rule id pairs. */
+    std::vector<std::pair<int32_t, int32_t>> trigger_rule_pairs;
+    /*! \brief If true, the token tag dispatch will loop after dispatching. */
+    bool loop_after_dispatch;
+    /*! \brief The token ids that are excluded by the token tag dispatch. */
+    std::vector<int32_t> excludes;
+  };
+
+  /******************* GrammarExpr Getters *******************/
+
+  /*! \brief Get the view of a byte string expr. */
+  ByteStringView GetByteString(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kByteString)
+        << "GrammarExpr is not a byte string";
+    return {grammar_expr.data, grammar_expr.data_len};
+  }
+  ByteStringView GetByteString(int32_t grammar_expr_id) const {
+    return GetByteString(GetGrammarExpr(grammar_expr_id));
+  }
+
+  /*! \brief Get the view of a character class or character class star expr. */
+  CharacterClassView GetCharacterClass(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(
+        grammar_expr.type == GrammarExprType::kCharacterClass ||
+        grammar_expr.type == GrammarExprType::kCharacterClassStar
+    ) << "GrammarExpr is not a character class";
+    XGRAMMAR_DCHECK(grammar_expr.data_len % 2 == 1);
+    return {
+        static_cast<bool>(grammar_expr[0]), grammar_expr.data + 1, (grammar_expr.data_len - 1) / 2
+    };
+  }
+  CharacterClassView GetCharacterClass(int32_t grammar_expr_id) const {
+    return GetCharacterClass(GetGrammarExpr(grammar_expr_id));
+  }
+
+  /*! \brief Get the rule id referenced by a rule ref expr. */
+  int32_t GetRuleRef(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kRuleRef)
+        << "GrammarExpr is not a rule ref";
+    return grammar_expr[0];
+  }
+  int32_t GetRuleRef(int32_t grammar_expr_id) const {
+    return GetRuleRef(GetGrammarExpr(grammar_expr_id));
+  }
+
+  /*! \brief Get the sub-expr ids of a sequence expr. */
+  Int32Span GetSequence(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kSequence)
+        << "GrammarExpr is not a sequence";
+    return {grammar_expr.data, grammar_expr.data_len};
+  }
+  Int32Span GetSequence(int32_t grammar_expr_id) const {
+    return GetSequence(GetGrammarExpr(grammar_expr_id));
+  }
+
+  /*! \brief Get the sub-expr ids of a choices expr. */
+  Int32Span GetChoices(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kChoices)
+        << "GrammarExpr is not a choices";
+    return {grammar_expr.data, grammar_expr.data_len};
+  }
+  Int32Span GetChoices(int32_t grammar_expr_id) const {
+    return GetChoices(GetGrammarExpr(grammar_expr_id));
+  }
+
+  /*! \brief Get the typed representation of a repeat expr. */
+  Repeat GetRepeat(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kRepeat) << "GrammarExpr is not a repeat";
+    XGRAMMAR_DCHECK(grammar_expr.data_len == 3);
+    return {grammar_expr[0], grammar_expr[1], grammar_expr[2]};
+  }
+  Repeat GetRepeat(int32_t grammar_expr_id) const {
+    return GetRepeat(GetGrammarExpr(grammar_expr_id));
+  }
+
+  /*! \brief Get the token ids of a token expr. */
+  Int32Span GetToken(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kToken) << "GrammarExpr is not a token";
+    return {grammar_expr.data, grammar_expr.data_len};
+  }
+  Int32Span GetToken(int32_t grammar_expr_id) const {
+    return GetToken(GetGrammarExpr(grammar_expr_id));
+  }
+
+  /*! \brief Get the token ids of an exclude token expr. */
+  Int32Span GetExcludeToken(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kExcludeToken)
+        << "GrammarExpr is not an exclude token";
+    return {grammar_expr.data, grammar_expr.data_len};
+  }
+  Int32Span GetExcludeToken(int32_t grammar_expr_id) const {
+    return GetExcludeToken(GetGrammarExpr(grammar_expr_id));
+  }
+
+  /*! \brief Get the typed representation of a tag dispatch expr. Materializes the tag strings;
+   * only use it on cold paths. */
+  TagDispatch GetTagDispatch(const GrammarExpr& grammar_expr) const {
     XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kTagDispatch)
         << "GrammarExpr is not a tag dispatch";
 
@@ -214,7 +389,7 @@ class Grammar::Impl {
     for (int i = 0; i < grammar_expr.size() - TagDispatch::kTagDispatchExtraParameter; i += 2) {
       auto tag_expr_id = grammar_expr[i];
       auto rule_id = grammar_expr[i + 1];
-      result.tag_rule_pairs.push_back({GetByteString(tag_expr_id), rule_id});
+      result.tag_rule_pairs.push_back({GetByteString(tag_expr_id).ToString(), rule_id});
     }
 
     result.loop_after_dispatch = static_cast<bool>(
@@ -227,29 +402,23 @@ class Grammar::Impl {
     XGRAMMAR_DCHECK(exclude_str_expr.type == GrammarExprType::kChoices);
     result.excludes.reserve(exclude_str_expr.size());
     for (int j = 0; j < exclude_str_expr.size(); j++) {
-      result.excludes.push_back(GetByteString(exclude_str_expr[j]));
+      result.excludes.push_back(GetByteString(exclude_str_expr[j]).ToString());
     }
     return result;
   }
-
-  /*! \brief Get the tag dispatch from the grammar expr with the given id. */
-  TagDispatch GetTagDispatch(int32_t grammar_expr_id) {
+  TagDispatch GetTagDispatch(int32_t grammar_expr_id) const {
     return GetTagDispatch(GetGrammarExpr(grammar_expr_id));
   }
 
-  /*! \brief The object representing a token tag dispatch. */
-  struct TokenTagDispatch {
-    std::vector<std::pair<int32_t, int32_t>> trigger_rule_pairs;  // token_id → rule_id
-    bool loop_after_dispatch;
-    std::vector<int32_t> excludes;
-  };
-
-  /*! \brief Decode a kTokenTagDispatch expr into the TokenTagDispatch struct. */
-  TokenTagDispatch GetTokenTagDispatch(const GrammarExpr& grammar_expr) {
-    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kTokenTagDispatch);
+  /*! \brief Get the typed representation of a token tag dispatch expr. Materializes vectors;
+   * only use it on cold paths. */
+  TokenTagDispatch GetTokenTagDispatch(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kTokenTagDispatch)
+        << "GrammarExpr is not a token tag dispatch";
     TokenTagDispatch result;
     int pos = 0;
     int32_t trigger_count = grammar_expr[pos++];
+    result.trigger_rule_pairs.reserve(trigger_count);
     for (int i = 0; i < trigger_count; ++i) {
       auto token_id = grammar_expr[pos++];
       auto rule_id = grammar_expr[pos++];
@@ -257,15 +426,14 @@ class Grammar::Impl {
     }
     result.loop_after_dispatch = static_cast<bool>(grammar_expr[pos++]);
     int32_t exclude_count = grammar_expr[pos++];
+    result.excludes.reserve(exclude_count);
     for (int i = 0; i < exclude_count; ++i) {
       result.excludes.push_back(grammar_expr[pos++]);
     }
     XGRAMMAR_DCHECK(pos == grammar_expr.size());
     return result;
   }
-
-  /*! \brief Get the token tag dispatch from the grammar expr with the given id. */
-  TokenTagDispatch GetTokenTagDispatch(int32_t grammar_expr_id) {
+  TokenTagDispatch GetTokenTagDispatch(int32_t grammar_expr_id) const {
     return GetTokenTagDispatch(GetGrammarExpr(grammar_expr_id));
   }
 

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -1036,7 +1036,7 @@ int32_t EBNFParser::ParseTokenSet() {
   std::sort(token_ids.begin(), token_ids.end());
   token_ids.erase(std::unique(token_ids.begin(), token_ids.end()), token_ids.end());
 
-  return builder_.AddTokenSet(token_ids);
+  return builder_.AddToken(token_ids);
 }
 
 int32_t EBNFParser::ParseExcludeToken() {
@@ -1063,7 +1063,7 @@ int32_t EBNFParser::ParseExcludeToken() {
   std::sort(token_ids.begin(), token_ids.end());
   token_ids.erase(std::unique(token_ids.begin(), token_ids.end()), token_ids.end());
 
-  return builder_.AddExcludeTokenSet(token_ids);
+  return builder_.AddExcludeToken(token_ids);
 }
 
 int32_t EBNFParser::ParseTokenTagDispatch() {

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -1802,7 +1802,7 @@ Grammar StructuralTagGrammarConverter::AddRootRuleAndGetGrammar(int ref_rule_id)
   auto sequence_expr = grammar_builder_.AddSequence({expr});
   auto choices_expr = grammar_builder_.AddChoices({sequence_expr});
   auto root_rule_id = grammar_builder_.AddRuleWithHint("root", choices_expr);
-  return grammar_builder_.Get(root_rule_id);
+  return grammar_builder_.Get(root_rule_id, /*normalize=*/true);
 }
 
 Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format) {
@@ -1872,19 +1872,19 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFo
   }
   std::string ebnf = converter->second(format.json_schema, format.any_order);
   auto sub_grammar = Grammar::FromEBNF(ebnf);
-  auto added_root_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
+  auto added_root_rule_id = grammar_builder_.AddSubGrammar(sub_grammar);
   return ResultOk(added_root_rule_id);
 }
 
 Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const GrammarFormat& format) {
   auto sub_grammar = Grammar::FromEBNF(format.grammar);
-  auto added_root_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
+  auto added_root_rule_id = grammar_builder_.AddSubGrammar(sub_grammar);
   return ResultOk(added_root_rule_id);
 }
 
 Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const RegexFormat& format) {
   auto sub_grammar = Grammar::FromRegex(format.pattern);
-  auto added_root_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
+  auto added_root_rule_id = grammar_builder_.AddSubGrammar(sub_grammar);
   return ResultOk(added_root_rule_id);
 }
 
@@ -1942,12 +1942,12 @@ int StructuralTagGrammarConverter::BuildBeginExpr(const TagFormat& tag) {
   if (std::holds_alternative<std::string>(tag.begin)) {
     return grammar_builder_.AddByteString(std::get<std::string>(tag.begin));
   }
-  return grammar_builder_.AddTokenSet({std::get<TokenFormat>(tag.begin).resolved_token_id_});
+  return grammar_builder_.AddToken({std::get<TokenFormat>(tag.begin).resolved_token_id_});
 }
 
 int StructuralTagGrammarConverter::BuildEndExpr(const TagFormat& tag) {
   if (std::holds_alternative<TokenFormat>(tag.end)) {
-    return grammar_builder_.AddTokenSet({std::get<TokenFormat>(tag.end).resolved_token_id_});
+    return grammar_builder_.AddToken({std::get<TokenFormat>(tag.end).resolved_token_id_});
   }
   const auto& ends = std::get<std::vector<std::string>>(tag.end);
   if (ends.size() == 1) {
@@ -2231,7 +2231,7 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const StarFormat& 
 Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TokenFormat& format) {
   XGRAMMAR_DCHECK(format.resolved_token_id_ >= 0)
       << "TokenFormat must be resolved before conversion";
-  auto token_set_expr = grammar_builder_.AddTokenSet({format.resolved_token_id_});
+  auto token_set_expr = grammar_builder_.AddToken({format.resolved_token_id_});
   auto seq = grammar_builder_.AddSequence({token_set_expr});
   auto choices = grammar_builder_.AddChoices({seq});
   return ResultOk(grammar_builder_.AddRuleWithHint("token", choices));
@@ -2242,7 +2242,7 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const ExcludeToken
   for (auto tid : format.detected_end_token_ids_) {
     all_excludes.push_back(tid);
   }
-  int expr = grammar_builder_.AddExcludeTokenSet(all_excludes);
+  int expr = grammar_builder_.AddExcludeToken(all_excludes);
   auto seq = grammar_builder_.AddSequence({expr});
   auto choices = grammar_builder_.AddChoices({seq});
   return ResultOk(grammar_builder_.AddRuleWithHint("exclude_token", choices));
@@ -2253,7 +2253,7 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const AnyTokensFor
   for (auto tid : format.detected_end_token_ids_) {
     all_excludes.push_back(tid);
   }
-  int exclude_expr = grammar_builder_.AddExcludeTokenSet(all_excludes);
+  int exclude_expr = grammar_builder_.AddExcludeToken(all_excludes);
   int exclude_seq = grammar_builder_.AddSequence({exclude_expr});
   int exclude_choices = grammar_builder_.AddChoices({exclude_seq});
   int inner_rule = grammar_builder_.AddRuleWithHint("any_tokens_inner", exclude_choices);
@@ -2436,11 +2436,12 @@ Result<Grammar, StructuralTagError> StructuralTagToGrammar(
     return ResultErr(std::move(err).value());
   }
 
+  // The result grammar is already normalized by the grammar builder.
   auto result = StructuralTagGrammarConverter::Convert(structural_tag);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }
-  return ResultOk(GrammarNormalizer::Apply(std::move(result).Unwrap()));
+  return ResultOk(std::move(result).Unwrap());
 }
 
 }  // namespace xgrammar

--- a/tests/cpp/test_grammar_builder.cc
+++ b/tests/cpp/test_grammar_builder.cc
@@ -1,0 +1,202 @@
+/*!
+ *  Copyright (c) 2026 by Contributors
+ * \file tests/cpp/test_grammar_builder.cc
+ * \brief Tests for GrammarBuilder: nested GrammarExprSpec construction, self references,
+ * sub grammar addition, typed getters, and normalization on Get().
+ */
+
+#include <gtest/gtest.h>
+#include <xgrammar/xgrammar.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "grammar_builder.h"
+#include "grammar_impl.h"
+
+using namespace xgrammar;
+
+using Spec = GrammarExprSpec;
+
+TEST(XGrammarGrammarBuilderTest, NestedSpec) {
+  GrammarBuilder builder;
+  builder.AddRule(
+      "root",
+      Spec::Choices(
+          Spec::Sequence(Spec::ByteString("abc"), Spec::CharacterClass({{'a', 'z'}})),
+          Spec::ByteString("def"),
+          Spec::Sequence(Spec::CharacterClassStar({{'0', '9'}}), Spec::EmptyStr())
+      )
+  );
+  auto grammar = builder.Get("root");
+  EXPECT_EQ(grammar.ToString(), "root ::= ((\"abc\" [a-z]) | \"def\" | ([0-9]* \"\"))\n");
+}
+
+TEST(XGrammarGrammarBuilderTest, SelfRef) {
+  GrammarBuilder builder;
+  auto item_rule_id = builder.AddRule("item", Spec::ByteString("a"));
+  builder.AddRule(
+      "list",
+      Spec::Choices(Spec::EmptyStr(), Spec::Sequence(Spec::RuleRef(item_rule_id), Spec::SelfRef()))
+  );
+  auto grammar = builder.Get("list");
+  EXPECT_EQ(grammar.ToString(), "item ::= \"a\"\nlist ::= (\"\" | (item list))\n");
+}
+
+TEST(XGrammarGrammarBuilderTest, MixExprIdsInSpec) {
+  GrammarBuilder builder;
+  auto expr_id1 = builder.AddByteString("x");
+  auto expr_id2 = builder.AddCharacterClass({{'a', 'z'}}, /*is_negative=*/true);
+  builder.AddRule("root", Spec::Choices(expr_id1, expr_id2, Spec::ByteString("y")));
+  auto grammar = builder.Get("root");
+  EXPECT_EQ(grammar.ToString(), "root ::= (\"x\" | [^a-z] | \"y\")\n");
+}
+
+TEST(XGrammarGrammarBuilderTest, RepeatSpec) {
+  GrammarBuilder builder;
+  auto item_rule_id = builder.AddRule("item", Spec::ByteString("a"));
+  builder.AddRule(
+      "root",
+      Spec::Sequence(
+          Spec::Repeat(Spec::RuleRef(item_rule_id), 2, 4),
+          Spec::Repeat(Spec::ByteString("b"), 0, -1)
+      )
+  );
+  auto grammar = builder.Get("root");
+  // The non-rule-ref repeat element is wrapped into a new rule root_1.
+  EXPECT_EQ(
+      grammar.ToString(), "item ::= \"a\"\nroot ::= (item{2, 4} root_1{0, -1})\nroot_1 ::= \"b\"\n"
+  );
+}
+
+TEST(XGrammarGrammarBuilderTest, TagDispatchSpec) {
+  GrammarBuilder builder;
+  auto tag_a_rule_id = builder.AddRule("tag_a", Spec::ByteString("A"));
+  auto tag_b_rule_id = builder.AddRule("tag_b", Spec::ByteString("B"));
+  builder.AddRule(
+      "root",
+      Spec::TagDispatch(Grammar::Impl::TagDispatch{
+          {{"<a>", tag_a_rule_id}, {"<b>", tag_b_rule_id}}, true, {"</end>"}
+      })
+  );
+  auto grammar = builder.Get("root");
+  EXPECT_EQ(
+      grammar.ToString(),
+      "tag_a ::= \"A\"\n"
+      "tag_b ::= \"B\"\n"
+      "root ::= TagDispatch(\n"
+      "  (\"<a>\", tag_a),\n"
+      "  (\"<b>\", tag_b),\n"
+      "  loop_after_dispatch=true,\n"
+      "  excludes=(\"</end>\")\n"
+      ")\n"
+  );
+}
+
+TEST(XGrammarGrammarBuilderTest, GetWithNormalize) {
+  GrammarBuilder builder;
+  builder.AddRule(
+      "root",
+      Spec::Choices(
+          Spec::ByteString("a"), Spec::Choices(Spec::ByteString("b"), Spec::ByteString("c"))
+      )
+  );
+  auto grammar = builder.Get("root", /*normalize=*/true);
+  EXPECT_EQ(grammar.ToString(), "root ::= ((\"a\") | (\"b\") | (\"c\"))\n");
+}
+
+TEST(XGrammarGrammarBuilderTest, AddSubGrammar) {
+  auto sub_grammar1 = Grammar::FromEBNF("root ::= \"a\" sub\nsub ::= \"b\"\n");
+  auto sub_grammar2 = Grammar::FromEBNF("root ::= \"c\" sub\nsub ::= \"d\"\n");
+
+  GrammarBuilder builder;
+  auto root_rule_id = builder.AddEmptyRule("root");
+  auto sub_root_id1 = builder.AddSubGrammar(sub_grammar1);
+  auto sub_root_id2 = builder.AddSubGrammar(sub_grammar2);
+  builder.UpdateRuleBody(
+      root_rule_id,
+      builder.AddExpr(Spec::Choices(
+          Spec::Sequence(Spec::RuleRef(sub_root_id1)), Spec::Sequence(Spec::RuleRef(sub_root_id2))
+      ))
+  );
+  auto grammar = builder.Get(root_rule_id);
+
+  // Conflicting rule names are renamed, and rule refs are remapped to the new rule ids.
+  EXPECT_EQ(
+      grammar.ToString(),
+      "root ::= ((root_1) | (root_2))\n"
+      "root_1 ::= ((\"a\" sub))\n"
+      "sub ::= ((\"b\"))\n"
+      "root_2 ::= ((\"c\" sub_1))\n"
+      "sub_1 ::= ((\"d\"))\n"
+  );
+}
+
+TEST(XGrammarGrammarBuilderTest, AddSubGrammarWithLookaheadAndTagDispatch) {
+  auto sub_grammar = Grammar::FromEBNF(
+      "root ::= TagDispatch((\"<a>\", tag_a), loop_after_dispatch=false)\n"
+      "tag_a ::= \"A\" (=\"end\")\n"
+  );
+  GrammarBuilder builder;
+  builder.AddRule("root", Spec::ByteString("prefix"));
+  auto sub_root_id = builder.AddSubGrammar(sub_grammar);
+  auto grammar = builder.Get(sub_root_id);
+
+  // The tag dispatch's rule refs are remapped, and the lookahead assertion is preserved.
+  EXPECT_EQ(
+      grammar.ToString(),
+      "root ::= \"prefix\"\n"
+      "root_1 ::= TagDispatch(\n"
+      "  (\"<a>\", tag_a),\n"
+      "  loop_after_dispatch=false,\n"
+      "  excludes=()\n"
+      ")\n"
+      "tag_a ::= ((\"A\")) (=(\"end\"))\n"
+  );
+}
+
+TEST(XGrammarGrammarBuilderTest, TypedGetters) {
+  GrammarBuilder builder;
+  auto byte_string_id = builder.AddByteString("ab");
+  auto character_class_id =
+      builder.AddCharacterClass({{'a', 'z'}, {'0', '9'}}, /*is_negative=*/true);
+  auto sequence_id = builder.AddSequence({byte_string_id, character_class_id});
+  auto choices_id = builder.AddChoices({sequence_id});
+  auto rule_id = builder.AddRule("root", choices_id);
+  auto rule_ref_id = builder.AddRuleRef(rule_id);
+  auto repeat_id = builder.AddRepeat(rule_id, 1, 5);
+  auto token_id = builder.AddToken({1, 2, 3});
+  auto exclude_token_id = builder.AddExcludeToken({4, 5});
+  auto grammar = builder.Get("root");
+  const Grammar::Impl& impl = *grammar.operator->();
+
+  EXPECT_EQ(impl.GetByteString(byte_string_id).ToString(), "ab");
+
+  auto character_class = impl.GetCharacterClass(character_class_id);
+  EXPECT_TRUE(character_class.is_negative);
+  ASSERT_EQ(character_class.size(), 2);
+  EXPECT_EQ(character_class[0].lower, 'a');
+  EXPECT_EQ(character_class[0].upper, 'z');
+  EXPECT_EQ(character_class[1].lower, '0');
+  EXPECT_EQ(character_class[1].upper, '9');
+
+  auto sequence = impl.GetSequence(sequence_id);
+  ASSERT_EQ(sequence.size(), 2);
+  EXPECT_EQ(sequence[0], byte_string_id);
+  EXPECT_EQ(sequence[1], character_class_id);
+
+  auto choices = impl.GetChoices(choices_id);
+  ASSERT_EQ(choices.size(), 1);
+  EXPECT_EQ(choices[0], sequence_id);
+
+  EXPECT_EQ(impl.GetRuleRef(rule_ref_id), rule_id);
+
+  auto repeat = impl.GetRepeat(repeat_id);
+  EXPECT_EQ(repeat.rule_id, rule_id);
+  EXPECT_EQ(repeat.min_repeat_count, 1);
+  EXPECT_EQ(repeat.max_repeat_count, 5);
+
+  EXPECT_EQ(impl.GetToken(token_id).ToVector(), (std::vector<int32_t>{1, 2, 3}));
+  EXPECT_EQ(impl.GetExcludeToken(exclude_token_id).ToVector(), (std::vector<int32_t>{4, 5}));
+}

--- a/tests/cpp/test_grammar_builder.cc
+++ b/tests/cpp/test_grammar_builder.cc
@@ -17,16 +17,16 @@
 
 using namespace xgrammar;
 
-using Spec = GrammarExprSpec;
+using namespace xgrammar::grammar_spec;
 
 TEST(XGrammarGrammarBuilderTest, NestedSpec) {
   GrammarBuilder builder;
   builder.AddRule(
       "root",
-      Spec::Choices(
-          Spec::Sequence(Spec::ByteString("abc"), Spec::CharacterClass({{'a', 'z'}})),
-          Spec::ByteString("def"),
-          Spec::Sequence(Spec::CharacterClassStar({{'0', '9'}}), Spec::EmptyStr())
+      Choices(
+          Sequence(ByteString("abc"), CharacterClass({{'a', 'z'}})),
+          ByteString("def"),
+          Sequence(CharacterClassStar({{'0', '9'}}), EmptyStr())
       )
   );
   auto grammar = builder.Get("root");
@@ -35,11 +35,8 @@ TEST(XGrammarGrammarBuilderTest, NestedSpec) {
 
 TEST(XGrammarGrammarBuilderTest, SelfRef) {
   GrammarBuilder builder;
-  auto item_rule_id = builder.AddRule("item", Spec::ByteString("a"));
-  builder.AddRule(
-      "list",
-      Spec::Choices(Spec::EmptyStr(), Spec::Sequence(Spec::RuleRef(item_rule_id), Spec::SelfRef()))
-  );
+  auto item_rule_id = builder.AddRule("item", ByteString("a"));
+  builder.AddRule("list", Choices(EmptyStr(), Sequence(RuleRef(item_rule_id), SelfRef())));
   auto grammar = builder.Get("list");
   EXPECT_EQ(grammar.ToString(), "item ::= \"a\"\nlist ::= (\"\" | (item list))\n");
 }
@@ -48,20 +45,16 @@ TEST(XGrammarGrammarBuilderTest, MixExprIdsInSpec) {
   GrammarBuilder builder;
   auto expr_id1 = builder.AddByteString("x");
   auto expr_id2 = builder.AddCharacterClass({{'a', 'z'}}, /*is_negative=*/true);
-  builder.AddRule("root", Spec::Choices(expr_id1, expr_id2, Spec::ByteString("y")));
+  builder.AddRule("root", Choices(expr_id1, expr_id2, ByteString("y")));
   auto grammar = builder.Get("root");
   EXPECT_EQ(grammar.ToString(), "root ::= (\"x\" | [^a-z] | \"y\")\n");
 }
 
 TEST(XGrammarGrammarBuilderTest, RepeatSpec) {
   GrammarBuilder builder;
-  auto item_rule_id = builder.AddRule("item", Spec::ByteString("a"));
+  auto item_rule_id = builder.AddRule("item", ByteString("a"));
   builder.AddRule(
-      "root",
-      Spec::Sequence(
-          Spec::Repeat(Spec::RuleRef(item_rule_id), 2, 4),
-          Spec::Repeat(Spec::ByteString("b"), 0, -1)
-      )
+      "root", Sequence(Repeat(RuleRef(item_rule_id), 2, 4), Repeat(ByteString("b"), 0, -1))
   );
   auto grammar = builder.Get("root");
   // The non-rule-ref repeat element is wrapped into a new rule root_1.
@@ -72,13 +65,10 @@ TEST(XGrammarGrammarBuilderTest, RepeatSpec) {
 
 TEST(XGrammarGrammarBuilderTest, TagDispatchSpec) {
   GrammarBuilder builder;
-  auto tag_a_rule_id = builder.AddRule("tag_a", Spec::ByteString("A"));
-  auto tag_b_rule_id = builder.AddRule("tag_b", Spec::ByteString("B"));
+  auto tag_a_rule_id = builder.AddRule("tag_a", ByteString("A"));
+  auto tag_b_rule_id = builder.AddRule("tag_b", ByteString("B"));
   builder.AddRule(
-      "root",
-      Spec::TagDispatch(Grammar::Impl::TagDispatch{
-          {{"<a>", tag_a_rule_id}, {"<b>", tag_b_rule_id}}, true, {"</end>"}
-      })
+      "root", TagDispatch{{{"<a>", tag_a_rule_id}, {"<b>", tag_b_rule_id}}, true, {"</end>"}}
   );
   auto grammar = builder.Get("root");
   EXPECT_EQ(
@@ -96,12 +86,7 @@ TEST(XGrammarGrammarBuilderTest, TagDispatchSpec) {
 
 TEST(XGrammarGrammarBuilderTest, GetWithNormalize) {
   GrammarBuilder builder;
-  builder.AddRule(
-      "root",
-      Spec::Choices(
-          Spec::ByteString("a"), Spec::Choices(Spec::ByteString("b"), Spec::ByteString("c"))
-      )
-  );
+  builder.AddRule("root", Choices(ByteString("a"), Choices(ByteString("b"), ByteString("c"))));
   auto grammar = builder.Get("root", /*normalize=*/true);
   EXPECT_EQ(grammar.ToString(), "root ::= ((\"a\") | (\"b\") | (\"c\"))\n");
 }
@@ -116,9 +101,7 @@ TEST(XGrammarGrammarBuilderTest, AddSubGrammar) {
   auto sub_root_id2 = builder.AddSubGrammar(sub_grammar2);
   builder.UpdateRuleBody(
       root_rule_id,
-      builder.AddExpr(Spec::Choices(
-          Spec::Sequence(Spec::RuleRef(sub_root_id1)), Spec::Sequence(Spec::RuleRef(sub_root_id2))
-      ))
+      builder.AddExpr(Choices(Sequence(RuleRef(sub_root_id1)), Sequence(RuleRef(sub_root_id2))))
   );
   auto grammar = builder.Get(root_rule_id);
 
@@ -139,7 +122,7 @@ TEST(XGrammarGrammarBuilderTest, AddSubGrammarWithLookaheadAndTagDispatch) {
       "tag_a ::= \"A\" (=\"end\")\n"
   );
   GrammarBuilder builder;
-  builder.AddRule("root", Spec::ByteString("prefix"));
+  builder.AddRule("root", ByteString("prefix"));
   auto sub_root_id = builder.AddSubGrammar(sub_grammar);
   auto grammar = builder.Get(sub_root_id);
 


### PR DESCRIPTION
## Summary

This PR makes `GrammarBuilder` the single entry point for constructing the grammar AST. Previously the construction logic was spread over several inconsistent components (`GrammarBuilder`, `SubGrammarAdderImpl` in the functor framework, and ad-hoc `GrammarExpr` decoding at call sites).

- **Typed getters for every `GrammarExprType`** in `Grammar::Impl`: `GetByteString` / `GetCharacterClass` (incl. star) / `GetRuleRef` / `GetSequence` / `GetChoices` / `GetRepeat` / `GetToken` / `GetExcludeToken` / `GetTagDispatch` / `GetTokenTagDispatch`, all `const`, each with a `GrammarExpr` and an expr-id overload. The representations are zero-cost non-owning views (pointer + length into the grammar buffer, no allocation); only the two dispatch getters materialize owning structs, as before. `CharacterClassElement` moves from `GrammarBuilder` to `Grammar::Impl`.
- **`GrammarExprSpec`: a nestable build-time expression tree** with static factories covering all expr types, materialized by `GrammarBuilder::AddExpr` / `AddRule(name, spec)`:
  ```cpp
  using Spec = GrammarExprSpec;
  // list ::= "" | item list
  builder.AddRule("list", Spec::Choices(
      Spec::EmptyStr(),
      Spec::Sequence(Spec::RuleRef(item_rule_id), Spec::SelfRef())));
  ```
  `int32_t` expr ids convert implicitly, so existing ids can be mixed into specs. `SelfRef()` refers to the rule being defined, enabling recursive rules in one call. `Repeat` wraps non-rule-ref elements into a new rule automatically.
- **`GrammarBuilder::AddSubGrammar(grammar)`** absorbs `SubGrammarAdderImpl`: copies all rules of a grammar into the builder, renaming on conflicts and remapping rule ids (incl. tag dispatches and repeats). It now also preserves `is_exact_lookahead`, which the old implementation dropped. `GrammarUnionFunctor` / `GrammarConcatFunctor` are reimplemented on top of it, and `structural_tag.cc` call sites are migrated.
- **`GrammarBuilder::Get(root, normalize)`** optionally normalizes the result grammar, so "build (+ normalize) into an AST" is a single entry. `structural_tag.cc` now uses it instead of a separate `GrammarNormalizer::Apply` step.
- Consistency renames: `AddTokenSet`/`AddExcludeTokenSet` → `AddToken`/`AddExcludeToken` (matching `kToken`/`kExcludeToken`); new `AddRepeat(Repeat)` overload for a symmetric Get/Add round trip.

The grammar storage format is unchanged; serialization and the hot matching paths are unaffected.

As a follow-up, `json_schema_converter` (currently schema → EBNF string → parser → AST) can be migrated to build the AST directly with `GrammarExprSpec`, after which `EBNFScriptCreator` can be removed.

## Test plan

- [x] New `tests/cpp/test_grammar_builder.cc` (9 cases): nested specs, `SelfRef` recursion, mixing expr ids, `Repeat` rule wrapping, tag dispatch specs, `Get(normalize)`, `AddSubGrammar` renaming/remapping/lookahead preservation, typed getter round trips.
- [x] Full C++ test suite passes (56/56).
- [x] Python tests: `test_grammar_union_concat`, `test_grammar_parser`, `test_grammar_parser_macro`, `test_structural_tag_converter`, `test_grammar_matcher_structural_tag`, `test_token_edge`, `test_json_schema_converter`, `test_function_calling_converter` pass locally (remaining local failures are pre-existing environment issues: HF model download permissions and an incompatible local pytest).