### PR TITLE
fix: escape control characters in XML tool-calling property names

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2496,6 +2496,27 @@ std::string JSONSchemaConverter::JSONStrToPrintableStr(const std::string& json_s
   return result;
 }
 
+std::string JSONSchemaConverter::EscapeStringForEBNFLiteral(const std::string& str) {
+  static const char* kHexDigits = "0123456789abcdef";
+  std::string result;
+  result.reserve(str.size());
+  for (char ch : str) {
+    unsigned char c = static_cast<unsigned char>(ch);
+    if (c == '"') {
+      result += "\\\"";
+    } else if (c == '\\') {
+      result += "\\\\";
+    } else if (c < 0x20 || c == 0x7f) {
+      result += "\\u00";
+      result += kHexDigits[(c >> 4) & 0xf];
+      result += kHexDigits[c & 0xf];
+    } else {
+      result += ch;
+    }
+  }
+  return result;
+}
+
 bool JSONSchemaConverter::StringSpecKey::operator==(const StringSpecKey& other) const {
   return pattern == other.pattern && min_length == other.min_length &&
          max_length == other.max_length && wrapper == other.wrapper;

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -451,6 +451,15 @@ class JSONSchemaConverter {
   static std::string JSONStrToPrintableStr(const std::string& json_str);
 
  protected:
+  // Escape `str` (no surrounding quotes added) so it can be placed inside an
+  // EBNF string literal ("...") and match those exact raw bytes: escapes the
+  // EBNF metacharacters " and \, and any control byte (which would otherwise
+  // terminate the literal early, e.g. a newline) as \u00XX, leaving every other
+  // byte -- including '/' and UTF-8 -- verbatim. Used by the tool-calling
+  // subclasses that emit the property key as raw (non-JSON) text between
+  // format-specific delimiters.
+  static std::string EscapeStringForEBNFLiteral(const std::string& str);
+
   static std::optional<std::string> JSONFormatToRegexPattern(const std::string& format);
 
   // Expose for testing

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -230,7 +230,12 @@ std::string XMLToolCallingConverter::GenerateEnum(
 
 std::string XMLToolCallingConverter::FormatPropertyKey(const std::string& key) {
   if (nested_object_level_ <= 1) {
-    return "\"" + xml_wrapper_.key_wrapper_prefix + key + xml_wrapper_.key_wrapper_suffix + "\"";
+    // The key is emitted as raw text inside the XML wrapper, so escape it for the
+    // EBNF string literal; a control character such as a newline would otherwise
+    // terminate the literal and abort grammar compilation. The wrappers are
+    // pre-built EBNF fragments and must be left as-is.
+    return "\"" + xml_wrapper_.key_wrapper_prefix + EscapeStringForEBNFLiteral(key) +
+           xml_wrapper_.key_wrapper_suffix + "\"";
   }
   return JSONSchemaConverter::FormatPropertyKey(key);
 }
@@ -240,13 +245,13 @@ std::string XMLToolCallingConverter::FormatProperty(
 ) {
   if (nested_object_level_ <= 1) {
     std::string whitespace = GetWhitespacePattern();
+    std::string key_tag = FormatPropertyKey(key);
     if (!xml_wrapper_.value_wrapper_prefix.empty()) {
-      return "\"" + xml_wrapper_.key_wrapper_prefix + key + xml_wrapper_.key_wrapper_suffix +
-             "\" " + whitespace + " \"" + xml_wrapper_.value_wrapper_prefix + "\" " + whitespace +
-             " " + value_rule + " " + whitespace + " \"" + xml_wrapper_.parameter_suffix + "\"";
+      return key_tag + " " + whitespace + " \"" + xml_wrapper_.value_wrapper_prefix + "\" " +
+             whitespace + " " + value_rule + " " + whitespace + " \"" +
+             xml_wrapper_.parameter_suffix + "\"";
     }
-    return "\"" + xml_wrapper_.key_wrapper_prefix + key + xml_wrapper_.key_wrapper_suffix + "\" " +
-           whitespace + " " + value_rule + " " + whitespace + " \"" +
+    return key_tag + " " + whitespace + " " + value_rule + " " + whitespace + " \"" +
            xml_wrapper_.parameter_suffix + "\"";
   }
   return JSONSchemaConverter::FormatProperty(key, value_rule, rule_name, idx);

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -1366,5 +1366,34 @@ def test_true_schema():
     assert not _is_grammar_accept_string(ebnf_grammar, "anything")
 
 
+def test_control_character_in_property_name_qwen():
+    # A property name containing a control character (here a newline) must be
+    # escaped before being embedded in the EBNF string literal. Previously the
+    # XML converters emitted the raw key, so the newline terminated the string
+    # literal mid-token and aborted grammar compilation with
+    # "EBNF lexer error ... Expect \" in string literal".
+    schema = {"type": "object", "properties": {"a\nb": {"type": "string"}}, "required": ["a\nb"]}
+    ebnf_grammar = _qwen_xml_tool_calling_to_ebnf(schema)  # must not raise
+    # Qwen emits the key verbatim in the tag, so the newline is matched literally.
+    check_grammar_with_instance(ebnf_grammar, "<parameter=a\nb>hello</parameter>", True)
+    check_grammar_with_instance(ebnf_grammar, "<parameter=ab>hello</parameter>", False)
+
+
+@pytest.mark.parametrize(
+    "to_ebnf",
+    [
+        _qwen_xml_tool_calling_to_ebnf,
+        _minimax_xml_tool_calling_to_ebnf,
+        _deepseek_xml_tool_calling_to_ebnf,
+        _glm_xml_tool_calling_to_ebnf,
+    ],
+)
+def test_control_character_in_property_name_compiles(to_ebnf):
+    # Every XML tool-calling style must escape control characters in a property
+    # name so grammar compilation never aborts on the raw key.
+    schema = {"type": "object", "properties": {"a\nb": {"type": "string"}}, "required": ["a\nb"]}
+    to_ebnf(schema)  # previously raised an EBNF lexer error
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
# Changes

The Qwen/MiniMax/DeepSeek/GLM XML tool-calling converters emit a parameter name as raw text inside an EBNF string literal (`XMLToolCallingConverter`'s `FormatPropertyKey/FormatProperty`), unlike the base converter which serializes the key. A control character in a parameter name (e.g. a newline) therefore terminated the EBNF string literal mid-token and aborted grammar compilation with `"EBNF lexer error ... Expect \" in string literal"`.

Add `JSONSchemaConverter::EscapeStringForEBNFLiteral` (escapes `"` and `\`, and any control byte as `\u00XX`; leaves `'/'` and UTF-8 verbatim) and apply it to the raw-key sites in `XMLToolCallingConverter.` The XML wrappers are pre-built EBNF fragments and are left untouched, so output is byte-identical for keys without special characters. Adds regression tests for all four XML styles.