### PR TITLE
[PoC] add json schema to structural tag to public API

### DIFF
--- a/python/xgrammar/__init__.py
+++ b/python/xgrammar/__init__.py
@@ -20,6 +20,7 @@ from .exception import (
     InvalidStructuralTagError,
 )
 from .grammar import Grammar, StructuralTagItem
+from .json_schema_to_structural_tag import json_schema_to_structural_tag
 from .matcher import (
     BatchGrammarMatcher,
     GrammarMatcher,
@@ -60,6 +61,7 @@ __all__ = [
     "TokenizerInfo",
     "VocabType",
     "get_model_structural_tag",
+    "json_schema_to_structural_tag",
     "normalize_tool_choice",
     "register_model_structural_tag",
     "get_builtin_structural_tag",

--- a/python/xgrammar/json_schema_to_structural_tag.py
+++ b/python/xgrammar/json_schema_to_structural_tag.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict, Optional
+
+from xgrammar.structural_tag import (
+    AnyTextFormat,
+    ConstStringFormat,
+    JSONSchemaFormat,
+    SequenceFormat,
+    StructuralTag,
+    TagFormat,
+)
+
+_THINK_TAG_END = "</think>"
+_THINK_SUFFIX = "\n\n"
+
+# Models that emit optional thinking before plain JSON output.
+_QWEN_STYLE_MODELS = frozenset({"qwen_3_5", "qwen_3_coder", "qwen_3"})
+
+
+def json_schema_to_structural_tag(
+    model: str,
+    schema: Dict[str, Any],
+    reasoning: bool = True,
+    *,
+    any_order: bool = False,
+    max_whitespace_cnt: Optional[int] = None,
+) -> StructuralTag:
+    """Build a structural tag that constrains output to a JSON schema.
+
+    For models with optional thinking (e.g. Qwen3.5), ``reasoning=True`` allows
+    free-form thinking before the JSON payload, matching the prefix used by
+    :func:`get_model_structural_tag`.
+    """
+    suffix_tag = JSONSchemaFormat(
+        json_schema=schema, style="json", any_order=any_order, max_whitespace_cnt=max_whitespace_cnt
+    )
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    if model not in _QWEN_STYLE_MODELS:
+        supported = sorted(_QWEN_STYLE_MODELS)
+        raise ValueError(
+            f"Unknown model for json_schema_to_structural_tag: {model}. "
+            f"Supported models: {supported}"
+        )
+
+    prefix_tag = SequenceFormat(
+        elements=[
+            TagFormat(begin="", content=AnyTextFormat(), end=_THINK_TAG_END),
+            ConstStringFormat(value=_THINK_SUFFIX),
+        ]
+    )
+    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))


### PR DESCRIPTION
Currently public API exposes only `get_model_structural_tag` to process tool calls with reasoning filtering. But there is also an important case where reasoning filtering on Xgrammar's side can help to reduce complexity from vLLM - structured output with json schema set. This PR is a PoC that demonstrates this new feature `json_schema_to_structural_tag`. It converts input json schema to structural tag filtering reasoning. If this idea makes sense and viable then I will complete the implementation of this feature since now it supports only Qwen3.5 model as an example.

How to use `json_schema_to_structural_tag`:
<details>
<summary>main.py</summary>

```python
#!/usr/bin/env python3

from xgrammar import get_model_structural_tag, json_schema_to_structural_tag
from rich.console import Console
import json

tag = json_schema_to_structural_tag(
    model="qwen_3_5",
    schema={
        "type": "object",
        "properties": {"location": {"type": "string"}},
    },
    reasoning=True,
)

data = json.loads(tag.model_dump_json())
Console().print_json(data=data)
```
</details>

**Result:**

<details>
<summary>output</summary>

```json
{
  "type": "structural_tag",
  "format": {
    "type": "sequence",
    "elements": [
      {
        "type": "sequence",
        "elements": [
          {
            "type": "tag",
            "begin": "",
            "content": {
              "type": "any_text",
              "excludes": []
            },
            "end": "</think>"
          },
          {
            "type": "const_string",
            "value": "\n\n"
          }
        ]
      },
      {
        "type": "json_schema",
        "json_schema": {
          "type": "object",
          "properties": {
            "location": {
              "type": "string"
            }
          }
        },
        "style": "json",
        "any_order": false,
        "max_whitespace_cnt": null
      }
    ]
  }
}
```
</details>