### PR TITLE
fix: make fill_next_token_bitmask stride-aware

### DIFF
--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -190,6 +190,12 @@ int32_t* CheckAndGetBitmaskPtr(const DLTensor& token_bitmask, int vocab_size, in
         << vocab_stride;
     if (token_bitmask.ndim == 2) {
       row_stride = token_bitmask.strides[0];
+      // A row spans buffer_size int32s; with more than one row a smaller stride would overlap
+      // adjacent rows and let a write run past the buffer. A single row cannot overlap, whatever
+      // its stride, so only guard when rows > 1. Reject rather than corrupt memory.
+      XGRAMMAR_CHECK(token_bitmask.shape[0] <= 1 || row_stride >= buffer_size)
+          << "The row stride of the bitmask must be at least " << buffer_size
+          << " so rows do not overlap, but got " << row_stride;
     }
   }
 
@@ -235,6 +241,19 @@ void ApplyMask32Bits(
   int bitmask_stride0 = bitmask.strides != nullptr
                             ? static_cast<int>(bitmask.strides[0])
                             : static_cast<int>(bitmask.shape[bitmask.ndim - 1]);
+  // Mirror the fill-side check: with more than one row, a row stride smaller than the per-row
+  // span (shape[-1]) overlaps adjacent rows -- corrupting on the logits -inf write. A single row
+  // cannot overlap and legitimately carries an unconstrained stride, so only guard when rows > 1.
+  if (logits_shape.first > 1) {
+    XGRAMMAR_CHECK(logits_stride0 >= logits_shape.second)
+        << "The row stride of the logits must be at least " << logits_shape.second
+        << " so rows do not overlap, but got " << logits_stride0;
+  }
+  if (bitmask.ndim == 2 && bitmask.shape[0] > 1) {
+    XGRAMMAR_CHECK(bitmask_stride0 >= static_cast<int>(bitmask.shape[1]))
+        << "The row stride of the bitmask must be at least " << bitmask.shape[1]
+        << " so rows do not overlap, but got " << bitmask_stride0;
+  }
   if (indices.has_value()) {
     for (auto idx : indices.value()) {
       uint32_t* data_ptr = reinterpret_cast<uint32_t*>(bitmask.data) + idx * bitmask_stride0;
@@ -288,6 +307,19 @@ void ApplyMask16Bits(
   int bitmask_stride0 = bitmask.strides != nullptr
                             ? static_cast<int>(bitmask.strides[0])
                             : static_cast<int>(bitmask.shape[bitmask.ndim - 1]);
+  // Mirror the fill-side check: with more than one row, a row stride smaller than the per-row
+  // span (shape[-1]) overlaps adjacent rows -- corrupting on the logits -inf write. A single row
+  // cannot overlap and legitimately carries an unconstrained stride, so only guard when rows > 1.
+  if (logits_shape.first > 1) {
+    XGRAMMAR_CHECK(logits_stride0 >= logits_shape.second)
+        << "The row stride of the logits must be at least " << logits_shape.second
+        << " so rows do not overlap, but got " << logits_stride0;
+  }
+  if (bitmask.ndim == 2 && bitmask.shape[0] > 1) {
+    XGRAMMAR_CHECK(bitmask_stride0 >= static_cast<int>(bitmask.shape[1]))
+        << "The row stride of the bitmask must be at least " << bitmask.shape[1]
+        << " so rows do not overlap, but got " << bitmask_stride0;
+  }
   if (indices.has_value()) {
     for (auto idx : indices.value()) {
       uint32_t* data_ptr = reinterpret_cast<uint32_t*>(bitmask.data) + idx * bitmask_stride0;

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -177,7 +177,23 @@ int32_t* CheckAndGetBitmaskPtr(const DLTensor& token_bitmask, int vocab_size, in
       token_bitmask.device.device_type == kDLROCMHost
   ) << "The provided bitmask's device is not valid: should be CPU";
 
-  return reinterpret_cast<int32_t*>(token_bitmask.data) + index * buffer_size;
+  // The bitmask may be a non-contiguous view, so the row offset must follow strides[0] instead
+  // of assuming a compact layout: ApplyMask32Bits addresses rows the same way, and filling and
+  // applying must agree on where a row lives. Null strides means compact (DLPack). The vocab
+  // dimension must stay unit-stride, since a row is read as one contiguous DynamicBitset.
+  int64_t row_stride = buffer_size;
+  if (token_bitmask.strides != nullptr) {
+    int64_t vocab_stride = token_bitmask.strides[token_bitmask.ndim - 1];
+    XGRAMMAR_CHECK(vocab_stride == 1)
+        << "The provided bitmask must be contiguous along the vocabulary dimension, but got "
+           "stride "
+        << vocab_stride;
+    if (token_bitmask.ndim == 2) {
+      row_stride = token_bitmask.strides[0];
+    }
+  }
+
+  return reinterpret_cast<int32_t*>(token_bitmask.data) + index * row_stride;
 }
 
 void _DebugGetMaskedTokensFromBitmask(
@@ -213,8 +229,12 @@ void ApplyMask32Bits(
       logits->ndim == 2
           ? std::make_pair(static_cast<int>(logits->shape[0]), static_cast<int>(logits->shape[1]))
           : std::make_pair(1, static_cast<int>(logits->shape[0]));
-  int logits_stride0 = logits->strides[0];
-  int bitmask_stride0 = bitmask.strides[0];
+  // Null strides means compact (DLPack), in which case a row is one shape[-1]-long span.
+  int logits_stride0 =
+      logits->strides != nullptr ? static_cast<int>(logits->strides[0]) : logits_shape.second;
+  int bitmask_stride0 = bitmask.strides != nullptr
+                            ? static_cast<int>(bitmask.strides[0])
+                            : static_cast<int>(bitmask.shape[bitmask.ndim - 1]);
   if (indices.has_value()) {
     for (auto idx : indices.value()) {
       uint32_t* data_ptr = reinterpret_cast<uint32_t*>(bitmask.data) + idx * bitmask_stride0;
@@ -262,8 +282,12 @@ void ApplyMask16Bits(
       logits->ndim == 2
           ? std::make_pair(static_cast<int>(logits->shape[0]), static_cast<int>(logits->shape[1]))
           : std::make_pair(1, static_cast<int>(logits->shape[0]));
-  int logits_stride0 = logits->strides[0];
-  int bitmask_stride0 = bitmask.strides[0];
+  // Null strides means compact (DLPack), in which case a row is one shape[-1]-long span.
+  int logits_stride0 =
+      logits->strides != nullptr ? static_cast<int>(logits->strides[0]) : logits_shape.second;
+  int bitmask_stride0 = bitmask.strides != nullptr
+                            ? static_cast<int>(bitmask.strides[0])
+                            : static_cast<int>(bitmask.shape[bitmask.ndim - 1]);
   if (indices.has_value()) {
     for (auto idx : indices.value()) {
       uint32_t* data_ptr = reinterpret_cast<uint32_t*>(bitmask.data) + idx * bitmask_stride0;

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -202,6 +202,12 @@ int32_t* CheckAndGetBitmaskPtr(const DLTensor& token_bitmask, int vocab_size, in
         << vocab_stride;
     if (token_bitmask.ndim == 2) {
       row_stride = token_bitmask.strides[0];
+      // A row spans buffer_size int32s; with more than one row a smaller stride would overlap
+      // adjacent rows and let a write run past the buffer. A single row cannot overlap, whatever
+      // its stride, so only guard when rows > 1. Reject rather than corrupt memory.
+      XGRAMMAR_CHECK(token_bitmask.shape[0] <= 1 || row_stride >= buffer_size)
+          << "The row stride of the bitmask must be at least " << buffer_size
+          << " so rows do not overlap, but got " << row_stride;
     }
   }
 
@@ -247,6 +253,19 @@ void ApplyMask32Bits(
   int bitmask_stride0 = bitmask.strides != nullptr
                             ? static_cast<int>(bitmask.strides[0])
                             : static_cast<int>(bitmask.shape[bitmask.ndim - 1]);
+  // Mirror the fill-side check: with more than one row, a row stride smaller than the per-row
+  // span (shape[-1]) overlaps adjacent rows -- corrupting on the logits -inf write. A single row
+  // cannot overlap and legitimately carries an unconstrained stride, so only guard when rows > 1.
+  if (logits_shape.first > 1) {
+    XGRAMMAR_CHECK(logits_stride0 >= logits_shape.second)
+        << "The row stride of the logits must be at least " << logits_shape.second
+        << " so rows do not overlap, but got " << logits_stride0;
+  }
+  if (bitmask.ndim == 2 && bitmask.shape[0] > 1) {
+    XGRAMMAR_CHECK(bitmask_stride0 >= static_cast<int>(bitmask.shape[1]))
+        << "The row stride of the bitmask must be at least " << bitmask.shape[1]
+        << " so rows do not overlap, but got " << bitmask_stride0;
+  }
   if (indices.has_value()) {
     for (auto idx : indices.value()) {
       uint32_t* data_ptr = reinterpret_cast<uint32_t*>(bitmask.data) + idx * bitmask_stride0;
@@ -300,6 +319,19 @@ void ApplyMask16Bits(
   int bitmask_stride0 = bitmask.strides != nullptr
                             ? static_cast<int>(bitmask.strides[0])
                             : static_cast<int>(bitmask.shape[bitmask.ndim - 1]);
+  // Mirror the fill-side check: with more than one row, a row stride smaller than the per-row
+  // span (shape[-1]) overlaps adjacent rows -- corrupting on the logits -inf write. A single row
+  // cannot overlap and legitimately carries an unconstrained stride, so only guard when rows > 1.
+  if (logits_shape.first > 1) {
+    XGRAMMAR_CHECK(logits_stride0 >= logits_shape.second)
+        << "The row stride of the logits must be at least " << logits_shape.second
+        << " so rows do not overlap, but got " << logits_stride0;
+  }
+  if (bitmask.ndim == 2 && bitmask.shape[0] > 1) {
+    XGRAMMAR_CHECK(bitmask_stride0 >= static_cast<int>(bitmask.shape[1]))
+        << "The row stride of the bitmask must be at least " << bitmask.shape[1]
+        << " so rows do not overlap, but got " << bitmask_stride0;
+  }
   if (indices.has_value()) {
     for (auto idx : indices.value()) {
       uint32_t* data_ptr = reinterpret_cast<uint32_t*>(bitmask.data) + idx * bitmask_stride0;

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -189,7 +189,23 @@ int32_t* CheckAndGetBitmaskPtr(const DLTensor& token_bitmask, int vocab_size, in
       token_bitmask.device.device_type == kDLROCMHost
   ) << "The provided bitmask's device is not valid: should be CPU";
 
-  return reinterpret_cast<int32_t*>(token_bitmask.data) + index * buffer_size;
+  // The bitmask may be a non-contiguous view, so the row offset must follow strides[0] instead
+  // of assuming a compact layout: ApplyMask32Bits addresses rows the same way, and filling and
+  // applying must agree on where a row lives. Null strides means compact (DLPack). The vocab
+  // dimension must stay unit-stride, since a row is read as one contiguous DynamicBitset.
+  int64_t row_stride = buffer_size;
+  if (token_bitmask.strides != nullptr) {
+    int64_t vocab_stride = token_bitmask.strides[token_bitmask.ndim - 1];
+    XGRAMMAR_CHECK(vocab_stride == 1)
+        << "The provided bitmask must be contiguous along the vocabulary dimension, but got "
+           "stride "
+        << vocab_stride;
+    if (token_bitmask.ndim == 2) {
+      row_stride = token_bitmask.strides[0];
+    }
+  }
+
+  return reinterpret_cast<int32_t*>(token_bitmask.data) + index * row_stride;
 }
 
 void _DebugGetMaskedTokensFromBitmask(
@@ -225,8 +241,12 @@ void ApplyMask32Bits(
       logits->ndim == 2
           ? std::make_pair(static_cast<int>(logits->shape[0]), static_cast<int>(logits->shape[1]))
           : std::make_pair(1, static_cast<int>(logits->shape[0]));
-  int logits_stride0 = logits->strides[0];
-  int bitmask_stride0 = bitmask.strides[0];
+  // Null strides means compact (DLPack), in which case a row is one shape[-1]-long span.
+  int logits_stride0 =
+      logits->strides != nullptr ? static_cast<int>(logits->strides[0]) : logits_shape.second;
+  int bitmask_stride0 = bitmask.strides != nullptr
+                            ? static_cast<int>(bitmask.strides[0])
+                            : static_cast<int>(bitmask.shape[bitmask.ndim - 1]);
   if (indices.has_value()) {
     for (auto idx : indices.value()) {
       uint32_t* data_ptr = reinterpret_cast<uint32_t*>(bitmask.data) + idx * bitmask_stride0;
@@ -274,8 +294,12 @@ void ApplyMask16Bits(
       logits->ndim == 2
           ? std::make_pair(static_cast<int>(logits->shape[0]), static_cast<int>(logits->shape[1]))
           : std::make_pair(1, static_cast<int>(logits->shape[0]));
-  int logits_stride0 = logits->strides[0];
-  int bitmask_stride0 = bitmask.strides[0];
+  // Null strides means compact (DLPack), in which case a row is one shape[-1]-long span.
+  int logits_stride0 =
+      logits->strides != nullptr ? static_cast<int>(logits->strides[0]) : logits_shape.second;
+  int bitmask_stride0 = bitmask.strides != nullptr
+                            ? static_cast<int>(bitmask.strides[0])
+                            : static_cast<int>(bitmask.shape[bitmask.ndim - 1]);
   if (indices.has_value()) {
     for (auto idx : indices.value()) {
       uint32_t* data_ptr = reinterpret_cast<uint32_t*>(bitmask.data) + idx * bitmask_stride0;

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -131,7 +131,9 @@ def _bitmask_buffer_size(vocab_size: int) -> int:
 
 def _single_token_grammar() -> Tuple[xgr.TokenizerInfo, xgr.CompiledGrammar]:
     """A grammar accepting exactly one token, so the expected mask is unambiguous."""
-    tokenizer_info = xgr.TokenizerInfo([f"t{i}" for i in range(40)] + ["<eos>"], stop_token_ids=[40])
+    tokenizer_info = xgr.TokenizerInfo(
+        [f"t{i}" for i in range(40)] + ["<eos>"], stop_token_ids=[40]
+    )
     compiled_grammar = xgr.GrammarCompiler(tokenizer_info).compile_grammar(
         xgr.Grammar.from_ebnf('root ::= "t0"')
     )

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -226,6 +226,20 @@ def test_fill_next_token_bitmask_rejects_strided_vocab_dim():
         xgr.GrammarMatcher(compiled_grammar).fill_next_token_bitmask(bitmask, 1)
 
 
+def test_fill_next_token_bitmask_rejects_overlapping_rows():
+    """A row spans buffer_size int32s, so a row stride smaller than that overlaps adjacent rows
+    and a write would run past the buffer. Such a layout must be rejected, not silently corrupt
+    memory."""
+    tokenizer_info, compiled_grammar = _single_token_grammar()
+    buffer_size = _bitmask_buffer_size(tokenizer_info.vocab_size)
+    assert buffer_size >= 2  # otherwise there is no room for an overlapping row stride
+    # Two rows with row stride 1 < buffer_size, vocab dim still unit-stride: rows overlap.
+    bitmask = torch.zeros(buffer_size + 1, dtype=torch.int32).as_strided((2, buffer_size), (1, 1))
+
+    with pytest.raises(RuntimeError, match="rows do not overlap"):
+        xgr.GrammarMatcher(compiled_grammar).fill_next_token_bitmask(bitmask, 1)
+
+
 def get_apply_token_bitmask_kernel(impl: str) -> Callable:
     if impl == "cpu":
         from xgrammar.kernels.apply_token_bitmask_inplace_cpu import apply_token_bitmask_inplace_cpu

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -125,6 +125,105 @@ def test_apply_token_bitmask_inplace_shape_stride_mismatch(device: str):
     torch.testing.assert_close(logits, expected)
 
 
+def _bitmask_buffer_size(vocab_size: int) -> int:
+    return xgr.get_bitmask_shape(1, vocab_size)[-1]
+
+
+def _single_token_grammar() -> Tuple[xgr.TokenizerInfo, xgr.CompiledGrammar]:
+    """A grammar accepting exactly one token, so the expected mask is unambiguous."""
+    tokenizer_info = xgr.TokenizerInfo([f"t{i}" for i in range(40)] + ["<eos>"], stop_token_ids=[40])
+    compiled_grammar = xgr.GrammarCompiler(tokenizer_info).compile_grammar(
+        xgr.Grammar.from_ebnf('root ::= "t0"')
+    )
+    return tokenizer_info, compiled_grammar
+
+
+def _bitmask_allocated(batch_size: int, vocab_size: int) -> torch.Tensor:
+    return xgr.allocate_token_bitmask(batch_size, vocab_size)
+
+
+def _bitmask_row_sliced(batch_size: int, vocab_size: int) -> torch.Tensor:
+    buffer_size = _bitmask_buffer_size(vocab_size)
+    return torch.zeros(batch_size * 2, buffer_size, dtype=torch.int32)[:batch_size]
+
+
+def _bitmask_strided(batch_size: int, vocab_size: int) -> torch.Tensor:
+    buffer_size = _bitmask_buffer_size(vocab_size)
+    return torch.zeros(batch_size * 2, buffer_size, dtype=torch.int32)[::2]
+
+
+def _bitmask_col_cropped(batch_size: int, vocab_size: int) -> torch.Tensor:
+    """A buffer preallocated on a padded vocab, then cropped to the real buffer size."""
+    buffer_size = _bitmask_buffer_size(vocab_size)
+    return torch.zeros(batch_size, buffer_size + 3, dtype=torch.int32)[:, :buffer_size]
+
+
+# `allocate` and `row_slice` are contiguous and act as negative controls: they must pass
+# both before and after any stride fix. `strided` and `col_cropped` have
+# stride(0) != buffer_size, which is what these tests are about.
+bitmask_layouts = {
+    "allocate": _bitmask_allocated,
+    "row_slice": _bitmask_row_sliced,
+    "strided": _bitmask_strided,
+    "col_cropped": _bitmask_col_cropped,
+}
+
+
+@pytest.mark.parametrize("layout", list(bitmask_layouts))
+def test_fill_next_token_bitmask_row_addressing(layout: str):
+    """fill_next_token_bitmask must write into the row the caller asked for, regardless of
+    the bitmask's memory layout.
+
+    It addresses rows as `data + index * buffer_size`, ignoring stride(0), so for a
+    non-contiguous bitmask it writes outside the requested row.
+    """
+    tokenizer_info, compiled_grammar = _single_token_grammar()
+    batch_size, index = 2, 1
+
+    expected = xgr.allocate_token_bitmask(batch_size, tokenizer_info.vocab_size)
+    xgr.GrammarMatcher(compiled_grammar).fill_next_token_bitmask(expected, index)
+
+    bitmask = bitmask_layouts[layout](batch_size, tokenizer_info.vocab_size)
+    xgr.GrammarMatcher(compiled_grammar).fill_next_token_bitmask(bitmask, index)
+
+    torch.testing.assert_close(bitmask[index], expected[index])
+
+
+@pytest.mark.parametrize("layout", list(bitmask_layouts))
+def test_fill_apply_round_trip_row_addressing(layout: str):
+    """fill_next_token_bitmask -> apply_token_bitmask_inplace must mask the logits row
+    corresponding to the bitmask row that was filled.
+
+    fill addresses rows by buffer_size and apply by stride(0). They agree only when the
+    bitmask is contiguous; otherwise the mask is written to one row and read from another,
+    leaving the victim row all -inf. Silent: nothing raises.
+    """
+    tokenizer_info, compiled_grammar = _single_token_grammar()
+    batch_size, index = 2, 1
+    vocab_size = tokenizer_info.vocab_size
+
+    bitmask = bitmask_layouts[layout](batch_size, vocab_size)
+    xgr.GrammarMatcher(compiled_grammar).fill_next_token_bitmask(bitmask, index)
+
+    logits = torch.zeros(batch_size, vocab_size)
+    xgr.apply_token_bitmask_inplace(logits, bitmask)
+
+    # `root ::= "t0"` accepts only token 0, so exactly that logit must stay finite.
+    surviving = torch.isfinite(logits[index]).nonzero().flatten().tolist()
+    assert surviving == [0]
+
+
+def test_fill_next_token_bitmask_rejects_strided_vocab_dim():
+    """A row of the bitmask is read as one packed bitset, so a bitmask whose vocabulary
+    dimension is not unit-stride must be rejected rather than silently misread."""
+    tokenizer_info, compiled_grammar = _single_token_grammar()
+    buffer_size = _bitmask_buffer_size(tokenizer_info.vocab_size)
+    bitmask = torch.zeros(2, buffer_size * 2, dtype=torch.int32)[:, ::2]
+
+    with pytest.raises(RuntimeError, match="contiguous along the vocabulary dimension"):
+        xgr.GrammarMatcher(compiled_grammar).fill_next_token_bitmask(bitmask, 1)
+
+
 def get_apply_token_bitmask_kernel(impl: str) -> Callable:
     if impl == "cpu":
         from xgrammar.kernels.apply_token_bitmask_inplace_cpu import apply_token_bitmask_inplace_cpu


### PR DESCRIPTION
## Summary

`fill_next_token_bitmask` addresses bitmask rows as `data + index * buffer_size` (compact layout),
while `apply_token_bitmask_inplace` addresses them as `data + idx * strides[0]`. For a
non-contiguous bitmask the two disagree: the mask is written to one row and read from another, and
the requested logits row comes out entirely `-inf`. Nothing raises — it is silent. The shape check
can't catch it: `bm[::2]` and a contiguous bitmask have identical shapes; only the strides differ.

**Why this matters:** non-contiguous bitmasks worked end to end before #390 — this is a regression,
not a new feature. The fix makes fill use `strides[0]` too, so both sides agree on where a row
lives, as they did before.

Trigger: `bitmask.stride(0) != GetBitmaskSize(vocab_size)`. Row slices `bm[:n]` are contiguous and
safe.

<details>
<summary><b>Reproduction</b> (pure Python, public API, CPU — on <code>main</code> / 0.2.3)</summary>

First two rows are negative controls:

```python
import torch, xgrammar as xgr

tok = xgr.TokenizerInfo([f"t{i}" for i in range(40)] + ["<eos>"], stop_token_ids=[40])
ctx = xgr.GrammarCompiler(tok).compile_grammar(xgr.Grammar.from_ebnf('root ::= "t0"'))
bs = xgr.get_bitmask_shape(1, tok.vocab_size)[-1]

def probe(bm, tag):
    m = xgr.GrammarMatcher(ctx)
    logits = torch.zeros(bm.shape[0], tok.vocab_size)
    m.fill_next_token_bitmask(bm, 1)
    xgr.apply_token_bitmask_inplace(logits, bm)
    # `root ::= "t0"` accepts only token 0, so exactly that logit must stay finite.
    print(f"{tag:22s} stride={str(bm.stride()):10s} -> "
          f"surviving={torch.isfinite(logits[1]).nonzero().flatten().tolist()}")

probe(xgr.allocate_token_bitmask(2, tok.vocab_size),      "official allocate")
probe(torch.zeros(4, bs, dtype=torch.int32)[:2],          "row slice bm[:2]")
probe(torch.zeros(4, bs, dtype=torch.int32)[::2],         "strided bm[::2]")
probe(torch.zeros(2, bs + 3, dtype=torch.int32)[:, :bs],  "col-cropped (padded)")
```

```
official allocate     stride=(2, 1)  -> surviving=[0]     OK
row slice bm[:2]      stride=(2, 1)  -> surviving=[0]     OK
strided bm[::2]       stride=(4, 1)  -> surviving=[]      ALL -inf  <-- BUG
col-cropped (padded)  stride=(5, 1)  -> surviving=[]      ALL -inf  <-- BUG
```

</details>

## This is a regression from #390 (first in v0.1.23), not a revert

Before #390, apply addressed rows as `idx * shape[1]`, and fill enforces `shape[1] == buffer_size`
(`grammar_matcher.cc:167`), so both sides computed the *same* offset. #390 changed apply to
`strides[0]` (correctly, to fix logits stride, vLLM
[#19493](https://github.com/vllm-project/vllm/issues/19493)) but left fill unchanged, so the two
diverged. Building both versions and running the identical script confirms it:

```
xgrammar 0.1.22                      xgrammar 0.2.3
strided bm[::2]     -> [0] OK        strided bm[::2]     -> []  ALL -inf
col-cropped padded  -> [0] OK        col-cropped padded  -> []  ALL -inf
```

The old version computes the *correct* mask (surviving `[0]`, not merely "not all -inf"). **This is
not a revert of #390** — its logits-stride fix is correct and stays; the defect is that fill is
still not stride-aware, consistent with the direction #359 and #390 took (apply *supports*
non-contiguous bitmasks).

## Changes (`cpp/grammar_matcher.cc`)

1. **`CheckAndGetBitmaskPtr`** — row offset becomes `index * row_stride`, with
   `row_stride = strides ? strides[0] : buffer_size`. All three callers
   (`fill_next_token_bitmask`, `_DebugGetMaskedTokensFromBitmask`, `_IsSingleTokenBitmask`) go
   through this one function.
2. **Vocab-dim unit-stride check** — a row is read as one packed `DynamicBitset`, so having
   trusted `strides[0]` the vocab dim must stay unit-stride; reject `bm[:, ::2]` rather than
   silently misread it (same constraint #359 documents for CUDA). Verified to fire.
3. **`ApplyMask32Bits`/`ApplyMask16Bits`** — fall back to compact layout when `strides` is NULL
   instead of dereferencing it. Vendored DLPack is v1.0, where NULL means compact, and that header
   ships in the package's include dir, so a C++ caller can follow it, pass NULL, and segfault.
4. **Overlapping-row guard** (fill and apply) — a row spans `shape[-1]` elements, so with more
   than one row a stride smaller than that overlaps adjacent rows and lets a write run past the
   buffer (the `stride(0) < buffer_size` OOB case). Reject it with a clear error rather than
   corrupt memory. Gated on row count > 1: a single row cannot overlap and legitimately carries an
   unconstrained stride (e.g. a `(1, vocab)` logits view with `stride0 == 1`).

## Tests

`tests/python/test_token_bitmask_operations.py`, next to #390's own stride test. Four parametrized
layouts (`allocate`/`row_slice` contiguous controls; `strided`/`col_cropped` non-contiguous), plus
guard tests for `bm[:, ::2]` (vocab stride) and an overlapping-row layout. The load-bearing one is
`test_fill_apply_round_trip_row_addressing`: it passes pre-#390 and fails on `main`, which is what
makes the regression checkable.

Results (CPU, macOS): the whole file is **55 passed / 0 failed** (57 skipped, CUDA/Triton/MLX);
full `tests/python/` **2456 passed / 0 failed**.

## Scope / honesty

- **Latent, not active.** Enumerated every xgrammar fill call site in vLLM (`7aab6e2`) and SGLang
  (`947a14d`), reproduced each in standalone torch: 13 paths, 0 trigger — they pass the whole
  tensor + a row index, or a step-1 slice. But it's out of reach, not defended: a
  `fill(bitmask[i:i+1])` refactor makes it active. (Secondary: with `stride(0) < buffer_size`, e.g.
  `expand`, it's an out-of-bounds write — contrived, raises the severity ceiling not the
  probability; change 4 now rejects it with a clear error.)
- **Alternative:** have fill *reject* non-contiguous bitmasks — smaller, but runs against #359/#390
  and kills usages that worked pre-#390. Happy to switch if maintainers prefer that contract.
- **The NULL-strides fallback (change 3)** is there because the vendored DLPack is v1.0, where NULL
  strides is legal and means compact; apply dereferenced it unconditionally. It's a defensive
  change, reachable only from C++. Happy to split it out.
- **Deferred:** per-index bounds-checking on the `indices` path (raised in review) is pre-existing
  behaviour this PR doesn't touch, so I kept it out of a focused stride fix — happy to do it in a
  follow-up.
- **Not tested on CUDA** (no local GPU); the change is in the shared CPU path, and CUDA already
  handles non-contiguous bitmasks per #359.

## Related, none duplicate

| # | relation |
|---|---|
| #390 | introduced this; fixed logits stride, also changed bitmask addressing |
| #359 | CUDA apply supports non-contiguous bitmask — the intended direction |
| #220 | logits vocab-dim padding — realistic source of the column-crop case |
