### PR TITLE
feat: support max_tokens/max_chars in AnyText/AnyTokensFormat via per-state budgets

### DIFF
--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -117,6 +118,20 @@ class CompiledGrammar::Impl {
 
   /*! \brief Mapping from the parser state to the adaptive token mask. */
   std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache> adaptive_token_mask_cache;
+
+  /*!
+   * \brief Lazily built per-vocab character (codepoint) count data, used by the matcher for
+   * character budget (TagDispatch::max_chars) boundary handling. Shared by all matchers of this
+   * compiled grammar; built thread-safely on first use; not serialized (rebuilt on demand).
+   * token_char_counts[i] is the character count of sorted vocab token i;
+   * sorted_indices_by_char_count lists all sorted vocab indices ordered by that count, with
+   * char_count_offsets[c] giving the first position whose count is >= c.
+   */
+  std::once_flag token_char_data_once;
+  int32_t max_token_chars = -1;
+  std::vector<int32_t> token_char_counts;
+  std::vector<int32_t> sorted_indices_by_char_count;
+  std::vector<int32_t> char_count_offsets;
 
   Grammar GetGrammar() const { return grammar; }
 

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -296,6 +296,7 @@ EarleyParser::EarleyParser(
     const Grammar& grammar, const ParserState& init_state, const bool need_expand
 )
     : grammar_(grammar) {
+  has_budgets_ = !grammar_->per_rule_budget_max_tokens.empty();
   if (!grammar->optimized) {
     XGRAMMAR_LOG(FATAL) << "The grammar is not optimized. Please optimize the grammar before using "
                            "the Earley parser.";
@@ -883,12 +884,33 @@ void EarleyParser::AdvanceCharacterClassStar(
 void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
   XGRAMMAR_DCHECK(state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value());
   const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
+  // Token / character budget of a budgeted TagDispatch rule. When a budget is exhausted, the
+  // state cannot consume any more input bytes; the hypothesis either completes here (already
+  // reported completable at an end node, so the parent's continuation stays scanable) or dies.
+  int32_t budget_char_delta = 0;
+  if (enforce_budgets_ && has_budgets_) {
+    const auto [max_tokens, max_chars] = GetRuleBudget(state.rule_id);
+    if (max_tokens >= 0 && state.repeat_count >= max_tokens) {
+      return;
+    }
+    if (max_chars >= 0) {
+      // Count Unicode characters: only a non-continuation byte starts a new character;
+      // continuation bytes of an already-counted character are always allowed.
+      if ((ch & 0xC0) != 0x80) {
+        if (state.budget_char_count >= max_chars) {
+          return;
+        }
+        budget_char_delta = 1;
+      }
+    }
+  }
   for (const auto& edge : current_fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
     if ((!edge.IsCharRange()) || ch < edge.min || ch > edge.max) {
       continue;
     }
     auto new_state = state;
     new_state.element_id = edge.target;
+    new_state.budget_char_count += budget_char_delta;
     if ((!current_fsm.GetFsm().IsNonTerminalState(edge.target)) &&
         (!current_fsm.GetFsm().IsEndState(edge.target) &&
          current_fsm.GetFsm().IsScanableState(edge.target))) {
@@ -902,6 +924,15 @@ void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
 void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
   if (state.rule_id == -1) return;
   XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
+  // Budgeted TagDispatch rules only have CharRange edges today; this guard keeps the budget
+  // semantics if token edges are ever combined with budgets.
+  if (enforce_budgets_ && has_budgets_) {
+    const auto [max_tokens, max_chars] = GetRuleBudget(state.rule_id);
+    if ((max_tokens >= 0 && state.repeat_count >= max_tokens) ||
+        (max_chars >= 0 && state.budget_char_count >= max_chars)) {
+      return;
+    }
+  }
   const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
   for (const auto& edge : current_fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
     bool matched = false;
@@ -953,6 +984,41 @@ bool EarleyParser::AdvanceAtomicToken(int32_t token_id, bool debug_print) {
   is_completed_.push_back(tmp_accept_stop_token_);
   scanable_state_history_.PushBack(tmp_states_to_be_added_);
   return true;
+}
+
+void EarleyParser::AdvanceTokenBoundary(int32_t rows_pushed) {
+  if (!enforce_budgets_ || !has_budgets_) {
+    return;
+  }
+  const int32_t latest = scanable_state_history_.size() - 1;
+  const int32_t prev = latest - rows_pushed;
+  XGRAMMAR_DCHECK(prev >= 0);
+  const auto prev_row = scanable_state_history_[prev];
+  auto row = scanable_state_history_.MutableRowAt(latest);
+  for (auto& state : row) {
+    if (state.rule_id == -1) {
+      continue;
+    }
+    const int32_t max_tokens = grammar_->per_rule_budget_max_tokens[state.rule_id];
+    // Saturate at max_tokens: only "budget left" vs "budget exhausted" matters afterwards.
+    if (max_tokens < 0 || state.repeat_count >= max_tokens) {
+      continue;
+    }
+    // A token counts against the budget only if this region instance (same rule predicted at the
+    // same position) already existed before the token. A region freshly entered during this token
+    // (e.g. a token that ends with the region's begin tag) has not consumed a whole token yet.
+    bool existed_before = false;
+    for (const auto& prev_state : prev_row) {
+      if (prev_state.rule_id == state.rule_id &&
+          prev_state.rule_start_pos == state.rule_start_pos) {
+        existed_before = true;
+        break;
+      }
+    }
+    if (existed_before) {
+      ++state.repeat_count;
+    }
+  }
 }
 
 bool RepeatDetector::IsVisited(const ParserState& state) const {

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -297,6 +297,7 @@ EarleyParser::EarleyParser(
 )
     : grammar_(grammar) {
   has_budgets_ = !grammar_->per_rule_budget_max_tokens.empty();
+  budget_checks_enabled_ = enforce_budgets_ && has_budgets_;
   if (!grammar->optimized) {
     XGRAMMAR_LOG(FATAL) << "The grammar is not optimized. Please optimize the grammar before using "
                            "the Earley parser.";
@@ -888,7 +889,7 @@ void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
   // state cannot consume any more input bytes; the hypothesis either completes here (already
   // reported completable at an end node, so the parent's continuation stays scanable) or dies.
   int32_t budget_char_delta = 0;
-  if (enforce_budgets_ && has_budgets_) {
+  if (budget_checks_enabled_) {
     const auto [max_tokens, max_chars] = GetRuleBudget(state.rule_id);
     if (max_tokens >= 0 && state.repeat_count >= max_tokens) {
       return;
@@ -926,7 +927,7 @@ void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
   XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
   // Budgeted TagDispatch rules only have CharRange edges today; this guard keeps the budget
   // semantics if token edges are ever combined with budgets.
-  if (enforce_budgets_ && has_budgets_) {
+  if (budget_checks_enabled_) {
     const auto [max_tokens, max_chars] = GetRuleBudget(state.rule_id);
     if ((max_tokens >= 0 && state.repeat_count >= max_tokens) ||
         (max_chars >= 0 && state.budget_char_count >= max_chars)) {
@@ -987,7 +988,7 @@ bool EarleyParser::AdvanceAtomicToken(int32_t token_id, bool debug_print) {
 }
 
 void EarleyParser::AdvanceTokenBoundary(int32_t rows_pushed) {
-  if (!enforce_budgets_ || !has_budgets_) {
+  if (!budget_checks_enabled_) {
     return;
   }
   const int32_t latest = scanable_state_history_.size() - 1;

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -307,8 +307,17 @@ class EarleyParser {
   /*! \brief Set by the constructor: whether the grammar has any budgeted TagDispatch rule. */
   bool has_budgets_ = false;
 
+  /*!
+   * \brief enforce_budgets_ && has_budgets_, precombined into the single flag that the byte-level
+   * hot paths (AdvanceFsm / ScanAtomicToken) branch on.
+   */
+  bool budget_checks_enabled_ = false;
+
   /*! \brief Disable budget enforcement (used by the token mask cache generator). */
-  void SetEnforceBudgets(bool enforce) { enforce_budgets_ = enforce; }
+  void SetEnforceBudgets(bool enforce) {
+    enforce_budgets_ = enforce;
+    budget_checks_enabled_ = enforce_budgets_ && has_budgets_;
+  }
 
   /*!
    * \brief Check if the state has been added into the queue.

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -48,7 +48,8 @@ struct ParserState {
       const int32_t& rule_start_pos,
       const int32_t& sub_element_id,
       const int32_t& repeat_count = 0,
-      const int32_t& partial_codepoint = 0
+      const int32_t& partial_codepoint = 0,
+      const int32_t& budget_char_count = 0
   )
       : rule_id(rule_id),
         sequence_id(sequence_id),
@@ -56,7 +57,8 @@ struct ParserState {
         rule_start_pos(rule_start_pos),
         sub_element_id(sub_element_id),
         repeat_count(repeat_count),
-        partial_codepoint(partial_codepoint) {}
+        partial_codepoint(partial_codepoint),
+        budget_char_count(budget_char_count) {}
 
   /*!
    * \brief A sequence_id value of kUnexpandedRuleStartSequenceId means a rule hasn't been
@@ -90,11 +92,21 @@ struct ParserState {
   /*! \brief The id of the sub element in the current selement of the sequence. */
   int32_t sub_element_id = 0;
 
-  /*! \brief The number of times the element is repeated. It will be used in kRepeat.*/
+  /*!
+   * \brief The number of times the element is repeated. It is used in kRepeat. For a
+   * token-budgeted TagDispatch rule (TagDispatch::max_tokens != -1, which never has kRepeatRef
+   * edges), it is reused as the number of whole tokens the region has consumed so far.
+   */
   int32_t repeat_count = 0;
 
   /*! \brief Partial codepoint accumulated during UTF-8 decoding for positive character classes. */
   int32_t partial_codepoint = 0;
+
+  /*!
+   * \brief For a character-budgeted TagDispatch rule (TagDispatch::max_chars != -1): the number
+   * of Unicode characters the region has consumed so far. Always 0 otherwise.
+   */
+  int32_t budget_char_count = 0;
 
   /*! \brief The element is invalid when sequence_id is -1. */
   bool IsInvalid() const { return sequence_id == -1; }
@@ -132,6 +144,9 @@ struct ParserState {
     if (partial_codepoint != 0) {
       result += ", partial_codepoint=" + std::to_string(partial_codepoint);
     }
+    if (budget_char_count != 0) {
+      result += ", budget_char_count=" + std::to_string(budget_char_count);
+    }
     result += ")";
     return result;
   }
@@ -145,7 +160,8 @@ XGRAMMAR_MEMBER_ARRAY(
     &ParserState::rule_start_pos,
     &ParserState::sub_element_id,
     &ParserState::repeat_count,
-    &ParserState::partial_codepoint
+    &ParserState::partial_codepoint,
+    &ParserState::budget_char_count
 );
 
 /*!
@@ -168,7 +184,8 @@ class StateEqualForParsing {
     return lhs.rule_id == rhs.rule_id && lhs.sequence_id == rhs.sequence_id &&
            lhs.element_id == rhs.element_id && lhs.rule_start_pos == rhs.rule_start_pos &&
            lhs.sub_element_id == rhs.sub_element_id && lhs.repeat_count == rhs.repeat_count &&
-           lhs.partial_codepoint == rhs.partial_codepoint;
+           lhs.partial_codepoint == rhs.partial_codepoint &&
+           lhs.budget_char_count == rhs.budget_char_count;
   }
 };
 
@@ -186,7 +203,8 @@ class StateHashForParsing {
         state.rule_start_pos,
         state.sub_element_id,
         state.repeat_count,
-        state.partial_codepoint
+        state.partial_codepoint,
+        state.budget_char_count
     );
   }
 };
@@ -275,6 +293,22 @@ class EarleyParser {
 
   /*! \brief Check if the stop token is accepted. */
   bool stop_token_is_accepted_ = false;
+
+  /*!
+   * \brief Whether TagDispatch token/character budgets (max_tokens / max_chars) are enforced,
+   * and the grammar has at least one budgeted rule. Budgets are enforced at runtime (in the
+   * matcher's parser); they must NOT be enforced when computing the adaptive token mask cache,
+   * so that cache entries stay budget-agnostic and can be shared across all budget counter
+   * values (the cache key ignores the counters) and across bounded/unbounded rules with the
+   * same FSM.
+   */
+  bool enforce_budgets_ = true;
+
+  /*! \brief Set by the constructor: whether the grammar has any budgeted TagDispatch rule. */
+  bool has_budgets_ = false;
+
+  /*! \brief Disable budget enforcement (used by the token mask cache generator). */
+  void SetEnforceBudgets(bool enforce) { enforce_budgets_ = enforce; }
 
   /*!
    * \brief Check if the state has been added into the queue.
@@ -467,6 +501,29 @@ class EarleyParser {
    * parser with the root rule.
    */
   void Reset();
+
+  /*!
+   * \brief Notify the parser that a whole token boundary has been crossed: increment the token
+   * budget counter of every latest scanable state that belongs to a token-budgeted TagDispatch
+   * rule (saturating at the rule's max_tokens). A region instance only consumes budget if it
+   * already existed before this token. Called by the matcher after each accepted token.
+   * The counters live in the state history, so rollback / fork restore them automatically.
+   * \param rows_pushed The number of state rows the accepted token pushed (>= 1).
+   */
+  void AdvanceTokenBoundary(int32_t rows_pushed);
+
+  /*!
+   * \brief Get the (max_tokens, max_chars) budget of the rule, or (-1, -1) if the rule has no
+   * budget. Only valid for rule_id >= 0.
+   */
+  std::pair<int32_t, int32_t> GetRuleBudget(int32_t rule_id) const {
+    if (!has_budgets_) {
+      return {-1, -1};
+    }
+    return {
+        grammar_->per_rule_budget_max_tokens[rule_id], grammar_->per_rule_budget_max_chars[rule_id]
+    };
+  }
 
   /*!
    * \brief Get the current scanable states.

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -134,8 +134,17 @@ int32_t GrammarBuilder::AddChoices(const std::vector<int32_t>& choices) {
 }
 
 int32_t GrammarBuilder::AddTagDispatch(const Grammar::Impl::TagDispatch& tag_dispatch) {
+  // The per-state budget counters are only propagated through CharRange edges, so a budgeted
+  // TagDispatch must not have triggers (whose rule-ref edges would reset the counters).
+  XGRAMMAR_CHECK(
+      (tag_dispatch.max_tokens == -1 && tag_dispatch.max_chars == -1) ||
+      tag_dispatch.tag_rule_pairs.empty()
+  ) << "max_tokens / max_chars are only supported for TagDispatch without triggers";
   std::vector<int32_t> data;
-  data.reserve(tag_dispatch.tag_rule_pairs.size() * 2 + 2);
+  data.reserve(
+      tag_dispatch.tag_rule_pairs.size() * 2 +
+      Grammar::Impl::TagDispatch::kTagDispatchExtraParameter
+  );
   for (const auto& [tag, rule_id] : tag_dispatch.tag_rule_pairs) {
     data.push_back(AddByteString(tag));
     data.push_back(rule_id);
@@ -146,6 +155,9 @@ int32_t GrammarBuilder::AddTagDispatch(const Grammar::Impl::TagDispatch& tag_dis
     exclude_str_expr_ids.push_back(AddByteString(exclude_str));
   }
   data.push_back(AddChoices(exclude_str_expr_ids));
+  // Trailing budgets (see TagDispatch::kTagDispatchExtraParameter layout).
+  data.push_back(tag_dispatch.max_tokens);
+  data.push_back(tag_dispatch.max_chars);
   return AddGrammarExpr(
       {GrammarExprType::kTagDispatch, data.data(), static_cast<int32_t>(data.size())}
   );

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -54,7 +54,14 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
         tag_dispatch_rule_id_to_second_slicing_bitset_(tag_dispatch_rule_id_to_second_slicing_bitset
         ),
         tokenizer_info_(tokenizer_info),
-        rule_level_cache_(rule_level_cache) {}
+        rule_level_cache_(rule_level_cache) {
+    // The adaptive token mask cache entries must be budget-agnostic: the cache key ignores the
+    // per-state budget counters, so one entry per position is shared across all counter values
+    // (and across bounded/unbounded rules with the same FSM in the rule-level cache). Budgets are
+    // enforced at runtime by the matcher's parser instead (skip / live-check in
+    // FillNextTokenBitmask, and AdvanceFsm during AcceptToken).
+    SetEnforceBudgets(false);
+  }
   /*!
    * \brief Get the adaptive token mask for the given ParserState.
    * \param is_root_rule Whether to consider the parent rule. If false, there will be

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -90,6 +90,8 @@ class SubGrammarAdderImpl : public GrammarMutator {
     }
     new_tag_dispatch.loop_after_dispatch = old_tag_dispatch.loop_after_dispatch;
     new_tag_dispatch.excludes = old_tag_dispatch.excludes;
+    new_tag_dispatch.max_tokens = old_tag_dispatch.max_tokens;
+    new_tag_dispatch.max_chars = old_tag_dispatch.max_chars;
     return builder_->AddTagDispatch(new_tag_dispatch);
   }
 
@@ -1051,12 +1053,29 @@ class GrammarFSMBuilderImpl {
     FSM complete_fsm;
     std::vector<std::optional<FSMWithStartEndWithSize>> per_rule_fsms((*grammar)->NumRules());
     std::vector<int> state_mapping;
+    // Per-rule budget lookup for budgeted TagDispatch rules (see Grammar::Impl); only
+    // materialized if some rule carries a budget.
+    std::vector<int32_t> budget_max_tokens;
+    std::vector<int32_t> budget_max_chars;
+    auto set_budget = [&](int rule_id, int32_t max_tokens, int32_t max_chars) {
+      if (max_tokens == -1 && max_chars == -1) {
+        return;
+      }
+      if (budget_max_tokens.empty()) {
+        budget_max_tokens.assign((*grammar)->NumRules(), -1);
+        budget_max_chars.assign((*grammar)->NumRules(), -1);
+      }
+      budget_max_tokens[rule_id] = max_tokens;
+      budget_max_chars[rule_id] = max_chars;
+    };
 
     for (int i = 0; i < (*grammar)->NumRules(); ++i) {
       auto rule = (*grammar)->GetRule(i);
       auto grammar_expr = (*grammar)->GetGrammarExpr(rule.body_expr_id);
       if (grammar_expr.type == Grammar::Impl::GrammarExprType::kTagDispatch) {
-        auto rule_fsm = TagDispatch((*grammar)->GetTagDispatch(grammar_expr));
+        auto tag_dispatch = (*grammar)->GetTagDispatch(grammar_expr);
+        set_budget(i, tag_dispatch.max_tokens, tag_dispatch.max_chars);
+        auto rule_fsm = TagDispatch(tag_dispatch);
         XGRAMMAR_CHECK(rule_fsm.has_value()) << "Failed to build tag dispatch fsm for rule " << i;
         per_rule_fsms[i] = rule_fsm->AddToCompleteFSM(&complete_fsm, &state_mapping);
       } else if (grammar_expr.type == Grammar::Impl::GrammarExprType::kTokenTagDispatch) {
@@ -1099,6 +1118,8 @@ class GrammarFSMBuilderImpl {
 
     (*grammar)->complete_fsm = std::move(compact_complete_fsm);
     (*grammar)->per_rule_fsms = std::move(compact_per_rule_fsms);
+    (*grammar)->per_rule_budget_max_tokens = std::move(budget_max_tokens);
+    (*grammar)->per_rule_budget_max_chars = std::move(budget_max_chars);
   }
 
   /* Basic Building functions.*/

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -120,7 +120,7 @@ class Grammar::Impl {
     // data format: [grammar_expr_id0, grammar_expr_id1, ...]
     kChoices,
     // data format: [tag_expr0, rule_id0, tag_expr1, rule_id1, ..., loop_after_dispatch,
-    // excluded_str_expr_id]
+    // excluded_str_expr_id, max_tokens, max_chars]
     kTagDispatch,
     // data format: [rule_id, min_repeat_count, max_repeat_count]
     kRepeat,
@@ -197,7 +197,20 @@ class Grammar::Impl {
     bool loop_after_dispatch;
     /*! \brief The strings that are excluded by the tag dispatch. */
     std::vector<std::string> excludes;
-    static const int kTagDispatchExtraParameter = 2;
+    /*!
+     * \brief Max number of whole tokens this tag dispatch may consume before it must complete;
+     * -1 = unbounded. The counter is tracked per parser state (see ParserState::repeat_count),
+     * so multiple budgeted regions and re-entry are supported.
+     */
+    int32_t max_tokens = -1;
+    /*!
+     * \brief Max number of Unicode characters this tag dispatch may consume before it must
+     * complete; -1 = unbounded.
+     */
+    int32_t max_chars = -1;
+    // Trailing (non tag/rule-pair) parameters in the kTagDispatch grammar expr, in order:
+    //   [loop_after_dispatch, excludes_choices_id, max_tokens, max_chars].
+    static const int kTagDispatchExtraParameter = 4;
   };
 
   /*! \brief Get the tag dispatch from the grammar expr. */
@@ -229,6 +242,11 @@ class Grammar::Impl {
     for (int j = 0; j < exclude_str_expr.size(); j++) {
       result.excludes.push_back(GetByteString(exclude_str_expr[j]));
     }
+
+    result.max_tokens =
+        grammar_expr[grammar_expr.size() - TagDispatch::kTagDispatchExtraParameter + 2];
+    result.max_chars =
+        grammar_expr[grammar_expr.size() - TagDispatch::kTagDispatchExtraParameter + 3];
     return result;
   }
 
@@ -303,6 +321,18 @@ class Grammar::Impl {
    */
   std::vector<std::vector<std::pair<int32_t, int32_t>>> per_rule_fsm_new_state_ids;
 
+  /*!
+   * \brief Per-rule token budget (TagDispatch::max_tokens) for budgeted TagDispatch rules;
+   * -1 if the rule has no token budget. Empty if the grammar has no budgeted rule at all.
+   * Built by GrammarFSMBuilder. Used by the Earley parser for O(1) budget lookup.
+   */
+  std::vector<int32_t> per_rule_budget_max_tokens;
+
+  /*!
+   * \brief Per-rule character budget (TagDispatch::max_chars); see per_rule_budget_max_tokens.
+   */
+  std::vector<int32_t> per_rule_budget_max_chars;
+
   /*! \brief The ids of the rules that are allowed to be empty. */
   std::vector<int32_t> allow_empty_rule_ids;
 
@@ -338,6 +368,10 @@ XGRAMMAR_MEMBER_TABLE(
     &Grammar::Impl::complete_fsm,
     "per_rule_fsms",
     &Grammar::Impl::per_rule_fsms,
+    "per_rule_budget_max_tokens",
+    &Grammar::Impl::per_rule_budget_max_tokens,
+    "per_rule_budget_max_chars",
+    &Grammar::Impl::per_rule_budget_max_chars,
     "allow_empty_rule_ids",
     &Grammar::Impl::allow_empty_rule_ids,
     "optimized",

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -522,11 +522,27 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   std::string PrintBitmask(int32_t* bitmask_data_ptr, const TokenizerInfo& tokenizer_info);
 
+  /*!
+   * \brief Max token byte length in the vocab, computed lazily. A character-budgeted region
+   * state with at least this many characters remaining behaves exactly like an unbounded one
+   * (every single token fits), so the budget-agnostic mask cache entry applies as is.
+   */
+  int32_t GetMaxTokenBytes();
+
+  /*!
+   * \brief Live-check all vocab tokens against a single state by byte-level simulation, setting
+   * the accepted bits. Used for states near a character budget boundary, where the cached
+   * (budget-agnostic) mask may not be valid. The simulation runs on the real parser, whose
+   * budget checks in AdvanceFsm make the result exact.
+   */
+  void LiveCheckAllTokensForState(const ParserState& state);
+
   CompiledGrammar compiled_grammar_;
   TokenizerInfo tokenizer_info_;
   std::vector<int> stop_token_ids_;
   bool terminate_without_stop_token_;
   std::deque<int> token_length_history;
+  int32_t max_token_bytes_ = -1;
 
   // Temporary data for FillNextTokenBitmask. They are stored here to avoid repeated allocation.
   DynamicBitset tmp_accepted_bitset_;
@@ -733,6 +749,15 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     }
   }
 
+  // Token budget: a whole token boundary has been crossed. Bump the token budget counter of the
+  // states that are (still) inside a token-budgeted region. The counters live in the state rows,
+  // so Rollback / Fork handle them automatically. Skip if this token pushed no state row (a
+  // zero-length token accepted through the pure byte path), since Rollback would not pop the
+  // mutated row then.
+  if (token_length_history.back() > 0) {
+    AdvanceTokenBoundary(token_length_history.back());
+  }
+
   if (debug_print) {
     XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<" << EscapeString(token) << "> accepted.";
   }
@@ -838,8 +863,32 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
 
   std::vector<std::pair<ParserState, decltype(adaptive_token_mask_cache.cbegin())>>
       latest_states_with_masks;
+  // States of character-budgeted regions that are near the budget boundary: their cached
+  // (budget-agnostic) masks may accept tokens longer than the remaining budget, so they are
+  // handled by exact live-checking instead.
+  std::vector<ParserState> live_check_all_states;
 
   for (const auto& state : latest_states) {
+    // Budget handling for budgeted TagDispatch rules. The cached masks are budget-agnostic
+    // (shared across all counter values), so the budget is applied here, per state.
+    if (has_budgets_ && state.rule_id != -1) {
+      const auto [max_tokens, max_chars] = GetRuleBudget(state.rule_id);
+      if ((max_tokens >= 0 && state.repeat_count >= max_tokens) ||
+          (max_chars >= 0 && state.budget_char_count >= max_chars)) {
+        // Budget exhausted: this state cannot consume anything, so it contributes nothing to
+        // the mask. Its completion continuations (e.g. the region's end tag) are covered by the
+        // parent states, which Earley has already made scanable.
+        continue;
+      }
+      if (max_chars >= 0 && max_chars - state.budget_char_count < GetMaxTokenBytes()) {
+        // Near the character budget boundary: some tokens may not fit in the remaining budget.
+        // Fall back to exact per-token live-checking for this state.
+        live_check_all_states.push_back(state);
+        continue;
+      }
+      // Otherwise every whole token fits in the remaining budget, so the budget-agnostic mask
+      // entry is exact for this state; fall through to the normal fast path.
+    }
     auto adaptive_token_mask_it = adaptive_token_mask_cache.find(state);
     XGRAMMAR_CHECK(adaptive_token_mask_it != adaptive_token_mask_cache.end()) << state;
     const auto& adaptive_token_mask = adaptive_token_mask_it->second;
@@ -950,6 +999,11 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
     }
   }
 
+  // Exact live-checking for states near a character budget boundary.
+  for (const auto& state : live_check_all_states) {
+    LiveCheckAllTokensForState(state);
+  }
+
   // Finally update the rejected_ids bitset
   bool can_reach_end = IsCompleted();
   SetTokenBitmask(
@@ -959,6 +1013,75 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
     XGRAMMAR_LOG(INFO) << "Filled bitmask: " << PrintBitmask(bitmask_data_ptr, tokenizer_info_);
   }
   return !IsTokenBitmaskAllTrue(bitmask_data_ptr);
+}
+
+int32_t GrammarMatcher::Impl::GetMaxTokenBytes() {
+  if (max_token_bytes_ == -1) {
+    size_t max_size = 0;
+    for (const auto& id_and_token : tokenizer_info_.GetSortedDecodedVocab()) {
+      max_size = std::max(max_size, id_and_token.second.size());
+    }
+    max_token_bytes_ = static_cast<int32_t>(max_size);
+  }
+  return max_token_bytes_;
+}
+
+void GrammarMatcher::Impl::LiveCheckAllTokensForState(const ParserState& state) {
+  const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
+  const auto& subtree_range = tokenizer_info_.GetTrieSubtreeNodesRange();
+
+  PushOneStateToCheck(state);
+
+  const std::string* prev_token = nullptr;
+  int prev_matched_size = 0;
+  int last_rejected_range = 0;
+  for (int i = 0; i < static_cast<int>(sorted_decoded_vocab.size()); ++i) {
+    // Skip tokens already accepted by other states.
+    if (tmp_accepted_bitset_[sorted_decoded_vocab[i].first]) {
+      continue;
+    }
+    // Skip the trie subtree of a rejected prefix.
+    if (i < last_rejected_range) {
+      continue;
+    }
+
+    const auto& cur_token = sorted_decoded_vocab[i].second;
+    bool accepted = true;
+
+    // Reuse the matched prefix of the previous token (tokens are sorted, so common prefixes are
+    // adjacent).
+    if (prev_token) {
+      int lcp_len =
+          std::mismatch(cur_token.begin(), cur_token.end(), prev_token->begin(), prev_token->end())
+              .first -
+          cur_token.begin();
+      if (lcp_len > prev_matched_size) {
+        last_rejected_range = subtree_range[i];
+        accepted = false;
+      } else if (lcp_len < prev_matched_size) {
+        PopLastStates(prev_matched_size - lcp_len);
+      }
+      prev_matched_size = std::min(prev_matched_size, lcp_len);
+    }
+
+    if (accepted) {
+      for (int j = prev_matched_size; j < static_cast<int>(cur_token.size()); ++j) {
+        if (!Advance(cur_token[j])) {
+          last_rejected_range = subtree_range[i];
+          accepted = false;
+          break;
+        }
+        prev_matched_size = j + 1;
+      }
+    }
+
+    if (accepted) {
+      tmp_accepted_bitset_.Set(sorted_decoded_vocab[i].first, true);
+    }
+    prev_token = &cur_token;
+  }
+
+  PopLastStates(prev_matched_size + 1);
 }
 
 std::string GrammarMatcher::Impl::FindJumpForwardString() {

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -10,8 +10,10 @@
 #include <xgrammar/matcher.h>
 
 #include <algorithm>
+#include <bitset>
 #include <chrono>
 #include <cstdint>
+#include <mutex>
 #include <optional>
 #include <thread>
 #include <utility>
@@ -523,31 +525,51 @@ class GrammarMatcher::Impl : public EarleyParser {
   std::string PrintBitmask(int32_t* bitmask_data_ptr, const TokenizerInfo& tokenizer_info);
 
   /*!
-   * \brief Max token byte length in the vocab, computed lazily. A character-budgeted region
-   * state with at least this many characters remaining behaves exactly like an unbounded one
-   * (every single token fits), so the budget-agnostic mask cache entry applies as is.
+   * \brief Max token character (Unicode codepoint) count in the vocab, computed lazily together
+   * with the other character-count data. A character-budgeted region state with at least this
+   * many characters remaining behaves exactly like an unbounded one (every single token fits),
+   * so the budget-agnostic mask cache entry applies as is.
    */
-  int32_t GetMaxTokenBytes();
+  int32_t GetMaxTokenChars();
+
+  /*! \brief Build the compiled grammar's lazy character-count data (no-op if already built). */
+  void EnsureTokenCharCounts();
 
   /*!
-   * \brief Live-check all vocab tokens against a single state by byte-level simulation, setting
-   * the accepted bits. Used for states near a character budget boundary, where the cached
-   * (budget-agnostic) mask may not be valid. The simulation runs on the real parser, whose
-   * budget checks in AdvanceFsm make the result exact.
+   * \brief Fill the accepted bits for a state near a character budget boundary, where the cached
+   * (budget-agnostic) mask may accept tokens that no longer fit in the remaining budget.
+   * The budget can only shrink the entry's accepted set, so entry-accepted tokens that fit in
+   * remaining_chars are accepted directly. An entry-accepted token longer than the budget is
+   * over-budget as pure region content; it can only survive by completing the region partway and
+   * continuing into a sibling continuation (e.g. content + end tag in one token), which requires
+   * it to contain a byte from sibling_first_bytes — others are rejected directly. The remaining
+   * candidates and the entry's uncertain tokens are re-checked by byte-level simulation on the
+   * real parser, whose budget checks in AdvanceFsm make the result exact.
    */
-  void LiveCheckAllTokensForState(const ParserState& state);
+  void FillBitmaskForCharBudgetBoundary(
+      const ParserState& state,
+      const AdaptiveTokenMask& mask_entry,
+      int32_t remaining_chars,
+      const std::bitset<256>& sibling_first_bytes
+  );
+
+  /*!
+   * \brief Add the set of bytes the state can consume next to *out. Conservative: byte sets that
+   * are hard to compute exactly are over-approximated by setting all bytes.
+   */
+  void AddStateFirstBytes(const ParserState& state, std::bitset<256>* out) const;
 
   CompiledGrammar compiled_grammar_;
   TokenizerInfo tokenizer_info_;
   std::vector<int> stop_token_ids_;
   bool terminate_without_stop_token_;
   std::deque<int> token_length_history;
-  int32_t max_token_bytes_ = -1;
 
   // Temporary data for FillNextTokenBitmask. They are stored here to avoid repeated allocation.
   DynamicBitset tmp_accepted_bitset_;
   std::vector<int32_t> tmp_rejected_indices_;
   std::vector<int32_t> tmp_rejected_indices_delta_;
+  DynamicBitset tmp_char_boundary_bitset_;
 };
 
 class BatchGrammarMatcher::Impl {
@@ -864,9 +886,9 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
   std::vector<std::pair<ParserState, decltype(adaptive_token_mask_cache.cbegin())>>
       latest_states_with_masks;
   // States of character-budgeted regions that are near the budget boundary: their cached
-  // (budget-agnostic) masks may accept tokens longer than the remaining budget, so they are
-  // handled by exact live-checking instead.
-  std::vector<ParserState> live_check_all_states;
+  // (budget-agnostic) masks may accept tokens longer than the remaining budget, so they get
+  // exact per-token handling instead.
+  std::vector<ParserState> char_boundary_states;
 
   for (const auto& state : latest_states) {
     // Budget handling for budgeted TagDispatch rules. The cached masks are budget-agnostic
@@ -880,10 +902,10 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
         // parent states, which Earley has already made scanable.
         continue;
       }
-      if (max_chars >= 0 && max_chars - state.budget_char_count < GetMaxTokenBytes()) {
+      if (max_chars >= 0 && max_chars - state.budget_char_count < GetMaxTokenChars()) {
         // Near the character budget boundary: some tokens may not fit in the remaining budget.
-        // Fall back to exact per-token live-checking for this state.
-        live_check_all_states.push_back(state);
+        // Fall back to exact per-token handling for this state.
+        char_boundary_states.push_back(state);
         continue;
       }
       // Otherwise every whole token fits in the remaining budget, so the budget-agnostic mask
@@ -999,9 +1021,30 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
     }
   }
 
-  // Exact live-checking for states near a character budget boundary.
-  for (const auto& state : live_check_all_states) {
-    LiveCheckAllTokensForState(state);
+  // Exact handling for states near a character budget boundary.
+  if (!char_boundary_states.empty()) {
+    // First bytes consumable by the sibling states (e.g. the region's end tag): an over-budget
+    // region token can only survive by exiting into one of these continuations mid-token.
+    std::bitset<256> sibling_first_bytes;
+    for (const auto& state : latest_states) {
+      bool is_boundary_state =
+          std::find_if(
+              char_boundary_states.begin(),
+              char_boundary_states.end(),
+              [&](const ParserState& s) { return StateEqualForParsing()(s, state); }
+          ) != char_boundary_states.end();
+      if (!is_boundary_state) {
+        AddStateFirstBytes(state, &sibling_first_bytes);
+      }
+    }
+    for (const auto& state : char_boundary_states) {
+      const int32_t max_chars = GetRuleBudget(state.rule_id).second;
+      auto mask_it = adaptive_token_mask_cache.find(state);
+      XGRAMMAR_CHECK(mask_it != adaptive_token_mask_cache.end()) << state;
+      FillBitmaskForCharBudgetBoundary(
+          state, mask_it->second, max_chars - state.budget_char_count, sibling_first_bytes
+      );
+    }
   }
 
   // Finally update the rejected_ids bitset
@@ -1015,32 +1058,193 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
   return !IsTokenBitmaskAllTrue(bitmask_data_ptr);
 }
 
-int32_t GrammarMatcher::Impl::GetMaxTokenBytes() {
-  if (max_token_bytes_ == -1) {
-    size_t max_size = 0;
-    for (const auto& id_and_token : tokenizer_info_.GetSortedDecodedVocab()) {
-      max_size = std::max(max_size, id_and_token.second.size());
+void GrammarMatcher::Impl::EnsureTokenCharCounts() {
+  auto* impl = compiled_grammar_.operator->();
+  std::call_once(impl->token_char_data_once, [&]() {
+    const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
+    impl->token_char_counts.reserve(sorted_decoded_vocab.size());
+    int32_t max_chars = 0;
+    for (const auto& id_and_token : sorted_decoded_vocab) {
+      int32_t chars = 0;
+      for (unsigned char ch : id_and_token.second) {
+        chars += (ch & 0xC0) != 0x80;  // count non-continuation bytes = codepoints
+      }
+      impl->token_char_counts.push_back(chars);
+      max_chars = std::max(max_chars, chars);
     }
-    max_token_bytes_ = static_cast<int32_t>(max_size);
-  }
-  return max_token_bytes_;
+    // Bucket-sort the sorted vocab indices by character count for O(1) lookup of "all tokens
+    // longer than a given remaining budget".
+    impl->char_count_offsets.assign(max_chars + 2, 0);
+    for (auto count : impl->token_char_counts) {
+      ++impl->char_count_offsets[count + 1];
+    }
+    for (int c = 1; c < static_cast<int>(impl->char_count_offsets.size()); ++c) {
+      impl->char_count_offsets[c] += impl->char_count_offsets[c - 1];
+    }
+    impl->sorted_indices_by_char_count.resize(impl->token_char_counts.size());
+    std::vector<int32_t> cursor(
+        impl->char_count_offsets.begin(), impl->char_count_offsets.end() - 1
+    );
+    for (int i = 0; i < static_cast<int>(impl->token_char_counts.size()); ++i) {
+      impl->sorted_indices_by_char_count[cursor[impl->token_char_counts[i]]++] = i;
+    }
+    impl->max_token_chars = max_chars;
+  });
 }
 
-void GrammarMatcher::Impl::LiveCheckAllTokensForState(const ParserState& state) {
+int32_t GrammarMatcher::Impl::GetMaxTokenChars() {
+  EnsureTokenCharCounts();
+  return compiled_grammar_->max_token_chars;
+}
+
+void GrammarMatcher::Impl::AddStateFirstBytes(const ParserState& state, std::bitset<256>* out)
+    const {
+  if (state.rule_id != -1) {
+    XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
+    const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
+    for (const auto& edge : fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
+      if (edge.IsCharRange()) {
+        for (int ch = edge.min; ch <= edge.max; ++ch) {
+          out->set(ch);
+        }
+      }
+    }
+    return;
+  }
+  const auto& sequence_expr = grammar_->GetGrammarExpr(state.sequence_id);
+  if (sequence_expr.type != GrammarExprType::kSequence ||
+      state.element_id >= sequence_expr.size()) {
+    out->set();  // conservative
+    return;
+  }
+  const auto& element_expr = grammar_->GetGrammarExpr(sequence_expr[state.element_id]);
+  if (element_expr.type == GrammarExprType::kByteString) {
+    if (state.sub_element_id < element_expr.size()) {
+      out->set(static_cast<uint8_t>(element_expr[state.sub_element_id]));
+      return;
+    }
+  }
+  // Character classes / mid-UTF8 positions etc.: over-approximate.
+  out->set();
+}
+
+void GrammarMatcher::Impl::FillBitmaskForCharBudgetBoundary(
+    const ParserState& state,
+    const AdaptiveTokenMask& mask_entry,
+    int32_t remaining_chars,
+    const std::bitset<256>& sibling_first_bytes
+) {
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
   const auto& subtree_range = tokenizer_info_.GetTrieSubtreeNodesRange();
+  EnsureTokenCharCounts();
+  const auto& token_char_counts = compiled_grammar_->token_char_counts;
+  const auto& char_count_offsets = compiled_grammar_->char_count_offsets;
+  const auto& sorted_indices_by_char_count = compiled_grammar_->sorted_indices_by_char_count;
 
+  // Step 1. Build the entry's accepted set as a scratch bitset (over token ids).
+  if (tmp_char_boundary_bitset_.Size() != tmp_accepted_bitset_.Size()) {
+    tmp_char_boundary_bitset_ = DynamicBitset(tmp_accepted_bitset_.Size());
+  } else {
+    tmp_char_boundary_bitset_.Reset();
+  }
+  if (mask_entry.store_type == StoreType::kAccepted) {
+    for (auto i : mask_entry.accepted_indices) {
+      tmp_char_boundary_bitset_.Set(sorted_decoded_vocab[i].first, true);
+    }
+  } else if (mask_entry.store_type == StoreType::kAcceptedBitset) {
+    tmp_char_boundary_bitset_ |= mask_entry.accepted_bitset;
+  } else {
+    // kRejected: accepted = all - rejected - uncertain.
+    tmp_char_boundary_bitset_.Set();
+    for (auto i : mask_entry.rejected_indices) {
+      tmp_char_boundary_bitset_.Set(sorted_decoded_vocab[i].first, false);
+    }
+    for (auto i : mask_entry.uncertain_indices) {
+      tmp_char_boundary_bitset_.Set(sorted_decoded_vocab[i].first, false);
+    }
+  }
+
+  // Step 2. Entry-accepted tokens that fit in the remaining character budget stay accepted: the
+  // budget can only shrink the accepted set, and a fitting token cannot overrun it.
+  // An entry-accepted token LONGER than the budget is removed from the scratch set; it is
+  // over-budget as pure region content, so it can only survive by completing the region partway
+  // and continuing into a sibling continuation (e.g. content + end tag prefix in one token).
+  // That requires (a) the region to be completable, which spawned the sibling states, and (b)
+  // the token to contain a sibling first byte at some position >= 1 (an exit at position 0 is
+  // covered by the sibling state's own mask contribution). Long tokens failing this necessary
+  // condition are rejected directly; the rest are re-checked by simulation.
+  const bool region_completable =
+      grammar_->per_rule_fsms[state.rule_id]->GetFsm().IsEndState(state.element_id);
+  auto may_exit_into_sibling = [&](const std::string& token) {
+    if (!region_completable) {
+      return true;  // cannot reason about exits; conservatively re-check
+    }
+    for (size_t p = 1; p < token.size(); ++p) {
+      if (sibling_first_bytes[static_cast<uint8_t>(token[p])]) {
+        return true;
+      }
+    }
+    return false;
+  };
+  std::vector<int32_t> recheck_indices;
+  const int32_t num_tokens = static_cast<int32_t>(sorted_decoded_vocab.size());
+  const int32_t tail_begin = remaining_chars + 1 < static_cast<int32_t>(char_count_offsets.size())
+                                 ? char_count_offsets[remaining_chars + 1]
+                                 : num_tokens;
+  const int32_t tail_size = num_tokens - tail_begin;
+  constexpr int32_t kBucketTailThreshold = 4096;
+  if (tail_size <= kBucketTailThreshold) {
+    // Few long tokens: visit them via the by-char-count bucket list (needs a sort afterwards to
+    // restore the ascending order required by the trie pruning in step 3).
+    for (int32_t pos = tail_begin; pos < num_tokens; ++pos) {
+      const int32_t i = sorted_indices_by_char_count[pos];
+      const int32_t token_id = sorted_decoded_vocab[i].first;
+      if (tmp_char_boundary_bitset_[token_id]) {
+        tmp_char_boundary_bitset_.Set(token_id, false);
+        if (may_exit_into_sibling(sorted_decoded_vocab[i].second)) {
+          recheck_indices.push_back(i);
+        }
+      }
+    }
+  } else {
+    // Many long tokens: a linear scan over the char counts is cheaper and yields sorted order.
+    for (int32_t i = 0; i < num_tokens; ++i) {
+      if (token_char_counts[i] <= remaining_chars) {
+        continue;
+      }
+      const int32_t token_id = sorted_decoded_vocab[i].first;
+      if (tmp_char_boundary_bitset_[token_id]) {
+        tmp_char_boundary_bitset_.Set(token_id, false);
+        if (may_exit_into_sibling(sorted_decoded_vocab[i].second)) {
+          recheck_indices.push_back(i);
+        }
+      }
+    }
+  }
+  tmp_accepted_bitset_ |= tmp_char_boundary_bitset_;
+
+  // Uncertain tokens are always re-checked (their acceptance depends on the parent anyway).
+  recheck_indices.insert(
+      recheck_indices.end(),
+      mask_entry.uncertain_indices.begin(),
+      mask_entry.uncertain_indices.end()
+  );
+  std::sort(recheck_indices.begin(), recheck_indices.end());
+
+  // Step 2. Re-check the remaining candidates by byte-level simulation on the real parser. The
+  // state carries its budget counter, so AdvanceFsm enforces the budget exactly; a token that
+  // overruns the region budget can still be accepted if it completes the region and continues
+  // into the parent (e.g. content + end tag in one token).
   PushOneStateToCheck(state);
 
   const std::string* prev_token = nullptr;
   int prev_matched_size = 0;
   int last_rejected_range = 0;
-  for (int i = 0; i < static_cast<int>(sorted_decoded_vocab.size()); ++i) {
-    // Skip tokens already accepted by other states.
+  for (auto i : recheck_indices) {
+    // Skip tokens already accepted by other states, and the trie subtree of a rejected prefix.
     if (tmp_accepted_bitset_[sorted_decoded_vocab[i].first]) {
       continue;
     }
-    // Skip the trie subtree of a rejected prefix.
     if (i < last_rejected_range) {
       continue;
     }

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -1154,13 +1154,27 @@ void GrammarMatcher::Impl::FillBitmaskForCharBudgetBoundary(
   } else if (mask_entry.store_type == StoreType::kAcceptedBitset) {
     tmp_char_boundary_bitset_ |= mask_entry.accepted_bitset;
   } else {
-    // kRejected: accepted = all - rejected - uncertain.
+    // kRejected: accepted = (sorted vocab) - rejected - uncertain.
     tmp_char_boundary_bitset_.Set();
     for (auto i : mask_entry.rejected_indices) {
       tmp_char_boundary_bitset_.Set(sorted_decoded_vocab[i].first, false);
     }
     for (auto i : mask_entry.uncertain_indices) {
       tmp_char_boundary_bitset_.Set(sorted_decoded_vocab[i].first, false);
+    }
+    // Token ids NOT in the sorted vocab (special tokens, stop tokens, padding ids) are never
+    // accepted by the entry; they must be cleared since this bitset is OR-ed into the accepted
+    // set, where a stray stop-token bit would e.g. allow EOS before the region's end tag.
+    for (auto id : tokenizer_info_.GetSpecialTokenIds()) {
+      tmp_char_boundary_bitset_.Set(id, false);
+    }
+    for (auto id : tokenizer_info_.GetStopTokenIds()) {
+      tmp_char_boundary_bitset_.Set(id, false);
+    }
+    for (int id = static_cast<int>(tokenizer_info_.GetDecodedVocab().size());
+         id < tmp_char_boundary_bitset_.Size();
+         ++id) {
+      tmp_char_boundary_bitset_.Set(id, false);
     }
   }
 

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <variant>
 #include <vector>
@@ -934,7 +935,7 @@ int32_t EBNFParser::ParseTagDispatch() {
   Grammar::Impl::TagDispatch tag_dispatch;
 
   static const std::unordered_set<std::string> kValidNamedArgs = {
-      "loop_after_dispatch", "excludes"
+      "loop_after_dispatch", "excludes", "max_tokens", "max_chars"
   };
   for (const auto& [name, _] : args.named_arguments) {
     if (kValidNamedArgs.count(name) == 0) {
@@ -994,6 +995,28 @@ int32_t EBNFParser::ParseTagDispatch() {
       }
       tag_dispatch.excludes.push_back(str_node->value);
     }
+  }
+
+  // max_tokens / max_chars — optional non-negative integer budgets
+  auto parse_budget = [&](const char* name, int32_t* out) {
+    if (auto it = args.named_arguments.find(name); it != args.named_arguments.end()) {
+      auto int_node = std::get_if<MacroIR::IntegerNode>(it->second.get());
+      if (int_node == nullptr || int_node->value < 0 ||
+          int_node->value > std::numeric_limits<int32_t>::max()) {
+        ReportParseError(
+            std::string(name) + " must be a non-negative integer literal", delta_element
+        );
+      }
+      *out = static_cast<int32_t>(int_node->value);
+    }
+  };
+  parse_budget("max_tokens", &tag_dispatch.max_tokens);
+  parse_budget("max_chars", &tag_dispatch.max_chars);
+  if ((tag_dispatch.max_tokens != -1 || tag_dispatch.max_chars != -1) &&
+      !tag_dispatch.tag_rule_pairs.empty()) {
+    ReportParseError(
+        "max_tokens / max_chars are only supported for TagDispatch without triggers", delta_element
+    );
   }
 
   // Well-formedness checks: string excludes vs string triggers

--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -147,7 +147,14 @@ std::string GrammarPrinter::PrintTagDispatch(const GrammarExpr& grammar_expr) {
     if (i > 0) result += ", ";
     result += PrintString(tag_dispatch.excludes[i]);
   }
-  result += ")\n)";
+  result += ")";
+  if (tag_dispatch.max_tokens != -1) {
+    result += ",\n" + indent + "max_tokens=" + std::to_string(tag_dispatch.max_tokens);
+  }
+  if (tag_dispatch.max_chars != -1) {
+    result += ",\n" + indent + "max_chars=" + std::to_string(tag_dispatch.max_chars);
+  }
+  result += "\n)";
   return result;
 }
 

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -128,6 +128,12 @@ picojson::value AnyTextFormat::ToJSON() const {
   obj["type"] = picojson::value(type);
   obj["excludes"] = StringVectorToJSONArray(excludes);
   obj["detected_end_strs"] = StringVectorToJSONArray(detected_end_strs_);
+  if (max_tokens != -1) {
+    obj["max_tokens"] = picojson::value(static_cast<double>(max_tokens));
+  }
+  if (max_chars != -1) {
+    obj["max_chars"] = picojson::value(static_cast<double>(max_chars));
+  }
   return picojson::value(std::move(obj));
 }
 
@@ -199,6 +205,9 @@ picojson::value AnyTokensFormat::ToJSON() const {
   picojson::object obj;
   obj["type"] = picojson::value(type);
   obj["exclude_tokens"] = IntOrStringVectorToJSONArray(exclude_tokens);
+  if (max_tokens.has_value()) {
+    obj["max_tokens"] = picojson::value(static_cast<double>(max_tokens.value()));
+  }
   return picojson::value(std::move(obj));
 }
 
@@ -573,14 +582,52 @@ Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
   );
 }
 
+/*!
+ * \brief Read an optional non-negative integer budget field (e.g. "max_tokens", "max_chars").
+ * Returns -1 if absent or null (unbounded). A present-but-invalid value is an error rather than
+ * silently unbounded.
+ */
+static Result<int32_t, ISTError> ParseOptionalBudgetField(
+    const picojson::object& obj, const std::string& field, const std::string& format_name
+) {
+  auto it = obj.find(field);
+  if (it == obj.end() || it->second.is<picojson::null>()) {
+    return ResultOk<int32_t>(-1);
+  }
+  if (!it->second.is<double>()) {
+    return ResultErr<ISTError>(
+        field + " in " + format_name + " must be a non-negative integer or null."
+    );
+  }
+  double raw = it->second.get<double>();
+  if (raw < 0 || raw > static_cast<double>(std::numeric_limits<int32_t>::max()) ||
+      raw != std::floor(raw)) {
+    return ResultErr<ISTError>(
+        field + " in " + format_name + " must be a non-negative integer in [0, INT32_MAX]."
+    );
+  }
+  return ResultOk<int32_t>(static_cast<int32_t>(raw));
+}
+
 Result<AnyTextFormat, ISTError> StructuralTagParser::ParseAnyTextFormat(const picojson::object& obj
 ) {
+  auto max_tokens_result = ParseOptionalBudgetField(obj, "max_tokens", "any_text");
+  if (max_tokens_result.IsErr()) {
+    return ResultErr<ISTError>(std::move(max_tokens_result).UnwrapErr());
+  }
+  int32_t max_tokens = std::move(max_tokens_result).Unwrap();
+  auto max_chars_result = ParseOptionalBudgetField(obj, "max_chars", "any_text");
+  if (max_chars_result.IsErr()) {
+    return ResultErr<ISTError>(std::move(max_chars_result).UnwrapErr());
+  }
+  int32_t max_chars = std::move(max_chars_result).Unwrap();
+
   auto excluded_strs_it = obj.find("excludes");
   if (excluded_strs_it == obj.end()) {
     if ((obj.find("type") == obj.end())) {
       return ResultErr<ISTError>("Any text format should not have any fields other than type");
     }
-    return ResultOk<AnyTextFormat>(std::vector<std::string>{});
+    return ResultOk<AnyTextFormat>(std::vector<std::string>{}, max_tokens, max_chars);
   }
   if (!excluded_strs_it->second.is<picojson::array>()) {
     return ResultErr<ISTError>("AnyText format's excluded_strs field must be an array");
@@ -594,7 +641,7 @@ Result<AnyTextFormat, ISTError> StructuralTagParser::ParseAnyTextFormat(const pi
     }
     excluded_strs.push_back(excluded_str.get<std::string>());
   }
-  return ResultOk<AnyTextFormat>(std::move(excluded_strs));
+  return ResultOk<AnyTextFormat>(std::move(excluded_strs), max_tokens, max_chars);
 }
 
 Result<GrammarFormat, ISTError> StructuralTagParser::ParseGrammarFormat(const picojson::object& obj
@@ -994,7 +1041,14 @@ Result<AnyTokensFormat, ISTError> StructuralTagParser::ParseAnyTokensFormat(
     }
     exclude_tokens = std::move(parsed).Unwrap();
   }
-  return ResultOk<AnyTokensFormat>(std::move(exclude_tokens));
+  auto max_tokens_result = ParseOptionalBudgetField(obj, "max_tokens", "any_tokens");
+  if (max_tokens_result.IsErr()) {
+    return ResultErr<ISTError>(std::move(max_tokens_result).UnwrapErr());
+  }
+  int32_t max_tokens_raw = std::move(max_tokens_result).Unwrap();
+  std::optional<int32_t> max_tokens =
+      max_tokens_raw == -1 ? std::nullopt : std::make_optional(max_tokens_raw);
+  return ResultOk<AnyTokensFormat>(std::move(exclude_tokens), max_tokens);
 }
 
 Result<TokenTriggeredTagsFormat, ISTError> StructuralTagParser::ParseTokenTriggeredTagsFormat(
@@ -1920,9 +1974,14 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const AnyTextForma
       all_excludes.push_back(s);
     }
   }
-  if (!all_excludes.empty()) {
-    auto tag_dispatch_expr =
-        grammar_builder_.AddTagDispatch(Grammar::Impl::TagDispatch{{}, false, all_excludes});
+  if (!all_excludes.empty() || format.max_tokens != -1 || format.max_chars != -1) {
+    // With excludes or a token/character budget, the region is a TagDispatch (an Aho-Corasick
+    // scan over the excludes; an empty exclude set matches any text). The budgets are carried on
+    // the TagDispatch and enforced per parser state: once a budget is reached, the region is
+    // forced to complete, so its enclosing end tag becomes the only valid continuation.
+    auto tag_dispatch_expr = grammar_builder_.AddTagDispatch(
+        Grammar::Impl::TagDispatch{{}, false, all_excludes, format.max_tokens, format.max_chars}
+    );
     return ResultOk(grammar_builder_.AddRuleWithHint("any_text", tag_dispatch_expr));
   } else {
     auto any_text_expr = grammar_builder_.AddCharacterClassStar({{0, 0x10FFFF}}, false);
@@ -2282,6 +2341,12 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const AnyTokensFor
   int exclude_seq = grammar_builder_.AddSequence({exclude_expr});
   int exclude_choices = grammar_builder_.AddChoices({exclude_seq});
   int inner_rule = grammar_builder_.AddRuleWithHint("any_tokens_inner", exclude_choices);
+  // Each inner_rule matches exactly one token, so a bounded repetition of it gives an exact
+  // token-count budget, reusing the existing kRepeat machinery.
+  if (format.max_tokens.has_value()) {
+    int repeat_expr = grammar_builder_.AddRepeat(inner_rule, 0, format.max_tokens.value());
+    return ResultOk(grammar_builder_.AddRuleWithHint("any_tokens", repeat_expr));
+  }
   auto inner_ref = grammar_builder_.AddRuleRef(inner_rule);
   auto star_rule_id = grammar_builder_.AddEmptyRuleWithHint("any_tokens");
   auto star_ref = grammar_builder_.AddRuleRef(star_rule_id);

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -119,7 +119,18 @@ struct RegexFormat {
 struct AnyTextFormat {
   static constexpr const char* type = "any_text";
   std::vector<std::string> excludes;
-  AnyTextFormat(std::vector<std::string> excluded_strs) : excludes(std::move(excluded_strs)) {}
+  /*!
+   * \brief Max number of whole tokens this region may consume; -1 = unbounded. Once the budget
+   * is reached the region is forced to end (its enclosing end tag becomes the only valid
+   * continuation). Enforced atomically at token granularity by the matcher.
+   */
+  int32_t max_tokens = -1;
+  /*! \brief Max number of Unicode characters this region may consume; -1 = unbounded. */
+  int32_t max_chars = -1;
+  AnyTextFormat(
+      std::vector<std::string> excluded_strs, int32_t max_tokens = -1, int32_t max_chars = -1
+  )
+      : excludes(std::move(excluded_strs)), max_tokens(max_tokens), max_chars(max_chars) {}
   picojson::value ToJSON() const;
 
  private:
@@ -163,8 +174,16 @@ struct ExcludeTokenFormat {
 struct AnyTokensFormat {
   static constexpr const char* type = "any_tokens";
   std::vector<std::variant<int32_t, std::string>> exclude_tokens;
-  AnyTokensFormat(std::vector<std::variant<int32_t, std::string>> exclude_tokens)
-      : exclude_tokens(std::move(exclude_tokens)) {}
+  /*!
+   * \brief If set, match at most max_tokens tokens (each excluding exclude_tokens), giving an
+   * exact token-count budget. If std::nullopt, the number of tokens is unbounded.
+   */
+  std::optional<int32_t> max_tokens = std::nullopt;
+  AnyTokensFormat(
+      std::vector<std::variant<int32_t, std::string>> exclude_tokens,
+      std::optional<int32_t> max_tokens = std::nullopt
+  )
+      : exclude_tokens(std::move(exclude_tokens)), max_tokens(max_tokens) {}
   picojson::value ToJSON() const;
 
  private:

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v14";
+  static constexpr const char kXGrammarSerializeVersion[] = "v15";
 };
 
 /*!

--- a/docs/structural_tag/structural_tag_api.md
+++ b/docs/structural_tag/structural_tag_api.md
@@ -279,13 +279,10 @@ Matches arbitrary text.
 When `any_text` appears inside a string-level `tag`, the enclosing end string is automatically
 treated as a stop condition.
 
-`max_tokens` (default `null`) caps how many **whole tokens** this region may consume. When set to
-a non-negative integer `N`, at most `N` tokens are matched and then the region is forced to end —
-i.e. its enclosing end tag (the next element after the region) becomes the only valid
-continuation, **not** the EOS/stop token. Because the limit is enforced at the token level by the
-matcher, it composes with **multi-token / multi-character `excludes`** (e.g. a `</think>` end
-marker that spans several tokens), which a token-level `any_tokens` budget cannot express. This
-gives, for example, a token budget on a reasoning/think section:
+`max_tokens` (default `null`) caps how many **whole tokens** the region may consume. Once the
+budget is reached, the region is forced to end: its enclosing end tag becomes the only valid
+continuation. Unlike `any_tokens`, it also works when the end marker spans multiple tokens. For
+example, a token budget on a reasoning/think section:
 
 ```json
 {
@@ -296,12 +293,8 @@ gives, for example, a token budget on a reasoning/think section:
 }
 ```
 
-`max_chars` (default `null`) similarly caps how many **Unicode characters** the region may
-consume. Both budgets may be combined; each is then enforced independently.
-
-The token budget is atomic at token granularity (the last admitted token is never split). The
-budgets are tracked per region instance, so a grammar may contain multiple bounded regions with
-independent budgets.
+`max_chars` (default `null`) similarly caps how many **Unicode characters** (codepoints, not
+bytes) the region may consume. Both budgets may be combined; each is then enforced independently.
 
 ### Composition Formats
 

--- a/docs/structural_tag/structural_tag_api.md
+++ b/docs/structural_tag/structural_tag_api.md
@@ -264,6 +264,8 @@ Matches arbitrary text.
 | Field | Type | Default |
 | --- | --- | --- |
 | `excludes` | `string[]` | `[]` |
+| `max_tokens` | `int \| null` | `null` |
+| `max_chars` | `int \| null` | `null` |
 
 - **Use it when**: the content should remain free-form until some enclosing boundary is reached
 
@@ -276,6 +278,30 @@ Matches arbitrary text.
 
 When `any_text` appears inside a string-level `tag`, the enclosing end string is automatically
 treated as a stop condition.
+
+`max_tokens` (default `null`) caps how many **whole tokens** this region may consume. When set to
+a non-negative integer `N`, at most `N` tokens are matched and then the region is forced to end —
+i.e. its enclosing end tag (the next element after the region) becomes the only valid
+continuation, **not** the EOS/stop token. Because the limit is enforced at the token level by the
+matcher, it composes with **multi-token / multi-character `excludes`** (e.g. a `</think>` end
+marker that spans several tokens), which a token-level `any_tokens` budget cannot express. This
+gives, for example, a token budget on a reasoning/think section:
+
+```json
+{
+    "type": "tag",
+    "begin": "<think>",
+    "content": {"type": "any_text", "excludes": ["</think>"], "max_tokens": 256},
+    "end": "</think>"
+}
+```
+
+`max_chars` (default `null`) similarly caps how many **Unicode characters** the region may
+consume. Both budgets may be combined; each is then enforced independently.
+
+The token budget is atomic at token granularity (the last admitted token is never split). The
+budgets are tracked per region instance, so a grammar may contain multiple bounded regions with
+independent budgets.
 
 ### Composition Formats
 
@@ -640,6 +666,7 @@ Matches zero or more tokens, excluding those in `exclude_tokens`.
 | Field | Type | Default |
 | --- | --- | --- |
 | `exclude_tokens` | `(int \| string)[]` | `[]` |
+| `max_tokens` | `int \| null` | `null` |
 
 - **Use it when**: content should remain unconstrained until a token-level boundary is reached
 
@@ -648,6 +675,18 @@ Matches zero or more tokens, excluding those in `exclude_tokens`.
 ```
 
 Semantically, `any_tokens` is equivalent to `star(exclude_token(...))`.
+
+`max_tokens` (default `null`) caps how many tokens this format may consume. When set to a
+non-negative integer `N`, the region matches **at most** `N` tokens (each of which still excludes
+the values in `exclude_tokens`), giving an exact token-count budget; when `null`, there is no
+limit. This is useful for bounding an otherwise-unlimited region, e.g. a token budget on a
+think/reasoning section whose end marker is a single token:
+
+```json
+{"type": "any_tokens", "exclude_tokens": ["<|eos|>"], "max_tokens": 256}
+```
+
+With `max_tokens` set, `any_tokens` is equivalent to `repeat(exclude_token(...), min=0, max=N)`.
 
 #### `token_triggered_tags`
 

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -60,6 +60,17 @@ class AnyTextFormat(BaseModel):
     excludes: List[str] = []
     """List of strings that should not appear in the matched text."""
 
+    max_tokens: Optional[int] = Field(default=None, ge=0)
+    """Maximum number of whole tokens this region may match. If None, unbounded. When set, at
+    most max_tokens tokens are matched and then the region is forced to end (e.g. its enclosing
+    end tag becomes the only valid continuation) -- a token budget that composes with
+    multi-token / multi-character ``excludes``. Enforced atomically at token granularity."""
+
+    max_chars: Optional[int] = Field(default=None, ge=0)
+    """Maximum number of Unicode characters this region may match. If None, unbounded. When set,
+    the region is forced to end once max_chars characters have been matched. May be combined
+    with ``max_tokens``; both budgets are then enforced."""
+
 
 class TokenFormat(BaseModel):
     """A format that matches a single token by ID or string representation."""
@@ -89,6 +100,11 @@ class AnyTokensFormat(BaseModel):
 
     exclude_tokens: List[Union[int, str]] = []
     """List of token IDs or strings to exclude."""
+
+    max_tokens: Optional[int] = Field(default=None, ge=0)
+    """Maximum number of tokens to match. If None, there is no limit. If set, at most
+    max_tokens tokens are matched (each excluding the tokens in exclude_tokens), giving an
+    exact token-count budget. It must be a non-negative integer."""
 
 
 class GrammarFormat(BaseModel):

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -745,6 +745,10 @@ def test_any_text_max_chars_enforced():
     assert _mask_allows(cg, ["<think>", "a", "b"], "</")
     assert not _mask_allows(cg, ["<think>", "a", "b", "c"], "a")
     assert _mask_allows(cg, ["<think>", "a", "b", "c"], "</")
+    # EOS must never leak into the mask near or at the boundary (the region is not the grammar
+    # end; only the end tag may follow)
+    assert not _mask_allows(cg, ["<think>", "a", "b"], "<eos>")
+    assert not _mask_allows(cg, ["<think>", "a", "b", "c"], "<eos>")
 
 
 def test_any_text_max_chars_hybrid_content_plus_end_tag_token():
@@ -761,6 +765,45 @@ def test_any_text_max_chars_hybrid_content_plus_end_tag_token():
     assert _mask_allows(cg, ["<think>", "a", "b"], "</")
     assert not _mask_allows(cg, ["<think>", "a", "b"], "a</")
     assert _allowed(cg, ["<think>", "a", "b"], "a</") is False
+
+
+def test_any_text_max_chars_boundary_large_vocab_no_eos_leak():
+    """Regression test for the char-budget boundary path with a large vocab. With >1000 tokens
+    the region's cached mask is stored in the kRejected/bitset forms, whose reconstruction in the
+    boundary handler must not leak token ids outside the sorted vocab (special/stop tokens) into
+    the accepted set: EOS stays masked until the end tag is matched."""
+    vocab = ["<think>", "</", "think>", "<eos>", "a"] + [f"w{i}" for i in range(1200)]
+    eos_id = vocab.index("<eos>")
+    tokenizer_info = xgr.TokenizerInfo(vocab, stop_token_ids=[eos_id])
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+    stag = {
+        "type": "structural_tag",
+        "format": {
+            "type": "tag",
+            "begin": "<think>",
+            "content": {"type": "any_text", "excludes": ["</think>"], "max_chars": 3},
+            "end": "</think>",
+        },
+    }
+    compiled = compiler.compile_structural_tag(stag)
+    matcher = xgr.GrammarMatcher(compiled)
+    assert matcher.accept_token(vocab.index("<think>"))
+    bitmask = xgr.allocate_token_bitmask(1, len(vocab))
+    for step_token in ["a", "a", "a"]:  # consume the 3-char budget one char at a time
+        matcher.fill_next_token_bitmask(bitmask)
+        masked = _get_masked_tokens_from_bitmask(bitmask, len(vocab))
+        assert eos_id in masked  # EOS never allowed inside the region
+        assert vocab.index("</") not in masked  # the end tag is always allowed
+        assert matcher.accept_token(vocab.index(step_token))
+    # budget exhausted: only the end tag may follow
+    matcher.fill_next_token_bitmask(bitmask)
+    masked = _get_masked_tokens_from_bitmask(bitmask, len(vocab))
+    assert eos_id in masked
+    assert vocab.index("a") in masked
+    assert vocab.index("</") not in masked
+    assert matcher.accept_token(vocab.index("</"))
+    assert matcher.accept_token(vocab.index("think>"))
+    assert matcher.is_completed()
 
 
 def test_any_text_max_tokens_and_max_chars_combined():

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -543,17 +543,29 @@ def test_tag_dispatch_perf(ebnf, input_str):
 
 
 # ---------- any_text max_tokens / max_chars (region budgets) ----------
+#
+# All budget tests below share this small vocabulary. Tests refer to tokens by their string via
+# the helpers, so token sequences read like the generated text:
+#
+#   "<think>"       the begin tag, as one whole token
+#   "</", "think>"  the end tag "</think>" SPANS TWO TOKENS: a byte-level any_text budget must
+#                   handle multi-token end markers (a token-level any_tokens budget cannot)
+#   "a", "b", "c"   1-character content tokens
+#   "de"            a 2-character content token (for max_chars)
+#   "中"            a 1-character but 3-byte content token (max_chars counts characters, not bytes)
+#   "a</"           a hybrid token: 1 character of content followed by the START of the end tag
+#   "<eos>"         the stop token
 
-# Synthetic vocab where the end tag "</think>" spans MULTIPLE tokens ("</" + "think>"), which is
-# exactly the case a byte-level any_text token budget must handle (AnyTokensFormat cannot, since
-# its excludes are single tokens). "de" is a 2-char token and "中" is a 1-char / 3-byte token,
-# used by the max_chars tests.
-_TB_VOCAB = ["<think>", "a", "b", "</", "think>", "c", "<eos>", "de", "中"]
-_TB_B, _TB_A, _TB_BB, _TB_E1, _TB_E2, _TB_C, _TB_EOS, _TB_DE, _TB_ZH = range(9)
+_BUDGET_VOCAB = ["<think>", "a", "b", "c", "de", "中", "a</", "</", "think>", "<eos>"]
+
+
+def _tok(token: str) -> int:
+    return _BUDGET_VOCAB.index(token)
 
 
 def _think_budget_compiled(max_tokens=None, max_chars=None, *, cache_enabled=True, compiler=None):
-    tokenizer_info = xgr.TokenizerInfo(_TB_VOCAB, stop_token_ids=[_TB_EOS])
+    """Compile ``<think>`` + any_text(excludes=["</think>"], budgets...) + ``</think>``."""
+    tokenizer_info = xgr.TokenizerInfo(_BUDGET_VOCAB, stop_token_ids=[_tok("<eos>")])
     compiler = compiler or xgr.GrammarCompiler(tokenizer_info, cache_enabled=cache_enabled)
     content = {"type": "any_text", "excludes": ["</think>"]}
     if max_tokens is not None:
@@ -567,94 +579,93 @@ def _think_budget_compiled(max_tokens=None, max_chars=None, *, cache_enabled=Tru
     return compiler, compiler.compile_structural_tag(stag)
 
 
-def _accepts(compiled, tokens):
+def _accepts(compiled, *tokens: str) -> bool:
+    """Whether the token string sequence is accepted and completes the grammar."""
     matcher = xgr.GrammarMatcher(compiled)
     for t in tokens:
-        if not matcher.accept_token(t):
+        if not matcher.accept_token(_tok(t)):
             return False
     return matcher.is_completed()
 
 
-def _allowed(compiled, prefix, token):
+def _allowed(compiled, prefix: List[str], token: str) -> bool:
+    """Whether `token` can be accepted right after the given prefix."""
     matcher = xgr.GrammarMatcher(compiled)
     for t in prefix:
-        assert matcher.accept_token(t)
-    return matcher.accept_token(token)
+        assert matcher.accept_token(_tok(t))
+    return matcher.accept_token(_tok(token))
 
 
-def _mask_allows(compiled, prefix, token):
+def _mask_allows(compiled, prefix: List[str], token: str) -> bool:
+    """Whether the token bitmask generated after the given prefix allows `token`."""
     matcher = xgr.GrammarMatcher(compiled)
     for t in prefix:
-        assert matcher.accept_token(t)
-    bitmask = xgr.allocate_token_bitmask(1, len(_TB_VOCAB))
+        assert matcher.accept_token(_tok(t))
+    bitmask = xgr.allocate_token_bitmask(1, len(_BUDGET_VOCAB))
     matcher.fill_next_token_bitmask(bitmask)
-    return token not in _get_masked_tokens_from_bitmask(bitmask, len(_TB_VOCAB))
+    return _tok(token) not in _get_masked_tokens_from_bitmask(bitmask, len(_BUDGET_VOCAB))
 
 
 def test_any_text_max_tokens_forces_end_tag_not_eos():
     """After N content tokens the bounded region is forced to END: only the (multi-token) end tag
     is valid, content is rejected, and EOS is NOT allowed (the end tag is forced, not a stop)."""
     _, cg = _think_budget_compiled(max_tokens=2)
-    B, A, BB, E1, E2, C, EOS = _TB_B, _TB_A, _TB_BB, _TB_E1, _TB_E2, _TB_C, _TB_EOS
-    assert _accepts(cg, [B, A, BB, E1, E2])  # 2 content tokens + end -> complete
-    assert _accepts(cg, [B, A, E1, E2])  # 1 content token
-    assert _accepts(cg, [B, E1, E2])  # 0 content tokens
-    assert not _accepts(cg, [B, A, BB, C, E1, E2])  # 3 content tokens exceeds budget
+    assert _accepts(cg, "<think>", "a", "b", "</", "think>")  # 2 content tokens + end
+    assert _accepts(cg, "<think>", "a", "</", "think>")  # 1 content token
+    assert _accepts(cg, "<think>", "</", "think>")  # 0 content tokens
+    assert not _accepts(cg, "<think>", "a", "b", "c", "</", "think>")  # 3 > budget
     # at the budget, content is rejected but the end tag is allowed; EOS is not (region not done)
-    assert _allowed(cg, [B, A, BB], E1) is True
-    assert _allowed(cg, [B, A, BB], A) is False
-    assert _allowed(cg, [B, A, BB], EOS) is False
+    assert _allowed(cg, ["<think>", "a", "b"], "</") is True
+    assert _allowed(cg, ["<think>", "a", "b"], "a") is False
+    assert _allowed(cg, ["<think>", "a", "b"], "<eos>") is False
     # the token mask agrees with accept_token
-    assert _mask_allows(cg, [B, A, BB], E1)
-    assert not _mask_allows(cg, [B, A, BB], A)
-    assert _mask_allows(cg, [B, A], A)  # budget not exhausted yet
+    assert _mask_allows(cg, ["<think>", "a", "b"], "</")
+    assert not _mask_allows(cg, ["<think>", "a", "b"], "a")
+    assert _mask_allows(cg, ["<think>", "a"], "a")  # budget not exhausted yet
 
 
 def test_any_text_max_tokens_zero_forces_immediate_end():
     _, cg = _think_budget_compiled(max_tokens=0)
-    B, A, E1, E2 = _TB_B, _TB_A, _TB_E1, _TB_E2
-    assert _accepts(cg, [B, E1, E2])
-    assert _allowed(cg, [B], A) is False
-    assert _allowed(cg, [B], E1) is True
+    assert _accepts(cg, "<think>", "</", "think>")
+    assert _allowed(cg, ["<think>"], "a") is False
+    assert _allowed(cg, ["<think>"], "</") is True
 
 
 def test_any_text_max_tokens_rollback_restores_budget():
     """The budget counters live in the parser state history, so rollback restores them."""
     _, cg = _think_budget_compiled(max_tokens=2)
-    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
     matcher = xgr.GrammarMatcher(cg)
-    assert matcher.accept_token(B)
-    assert matcher.accept_token(A)
-    assert matcher.accept_token(BB)  # budget full
-    assert not matcher.accept_token(C)  # over budget
+    assert matcher.accept_token(_tok("<think>"))
+    assert matcher.accept_token(_tok("a"))
+    assert matcher.accept_token(_tok("b"))  # budget full
+    assert not matcher.accept_token(_tok("c"))  # over budget
     matcher.rollback(1)  # undo one content token
-    assert matcher.accept_token(C)  # budget restored: one content token allowed again
-    assert not matcher.accept_token(A)  # full again
-    assert matcher.accept_token(E1) and matcher.accept_token(E2)
+    assert matcher.accept_token(_tok("c"))  # budget restored: one content token allowed again
+    assert not matcher.accept_token(_tok("a"))  # full again
+    assert matcher.accept_token(_tok("</")) and matcher.accept_token(_tok("think>"))
     assert matcher.is_completed()
 
 
 def test_any_text_max_tokens_fork_independent():
     _, cg = _think_budget_compiled(max_tokens=2)
-    B, A, BB, C = _TB_B, _TB_A, _TB_BB, _TB_C
     matcher = xgr.GrammarMatcher(cg)
-    assert matcher.accept_token(B) and matcher.accept_token(A)  # 1 content used
+    assert matcher.accept_token(_tok("<think>"))
+    assert matcher.accept_token(_tok("a"))  # 1 of 2 content tokens used
     child = matcher.fork()
-    assert child.accept_token(BB)  # child uses its 2nd
-    assert not child.accept_token(C)  # child exhausted
-    assert matcher.accept_token(BB)  # parent budget independent, still has its 2nd
+    assert child.accept_token(_tok("b"))  # child uses its 2nd
+    assert not child.accept_token(_tok("c"))  # child exhausted
+    assert matcher.accept_token(_tok("b"))  # parent budget independent, still has its 2nd
 
 
 def test_any_text_max_tokens_reset_restores_budget():
     _, cg = _think_budget_compiled(max_tokens=1)
-    B, A, BB, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_E1, _TB_E2
     matcher = xgr.GrammarMatcher(cg)
-    assert matcher.accept_token(B) and matcher.accept_token(A)
-    assert not matcher.accept_token(BB)
+    assert matcher.accept_token(_tok("<think>")) and matcher.accept_token(_tok("a"))
+    assert not matcher.accept_token(_tok("b"))
     matcher.reset()
-    assert matcher.accept_token(B) and matcher.accept_token(A)
-    assert not matcher.accept_token(BB)
-    assert matcher.accept_token(E1) and matcher.accept_token(E2)
+    assert matcher.accept_token(_tok("<think>")) and matcher.accept_token(_tok("a"))
+    assert not matcher.accept_token(_tok("b"))
+    assert matcher.accept_token(_tok("</")) and matcher.accept_token(_tok("think>"))
     assert matcher.is_completed()
 
 
@@ -662,38 +673,35 @@ def test_any_text_max_tokens_cache_no_staleness():
     """Bounded and unbounded regions with the same excludes share the same (budget-agnostic)
     cached masks; the budget is applied per state at runtime, so sharing is safe in BOTH
     directions."""
-    tokenizer_info = xgr.TokenizerInfo(_TB_VOCAB, stop_token_ids=[_TB_EOS])
-    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
+    tokenizer_info = xgr.TokenizerInfo(_BUDGET_VOCAB, stop_token_ids=[_tok("<eos>")])
     # compile the UNBOUNDED variant first to populate the FSM-hash cache
     compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=True)
     _, cg_unbounded = _think_budget_compiled(compiler=compiler)
-    assert _accepts(cg_unbounded, [B, A, BB, C, A, E1, E2])  # 5 content tokens, no budget
+    assert _accepts(cg_unbounded, "<think>", "a", "b", "c", "a", "</", "think>")  # no budget
     # now the bounded variant (same excludes/FSM) must still enforce
     _, cg_bounded = _think_budget_compiled(max_tokens=2, compiler=compiler)
-    assert _allowed(cg_bounded, [B, A, BB], A) is False
-    assert not _accepts(cg_bounded, [B, A, BB, C, E1, E2])
-    assert _accepts(cg_bounded, [B, A, BB, E1, E2])
+    assert _allowed(cg_bounded, ["<think>", "a", "b"], "a") is False
+    assert not _accepts(cg_bounded, "<think>", "a", "b", "c", "</", "think>")
+    assert _accepts(cg_bounded, "<think>", "a", "b", "</", "think>")
     # the reverse direction: a bounded variant cached first must not restrict the unbounded one
     compiler2 = xgr.GrammarCompiler(tokenizer_info, cache_enabled=True)
     _, cg_bounded2 = _think_budget_compiled(max_tokens=1, compiler=compiler2)
-    assert not _accepts(cg_bounded2, [B, A, BB, E1, E2])
+    assert not _accepts(cg_bounded2, "<think>", "a", "b", "</", "think>")
     _, cg_unbounded2 = _think_budget_compiled(compiler=compiler2)
-    assert _accepts(cg_unbounded2, [B, A, BB, C, A, E1, E2])
+    assert _accepts(cg_unbounded2, "<think>", "a", "b", "c", "a", "</", "think>")
 
 
 def test_any_text_unbounded_no_regression():
     _, cg = _think_budget_compiled()
-    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
     # without a budget the region accepts arbitrarily many content tokens
-    assert _accepts(cg, [B, A, BB, C, A, BB, C, E1, E2])
+    assert _accepts(cg, "<think>", "a", "b", "c", "a", "b", "c", "</", "think>")
 
 
 def test_any_text_max_tokens_multiple_regions():
     """Each budgeted region instance has its own per-state counter, so one grammar can contain
     multiple bounded regions with independent budgets."""
-    tokenizer_info = xgr.TokenizerInfo(_TB_VOCAB, stop_token_ids=[_TB_EOS])
+    tokenizer_info = xgr.TokenizerInfo(_BUDGET_VOCAB, stop_token_ids=[_tok("<eos>")])
     compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
-    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
 
     def think_tag(max_tokens):
         return {
@@ -708,51 +716,70 @@ def test_any_text_max_tokens_multiple_regions():
         "format": {"type": "sequence", "elements": [think_tag(1), think_tag(2)]},
     }
     cg = compiler.compile_structural_tag(stag)
-    assert _accepts(cg, [B, A, E1, E2, B, A, BB, E1, E2])
-    assert not _accepts(cg, [B, A, BB, E1, E2, B, A, E1, E2])  # first region over budget
-    assert not _accepts(cg, [B, A, E1, E2, B, A, BB, C, E1, E2])  # second region over budget
+    region1 = ["<think>", "a", "</", "think>"]  # 1 content token, at its budget
+    region2 = ["<think>", "a", "b", "</", "think>"]  # 2 content tokens, at its budget
+    assert _accepts(cg, *region1, *region2)
+    # first region over ITS budget (2 content tokens), even though region 2 would allow it
+    assert not _accepts(cg, *region2, *region1)
+    # second region over its budget (3 content tokens)
+    assert not _accepts(cg, *region1, "<think>", "a", "b", "c", "</", "think>")
 
 
 def test_any_text_max_chars_enforced():
     """max_chars counts Unicode characters: multi-char tokens consume more budget, and multi-byte
     (UTF-8) tokens consume one unit per character, not per byte."""
     _, cg = _think_budget_compiled(max_chars=3)
-    B, A, DE, ZH, E1, E2 = _TB_B, _TB_A, _TB_DE, _TB_ZH, _TB_E1, _TB_E2
-    assert _accepts(cg, [B, A, A, A, E1, E2])  # 3 chars
-    assert not _accepts(cg, [B, A, A, A, A, E1, E2])  # 4 chars
-    assert _accepts(cg, [B, DE, A, E1, E2])  # 2 + 1 = 3 chars
-    assert not _accepts(cg, [B, DE, DE, E1, E2])  # 4 chars
-    assert _accepts(cg, [B, ZH, ZH, ZH, E1, E2])  # 3 characters (9 bytes)
-    assert not _accepts(cg, [B, ZH, ZH, ZH, ZH, E1, E2])
-    assert _allowed(cg, [B, A, A, A], E1) is True
-    assert _allowed(cg, [B, A, A, A], A) is False
+    end = ["</", "think>"]
+    assert _accepts(cg, "<think>", "a", "b", "c", *end)  # 3 chars
+    assert not _accepts(cg, "<think>", "a", "b", "c", "a", *end)  # 4 chars
+    assert _accepts(cg, "<think>", "de", "a", *end)  # 2 + 1 = 3 chars
+    assert not _accepts(cg, "<think>", "de", "de", *end)  # 4 chars
+    assert _accepts(cg, "<think>", "中", "中", "中", *end)  # 3 characters (9 bytes)
+    assert not _accepts(cg, "<think>", "中", "中", "中", "中", *end)
+    assert _allowed(cg, ["<think>", "a", "b", "c"], "</") is True
+    assert _allowed(cg, ["<think>", "a", "b", "c"], "a") is False
     # the token mask near the boundary is exact: with 1 char remaining, a 1-char token is
     # allowed but a 2-char token is masked out
-    assert _mask_allows(cg, [B, A, A], A)
-    assert not _mask_allows(cg, [B, A, A], DE)
-    assert _mask_allows(cg, [B, A, A], E1)
-    assert not _mask_allows(cg, [B, A, A, A], A)
-    assert _mask_allows(cg, [B, A, A, A], E1)
+    assert _mask_allows(cg, ["<think>", "a", "b"], "a")
+    assert not _mask_allows(cg, ["<think>", "a", "b"], "de")
+    assert _mask_allows(cg, ["<think>", "a", "b"], "</")
+    assert not _mask_allows(cg, ["<think>", "a", "b", "c"], "a")
+    assert _mask_allows(cg, ["<think>", "a", "b", "c"], "</")
+
+
+def test_any_text_max_chars_hybrid_content_plus_end_tag_token():
+    """A token can spend the last budget characters as content and continue into the end tag
+    ("a</" = 1 char of content + the start of "</think>"). With 1 char remaining it must stay
+    allowed, while a pure 2-char content token must be masked out."""
+    _, cg = _think_budget_compiled(max_chars=2)
+    # 1 of 2 chars used, 1 remaining
+    assert _mask_allows(cg, ["<think>", "a"], "a</")
+    assert not _mask_allows(cg, ["<think>", "a"], "de")
+    assert _allowed(cg, ["<think>", "a"], "a</") is True
+    assert _accepts(cg, "<think>", "a", "a</", "think>")
+    # 2 of 2 chars used: even the hybrid token is over budget now
+    assert _mask_allows(cg, ["<think>", "a", "b"], "</")
+    assert not _mask_allows(cg, ["<think>", "a", "b"], "a</")
+    assert _allowed(cg, ["<think>", "a", "b"], "a</") is False
 
 
 def test_any_text_max_tokens_and_max_chars_combined():
     """When both budgets are set, both are enforced."""
     _, cg = _think_budget_compiled(max_tokens=2, max_chars=3)
-    B, A, DE, E1, E2 = _TB_B, _TB_A, _TB_DE, _TB_E1, _TB_E2
-    assert _accepts(cg, [B, DE, A, E1, E2])  # 2 tokens, 3 chars
-    assert not _accepts(cg, [B, A, A, A, E1, E2])  # 3 tokens > max_tokens
-    assert not _accepts(cg, [B, DE, DE, E1, E2])  # 4 chars > max_chars
+    end = ["</", "think>"]
+    assert _accepts(cg, "<think>", "de", "a", *end)  # 2 tokens, 3 chars
+    assert not _accepts(cg, "<think>", "a", "b", "c", *end)  # 3 tokens > max_tokens
+    assert not _accepts(cg, "<think>", "de", "de", *end)  # 4 chars > max_chars
 
 
 def test_any_text_budget_compiled_grammar_serialization_roundtrip():
     """The budget is part of the grammar, so serialized compiled grammars keep enforcing it."""
-    tokenizer_info = xgr.TokenizerInfo(_TB_VOCAB, stop_token_ids=[_TB_EOS])
+    tokenizer_info = xgr.TokenizerInfo(_BUDGET_VOCAB, stop_token_ids=[_tok("<eos>")])
     compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
     _, cg = _think_budget_compiled(max_tokens=2, compiler=compiler)
-    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
     recovered = xgr.CompiledGrammar.deserialize_json(cg.serialize_json(), tokenizer_info)
-    assert _accepts(recovered, [B, A, BB, E1, E2])
-    assert not _accepts(recovered, [B, A, BB, C, E1, E2])
+    assert _accepts(recovered, "<think>", "a", "b", "</", "think>")
+    assert not _accepts(recovered, "<think>", "a", "b", "c", "</", "think>")
 
 
 if __name__ == "__main__":

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -542,5 +542,218 @@ def test_tag_dispatch_perf(ebnf, input_str):
     print(f"Accept token: avg={statistics.mean(flat_accept):.2f} us, max={max(flat_accept):.2f} us")
 
 
+# ---------- any_text max_tokens / max_chars (region budgets) ----------
+
+# Synthetic vocab where the end tag "</think>" spans MULTIPLE tokens ("</" + "think>"), which is
+# exactly the case a byte-level any_text token budget must handle (AnyTokensFormat cannot, since
+# its excludes are single tokens). "de" is a 2-char token and "中" is a 1-char / 3-byte token,
+# used by the max_chars tests.
+_TB_VOCAB = ["<think>", "a", "b", "</", "think>", "c", "<eos>", "de", "中"]
+_TB_B, _TB_A, _TB_BB, _TB_E1, _TB_E2, _TB_C, _TB_EOS, _TB_DE, _TB_ZH = range(9)
+
+
+def _think_budget_compiled(max_tokens=None, max_chars=None, *, cache_enabled=True, compiler=None):
+    tokenizer_info = xgr.TokenizerInfo(_TB_VOCAB, stop_token_ids=[_TB_EOS])
+    compiler = compiler or xgr.GrammarCompiler(tokenizer_info, cache_enabled=cache_enabled)
+    content = {"type": "any_text", "excludes": ["</think>"]}
+    if max_tokens is not None:
+        content["max_tokens"] = max_tokens
+    if max_chars is not None:
+        content["max_chars"] = max_chars
+    stag = {
+        "type": "structural_tag",
+        "format": {"type": "tag", "begin": "<think>", "content": content, "end": "</think>"},
+    }
+    return compiler, compiler.compile_structural_tag(stag)
+
+
+def _accepts(compiled, tokens):
+    matcher = xgr.GrammarMatcher(compiled)
+    for t in tokens:
+        if not matcher.accept_token(t):
+            return False
+    return matcher.is_completed()
+
+
+def _allowed(compiled, prefix, token):
+    matcher = xgr.GrammarMatcher(compiled)
+    for t in prefix:
+        assert matcher.accept_token(t)
+    return matcher.accept_token(token)
+
+
+def _mask_allows(compiled, prefix, token):
+    matcher = xgr.GrammarMatcher(compiled)
+    for t in prefix:
+        assert matcher.accept_token(t)
+    bitmask = xgr.allocate_token_bitmask(1, len(_TB_VOCAB))
+    matcher.fill_next_token_bitmask(bitmask)
+    return token not in _get_masked_tokens_from_bitmask(bitmask, len(_TB_VOCAB))
+
+
+def test_any_text_max_tokens_forces_end_tag_not_eos():
+    """After N content tokens the bounded region is forced to END: only the (multi-token) end tag
+    is valid, content is rejected, and EOS is NOT allowed (the end tag is forced, not a stop)."""
+    _, cg = _think_budget_compiled(max_tokens=2)
+    B, A, BB, E1, E2, C, EOS = _TB_B, _TB_A, _TB_BB, _TB_E1, _TB_E2, _TB_C, _TB_EOS
+    assert _accepts(cg, [B, A, BB, E1, E2])  # 2 content tokens + end -> complete
+    assert _accepts(cg, [B, A, E1, E2])  # 1 content token
+    assert _accepts(cg, [B, E1, E2])  # 0 content tokens
+    assert not _accepts(cg, [B, A, BB, C, E1, E2])  # 3 content tokens exceeds budget
+    # at the budget, content is rejected but the end tag is allowed; EOS is not (region not done)
+    assert _allowed(cg, [B, A, BB], E1) is True
+    assert _allowed(cg, [B, A, BB], A) is False
+    assert _allowed(cg, [B, A, BB], EOS) is False
+    # the token mask agrees with accept_token
+    assert _mask_allows(cg, [B, A, BB], E1)
+    assert not _mask_allows(cg, [B, A, BB], A)
+    assert _mask_allows(cg, [B, A], A)  # budget not exhausted yet
+
+
+def test_any_text_max_tokens_zero_forces_immediate_end():
+    _, cg = _think_budget_compiled(max_tokens=0)
+    B, A, E1, E2 = _TB_B, _TB_A, _TB_E1, _TB_E2
+    assert _accepts(cg, [B, E1, E2])
+    assert _allowed(cg, [B], A) is False
+    assert _allowed(cg, [B], E1) is True
+
+
+def test_any_text_max_tokens_rollback_restores_budget():
+    """The budget counters live in the parser state history, so rollback restores them."""
+    _, cg = _think_budget_compiled(max_tokens=2)
+    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
+    matcher = xgr.GrammarMatcher(cg)
+    assert matcher.accept_token(B)
+    assert matcher.accept_token(A)
+    assert matcher.accept_token(BB)  # budget full
+    assert not matcher.accept_token(C)  # over budget
+    matcher.rollback(1)  # undo one content token
+    assert matcher.accept_token(C)  # budget restored: one content token allowed again
+    assert not matcher.accept_token(A)  # full again
+    assert matcher.accept_token(E1) and matcher.accept_token(E2)
+    assert matcher.is_completed()
+
+
+def test_any_text_max_tokens_fork_independent():
+    _, cg = _think_budget_compiled(max_tokens=2)
+    B, A, BB, C = _TB_B, _TB_A, _TB_BB, _TB_C
+    matcher = xgr.GrammarMatcher(cg)
+    assert matcher.accept_token(B) and matcher.accept_token(A)  # 1 content used
+    child = matcher.fork()
+    assert child.accept_token(BB)  # child uses its 2nd
+    assert not child.accept_token(C)  # child exhausted
+    assert matcher.accept_token(BB)  # parent budget independent, still has its 2nd
+
+
+def test_any_text_max_tokens_reset_restores_budget():
+    _, cg = _think_budget_compiled(max_tokens=1)
+    B, A, BB, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_E1, _TB_E2
+    matcher = xgr.GrammarMatcher(cg)
+    assert matcher.accept_token(B) and matcher.accept_token(A)
+    assert not matcher.accept_token(BB)
+    matcher.reset()
+    assert matcher.accept_token(B) and matcher.accept_token(A)
+    assert not matcher.accept_token(BB)
+    assert matcher.accept_token(E1) and matcher.accept_token(E2)
+    assert matcher.is_completed()
+
+
+def test_any_text_max_tokens_cache_no_staleness():
+    """Bounded and unbounded regions with the same excludes share the same (budget-agnostic)
+    cached masks; the budget is applied per state at runtime, so sharing is safe in BOTH
+    directions."""
+    tokenizer_info = xgr.TokenizerInfo(_TB_VOCAB, stop_token_ids=[_TB_EOS])
+    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
+    # compile the UNBOUNDED variant first to populate the FSM-hash cache
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=True)
+    _, cg_unbounded = _think_budget_compiled(compiler=compiler)
+    assert _accepts(cg_unbounded, [B, A, BB, C, A, E1, E2])  # 5 content tokens, no budget
+    # now the bounded variant (same excludes/FSM) must still enforce
+    _, cg_bounded = _think_budget_compiled(max_tokens=2, compiler=compiler)
+    assert _allowed(cg_bounded, [B, A, BB], A) is False
+    assert not _accepts(cg_bounded, [B, A, BB, C, E1, E2])
+    assert _accepts(cg_bounded, [B, A, BB, E1, E2])
+    # the reverse direction: a bounded variant cached first must not restrict the unbounded one
+    compiler2 = xgr.GrammarCompiler(tokenizer_info, cache_enabled=True)
+    _, cg_bounded2 = _think_budget_compiled(max_tokens=1, compiler=compiler2)
+    assert not _accepts(cg_bounded2, [B, A, BB, E1, E2])
+    _, cg_unbounded2 = _think_budget_compiled(compiler=compiler2)
+    assert _accepts(cg_unbounded2, [B, A, BB, C, A, E1, E2])
+
+
+def test_any_text_unbounded_no_regression():
+    _, cg = _think_budget_compiled()
+    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
+    # without a budget the region accepts arbitrarily many content tokens
+    assert _accepts(cg, [B, A, BB, C, A, BB, C, E1, E2])
+
+
+def test_any_text_max_tokens_multiple_regions():
+    """Each budgeted region instance has its own per-state counter, so one grammar can contain
+    multiple bounded regions with independent budgets."""
+    tokenizer_info = xgr.TokenizerInfo(_TB_VOCAB, stop_token_ids=[_TB_EOS])
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
+
+    def think_tag(max_tokens):
+        return {
+            "type": "tag",
+            "begin": "<think>",
+            "content": {"type": "any_text", "excludes": ["</think>"], "max_tokens": max_tokens},
+            "end": "</think>",
+        }
+
+    stag = {
+        "type": "structural_tag",
+        "format": {"type": "sequence", "elements": [think_tag(1), think_tag(2)]},
+    }
+    cg = compiler.compile_structural_tag(stag)
+    assert _accepts(cg, [B, A, E1, E2, B, A, BB, E1, E2])
+    assert not _accepts(cg, [B, A, BB, E1, E2, B, A, E1, E2])  # first region over budget
+    assert not _accepts(cg, [B, A, E1, E2, B, A, BB, C, E1, E2])  # second region over budget
+
+
+def test_any_text_max_chars_enforced():
+    """max_chars counts Unicode characters: multi-char tokens consume more budget, and multi-byte
+    (UTF-8) tokens consume one unit per character, not per byte."""
+    _, cg = _think_budget_compiled(max_chars=3)
+    B, A, DE, ZH, E1, E2 = _TB_B, _TB_A, _TB_DE, _TB_ZH, _TB_E1, _TB_E2
+    assert _accepts(cg, [B, A, A, A, E1, E2])  # 3 chars
+    assert not _accepts(cg, [B, A, A, A, A, E1, E2])  # 4 chars
+    assert _accepts(cg, [B, DE, A, E1, E2])  # 2 + 1 = 3 chars
+    assert not _accepts(cg, [B, DE, DE, E1, E2])  # 4 chars
+    assert _accepts(cg, [B, ZH, ZH, ZH, E1, E2])  # 3 characters (9 bytes)
+    assert not _accepts(cg, [B, ZH, ZH, ZH, ZH, E1, E2])
+    assert _allowed(cg, [B, A, A, A], E1) is True
+    assert _allowed(cg, [B, A, A, A], A) is False
+    # the token mask near the boundary is exact: with 1 char remaining, a 1-char token is
+    # allowed but a 2-char token is masked out
+    assert _mask_allows(cg, [B, A, A], A)
+    assert not _mask_allows(cg, [B, A, A], DE)
+    assert _mask_allows(cg, [B, A, A], E1)
+    assert not _mask_allows(cg, [B, A, A, A], A)
+    assert _mask_allows(cg, [B, A, A, A], E1)
+
+
+def test_any_text_max_tokens_and_max_chars_combined():
+    """When both budgets are set, both are enforced."""
+    _, cg = _think_budget_compiled(max_tokens=2, max_chars=3)
+    B, A, DE, E1, E2 = _TB_B, _TB_A, _TB_DE, _TB_E1, _TB_E2
+    assert _accepts(cg, [B, DE, A, E1, E2])  # 2 tokens, 3 chars
+    assert not _accepts(cg, [B, A, A, A, E1, E2])  # 3 tokens > max_tokens
+    assert not _accepts(cg, [B, DE, DE, E1, E2])  # 4 chars > max_chars
+
+
+def test_any_text_budget_compiled_grammar_serialization_roundtrip():
+    """The budget is part of the grammar, so serialized compiled grammars keep enforcing it."""
+    tokenizer_info = xgr.TokenizerInfo(_TB_VOCAB, stop_token_ids=[_TB_EOS])
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+    _, cg = _think_budget_compiled(max_tokens=2, compiler=compiler)
+    B, A, BB, C, E1, E2 = _TB_B, _TB_A, _TB_BB, _TB_C, _TB_E1, _TB_E2
+    recovered = xgr.CompiledGrammar.deserialize_json(cg.serialize_json(), tokenizer_info)
+    assert _accepts(recovered, [B, A, BB, E1, E2])
+    assert not _accepts(recovered, [B, A, BB, C, E1, E2])
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -44,7 +44,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v14"
+    assert xgr.get_serialization_version() == "v15"
 
 
 def test_serialize_grammar():
@@ -62,9 +62,11 @@ def test_serialize_grammar():
         "root_rule_id": 1,
         "complete_fsm": None,
         "per_rule_fsms": [],
+        "per_rule_budget_max_tokens": [],
+        "per_rule_budget_max_chars": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v14",
+        "__VERSION__": "v15",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -84,14 +86,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v14",
+        "__VERSION__": "v15",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v14"
+    expected_json["__VERSION__"] = "v15"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -143,7 +145,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v14"}'
+        '"__VERSION__":"v15"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -250,6 +252,8 @@ def test_serialize_compiled_grammar():
                 ]
             ],
             # fmt: on
+            "per_rule_budget_max_tokens": [],
+            "per_rule_budget_max_chars": [],
             "optimized": True,
         },
         "tokenizer_metadata": {
@@ -258,7 +262,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v14",
+        "__VERSION__": "v15",
     }
 
     class AdaptiveTokenMask(BaseModel):

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -3582,6 +3582,168 @@ root ::= ((any_tokens))
     )
 
 
+def test_any_tokens_format_max_tokens():
+    """max_tokens bounds the per-token star to {0, N} (an exact token-count budget)."""
+    check_stag_with_grammar(
+        {"type": "any_tokens", "exclude_tokens": [5, 10], "max_tokens": 3},
+        r"""any_tokens_inner ::= ((ExcludeToken(5, 10)))
+any_tokens ::= ((any_tokens_inner{0, 3}))
+root ::= ((any_tokens))
+""",
+    )
+
+
+def test_any_tokens_format_max_tokens_zero_grammar():
+    """max_tokens=0 produces a {0, 0} repetition (zero tokens), distinct from the unbounded star."""
+    check_stag_with_grammar(
+        {"type": "any_tokens", "exclude_tokens": [5], "max_tokens": 0},
+        r"""any_tokens_inner ::= ((ExcludeToken(5)))
+any_tokens ::= ((any_tokens_inner{0, 0}))
+root ::= ((any_tokens))
+""",
+    )
+
+
+def test_any_tokens_format_max_tokens_no_exclude_tokens_grammar():
+    """max_tokens applies even with an empty exclude set (ExcludeToken())."""
+    check_stag_with_grammar(
+        {"type": "any_tokens", "max_tokens": 2},
+        r"""any_tokens_inner ::= ((ExcludeToken()))
+any_tokens ::= ((any_tokens_inner{0, 2}))
+root ::= ((any_tokens))
+""",
+    )
+
+
+def test_any_tokens_format_max_tokens_none_uses_unbounded_star():
+    """When max_tokens is unset the grammar uses the unbounded star (NOT the {0, N} form)."""
+    from xgrammar.structural_tag import AnyTokensFormat
+
+    assert AnyTokensFormat(exclude_tokens=[5]).model_dump()["max_tokens"] is None
+    check_stag_with_grammar(
+        {"type": "any_tokens", "exclude_tokens": [5]},
+        r"""any_tokens_inner ::= ((ExcludeToken(5)))
+any_tokens ::= ("" | (any_tokens_inner any_tokens))
+root ::= ((any_tokens))
+""",
+    )
+
+
+def test_any_tokens_format_max_tokens_enforced():
+    """End-to-end: max_tokens=N accepts at most N tokens (each excluding exclude_tokens),
+    then the section must end. Each token counts exactly once."""
+    # raw vocab: a=0, b=1, c=2, X=3
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c", "X"])
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+    spec = {
+        "type": "structural_tag",
+        "format": {
+            "type": "sequence",
+            "elements": [
+                {"type": "any_tokens", "exclude_tokens": ["X"], "max_tokens": 2},
+                {"type": "const_string", "value": "X"},
+            ],
+        },
+    }
+    compiled = compiler.compile_structural_tag(spec)
+    A, B, C, X = 0, 1, 2, 3
+
+    def accepts(tokens):
+        matcher = xgr.GrammarMatcher(compiled)
+        for token_id in tokens:
+            if not matcher.accept_token(token_id):
+                return False
+        return matcher.is_completed()
+
+    assert accepts([X])  # 0 budget tokens, then end
+    assert accepts([A, X])  # 1 budget token
+    assert accepts([A, B, X])  # 2 budget tokens (budget full), then end
+    assert not accepts([A, B, C])  # 3rd budget token exceeds max_tokens -> rejected
+    assert not accepts([A, B, C, X])
+
+
+def test_any_tokens_max_tokens_inside_tag_grammar():
+    """AnyTokensFormat with max_tokens nested in a TagFormat with token begin/end: the parent
+    end token is auto-detected and folded into ExcludeToken while {0, N} is preserved."""
+    check_stag_with_grammar(
+        {
+            "type": "tag",
+            "begin": {"type": "token", "token": 1},
+            "content": {"type": "any_tokens", "exclude_tokens": [5], "max_tokens": 3},
+            "end": {"type": "token", "token": 99},
+        },
+        r"""any_tokens_inner ::= ((ExcludeToken(5, 99)))
+any_tokens ::= ((any_tokens_inner{0, 3}))
+tag ::= ((Token(1) any_tokens Token(99)))
+root ::= ((tag))
+""",
+    )
+
+
+def test_any_tokens_max_tokens_inside_tag_enforced():
+    """Think-style enforcement: end reachable after 0..N content tokens (early end allowed),
+    end forced once the budget is reached, and content cannot exceed N tokens."""
+    # vocab: B=0 (begin), x=1 (content), y=2 (content), E=3 (end)
+    tokenizer_info = xgr.TokenizerInfo(["<b>", "x", "y", "</e>"])
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+    spec = {
+        "type": "structural_tag",
+        "format": {
+            "type": "tag",
+            "begin": {"type": "token", "token": 0},
+            "content": {"type": "any_tokens", "exclude_tokens": [], "max_tokens": 3},
+            "end": {"type": "token", "token": 3},
+        },
+    }
+    compiled = compiler.compile_structural_tag(spec)
+    B, X, E = 0, 1, 3
+
+    def accepts(token_ids):
+        matcher = xgr.GrammarMatcher(compiled)
+        for token_id in token_ids:
+            if not matcher.accept_token(token_id):
+                return False
+        return matcher.is_completed()
+
+    assert accepts([B, E])  # 0 content tokens
+    assert accepts([B, X, E])  # 1 content token
+    assert accepts([B, X, X, X, E])  # exactly N=3 content tokens
+    assert not accepts([B, X, X, X, X, E])  # 4 content tokens > N
+
+    # end is FORCED once budget is reached
+    matcher = xgr.GrammarMatcher(compiled)
+    assert matcher.accept_token(B)
+    for _ in range(3):
+        assert matcher.accept_token(X)
+    assert not matcher.accept_token(X)  # 4th content token rejected
+    assert matcher.accept_token(E)  # only the end is allowed
+    assert matcher.is_completed()
+
+
+def test_any_tokens_format_max_tokens_invalid_raises():
+    """Invalid max_tokens values are rejected at grammar build, not silently ignored."""
+    for bad in [-1, "2", 2.5, 10**12]:
+        stag = {
+            "type": "structural_tag",
+            "format": {"type": "any_tokens", "exclude_tokens": [5], "max_tokens": bad},
+        }
+        with pytest.raises(Exception, match="non-negative integer"):
+            xgr.Grammar.from_structural_tag(stag)
+
+
+def test_any_tokens_format_max_tokens_roundtrip_json():
+    """Round-trip through the pydantic model preserves max_tokens and exclude_tokens."""
+    from xgrammar.structural_tag import AnyTokensFormat
+
+    m = AnyTokensFormat(exclude_tokens=[5, 10], max_tokens=3)
+    dumped = m.model_dump()
+    assert dumped["max_tokens"] == 3 and dumped["exclude_tokens"] == [5, 10]
+    m2 = AnyTokensFormat.model_validate_json(m.model_dump_json())
+    assert m2.max_tokens == 3 and m2.exclude_tokens == [5, 10]
+    with pytest.raises(Exception):
+        AnyTokensFormat(exclude_tokens=[5], max_tokens=-1)
+
+
 def test_any_tokens_detects_end_from_parent_tag():
     """AnyTokensFormat inside a tag with token end should auto-detect end token IDs."""
     check_stag_with_grammar(
@@ -4215,6 +4377,88 @@ def test_structural_tag_max_whitespace_cnt_compile_cache():
     g_bounded = compiler.compile_structural_tag(_ws_stag(max_whitespace_cnt=2)).grammar
     assert _is_grammar_accept_string(g_unbounded, _ws_instance(5))
     assert not _is_grammar_accept_string(g_bounded, _ws_instance(5))
+
+
+def test_any_text_budget_builds_tag_dispatch():
+    """A budgeted any_text (with or without excludes) compiles to a TagDispatch carrying the
+    budget; the budget itself is enforced by the matcher (see
+    test_grammar_matcher_structural_tag)."""
+    check_stag_with_grammar(
+        {"type": "any_text", "excludes": ["</think>"], "max_tokens": 4},
+        r"""any_text ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</think>"),
+  max_tokens=4
+)
+root ::= ((any_text))
+""",
+    )
+    check_stag_with_grammar(
+        {"type": "any_text", "max_tokens": 4, "max_chars": 100},
+        r"""any_text ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=(),
+  max_tokens=4,
+  max_chars=100
+)
+root ::= ((any_text))
+""",
+    )
+    # unbounded no-excludes stays a plain character-class star (no regression)
+    check_stag_with_grammar(
+        {"type": "any_text"},
+        r"""any_text ::= (([\0-\U0010ffff]*))
+root ::= ((any_text))
+""",
+    )
+
+
+def test_any_text_budget_roundtrips_through_ebnf():
+    """The printed TagDispatch(max_tokens=..., max_chars=...) form can be re-parsed."""
+    grammar = xgr.Grammar.from_structural_tag(
+        {
+            "type": "structural_tag",
+            "format": {
+                "type": "any_text",
+                "excludes": ["</think>"],
+                "max_tokens": 4,
+                "max_chars": 9,
+            },
+        }
+    )
+    reparsed = xgr.Grammar.from_ebnf(str(grammar))
+    assert "max_tokens=4" in str(reparsed)
+    assert "max_chars=9" in str(reparsed)
+
+
+def test_any_text_budget_model_roundtrip():
+    from xgrammar.structural_tag import AnyTextFormat
+
+    model = AnyTextFormat(excludes=["</think>"], max_tokens=8, max_chars=32)
+    dumped = model.model_dump()
+    assert dumped["max_tokens"] == 8 and dumped["max_chars"] == 32
+    recovered = AnyTextFormat.model_validate_json(model.model_dump_json())
+    assert recovered.max_tokens == 8 and recovered.max_chars == 32
+    # unset -> None (unbounded), distinct from 0
+    assert AnyTextFormat(excludes=["</think>"]).model_dump()["max_tokens"] is None
+    assert AnyTextFormat(excludes=["</think>"]).model_dump()["max_chars"] is None
+
+
+@pytest.mark.parametrize("bad", [-1, "2", 2.5, 10**12])
+@pytest.mark.parametrize("field", ["max_tokens", "max_chars"])
+def test_any_text_budget_invalid_raises(bad, field):
+    stag = {"type": "structural_tag", "format": {"type": "any_text", field: bad}}
+    with pytest.raises(Exception):
+        xgr.Grammar.from_structural_tag(stag)
+
+
+def test_any_text_budget_negative_rejected_by_pydantic():
+    from xgrammar.structural_tag import AnyTextFormat
+
+    with pytest.raises(Exception):
+        AnyTextFormat(excludes=["</think>"], max_tokens=-1)
+    with pytest.raises(Exception):
+        AnyTextFormat(excludes=["</think>"], max_chars=-1)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -3632,8 +3632,8 @@ root ::= ((any_tokens))
 def test_any_tokens_format_max_tokens_enforced():
     """End-to-end: max_tokens=N accepts at most N tokens (each excluding exclude_tokens),
     then the section must end. Each token counts exactly once."""
-    # raw vocab: a=0, b=1, c=2, X=3
-    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c", "X"])
+    vocab = ["a", "b", "c", "X"]  # "X" ends the section; the rest are content tokens
+    tokenizer_info = xgr.TokenizerInfo(vocab)
     compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
     spec = {
         "type": "structural_tag",
@@ -3646,20 +3646,19 @@ def test_any_tokens_format_max_tokens_enforced():
         },
     }
     compiled = compiler.compile_structural_tag(spec)
-    A, B, C, X = 0, 1, 2, 3
 
-    def accepts(tokens):
+    def accepts(*tokens):
         matcher = xgr.GrammarMatcher(compiled)
-        for token_id in tokens:
-            if not matcher.accept_token(token_id):
+        for token in tokens:
+            if not matcher.accept_token(vocab.index(token)):
                 return False
         return matcher.is_completed()
 
-    assert accepts([X])  # 0 budget tokens, then end
-    assert accepts([A, X])  # 1 budget token
-    assert accepts([A, B, X])  # 2 budget tokens (budget full), then end
-    assert not accepts([A, B, C])  # 3rd budget token exceeds max_tokens -> rejected
-    assert not accepts([A, B, C, X])
+    assert accepts("X")  # 0 budget tokens, then end
+    assert accepts("a", "X")  # 1 budget token
+    assert accepts("a", "b", "X")  # 2 budget tokens (budget full), then end
+    assert not accepts("a", "b", "c")  # 3rd budget token exceeds max_tokens -> rejected
+    assert not accepts("a", "b", "c", "X")
 
 
 def test_any_tokens_max_tokens_inside_tag_grammar():
@@ -3683,40 +3682,39 @@ root ::= ((tag))
 def test_any_tokens_max_tokens_inside_tag_enforced():
     """Think-style enforcement: end reachable after 0..N content tokens (early end allowed),
     end forced once the budget is reached, and content cannot exceed N tokens."""
-    # vocab: B=0 (begin), x=1 (content), y=2 (content), E=3 (end)
-    tokenizer_info = xgr.TokenizerInfo(["<b>", "x", "y", "</e>"])
+    vocab = ["<b>", "x", "y", "</e>"]  # begin token, two content tokens, end token
+    tokenizer_info = xgr.TokenizerInfo(vocab)
     compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
     spec = {
         "type": "structural_tag",
         "format": {
             "type": "tag",
-            "begin": {"type": "token", "token": 0},
+            "begin": {"type": "token", "token": vocab.index("<b>")},
             "content": {"type": "any_tokens", "exclude_tokens": [], "max_tokens": 3},
-            "end": {"type": "token", "token": 3},
+            "end": {"type": "token", "token": vocab.index("</e>")},
         },
     }
     compiled = compiler.compile_structural_tag(spec)
-    B, X, E = 0, 1, 3
 
-    def accepts(token_ids):
+    def accepts(*tokens):
         matcher = xgr.GrammarMatcher(compiled)
-        for token_id in token_ids:
-            if not matcher.accept_token(token_id):
+        for token in tokens:
+            if not matcher.accept_token(vocab.index(token)):
                 return False
         return matcher.is_completed()
 
-    assert accepts([B, E])  # 0 content tokens
-    assert accepts([B, X, E])  # 1 content token
-    assert accepts([B, X, X, X, E])  # exactly N=3 content tokens
-    assert not accepts([B, X, X, X, X, E])  # 4 content tokens > N
+    assert accepts("<b>", "</e>")  # 0 content tokens
+    assert accepts("<b>", "x", "</e>")  # 1 content token
+    assert accepts("<b>", "x", "x", "x", "</e>")  # exactly N=3 content tokens
+    assert not accepts("<b>", "x", "x", "x", "x", "</e>")  # 4 content tokens > N
 
     # end is FORCED once budget is reached
     matcher = xgr.GrammarMatcher(compiled)
-    assert matcher.accept_token(B)
+    assert matcher.accept_token(vocab.index("<b>"))
     for _ in range(3):
-        assert matcher.accept_token(X)
-    assert not matcher.accept_token(X)  # 4th content token rejected
-    assert matcher.accept_token(E)  # only the end is allowed
+        assert matcher.accept_token(vocab.index("x"))
+    assert not matcher.accept_token(vocab.index("x"))  # 4th content token rejected
+    assert matcher.accept_token(vocab.index("</e>"))  # only the end is allowed
     assert matcher.is_completed()
 
 


### PR DESCRIPTION
## Support region budgets (`max_tokens` / `max_chars`) in structural-tag free-form regions

### Purpose

Enable a **think budget**: cap how much a model may emit inside an unbounded region of a structural tag (e.g. a `<think>…</think>` reasoning span). This adds:

- `AnyTokensFormat.max_tokens`: bound the number of tokens of a token-level region.
- `AnyTextFormat.max_tokens`: bound the number of **whole tokens** of a byte-level region. Composes with multi-token `excludes` / end markers (e.g. a `</think>` that spans several tokens).
- `AnyTextFormat.max_chars`: bound the number of **Unicode characters** of a byte-level region.

All budgets are opt-in; unset means unbounded (unchanged behavior).

### Design: budgets are per-parser-state counters

The guiding principle is the same one `kRepeat` already uses: **context that affects matching lives in the `ParserState`, not in side channels**, so that the token mask cache contract — masks are a function of the position only; context is encoded by which states are live, with parent-dependent tokens resolved by the uncertain live-check — keeps holding.

- `AnyTokensFormat.max_tokens` is simply lowered to the existing bounded repetition: `any_tokens ::= any_tokens_inner{0, N}`. No parser changes at all.
- `AnyTextFormat.max_tokens` / `max_chars` are carried on the `TagDispatch` grammar expr. The matcher bumps a per-state token counter at each whole-token boundary (reusing `repeat_count`, which trigger-less TagDispatch rules never use), and `AdvanceFsm` counts characters and refuses to consume further bytes once a state's budget is exhausted — a pure function of state + grammar.

Because the counters live in the parser state and the cached adaptive token masks stay **budget-agnostic** (the budget is applied per state at mask-fill time):

- **Rollback / fork / reset** restore the counters automatically with the state history — no parallel bookkeeping.
- **The rule-level (FSM-hash) cross-grammar cache stays enabled** and is shared between bounded and unbounded regions, in both directions, with no staleness by construction.
- **Multiple budgeted regions per grammar** (and re-entry) work, each region instance counts independently.
- **Performance**: while budget remains, mask fill uses exactly the unbounded fast paths (TagDispatch fast-accept, second slicing, speculative calculation). For `max_tokens` there is *no* slow step at all (an exhausted region state is simply skipped; the end tag comes from the already-scanable parent states). For `max_chars` only the last `max-token-char-count` characters of the region take an exact boundary path that starts from the cached mask and only re-simulates the few candidates that may straddle the boundary (see the measurements below).
- **Serialization**: the budget is part of the grammar; serialized compiled grammars keep enforcing it. The serialization version is bumped (`v14` → `v15`) since the `kTagDispatch` expr layout gains two trailing fields.

### Behavior

- A bounded `any_text` (with or without `excludes`) compiles to a `TagDispatch` carrying the budgets; an unbounded, no-excludes `any_text` still lowers to a plain character-class star (no regression).
- When a budget is reached, the region is forced to end: its enclosing end tag becomes the only valid continuation (not EOS).
- The token budget is atomic at token granularity; a token only counts against a region that already existed before that token (a token that *enters* the region, e.g. ends with the begin tag, does not consume budget).
- `max_chars` counts Unicode codepoints (UTF-8 continuation bytes are free).
- Budgets round-trip through the pydantic models, JSON, and the printed EBNF (`TagDispatch(..., max_tokens=N, max_chars=M)`).

### Performance measurements

Benchmarked against pre-PR `main` (each in its own worktree, release build) with the Llama-3.1-8B tokenizer (128k vocab), feeding a ~2000-token / ~8.2k-char reasoning text through a `<think>…</think>` structural tag, plus regression workloads that use no budgets at all. Per-step `fill_next_token_bitmask` latency (us):

| workload | pre-PR mean / p50 / p99 | this PR mean / p50 / p99 |
| --- | --- | --- |
| think region, unbounded | 1.90 / 1.88 / 2.06 | 1.90 / 1.86 / 2.72 |
| builtin `deepseek_r1` + tools (no budget) | 1.93 / 1.88 / 2.09 | 1.92 / 1.86 / 2.11 |
| complex JSON schema (no budget) | 9.86 / 2.62 / 37.8 | 9.54 / 2.65 / 38.1 |

`accept_token` (~0.8 us) and grammar compile times (interleaved A/B, 10 reps: JSON schema 9.19 vs 9.19 ms, `deepseek_r1` 12.86 vs 13.03 ms, think tag 2.54 vs 2.47 ms) show no measurable difference either, i.e. **no regression for unbudgeted grammars**.

For the budgets themselves:

- `max_tokens=N`: in-region steps are identical to unbounded (1.91 vs 1.90 us mean); the forced-end-tag steps after exhaustion are *faster* (~1.5 us, the region state is skipped and only the end tag remains). No compile-time change (mask entries are shared with the unbounded variant).
- `max_chars=M`: in-region steps are identical to unbounded until the remaining budget drops below the max token character count (128 for this vocab, i.e. the last ~84 of 2000 steps here). Those boundary steps take p50 ≈ 11 us / p90 ≈ 38 us, with only the very last steps (< 10 chars remaining) reaching ~0.5–1.7 ms. A one-time per-`CompiledGrammar` char-count table (~1.4 ms for a 128k vocab) is built lazily and shared across matchers/forks.

The boundary path was additionally cross-validated for correctness on the 128k vocab: at sampled steps inside and outside the `max_chars` boundary window, the generated bitmask was compared bit-by-bit against per-token `accept_token` ground truth over the whole vocab. This caught (and the PR fixes) a mask/accept mismatch: with the kRejected mask store type (common at large vocabs), the boundary handler reconstructed the accepted set as all-ones minus rejected/uncertain, wrongly including token ids outside the sorted vocab — e.g. **EOS could leak into the mask near the char budget boundary** (while `accept_token` correctly rejected it). The reconstruction now clears special/stop/out-of-vocab ids, and a >1000-token-vocab regression test forces the non-kAccepted store types and asserts EOS stays masked through and at the boundary.

### Tests

- Converter: TagDispatch construction for bounded regions, `{0, N}` lowering for `any_tokens`, unbounded no-regression, EBNF/pydantic/JSON round-trips, invalid-value rejection.
- Matcher: budget enforcement with a multi-token end tag (forced end tag, not EOS), zero budgets, rollback/fork/reset, bidirectional compiler-cache sharing, multiple bounded regions in one grammar, `max_chars` with multi-char and multi-byte (UTF-8) tokens, hybrid content-plus-end-tag tokens at the boundary, no EOS leak into the boundary mask with a large (>1000-token) vocab, combined `max_tokens`+`max_chars`, compiled-grammar serialization round-trip.
- All existing suites pass (converter, matchers, builtin structural tags, serialization, C++ tests), also with `XGRAMMAR_ENABLE_INTERNAL_CHECK=ON`.

