### PR TITLE
feat: warn when apply_token_bitmask_inplace leaves logits unmasked (undersized bitmask)

### DIFF
--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -88,7 +88,11 @@ def apply_token_bitmask_inplace(
         will be applied to logits[..., :vocab_size] and bitmask[..., :ceil(vocab_size / 32)].
 
         If vocab_size is not provided, the vocab size will be detected as min(logits.shape[-1],
-        bitmask.shape[-1] * 32).
+        bitmask.shape[-1] * 32). In this case, if the bitmask covers fewer tokens than
+        logits.shape[-1], the trailing logits are left unmasked and out-of-grammar tokens there
+        (e.g. padded/reserved vocabulary ids) can still be sampled, which may cause the sampled
+        token to be rejected downstream. Allocate the bitmask with the model's full (padded)
+        vocabulary size to avoid this. A warning is emitted when this mismatch is detected.
 
     Indices:
         Indices can be used to specify which logits in the batch to apply the bitmask to. It is
@@ -145,6 +149,20 @@ def apply_token_bitmask_inplace(
             "logits and bitmask should be on the same device. "
             + f"But got logits.device: {logits.device}, bitmask.device: {bitmask.device}"
         )
+
+    if vocab_size is None:
+        masked_width = bitmask.shape[-1] * 32
+        if masked_width < logits.shape[-1]:
+            warnings.warn(
+                f"The bitmask covers fewer tokens (bitmask.shape[-1] * 32 = {masked_width}) than "
+                f"the logits (logits.shape[-1] = {logits.shape[-1]}). Only logits[..., "
+                f":{masked_width}] will be masked; logits[..., {masked_width}:] are left unmasked, "
+                "so out-of-grammar tokens there (e.g. padded/reserved vocabulary ids) can still be "
+                "sampled. Allocate the bitmask with the model's full (padded) vocabulary size so it "
+                "covers every logit. To intentionally mask only a prefix, pass vocab_size = your "
+                "real (unpadded) vocab size, which must be <= bitmask.shape[-1] * 32.",
+                stacklevel=2,
+            )
 
     if backend == "auto":
         if logits.device.type == "cpu":

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -154,13 +154,9 @@ def apply_token_bitmask_inplace(
         masked_width = bitmask.shape[-1] * 32
         if masked_width < logits.shape[-1]:
             warnings.warn(
-                f"The bitmask covers fewer tokens (bitmask.shape[-1] * 32 = {masked_width}) than "
-                f"the logits (logits.shape[-1] = {logits.shape[-1]}). Only logits[..., "
-                f":{masked_width}] will be masked; logits[..., {masked_width}:] are left unmasked, "
-                "so out-of-grammar tokens there (e.g. padded/reserved vocabulary ids) can still be "
-                "sampled. Allocate the bitmask with the model's full (padded) vocabulary size so it "
-                "covers every logit. To intentionally mask only a prefix, pass vocab_size = your "
-                "real (unpadded) vocab size, which must be <= bitmask.shape[-1] * 32.",
+                f"The bitmask covers only {masked_width} tokens but logits have "
+                f"{logits.shape[-1]}, so logits[..., {masked_width}:] are left unmasked. "
+                "Allocate the bitmask with the full vocab size, or pass vocab_size explicitly.",
                 stacklevel=2,
             )
 

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -2,6 +2,7 @@
 
 import sys
 import time
+import warnings
 from typing import Callable, List, Optional, Tuple
 
 import pytest
@@ -430,6 +431,70 @@ def test_apply_token_bitmask_inplace_indices_bf16(
 
     kernel(logits, bitmask, indices=indices)
     torch.testing.assert_close(logits, logits_expected)
+
+
+def _assert_no_undersized_warning(logits, bitmask, **kwargs):
+    """apply_token_bitmask_inplace must not emit the undersized-bitmask warning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        xgr.apply_token_bitmask_inplace(logits, bitmask, **kwargs)
+    footgun = [
+        w
+        for w in caught
+        if issubclass(w.category, UserWarning) and "left unmasked" in str(w.message)
+    ]
+    assert not footgun, [str(w.message) for w in footgun]
+
+
+def test_apply_token_bitmask_inplace_warns_on_undersized_bitmask():
+    # Regression for the crash class in mlc-ai/xgrammar#611: when the bitmask covers fewer
+    # tokens than the logits width and vocab_size is not given, the auto-detected vocab size is
+    # min(logits.shape[-1], bitmask.shape[-1] * 32), so the trailing logits are left unmasked and
+    # out-of-grammar tokens there (e.g. padded/reserved vocabulary ids) can still be sampled. Warn.
+    logits = torch.ones(1, 70, dtype=torch.float32)
+    bitmask = xgr.allocate_token_bitmask(1, 40)  # ceil(40 / 32) = 2 blocks -> 64 bits < 70
+    assert bitmask.shape[-1] * 32 == 64
+    bitmask.fill_(0)  # reject every token the bitmask covers
+
+    with pytest.warns(UserWarning, match="left unmasked"):
+        xgr.apply_token_bitmask_inplace(logits, bitmask)
+
+    # Masking behavior is unchanged: only logits[..., :64] is masked; the tail stays finite.
+    assert torch.isinf(logits[0, :64]).all()
+    assert torch.isfinite(logits[0, 64:]).all()
+
+
+def test_apply_token_bitmask_inplace_warns_on_undersized_bitmask_batched():
+    # The check keys on the vocab dimension (shape[-1]), so batch size is irrelevant.
+    logits = torch.ones(4, 70, dtype=torch.float32)
+    bitmask = xgr.allocate_token_bitmask(4, 40)  # 64 bits < 70
+    bitmask.fill_(0)
+
+    with pytest.warns(UserWarning, match="left unmasked"):
+        xgr.apply_token_bitmask_inplace(logits, bitmask)
+
+    assert torch.isinf(logits[:, :64]).all()
+    assert torch.isfinite(logits[:, 64:]).all()
+
+
+@pytest.mark.parametrize("bitmask_vocab", (96, 64))  # wider than, and exactly covering, 64 logits
+def test_apply_token_bitmask_inplace_no_warn_when_bitmask_covers_logits(bitmask_vocab: int):
+    logits = torch.ones(1, 64, dtype=torch.float32)
+    bitmask = xgr.allocate_token_bitmask(1, bitmask_vocab)
+    assert bitmask.shape[-1] * 32 >= logits.shape[-1]  # boundary: no warning at exact equality
+    bitmask.fill_(0)
+    _assert_no_undersized_warning(logits, bitmask)
+    assert torch.isinf(logits).all()
+
+
+def test_apply_token_bitmask_inplace_no_warn_when_vocab_size_given():
+    # Passing vocab_size explicitly opts into masking only that prefix; do not warn.
+    logits = torch.ones(1, 70, dtype=torch.float32)
+    bitmask = xgr.allocate_token_bitmask(1, 40)  # 64 bits < 70
+    bitmask.fill_(0)
+    _assert_no_undersized_warning(logits, bitmask, vocab_size=40)
+    assert torch.isinf(logits[0, :40]).all()
+    assert torch.isfinite(logits[0, 40:]).all()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Addresses the crash class reported in #611 (and upstream mlc-ai/web-llm#807).

`apply_token_bitmask_inplace(logits, bitmask)` auto-detects the vocab size as
`min(logits.shape[-1], bitmask.shape[-1] * 32)` when `vocab_size` is not passed. If the bitmask
is narrower than the logits, the trailing logits `[bitmask.shape[-1] * 32, logits.shape[-1])` are
**silently left unmasked**, so out-of-grammar tokens there (e.g. padded/reserved vocabulary ids)
can still be sampled and are then rejected/aborted by the matcher.

This is exactly what happens in #611: a caller allocates the bitmask with the tokenizer length
(Qwen3 = 151669) while the model emits logits of the padded width (151936). Token id 151757 sits
in the unmasked tail, gets sampled, and triggers `Invalid token id 151757 for GrammarMatcher` /
`Grammar matcher rejected the newly sampled token`.

Minimal repro:

```python
import torch, xgrammar as xgr

logits = torch.ones(1, 151936)                   # model's padded logit width
bitmask = xgr.allocate_token_bitmask(1, 151669)  # sized from tokenizer length (the bug)
bitmask.fill_(0)
xgr.apply_token_bitmask_inplace(logits, bitmask)
assert torch.isfinite(logits[0, 151757])         # reserved id left unmasked -> sampleable
```

## Change

- Emit a `UserWarning` from `apply_token_bitmask_inplace` when `vocab_size is None` **and**
  `bitmask.shape[-1] * 32 < logits.shape[-1]`, pointing the caller to size the bitmask to the
  model's full (padded) vocabulary (or pass the real, unpadded `vocab_size` to intentionally mask
  only a prefix).
- Document the pitfall in the "Padding" note of the docstring.

**No change to masking behavior.** The "logits wider than bitmask" path is intentionally supported
and left untouched; the warning is purely diagnostic and is skipped when `vocab_size` is passed
explicitly. It fires at most once per call site per process (Python's default warning dedup), and
keys only on the vocab dimension, so dynamic batch sizes do not defeat the dedup.

## Tests

Added to `tests/python/test_token_bitmask_operations.py`:

- `test_apply_token_bitmask_inplace_warns_on_undersized_bitmask` and `..._batched` — warns, and
  masking is unchanged (the tail stays finite).
- `test_apply_token_bitmask_inplace_no_warn_when_bitmask_covers_logits` (parametrized over wider /
  exactly-covering) — no warning at or above exact coverage.
- `test_apply_token_bitmask_inplace_no_warn_when_vocab_size_given` — explicit `vocab_size`
  suppresses the warning.

All pass on the CPU backend.

## Open question for maintainers

Since the wider-logits path is a supported feature, I kept this as a **diagnostic warning only**.
If you'd prefer it be doc-only, or gated behind an opt-in strict flag / opt-out kwarg, I'm happy to
adjust.
