### PR TITLE
fix(structural_tag): fix several models with `tool_choice="required"` to terminate instead of looping.

### DIFF
--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -625,7 +625,12 @@ def get_llama_structural_tag(
                 )
             )
         assert len(tags) > 0
-        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
+        suffix_tag = TriggeredTagsFormat(
+            triggers=[TOOLS_TRIGGER],
+            tags=tags,
+            excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
+            at_least_one=True,
+        )
 
     return StructuralTag(format=suffix_tag)
 
@@ -1113,7 +1118,12 @@ def get_qwen_3_5_structural_tag(
             )
 
         assert len(tags) > 0
-        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True)
+        suffix_tag = TriggeredTagsFormat(
+            triggers=[TOOL_CALL_TRIGGER],
+            tags=tags,
+            excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
+            at_least_one=True,
+        )
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)
@@ -1238,7 +1248,12 @@ def get_qwen_3_structural_tag(
             )
 
         assert len(tags) > 0
-        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True)
+        suffix_tag = TriggeredTagsFormat(
+            triggers=[TOOL_CALL_TRIGGER],
+            tags=tags,
+            excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
+            at_least_one=True,
+        )
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)
@@ -1919,7 +1934,12 @@ def _get_gemma_4_structural_tag(
                 )
             )
         assert len(tags) > 0
-        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
+        suffix_tag = TriggeredTagsFormat(
+            triggers=[TOOL_CALL_TRIGGER],
+            tags=tags,
+            excludes=_text_excludes(exclude_special_tokens, GEMMA4_EXCLUDE_TOKENS),
+            at_least_one=True,
+        )
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -1781,7 +1781,12 @@ def get_glm_4_7_structural_tag(
                 )
             )
         assert len(tags) > 0
-        suffix_tag = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
+        suffix_tag = TriggeredTagsFormat(
+            triggers=[TOOL_CALL_TRIGGER],
+            tags=tags,
+            excludes=_text_excludes(exclude_special_tokens, TEXT_EXCLUDES),
+            at_least_one=True,
+        )
 
     if not reasoning:
         return StructuralTag(format=suffix_tag)

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -1304,6 +1304,78 @@ def test_deepseek_dsml_parallel_invokes_double_newline_rejected(
     )
 
 
+# ---------- Regression: GLM-4.7 required tool choice must allow natural termination ----------
+#
+# tool_choice="required" used to build the suffix with TagsWithSeparatorFormat
+# (separator="", at_least_one=True), which forbids any text between or after
+# tool calls. Under greedy decoding the model could not emit its end-of-turn
+# token after </tool_call>, so it re-opened <tool_call> repeatedly until
+# max_tokens (a runaway tool-call loop, finish_reason="length"). Using the same
+# TriggeredTagsFormat as "auto" with at_least_one=True keeps the >=1-call floor
+# and parallel/chained calls, while letting the model terminate with trailing
+# free text (and thus its natural EOS).
+
+_GLM_REQUIRED_TOOLS = [
+    {
+        "function": {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    },
+    {
+        "function": {
+            "name": "get_time",
+            "parameters": {
+                "type": "object",
+                "properties": {"tz": {"type": "string"}},
+                "required": ["tz"],
+            },
+        }
+    },
+]
+
+
+def _glm_tool_call(name: str, arg: str, value: str) -> str:
+    """Render a single GLM-4.7 XML tool call."""
+    return f"<tool_call>{name}<arg_key>{arg}</arg_key><arg_value>{value}</arg_value></tool_call>"
+
+
+@pytest.mark.parametrize("reasoning", [False, True])
+def test_glm_required_allows_termination_with_trailing_text(reasoning: bool):
+    """Regression: required tool calls must accept trailing free text.
+
+    Before the fix the grammar rejected "tool_call + text", so a greedy LM could
+    not stop and emitted identical tool calls until max_tokens. With the
+    triggered-tags suffix the natural-termination output is accepted.
+    """
+    structural_tag = get_model_structural_tag(
+        "glm_4_7", tools=_GLM_REQUIRED_TOOLS, tool_choice="required", reasoning=reasoning
+    )
+    grammar = xgr.Grammar.from_structural_tag(structural_tag)
+
+    weather = _glm_tool_call("get_weather", "city", "Leon")
+    get_time = _glm_tool_call("get_time", "tz", "EET")
+    prefix = "planning the call</think>" if reasoning else ""
+
+    # required floor: zero tool calls is never accepted.
+    assert not _is_grammar_accept_string(
+        grammar, prefix + ""
+    ), "glm_4_7 required must reject zero tool calls"
+    # single and parallel tool calls are accepted (floor + multi-call preserved).
+    assert _is_grammar_accept_string(grammar, prefix + weather)
+    assert _is_grammar_accept_string(grammar, prefix + weather + get_time)
+    # THE FIX: a tool call followed by trailing free text must be accepted so the
+    # model can terminate naturally instead of looping until max_tokens.
+    assert _is_grammar_accept_string(grammar, prefix + weather + " done"), (
+        "glm_4_7 required rejected a tool call + trailing text; greedy decoding "
+        "cannot terminate and loops until max_tokens"
+    )
+
+
 # ---------- Test: any_order propagation ----------
 
 

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -1376,6 +1376,69 @@ def test_glm_required_allows_termination_with_trailing_text(reasoning: bool):
     )
 
 
+# ---------- Regression: required suffixes must allow termination (same bug as GLM-4.7 above) ----------
+
+_REQUIRED_TERMINATION_TOOLS = [
+    {
+        "function": {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"],
+            },
+        }
+    },
+    {
+        "function": {
+            "name": "get_time",
+            "parameters": {
+                "type": "object",
+                "properties": {"timezone": {"type": "string"}},
+                "required": ["timezone"],
+            },
+        }
+    },
+]
+
+# (stag_key, one call, parallel calls or None); strings are exact chat-template renderings.
+_REQUIRED_TERMINATION_CASES = [
+    ("llama", '{"name": "get_weather", "parameters": {"location": "Beijing"}}', None),
+    (
+        "qwen_3",
+        '<tool_call>\n{"name": "get_weather", "arguments": {"location": "Beijing"}}\n</tool_call>',
+        '<tool_call>\n{"name": "get_weather", "arguments": {"location": "Beijing"}}\n</tool_call>\n'
+        '<tool_call>\n{"name": "get_time", "arguments": {"timezone": "UTC"}}\n</tool_call>',
+    ),
+    (
+        "qwen_3_5",
+        "<tool_call>\n<function=get_weather>\n<parameter=location>\nBeijing\n</parameter>\n"
+        "</function>\n</tool_call>",
+        "<tool_call>\n<function=get_weather>\n<parameter=location>\nBeijing\n</parameter>\n"
+        "</function>\n</tool_call>\n<tool_call>\n<function=get_time>\n<parameter=timezone>\nUTC\n"
+        "</parameter>\n</function>\n</tool_call>",
+    ),
+]
+
+
+@pytest.mark.parametrize("stag_key, one_call, two_calls", _REQUIRED_TERMINATION_CASES)
+def test_required_allows_termination_with_trailing_text(stag_key, one_call, two_calls):
+    """Required tool calls must accept trailing free text so a greedy LM can stop."""
+    structural_tag = get_model_structural_tag(
+        stag_key, tools=_REQUIRED_TERMINATION_TOOLS, tool_choice="required", reasoning=False
+    )
+    grammar = xgr.Grammar.from_structural_tag(structural_tag)
+
+    assert not _is_grammar_accept_string(grammar, ""), f"{stag_key}: zero calls must be rejected"
+    assert _is_grammar_accept_string(grammar, one_call), f"{stag_key}: single call rejected"
+    if two_calls is not None:
+        assert _is_grammar_accept_string(grammar, two_calls), f"{stag_key}: parallel calls rejected"
+    # the fix: a call followed by trailing text must be accepted (else greedy loops to max_tokens).
+    assert _is_grammar_accept_string(
+        grammar, one_call + " done"
+    ), f"{stag_key}: tool call + trailing text rejected"
+
+
 # ---------- Test: any_order propagation ----------
 
 


### PR DESCRIPTION
With `tool_choice="required"`, some models like GLM models (running on vLLM) that use the GLM-4.7 tool call parser emits the same tool call repeatedly until `max_tokens` is reached (`finish_reason="length"`). `tool_choice="auto"` is unaffected and works fine.

## Root cause

In functions like `get_glm_4_7_structural_tag`, the `required` branch built the suffix with `TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)`. That format matches only tool-call tags back-to-back with no free text allowed, so after `</tool_call>` the only grammar-legal continuations are "open another `<tool_call>`" or "end of grammar". There is no grammar-compatible way to emit the end-of-turn token, so it re-opens `<tool_call>` forever.

The `auto` branch already uses `TriggeredTagsFormat`, which allows arbitrary free text between/after tool calls, so the model can terminate naturally. The grammar already permits 1..N calls under `required`, the defect is that it gives the model no possible path to terminate with text.

## Fix

Make `required` use the same `TriggeredTagsFormat` as `auto`, plus `at_least_one=True` (a field `TriggeredTagsFormat` already supports). This preserves the `required` guarantee of >=1 tool call, preserves parallel and chained tool calls, and allows the model to terminate with trailing free text / its natural EOS.