### PR TITLE
Bugfix(fsm): resolve trie back edges via Aho-Corasick failure links

### DIFF
--- a/cpp/fsm_builder.cc
+++ b/cpp/fsm_builder.cc
@@ -6,6 +6,7 @@
 
 #include <sys/types.h>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -892,66 +893,76 @@ std::optional<FSMWithStartEnd> TrieFSMBuilderImpl::Build(
 
 void TrieFSMBuilderImpl::AddBackEdges(FSM* fsm, int start, const std::unordered_set<int>& ends) {
   // Build an Aho-Corasick automaton by adding back edges.
-  // When matching on the trie fails, we should go back to the start state and
-  // find the next match. Back edges represent such state transitions.
+  // When matching on the trie fails at state u on byte b, the matcher must resume from
+  // the longest proper suffix of u's prefix that is still a path in the trie (the
+  // failure state), and retry b from there. Falling back only to the start state (or to
+  // the start state's direct children) loses matches whose start lies inside an
+  // already-followed branch of another pattern. Example: patterns {"bcd", "abce"} on
+  // input "abcd" -- after following "abc" of the "abce" branch, 'd' must transition to
+  // the "bcd" end state via the failure state "bc", not back to the start state.
 
-  auto f_add_range_edges = [&](int node, std::set<FSMEdge, FSMEdgeRangeComparator>& cur_edges_set) {
-    cur_edges_set.insert(FSMEdge(-1, -1, 0));
-    cur_edges_set.insert(FSMEdge(256, 256, 0));
-    XGRAMMAR_DCHECK(cur_edges_set.size() >= 2);
-    for (auto it = std::next(cur_edges_set.begin()); it != cur_edges_set.end(); ++it) {
-      FSMEdge prev_edge = *std::prev(it);
-      XGRAMMAR_DCHECK(prev_edge.max < it->min);
-      if (prev_edge.max + 1 != it->min) {
-        auto new_edge = FSMEdge(prev_edge.max + 1, it->min - 1, start);
-        // The new edge should be inserted before the current edge to avoid infinite loop.
-        XGRAMMAR_DCHECK(new_edge < *it);
-        cur_edges_set.insert(new_edge);
+  int num_states = fsm->NumStates();
+
+  // Step 1. Record the BFS order of the trie (a tree at this point), so that shallower
+  // states are always processed first.
+  std::vector<int> bfs_order;
+  bfs_order.reserve(num_states);
+  bfs_order.push_back(start);
+  for (size_t head = 0; head < bfs_order.size(); head++) {
+    for (const auto& edge : fsm->GetEdges(bfs_order[head])) {
+      XGRAMMAR_DCHECK(edge.min == edge.max && edge.min >= 0 && edge.min <= 255);
+      bfs_order.push_back(edge.target);
+    }
+  }
+  XGRAMMAR_DCHECK(static_cast<int>(bfs_order.size()) == num_states);
+
+  // Step 2. Compute the failure link and the fully resolved transition table with the
+  // textbook O(num_states * 256) dynamic program: delta[u][b] is the trie child when it
+  // exists, and delta[fail[u]][b] otherwise -- fail[u] is strictly shallower than u, so
+  // its row is already final when u is processed in BFS order.
+  std::vector<int> fail(num_states, start);
+  std::vector<std::array<int, 256>> delta(num_states);
+  for (auto& row : delta) {
+    row.fill(FSM::kNoNextState);
+  }
+  for (int u = 0; u < num_states; u++) {
+    for (const auto& edge : fsm->GetEdges(u)) {
+      delta[u][edge.min] = edge.target;
+    }
+  }
+  for (int u : bfs_order) {
+    for (int byte = 0; byte < 256; byte++) {
+      // Entries of deeper states are untouched so far, so a non-empty entry here is
+      // exactly a trie child of u.
+      int child = delta[u][byte];
+      int fallback = (u == start) ? start : delta[fail[u]][byte];
+      if (child == FSM::kNoNextState) {
+        delta[u][byte] = fallback;
+      } else {
+        fail[child] = fallback;
       }
     }
-
-    // Remove first and last element of cur_edges_set
-    XGRAMMAR_DCHECK(*cur_edges_set.begin() == FSMEdge(-1, -1, 0));
-    XGRAMMAR_DCHECK(*std::prev(cur_edges_set.end()) == FSMEdge(256, 256, 0));
-    cur_edges_set.erase(cur_edges_set.begin());
-    cur_edges_set.erase(std::prev(cur_edges_set.end()));
-
-    XGRAMMAR_DCHECK(cur_edges_set.begin()->min == 0);
-    XGRAMMAR_DCHECK(std::prev(cur_edges_set.end())->max == 255);
-  };
-
-  for (int i = 0; i < fsm->NumStates(); i++) {
-    if (i == start || ends.count(i) > 0) {
-      continue;
-    }
-    std::vector<FSMEdge>& cur_edges = fsm->GetEdges(i);
-    XGRAMMAR_DCHECK(cur_edges.size() > 0);
-    std::set<FSMEdge, FSMEdgeRangeComparator> cur_edges_set(cur_edges.begin(), cur_edges.end());
-
-    // Step 1. Add edges in the edges of the start state.
-    // For start--(c)-->t, add i--(c)-->t.
-    const auto& root_edges = fsm->GetEdges(start);
-    for (const auto& root_edge : root_edges) {
-      XGRAMMAR_DCHECK(root_edge.min == root_edge.max);
-      if (cur_edges_set.count(root_edge) == 0) {
-        cur_edges_set.insert(root_edge);
-      }
-    }
-
-    // Step 2. Add i--(c)-->start for c not in the edge set of i.
-    f_add_range_edges(i, cur_edges_set);
-
-    // Step 3. Update the edges of i.
-    cur_edges.clear();
-    cur_edges.insert(cur_edges.end(), cur_edges_set.begin(), cur_edges_set.end());
   }
 
-  // Finally, add range edges to the start state.
-  std::vector<FSMEdge>& start_edges = fsm->GetEdges(start);
-  std::set<FSMEdge, FSMEdgeRangeComparator> start_edges_set(start_edges.begin(), start_edges.end());
-  f_add_range_edges(start, start_edges_set);
-  start_edges.clear();
-  start_edges.insert(start_edges.end(), start_edges_set.begin(), start_edges_set.end());
+  // Step 3. Overwrite the edges of every non-end state with its resolved row,
+  // compressing consecutive bytes with the same target into range edges.
+  for (int u = 0; u < num_states; u++) {
+    if (u != start && ends.count(u) > 0) {
+      continue;
+    }
+    const auto& row = delta[u];
+    std::vector<FSMEdge> new_edges;
+    for (int byte = 0; byte < 256;) {
+      int target = row[byte];
+      int range_end = byte;
+      while (range_end + 1 < 256 && row[range_end + 1] == target) {
+        range_end++;
+      }
+      new_edges.push_back(FSMEdge(byte, range_end, target));
+      byte = range_end + 1;
+    }
+    fsm->GetEdges(u) = std::move(new_edges);
+  }
 }
 
 std::optional<FSMWithStartEnd> TrieFSMBuilder::Build(

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -293,6 +293,55 @@ def test_empty_tag_dispatch():
     assert not _is_grammar_accept_string(grammar_with_excludes, "endaaa")
 
 
+def test_excludes_overlapping_prefixes():
+    """An excluded pattern must be found even when its start lies inside an
+    already-followed trie branch of another excluded pattern. With excludes
+    {"bcd", "abce"}, input "abcd" follows the "abce" branch for "abc"; on 'd' the
+    Aho-Corasick failure link must resume at "bc" (a prefix of "bcd") and reject,
+    not fall back to the start state and miss the "bcd" match."""
+    grammar_str = """root ::= TagDispatch(
+  excludes=("bcd", "abce"),
+  loop_after_dispatch=true
+)
+"""
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    assert _is_grammar_accept_string(grammar, "abc")
+    assert _is_grammar_accept_string(grammar, "hello")
+    assert not _is_grammar_accept_string(grammar, "abcd")
+    assert not _is_grammar_accept_string(grammar, "abcdX")
+    assert not _is_grammar_accept_string(grammar, "aabce")
+    assert not _is_grammar_accept_string(grammar, "abcbcd")
+
+    # The same defect through a structural tag's any_text excludes, with multi-byte
+    # UTF-8 patterns sharing an overlapping prefix ("<｜" commits to the second
+    # pattern's branch, then "｜DSML｜" must still be found as a suffix).
+    tag = {
+        "format": {
+            "type": "sequence",
+            "elements": [
+                {
+                    "type": "tag",
+                    "begin": "<think>",
+                    "content": {
+                        "type": "any_text",
+                        "excludes": ["｜DSML｜", "<｜end▁of▁sentence｜>"],
+                    },
+                    "end": "</think>",
+                },
+                {"type": "any_text"},
+            ],
+        }
+    }
+    grammar = xgr.Grammar.from_structural_tag(json.dumps(tag))
+    assert _is_grammar_accept_string(grammar, "<think>clean</think>x", require_termination=True)
+    assert not _is_grammar_accept_string(
+        grammar, "<think>a ｜DSML｜ b</think>x", require_termination=True
+    )
+    assert not _is_grammar_accept_string(
+        grammar, "<think>a <｜DSML｜tool_calls> b</think>x", require_termination=True
+    )
+
+
 @pytest.mark.hf_token_required
 def test_utf8_structural_tag_begin_end():
     model = "deepseek-ai/DeepSeek-V3-0324"


### PR DESCRIPTION
## Bug

`any_text` / `TagDispatch` `excludes` fail to reject a string when the excluded pattern's match starts inside an already-followed trie branch of another pattern.

Minimal repro:

```python
import json, xgrammar as xgr
from xgrammar.testing import _is_grammar_accept_string

tag = {"format": {"type": "any_text", "excludes": ["bcd", "abce"]}}
grammar = xgr.Grammar.from_structural_tag(json.dumps(tag))
assert not _is_grammar_accept_string(grammar, "abcd")  # fails: accepted, but contains "bcd"
```

A real-world shape (structural tags for reasoning models): with think-content excludes `["｜DSML｜", "<｜end▁of▁sentence｜>"]`, text containing `<｜DSML｜tool_calls>` is wrongly accepted, so a grammar meant to keep DSML markup out of the think span does not.

## Root cause

`TrieFSMBuilderImpl::AddBackEdges` is not a full Aho-Corasick construction. On a mismatch it only falls back to the start state, plus the start state's depth-1 children (copied onto every state). Any suffix of length >= 2 that is still a prefix of another pattern is lost.

For `excludes=("bcd", "abce")`, input `"abcd"`: the matcher follows the `abce` branch for `abc`, mismatches on `d`, and drops back to the start state — forgetting it just consumed `bc`. The correct failure transition is to the `bc` state of the `bcd` branch, where `d` completes the match.

## Fix

Compute proper failure links and the fully resolved transition table with the textbook `O(num_states * 256)` BFS dynamic program (`delta[u][b] = trie child if present, else delta[fail[u]][b]` — `fail[u]` is strictly shallower, so its row is final when `u` is processed), then materialize each non-end state's row as range edges.

The output is still a deterministic full-coverage FSM of the same shape as before, so match-time behavior and cost are unchanged; for tries without cross-branch suffix overlaps the produced FSM is byte-identical (the pinned FSM-print expectations in `test_fsm_builder.cc` pass unchanged).

## Testing

- New regression test `test_excludes_overlapping_prefixes` (ASCII minimal case + the multi-byte UTF-8 structural-tag case).
- C++ tests: 47/47 pass, including the pinned `TagDispatch` FSM prints.
- Python suite: 2439 passed, 0 failed (HF-gated tests skipped).