### PR TITLE
perf: store FSM end states sparsely to remove quadratic memory in FSM building

### DIFF
--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -843,14 +843,8 @@ struct CompactFSMWithStartEndSerializeHelper {
       : fsm(compact_fsm_with_se.fsm_),
         start(compact_fsm_with_se.start_),
         is_dfa(compact_fsm_with_se.is_dfa_),
-        edge_num(compact_fsm_with_se.edge_num_) {
-    end_index.reserve(compact_fsm_with_se.NumStates());
-    for (int i = 0; i < static_cast<int>(compact_fsm_with_se.ends_.size()); ++i) {
-      if (compact_fsm_with_se.ends_[i]) {
-        end_index.push_back(i);
-      }
-    }
-  }
+        end_index(compact_fsm_with_se.ends_),
+        edge_num(compact_fsm_with_se.edge_num_) {}
 
   CompactFSMWithStartEndSerializeHelper() = default;
 };
@@ -879,11 +873,7 @@ std::optional<SerializationError> DeserializeJSONValue(
   result->start_ = tmp.start;
   result->is_dfa_ = tmp.is_dfa;
   result->edge_num_ = tmp.edge_num;
-  const auto& end_index = tmp.end_index;
-  result->ends_.resize(result->fsm_.NumStates(), false);
-  for (const auto& idx : end_index) {
-    result->ends_[idx] = true;
-  }
+  result->SetEndStates(std::move(tmp.end_index));
   return std::nullopt;
 }
 
@@ -942,15 +932,12 @@ std::string FSMWithStartEnd::ToString() const {
   std::sort(reachable_states_vec.begin(), reachable_states_vec.end());
 
   bool first = true;
-  for (int i = 0; i < NumStates(); ++i) {
-    if (!IsEndState(i)) {
-      continue;
-    }
+  for (auto end : ends_) {
     if (!first) {
       result += ", ";
     }
     first = false;
-    result += std::to_string(i);
+    result += std::to_string(end);
   }
 
   result += "], edges=" + fsm_.EdgesToString(reachable_states_vec) + ")";
@@ -971,13 +958,12 @@ FSMWithStartEnd FSMWithStartEnd::RebuildWithMapping(
 ) const {
   FSM new_fsm = fsm_.RebuildWithMapping(state_mapping, new_num_states);
   auto new_start = state_mapping[start_];
-  std::vector<bool> new_ends(new_num_states, false);
-  for (int end = 0; end < NumStates(); ++end) {
-    if (IsEndState(end)) {
-      new_ends[state_mapping[end]] = true;
-    }
+  std::vector<int32_t> new_ends;
+  new_ends.reserve(ends_.size());
+  for (auto end : ends_) {
+    new_ends.push_back(state_mapping[end]);
   }
-  return FSMWithStartEnd(new_fsm, new_start, new_ends);
+  return FSMWithStartEnd(new_fsm, new_start, std::move(new_ends));
 }
 
 CompactFSMWithStartEnd FSMWithStartEnd::ToCompact() {
@@ -990,11 +976,14 @@ FSMWithStartEndWithSize FSMWithStartEnd::AddToCompleteFSM(
   XGRAMMAR_DCHECK(state_mapping != nullptr) << "state_mapping cannot be nullptr";
   complete_fsm->AddFSM(fsm_, state_mapping);
   int new_start = (*state_mapping)[start_];
-  std::vector<bool> new_ends(complete_fsm->NumStates(), false);
-  for (int end = 0; end < NumStates(); ++end) {
-    if (IsEndState(end)) {
-      new_ends[(*state_mapping)[end]] = true;
-    }
+  // Map the end states to the states in the complete FSM. The mapping is monotonic, so the
+  // sorted invariant is preserved. The sparse representation is important here: this method is
+  // called once per rule, and the ends of each returned view must not scale with the size of the
+  // complete FSM, otherwise the total cost is O(num_rules * num_total_states).
+  std::vector<int32_t> new_ends;
+  new_ends.reserve(ends_.size());
+  for (auto end : ends_) {
+    new_ends.push_back((*state_mapping)[end]);
   }
 
   int num_edges = 0;
@@ -1004,7 +993,7 @@ FSMWithStartEndWithSize FSMWithStartEnd::AddToCompleteFSM(
 
   int num_nodes = fsm_.NumStates();
 
-  auto fsm_with_se = FSMWithStartEnd(*complete_fsm, new_start, new_ends, is_dfa_);
+  auto fsm_with_se = FSMWithStartEnd(*complete_fsm, new_start, std::move(new_ends), is_dfa_);
 
   return FSMWithStartEndWithSize(fsm_with_se, num_edges, num_nodes);
 }
@@ -1012,34 +1001,25 @@ FSMWithStartEndWithSize FSMWithStartEnd::AddToCompleteFSM(
 FSMWithStartEnd FSMWithStartEnd::Star() const {
   FSM fsm = fsm_.Copy();
   auto new_start = fsm.AddState();
-  for (int end = 0; end < NumStates(); ++end) {
-    if (IsEndState(end)) {
-      fsm.AddEpsilonEdge(end, new_start);
-    }
+  for (auto end : ends_) {
+    fsm.AddEpsilonEdge(end, new_start);
   }
   fsm.AddEpsilonEdge(new_start, start_);
-  std::vector<bool> is_end(NumStates() + 1, false);
-  is_end[new_start] = true;
-  return FSMWithStartEnd(fsm, new_start, is_end);
+  return FSMWithStartEnd(fsm, new_start, {new_start});
 }
 
 FSMWithStartEnd FSMWithStartEnd::Plus() const {
   FSM fsm = fsm_.Copy();
-  for (int end = 0; end < NumStates(); ++end) {
-    if (IsEndState(end)) {
-      fsm.AddEpsilonEdge(end, start_);
-    }
+  for (auto end : ends_) {
+    fsm.AddEpsilonEdge(end, start_);
   }
   return FSMWithStartEnd(fsm, start_, ends_);
 }
 
 FSMWithStartEnd FSMWithStartEnd::Optional() const {
   FSM fsm = fsm_.Copy();
-  for (int end = 0; end < NumStates(); ++end) {
-    if (IsEndState(end)) {
-      fsm.AddEpsilonEdge(start_, end);
-      break;
-    }
+  if (!ends_.empty()) {
+    fsm.AddEpsilonEdge(start_, ends_.front());
   }
   return FSMWithStartEnd(fsm, start_, ends_);
 }
@@ -1060,16 +1040,16 @@ Result<FSMWithStartEnd> FSMWithStartEnd::Not(int max_result_num_states) const {
     result = std::move(dfa_result).Unwrap();
   }
   // Reverse all the final states.
-  std::vector<bool> new_final_states(result.NumStates() + 1, false);
+  std::vector<int32_t> new_final_states;
   for (int i = 0; i < result.NumStates(); ++i) {
     if (!result.IsEndState(i)) {
-      new_final_states[i] = true;  // Mark all states as final except the original final states.
+      new_final_states.push_back(i);  // Mark all states as final except the original final states.
     }
   }
 
   // Add a new final state that accepts all characters.
   int accept_all_new_state = result.AddState();
-  new_final_states[accept_all_new_state] = true;
+  new_final_states.push_back(accept_all_new_state);
 
   std::bitset<256> char_set;
   for (int i = 0; i < result.NumStates(); i++) {
@@ -1111,19 +1091,19 @@ FSMWithStartEnd FSMWithStartEnd::Union(const std::vector<FSMWithStartEnd>& fsms)
 
   FSM fsm(1);
   int start = 0;
-  std::vector<bool> ends(1, false);
+  std::vector<int32_t> ends;
 
   std::vector<int> state_mapping;
 
   for (const auto& fsm_with_se : fsms) {
     fsm.AddFSM(fsm_with_se.GetFsm(), &state_mapping);
     fsm.AddEpsilonEdge(start, state_mapping[fsm_with_se.GetStart()]);
-    for (int state = 0; state < fsm_with_se.NumStates(); ++state) {
-      ends.push_back(fsm_with_se.IsEndState(state));
+    for (auto end : fsm_with_se.GetEnds()) {
+      ends.push_back(state_mapping[end]);
     }
   }
 
-  return FSMWithStartEnd(fsm, start, ends);
+  return FSMWithStartEnd(fsm, start, std::move(ends));
 }
 
 FSMWithStartEnd FSMWithStartEnd::Concat(const std::vector<FSMWithStartEnd>& fsms) {
@@ -1137,7 +1117,7 @@ FSMWithStartEnd FSMWithStartEnd::Concat(const std::vector<FSMWithStartEnd>& fsms
 
   FSM fsm;
   int start = 0;
-  std::vector<bool> ends;
+  std::vector<int32_t> ends;
 
   std::vector<int> state_mapping;
   std::vector<int> previous_ends;
@@ -1153,24 +1133,19 @@ FSMWithStartEnd FSMWithStartEnd::Concat(const std::vector<FSMWithStartEnd>& fsms
       }
     }
     if (i == static_cast<int>(fsms.size()) - 1) {
-      ends.resize(fsm.NumStates(), false);
-      for (int end = 0; end < fsms[i].NumStates(); ++end) {
-        if (fsms[i].IsEndState(end)) {
-          ends[state_mapping[end]] = true;
-        }
+      for (auto end : fsms[i].GetEnds()) {
+        ends.push_back(state_mapping[end]);
       }
     } else {
       previous_ends.clear();
-      previous_ends.reserve(fsms[i].GetFsm().NumStates());
-      for (int end = 0; end < fsms[i].NumStates(); ++end) {
-        if (fsms[i].IsEndState(end)) {
-          previous_ends.push_back(state_mapping[end]);
-        }
+      previous_ends.reserve(fsms[i].GetEnds().size());
+      for (auto end : fsms[i].GetEnds()) {
+        previous_ends.push_back(state_mapping[end]);
       }
     }
   }
 
-  return FSMWithStartEnd(fsm, start, ends);
+  return FSMWithStartEnd(fsm, start, std::move(ends));
 }
 
 Result<FSMWithStartEnd> FSMWithStartEnd::Intersect(
@@ -1193,7 +1168,7 @@ Result<FSMWithStartEnd> FSMWithStartEnd::Intersect(
   auto rhs_dfa = std::move(rhs_dfa_raw).Unwrap();
   // Initialize the result FSM.
   FSM result_fsm(0);
-  FSMWithStartEnd result(result_fsm, 0, std::vector<bool>(), true);
+  FSMWithStartEnd result(result_fsm, 0, std::vector<int32_t>(), true);
   std::unordered_map<std::pair<int, int>, int> state_map;
   std::unordered_set<std::pair<int, int>> visited;
   std::queue<std::pair<int, int>> queue;
@@ -1619,7 +1594,7 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states
 }
 
 Result<FSMWithStartEnd> FSMWithStartEnd::MinimizeDFA(int max_num_states) const {
-  FSMWithStartEnd now_fsm(FSM(0), 0, std::vector<bool>(), true);
+  FSMWithStartEnd now_fsm(FSM(0), 0, std::vector<int32_t>(), true);
   if (NumStates() > max_num_states) {
     return ResultErr("The number of states exceeds the limit.");
   }
@@ -1747,7 +1722,7 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
   if (NumStates() > max_num_states) {
     return ResultErr("The number of states exceeds the limit.");
   }
-  FSMWithStartEnd dfa(FSM(0), 0, std::vector<bool>(), true);
+  FSMWithStartEnd dfa(FSM(0), 0, std::vector<int32_t>(), true);
   std::vector<std::unordered_set<int>> closures;
   std::unordered_set<int> rules;
   std::unordered_set<int32_t> repeat_aux_indices;
@@ -1981,8 +1956,8 @@ std::string CompactFSMWithStartEnd::ToString() const {
   std::vector<int> reachable_states_vec(reachable_states.begin(), reachable_states.end());
   std::sort(reachable_states_vec.begin(), reachable_states_vec.end());
   bool first = true;
-  for (int end = 0; end < NumStates(); end++) {
-    if (reachable_states.count(end) && IsEndState(end)) {
+  for (auto end : ends_) {
+    if (reachable_states.count(end)) {
       if (!first) {
         result += ", ";
       }
@@ -2003,7 +1978,11 @@ std::ostream& operator<<(std::ostream& os, const CompactFSMWithStartEnd& fsm) {
 std::size_t MemorySize(const CompactFSM& self) { return MemorySize(*self.ImplPtr()); }
 
 std::size_t MemorySize(const CompactFSMWithStartEnd& self) {
-  return MemorySize(self.fsm_) + MemorySize(self.ends_);
+  // The underlying CompactFSM is not counted here: CompactFSMWithStartEnd is a view, and many
+  // views usually share one CompactFSM (e.g. the per-rule FSMs of a grammar all point to the
+  // grammar's complete FSM, which is counted by the grammar itself). Counting it per view would
+  // multiply the shared FSM's size by the number of views.
+  return MemorySize(self.ends_);
 }
 
 FSMWithStartEnd CompactFSMWithStartEnd::ToFSM() const {

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -597,10 +597,10 @@ class FSMWithStartEndBase {
   // For serialization only
   FSMWithStartEndBase() = default;
 
-  FSMWithStartEndBase(
-      const FSMType& fsm, int start, const std::vector<bool>& ends, bool is_dfa = false
-  )
-      : fsm_(fsm), start_(start), ends_(ends), is_dfa_(is_dfa) {}
+  FSMWithStartEndBase(const FSMType& fsm, int start, std::vector<int32_t> ends, bool is_dfa = false)
+      : fsm_(fsm), start_(start), ends_(std::move(ends)), is_dfa_(is_dfa) {
+    NormalizeEnds();
+  }
 
   /****************** Member Accessors and Mutators ******************/
 
@@ -610,15 +610,20 @@ class FSMWithStartEndBase {
   /*! \brief Returns the start state of the FSM. */
   int GetStart() const { return start_; }
 
-  /*! \brief Returns the end states of the FSM. */
-  const std::vector<bool>& GetEnds() const { return ends_; }
+  /*!
+   * \brief Returns the end states of the FSM as a sorted, deduplicated list of state ids.
+   * \note End states are stored sparsely because an FSM view over a large shared FSM (e.g. the
+   * per-rule FSMs over the complete FSM of a grammar) usually has only a few end states, while
+   * the state id space can be very large.
+   */
+  const std::vector<int32_t>& GetEnds() const { return ends_; }
 
   /*!
    * \brief Checks if a given state is an end/accepting state.
    * \param state The state to check.
    * \return True if the state is an end state, false otherwise.
    */
-  bool IsEndState(int state) const { return ends_[state]; }
+  bool IsEndState(int state) const { return std::binary_search(ends_.begin(), ends_.end(), state); }
 
   /*! \brief Check if a state is scanable.
    *  \param state The state to check.
@@ -662,23 +667,26 @@ class FSMWithStartEndBase {
    */
   void AddEndState(int state) {
     XGRAMMAR_DCHECK(state < NumStates());
-    ends_[state] = true;
+    auto it = std::lower_bound(ends_.begin(), ends_.end(), state);
+    if (it == ends_.end() || *it != state) {
+      ends_.insert(it, state);
+    }
   }
 
   /*!
    * \brief Adds a new state to the FSM and marks it as non-end.
    * \return The index of the newly added state.
    */
-  int AddState() {
-    ends_.push_back(false);
-    return fsm_.AddState();
-  }
+  int AddState() { return fsm_.AddState(); }
 
   /*!
    * \brief Sets the end states of the FSM.
-   * \param ends The new end states.
+   * \param ends The new end states, as a list of state ids. Need not be sorted or deduplicated.
    */
-  void SetEndStates(const std::vector<bool>& ends) { ends_ = ends; }
+  void SetEndStates(std::vector<int32_t> ends) {
+    ends_ = std::move(ends);
+    NormalizeEnds();
+  }
 
   /*! \brief Returns the total number of states in the FSM. */
   int NumStates() const { return fsm_.NumStates(); }
@@ -710,13 +718,23 @@ class FSMWithStartEndBase {
   bool IsLeaf() const;
 
  protected:
+  /*! \brief Sort and deduplicate the end states to maintain the sorted invariant. */
+  void NormalizeEnds() {
+    std::sort(ends_.begin(), ends_.end());
+    ends_.erase(std::unique(ends_.begin(), ends_.end()), ends_.end());
+  }
+
   /*! \brief The underlying finite state machine. */
   FSMType fsm_;
   /*! \brief The start state of the FSM. */
   int start_;
 
-  /*! \brief The set of accepting/end states. */
-  std::vector<bool> ends_;
+  /*!
+   * \brief The set of accepting/end states, stored as a sorted, deduplicated list of state ids.
+   * \note Stored sparsely (rather than as a bitvector over all states) because FSM views over a
+   * large shared FSM usually have only a few end states, while the state id space can be huge.
+   */
+  std::vector<int32_t> ends_;
 
  protected:
   /*! \brief Whether this FSM is a deterministic finite automaton. */
@@ -893,8 +911,9 @@ class CompactFSMWithStartEnd : public FSMWithStartEndBase<CompactFSM> {
   // For serialization only
   CompactFSMWithStartEnd() = default;
 
-  explicit CompactFSMWithStartEnd(const CompactFSM& fsm, int start, const std::vector<bool>& ends)
-      : FSMWithStartEndBase<CompactFSM>(fsm, start, ends), edge_num_(fsm.GetNumEdges()) {}
+  explicit CompactFSMWithStartEnd(const CompactFSM& fsm, int start, std::vector<int32_t> ends)
+      : FSMWithStartEndBase<CompactFSM>(fsm, start, std::move(ends)),
+        edge_num_(fsm.GetNumEdges()) {}
 
   using FSMWithStartEndBase<CompactFSM>::FSMWithStartEndBase;
 
@@ -1003,7 +1022,7 @@ inline bool FSMWithStartEndBase<FSMType>::AcceptString(const std::string& str) c
     start_states = result_states;
   }
   return std::any_of(start_states.begin(), start_states.end(), [&](int state) {
-    return ends_[state];
+    return IsEndState(state);
   });
 }
 

--- a/cpp/fsm_builder.cc
+++ b/cpp/fsm_builder.cc
@@ -193,7 +193,7 @@ Result<std::pair<int, int>> RegexIR::CheckRepeat(const std::string& regex, int& 
 Result<FSMWithStartEnd> RegexIR::Build() const {
   if (states.empty()) {
     FSM empty_fsm(1);
-    FSMWithStartEnd result(empty_fsm, 0, {true}, false);
+    FSMWithStartEnd result(empty_fsm, 0, {0}, false);
     return ResultOk(std::move(result));
   }
   std::vector<FSMWithStartEnd> fsm_list;
@@ -496,9 +496,7 @@ FSMWithStartEnd RegexIR::BuildLeafFSMFromRegex(const std::string& regex) {
         new_fsm.AddEdge(0, 1, last, 0xFF);
       }
     }
-    std::vector<bool> ends(new_fsm.NumStates(), false);
-    ends[1] = true;
-    result = FSMWithStartEnd(new_fsm, 0, ends, false);
+    result = FSMWithStartEnd(new_fsm, 0, {1}, false);
   } else {
     // TODO: The support for rules.
     XGRAMMAR_LOG(WARNING) << "rule is not supported yet.";
@@ -883,12 +881,7 @@ std::optional<FSMWithStartEnd> TrieFSMBuilderImpl::Build(
     XGRAMMAR_LOG(WARNING) << "Excluded patterns are ignored when back edges are not added.";
   }
 
-  std::vector<bool> is_end_state(fsm.NumStates(), false);
-  for (const auto& end : ends) {
-    is_end_state[end] = true;
-  }
-
-  return FSMWithStartEnd(fsm, start, is_end_state);
+  return FSMWithStartEnd(fsm, start, std::vector<int32_t>(ends.begin(), ends.end()));
 }
 
 void TrieFSMBuilderImpl::AddBackEdges(FSM* fsm, int start, const std::unordered_set<int>& ends) {

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -7,6 +7,7 @@
 
 #include <xgrammar/xgrammar.h>
 
+#include <array>
 #include <bitset>
 #include <cstdint>
 #include <map>
@@ -2040,6 +2041,13 @@ class GrammarFSMHasherImpl {
   std::vector<bool> has_inward_edges_;
 
   /*!
+   * \brief The worklist of fsms that are ready to be hashed: fsms whose references are all
+   * hashed (except possibly a self-recursion). Maintained incrementally so that the main hashing
+   * loop is O(V + E) instead of rescanning all rules after each hashed fsm.
+   */
+  std::queue<int32_t> ready_queue_;
+
+  /*!
    * \brief Get the hash value of a fsm, with a given grammar.
    */
   uint64_t HashFsm(int fsm_index);
@@ -2056,11 +2064,22 @@ class GrammarFSMHasherImpl {
   void HashSimpleCycle(const std::vector<int32_t>& simple_cycle);
 
   /*!
-   * \brief Find a simple fsm that can be hashed. If it can't, it will
-   * call FindSimpleCycle() and try to simplify the graph, and then try to
-   * find a simple fsm again.
+   * \brief Check if a fsm is ready to be hashed: it is not hashed yet, and it references no
+   * unhashed fsms other than itself.
    */
-  int32_t FindSimpleFsmCanBeHashed();
+  bool IsReadyToHash(int32_t fsm_index) const {
+    if (visited_[fsm_index]) {
+      return false;
+    }
+    const auto& referees = ref_graph_from_referrer_to_referee_[fsm_index];
+    return referees.empty() || (referees.size() == 1 && referees[0] == fsm_index);
+  }
+
+  /*!
+   * \brief Remove the hashed fsm from the reference graph, and push the referrers that become
+   * ready to hash into the ready queue.
+   */
+  void RemoveHashedFsmFromRefGraph(int32_t fsm_index);
 
   std::pair<bool, uint64_t> IsPartialHashable(int fsm_index);
 };
@@ -2068,6 +2087,9 @@ class GrammarFSMHasherImpl {
 bool GrammarFSMHasherImpl::FindSimpleCycle() {
   // Try to find a simple cycle.
   std::vector<bool> not_simple_cycle = visited_;
+  // Allocated once and cleaned up after each walk, to avoid an O(num_rules) allocation per
+  // outer iteration.
+  std::vector<bool> in_stack(ref_graph_from_referee_to_referrer_.size(), false);
   for (size_t i = 0; i < ref_graph_from_referee_to_referrer_.size(); i++) {
     if (not_simple_cycle[i]) {
       continue;
@@ -2075,10 +2097,11 @@ bool GrammarFSMHasherImpl::FindSimpleCycle() {
     // Not a simple cycle if it has more than one referee.
     std::stack<int32_t> dfs_stack;
     std::vector<int32_t> simple_cycle;
-    auto in_stack = std::vector<bool>(ref_graph_from_referee_to_referrer_.size(), false);
+    std::vector<int32_t> walked_states;
     dfs_stack.push(static_cast<int32_t>(i));
     int32_t current_fsm_index = i;
     in_stack[current_fsm_index] = true;
+    walked_states.push_back(current_fsm_index);
     while ((ref_graph_from_referrer_to_referee_[current_fsm_index].size() == 1) &&
            !not_simple_cycle[current_fsm_index]) {
       XGRAMMAR_CHECK(current_fsm_index != ref_graph_from_referrer_to_referee_[current_fsm_index][0])
@@ -2096,11 +2119,15 @@ bool GrammarFSMHasherImpl::FindSimpleCycle() {
       } else {
         dfs_stack.push(current_fsm_index);
         in_stack[current_fsm_index] = true;
+        walked_states.push_back(current_fsm_index);
       }
     }
     if (!simple_cycle.empty()) {
       HashSimpleCycle(simple_cycle);
       return true;
+    }
+    for (auto state : walked_states) {
+      in_stack[state] = false;
     }
   }
   return false;
@@ -2130,37 +2157,21 @@ void GrammarFSMHasherImpl::HashSimpleCycle(const std::vector<int32_t>& simple_cy
 
   for (int i = 0; i < static_cast<int>(simple_cycle.size()); i++) {
     grammar_->ImplPtr()->per_rule_fsm_hashes[simple_cycle[i]] = local_cycle_hash[i];
-    for (const auto& referer : ref_graph_from_referee_to_referrer_[simple_cycle[i]]) {
-      ref_graph_from_referrer_to_referee_[referer].erase(std::find_if(
-          ref_graph_from_referrer_to_referee_[referer].begin(),
-          ref_graph_from_referrer_to_referee_[referer].end(),
-          [&](int32_t rule_id) { return rule_id == simple_cycle[i]; }
-      ));
-    }
+    RemoveHashedFsmFromRefGraph(simple_cycle[i]);
   }
 }
 
-int32_t GrammarFSMHasherImpl::FindSimpleFsmCanBeHashed() {
-  bool possible_to_find = true;
-  while (possible_to_find) {
-    possible_to_find = false;
-    for (size_t i = 0; i < ref_graph_from_referrer_to_referee_.size(); i++) {
-      if (visited_[i]) {
-        continue;
-      }
-      if (ref_graph_from_referrer_to_referee_[i].empty()) {
-        return i;
-      }
-      if (ref_graph_from_referrer_to_referee_[i].size() == 1 &&
-          ref_graph_from_referrer_to_referee_[i][0] == static_cast<int32_t>(i)) {
-        // Self-recursion fsm.
-        return static_cast<int32_t>(i);
-      }
+void GrammarFSMHasherImpl::RemoveHashedFsmFromRefGraph(int32_t fsm_index) {
+  for (const auto& referer : ref_graph_from_referee_to_referrer_[fsm_index]) {
+    auto& referees = ref_graph_from_referrer_to_referee_[referer];
+    auto it = std::find(referees.begin(), referees.end(), fsm_index);
+    if (it != referees.end()) {
+      referees.erase(it);
     }
-    // Try to find a simple cycle. We must ensure there are not self-recursion cycles.
-    possible_to_find = FindSimpleCycle();
+    if (IsReadyToHash(referer)) {
+      ready_queue_.push(referer);
+    }
   }
-  return -1;
 }
 
 void GrammarFSMHasherImpl::Apply(Grammar* grammar) {
@@ -2209,24 +2220,34 @@ void GrammarFSMHasherImpl::Apply(Grammar* grammar) {
     }
   }
 
-  // Find the fsm which can be hashed: a terminal fsm, or a self-recursion fsm.
-  auto current_operating_index = FindSimpleFsmCanBeHashed();
-  while (current_operating_index != -1) {
+  // Hash the fsms which can be hashed: terminal fsms, or self-recursion fsms. The ready queue
+  // is seeded with all currently hashable fsms and maintained incrementally as fsms are hashed,
+  // so the whole loop is O(V + E) over the reference graph. When no fsm is ready, try to break
+  // a simple cycle in the reference graph and continue.
+  ready_queue_ = {};
+  for (int i = 0; i < (*grammar)->NumRules(); i++) {
+    if (IsReadyToHash(i)) {
+      ready_queue_.push(i);
+    }
+  }
+  while (true) {
+    if (ready_queue_.empty()) {
+      // Try to find a simple cycle. We must ensure there are not self-recursion cycles.
+      if (!FindSimpleCycle()) {
+        break;
+      }
+      continue;
+    }
+    int32_t current_operating_index = ready_queue_.front();
+    ready_queue_.pop();
+    // Skip stale entries: an fsm may be pushed multiple times before it is processed.
+    if (!IsReadyToHash(current_operating_index)) {
+      continue;
+    }
     visited_[current_operating_index] = true;
-
     grammar->ImplPtr()->per_rule_fsm_hashes[current_operating_index] =
         HashFsm(current_operating_index);
-    // Remove the fsm from the reference graph.
-    for (const auto& referer : ref_graph_from_referee_to_referrer_[current_operating_index]) {
-      ref_graph_from_referrer_to_referee_[referer].erase(std::find_if(
-          ref_graph_from_referrer_to_referee_[referer].begin(),
-          ref_graph_from_referrer_to_referee_[referer].end(),
-          [&](int32_t rule_id) { return rule_id == current_operating_index; }
-      ));
-    }
-
-    // Find if there are more fsms can be hashed.
-    current_operating_index = FindSimpleFsmCanBeHashed();
+    RemoveHashedFsmFromRefGraph(current_operating_index);
   }
 
   // Try to hash the remaining fsms: they must contain something can't be hashed, like repetition.
@@ -2568,17 +2589,44 @@ class RuleLevelCache::Impl {
 
   void ClearCache();
 
-  friend size_t MemorySize(const Impl* impl) { return impl->current_cache_memory_size_; }
+  friend size_t MemorySize(const Impl* impl) {
+    int64_t total = 0;
+    for (const auto& shard : impl->shards_) {
+      total += shard.current_cache_memory_size;
+    }
+    return total;
+  }
 
   size_t GetMaxSize() const { return max_cache_memory_size_; }
 
  private:
-  // The cache map: fsm_hash -> fsm_new_node_id -> AdaptiveTokenMask
-  std::mutex mutex_;
+  /*!
+   * \brief The cache is sharded to reduce lock contention: the token mask cache generation
+   * queries and inserts from all compilation threads, and a single global mutex would serialize
+   * them (large grammars issue millions of cache operations).
+   */
+  static constexpr size_t kNumShards = 16;
+
+  struct Shard {
+    std::mutex mutex;
+    int64_t current_cache_memory_size = 0;
+    // The cache map: (fsm_hash, node_id, ...) -> index in cache_list
+    List<NodeType> cache_list;
+    std::unordered_map<NodeKey, int> cache;
+  };
+
+  Shard& GetShard(const NodeKey& key) {
+    return shards_[HashCombine(std::get<0>(key), std::get<1>(key)) % kNumShards];
+  }
+
+  /*! \brief The memory budget of one shard. Eviction is performed per shard. */
+  size_t ShardMaxSize() const {
+    return max_cache_memory_size_ == kUnlimitedSize ? kUnlimitedSize
+                                                    : max_cache_memory_size_ / kNumShards;
+  }
+
   const size_t max_cache_memory_size_;
-  int64_t current_cache_memory_size_ = 0;
-  List<NodeType> cache_list_;
-  std::unordered_map<NodeKey, int> cache_;
+  std::array<Shard, kNumShards> shards_;
 };
 
 std::optional<AdaptiveTokenMask> RuleLevelCache::GetCache(
@@ -2621,16 +2669,17 @@ std::optional<AdaptiveTokenMask> RuleLevelCache::Impl::GetCache(
     const int32_t edge_cnt
 ) {
   // Find in the cache.
-  std::lock_guard<std::mutex> lock(mutex_);
   NodeKey key = std::make_tuple(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
-  auto it = cache_.find(key);
-  if (it == cache_.end()) {
+  Shard& shard = GetShard(key);
+  std::lock_guard<std::mutex> lock(shard.mutex);
+  auto it = shard.cache.find(key);
+  if (it == shard.cache.end()) {
     return std::nullopt;
   }
 
   // Move the node to the back of the list.
-  cache_list_.MoveBack(it->second);
-  return List<NodeType>::iterator(it->second, cache_list_)->second;
+  shard.cache_list.MoveBack(it->second);
+  return List<NodeType>::iterator(it->second, shard.cache_list)->second;
 }
 
 bool RuleLevelCache::Impl::AddCache(
@@ -2651,38 +2700,40 @@ bool RuleLevelCache::Impl::AddCache(
     AdaptiveTokenMask&& token_mask
 ) {
   // Check if we can add to the cache.
-  std::lock_guard<std::mutex> lock(mutex_);
   NodeKey key = std::make_tuple(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
-  if (max_cache_memory_size_ != kUnlimitedSize && MemorySize(token_mask) > max_cache_memory_size_) {
+  Shard& shard = GetShard(key);
+  const size_t shard_max_size = ShardMaxSize();
+  std::lock_guard<std::mutex> lock(shard.mutex);
+  if (shard_max_size != kUnlimitedSize && MemorySize(token_mask) > shard_max_size) {
     // The token mask is too large to be cached.
     return false;
   }
-  if (cache_.find(key) != cache_.end()) {
+  if (shard.cache.find(key) != shard.cache.end()) {
     // Already exists.
     return false;
   }
 
   // Evict old entries if needed.
-  if (max_cache_memory_size_ != kUnlimitedSize) {
+  if (shard_max_size != kUnlimitedSize) {
     size_t new_item_size = MemorySize(token_mask);
-    while ((current_cache_memory_size_) >
-           static_cast<int64_t>(max_cache_memory_size_ - new_item_size)) {
-      auto oldest_it = cache_list_.begin();
-      if (oldest_it == cache_list_.end()) {
+    while ((shard.current_cache_memory_size) > static_cast<int64_t>(shard_max_size - new_item_size)
+    ) {
+      auto oldest_it = shard.cache_list.begin();
+      if (oldest_it == shard.cache_list.end()) {
         // This should not happen if the size of the new item is smaller than
-        // max_cache_memory_size_, but this is a safeguard.
+        // the shard budget, but this is a safeguard.
         break;
       }
-      current_cache_memory_size_ -= MemorySize(oldest_it->second);
-      cache_.erase(oldest_it->first);
-      cache_list_.Erase(oldest_it);
+      shard.current_cache_memory_size -= MemorySize(oldest_it->second);
+      shard.cache.erase(oldest_it->first);
+      shard.cache_list.Erase(oldest_it);
     }
   }
 
   // Add to the cache.
-  auto new_it = cache_list_.PushBack(NodeType(key, std::move(token_mask)));
-  current_cache_memory_size_ += MemorySize(new_it->second);
-  cache_[key] = new_it.Index();
+  auto new_it = shard.cache_list.PushBack(NodeType(key, std::move(token_mask)));
+  shard.current_cache_memory_size += MemorySize(new_it->second);
+  shard.cache[key] = new_it.Index();
   return true;
 }
 
@@ -2690,10 +2741,12 @@ RuleLevelCache::RuleLevelCache(size_t max_cache_memory_size)
     : pimpl_(std::make_shared<Impl>(max_cache_memory_size)) {}
 
 void RuleLevelCache::Impl::ClearCache() {
-  std::lock_guard<std::mutex> lock(mutex_);
-  cache_list_.Clear();
-  cache_.clear();
-  current_cache_memory_size_ = 0;
+  for (auto& shard : shards_) {
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    shard.cache_list.Clear();
+    shard.cache.clear();
+    shard.current_cache_memory_size = 0;
+  }
 }
 
 size_t MemorySize(const RuleLevelCache& manager) { return MemorySize(manager.ImplPtr()); }

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1434,7 +1434,7 @@ FSMWithStartEnd GrammarFSMBuilderImpl::Token(const GrammarExpr& expr) {
   std::vector<int32_t> token_ids(expr.begin(), expr.end());
   FSM fsm(2);
   fsm.AddTokenEdge(0, 1, token_ids);
-  return FSMWithStartEnd(fsm, 0, {false, true});
+  return FSMWithStartEnd(fsm, 0, {1});
 }
 
 FSMWithStartEnd GrammarFSMBuilderImpl::ExcludeToken(const GrammarExpr& expr) {
@@ -1442,7 +1442,7 @@ FSMWithStartEnd GrammarFSMBuilderImpl::ExcludeToken(const GrammarExpr& expr) {
   std::vector<int32_t> token_ids(expr.begin(), expr.end());
   FSM fsm(2);
   fsm.AddExcludeTokenEdge(0, 1, token_ids);
-  return FSMWithStartEnd(fsm, 0, {false, true});
+  return FSMWithStartEnd(fsm, 0, {1});
 }
 
 std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::TokenTagDispatch(
@@ -1452,13 +1452,13 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::TokenTagDispatch(
   bool loop = ttd.loop_after_dispatch;
   int num_states = 1 + num_triggers + (loop ? 0 : 1);
   FSM fsm(num_states);
-  std::vector<bool> ends(num_states, false);
+  std::vector<int32_t> ends;
   int start = 0;
-  ends[start] = true;
+  ends.push_back(start);
   int end_state = -1;
   if (!loop) {
     end_state = num_states - 1;
-    ends[end_state] = true;
+    ends.push_back(end_state);
   }
   std::vector<int32_t> self_loop_exclude;
   for (const auto& [token_id, rule_id] : ttd.trigger_rule_pairs) {
@@ -1619,18 +1619,12 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildTagDispatch(
   }
   auto trie_fsm = trie_result->GetFsm();
   auto start = trie_result->GetStart();
-  std::unordered_set<int> old_ends;
-  std::vector<bool> ends(trie_fsm.NumStates(), false);
-  for (int end = 0; end < trie_result->NumStates(); end++) {
-    if (trie_result->IsEndState(end)) {
-      old_ends.insert(end);
-    }
-  }
 
-  // The final end states are all but old_ends.
+  // The final end states are all but the trie's original end states.
+  std::vector<int32_t> ends;
   for (int i = 0; i < trie_fsm.NumStates(); i++) {
-    if (old_ends.count(i) == 0) {
-      ends[i] = true;
+    if (!trie_result->IsEndState(i)) {
+      ends.push_back(i);
     }
   }
 
@@ -1641,12 +1635,12 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildTagDispatch(
       next_state = start;
     } else {
       next_state = trie_fsm.AddState();
-      ends.push_back(true);
+      ends.push_back(next_state);
     }
     trie_fsm.AddRuleEdge(end_states[i], next_state, string_trigger_rules[i].second);
   }
 
-  return FSMWithStartEnd(trie_fsm, start, ends);
+  return FSMWithStartEnd(trie_fsm, start, std::move(ends));
 }
 
 std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::TagDispatch(

--- a/cpp/support/memory_size.h
+++ b/cpp/support/memory_size.h
@@ -12,6 +12,7 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include "reflection.h"
 
@@ -30,6 +31,8 @@ inline constexpr std::size_t MemorySize(const std::tuple<Ts...>& tpl);
 
 template <typename T>
 inline constexpr std::size_t MemorySize(const std::optional<T>& optional_value);
+
+inline std::size_t MemorySize(const std::vector<bool>& value);
 
 /******************* MemorySize Implementations *******************/
 
@@ -112,6 +115,14 @@ template <typename T>
 inline constexpr std::size_t MemorySize(const std::optional<T>& optional_value) {
   return optional_value.has_value() ? MemorySize(*optional_value) : 0;
 }
+
+/*!
+ * \brief Compute the memory consumption of a std::vector<bool>, which is bit-packed: it stores
+ * one bit (not one byte) per element. The generic container overload would over-count it by 8x.
+ * \param value The vector<bool>.
+ * \return The memory consumption in heap memory of the vector<bool> in bytes.
+ */
+inline std::size_t MemorySize(const std::vector<bool>& value) { return (value.size() + 7) / 8; }
 
 }  // namespace xgrammar
 

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -577,7 +577,7 @@ TEST(XGrammarSerializationTest, TestCompactFSMWithStartEnd) {
     fsm.AddEpsilonEdge(0, 2);
 
     CompactFSM compact_fsm = fsm.ToCompact();
-    CompactFSMWithStartEnd compact_fsm_with_start_end(compact_fsm, 0, {false, false, true});
+    CompactFSMWithStartEnd compact_fsm_with_start_end(compact_fsm, 0, {2});
 
     auto json_value = AutoSerializeJSONValue(compact_fsm_with_start_end);
     ASSERT_TRUE(json_value.is<picojson::array>());
@@ -595,7 +595,7 @@ TEST(XGrammarSerializationTest, TestCompactFSMWithStartEnd) {
     // Test basic properties
     ASSERT_EQ(deserialized.GetFsm().NumStates(), compact_fsm.NumStates());
     ASSERT_EQ(deserialized.GetStart(), 0);
-    ASSERT_EQ(deserialized.GetEnds(), std::vector<bool>({false, false, true}));
+    ASSERT_EQ(deserialized.GetEnds(), std::vector<int32_t>({2}));
 
     // Test roundtrip
     auto json_value2 = AutoSerializeJSONValue(deserialized);
@@ -610,7 +610,7 @@ TEST(XGrammarSerializationTest, TestCompactFSMWithStartEnd) {
     fsm.AddEOSEdge(2, 0);
 
     CompactFSM compact_fsm = fsm.ToCompact();
-    CompactFSMWithStartEnd compact_fsm_with_start_end(compact_fsm, 0, {false, false, true});
+    CompactFSMWithStartEnd compact_fsm_with_start_end(compact_fsm, 0, {2});
 
     auto json_value = AutoSerializeJSONValue(compact_fsm_with_start_end);
 
@@ -626,7 +626,7 @@ TEST(XGrammarSerializationTest, TestCompactFSMWithStartEnd) {
 
     ASSERT_EQ(deserialized.GetFsm().NumStates(), compact_fsm.NumStates());
     ASSERT_EQ(deserialized.GetStart(), 0);
-    ASSERT_EQ(deserialized.GetEnds(), std::vector<bool>({false, false, true}));
+    ASSERT_EQ(deserialized.GetEnds(), std::vector<int32_t>({2}));
 
     // Test roundtrip
     auto json_value2 = AutoSerializeJSONValue(deserialized);

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -3,9 +3,11 @@
 import sys
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Tuple
 
 import pytest
+import torch
 from pydantic import BaseModel
 from transformers import AutoTokenizer
 
@@ -379,6 +381,152 @@ def test_grammar_compiler_crossing_cache_different_grammar_with_same_fsm():
     assert (
         contextb.serialize_json() == contextb_without_cache.serialize_json()
     ), "Cached and non-cached compilations should yield the same result."
+
+
+HASHER_GRAPH_CASES = [
+    (
+        """
+root ::= first
+first ::= "a" second
+second ::= "b" third
+third ::= "c"
+""",
+        ["abc"],
+        ["", "ab", "abd"],
+    ),
+    (
+        """
+root ::= left | right
+left ::= "a" leaf
+right ::= "b" leaf
+leaf ::= "c"
+""",
+        ["ac", "bc"],
+        ["a", "b", "cc"],
+    ),
+    (
+        """
+root ::= node
+node ::= "a" node | "z"
+""",
+        ["z", "az", "aaaz"],
+        ["", "a", "za"],
+    ),
+    (
+        """
+root ::= "s" outer
+outer ::= "a" middle | "z"
+middle ::= "b" inner
+inner ::= "c" outer | "d"
+""",
+        ["sz", "sabd", "sabcz", "sabcabd"],
+        ["", "s", "sab", "sabc"],
+    ),
+    (
+        """
+root ::= pair
+pair ::= leaf leaf | leaf
+leaf ::= "x" | "y"
+""",
+        ["x", "y", "xx", "xy", "yx", "yy"],
+        ["", "xxx", "z"],
+    ),
+    (
+        """
+root ::= item {2, 3}
+item ::= "a" | "bc"
+""",
+        ["aa", "abc", "bca", "bcbc", "aaa", "abca"],
+        ["", "a", "bc", "aaaa"],
+    ),
+]
+
+
+def _compiled_accepts(compiled_grammar: xgr.CompiledGrammar, input_str: str) -> bool:
+    matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+    return matcher.accept_string(input_str) and matcher.is_terminated()
+
+
+def _mask_trace(compiled_grammar: xgr.CompiledGrammar, input_str: str):
+    matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+    bitmask = xgr.allocate_token_bitmask(1, compiled_grammar.tokenizer_info.vocab_size)
+    trace = []
+    for char in input_str:
+        xgr.reset_token_bitmask(bitmask)
+        need_apply = matcher.fill_next_token_bitmask(bitmask)
+        trace.append((need_apply, bitmask.clone()))
+        assert matcher.accept_string(char)
+    assert matcher.is_terminated()
+    return trace
+
+
+@pytest.mark.parametrize(
+    "grammar_str,accepted_inputs,rejected_inputs",
+    HASHER_GRAPH_CASES,
+    ids=["chain", "diamond", "self-cycle", "cycle-with-tail", "duplicate-referee", "repeat"],
+)
+def test_grammar_fsm_hasher_worklist_graphs(
+    grammar_str: str, accepted_inputs: List[str], rejected_inputs: List[str]
+):
+    """Compare cache and threading paths across the hasher's graph corner cases."""
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c", "d", "s", "x", "y", "z", "ab", "bc", "abc"])
+    compiled_variants = [
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, cache_enabled=False).compile_grammar(
+            grammar_str
+        ),
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, cache_enabled=True).compile_grammar(
+            grammar_str
+        ),
+        xgr.GrammarCompiler(tokenizer_info, max_threads=8, cache_enabled=True).compile_grammar(
+            grammar_str
+        ),
+    ]
+
+    for compiled in compiled_variants:
+        for input_str in accepted_inputs:
+            assert _compiled_accepts(compiled, input_str)
+        for input_str in rejected_inputs:
+            assert not _compiled_accepts(compiled, input_str)
+
+    expected_trace = _mask_trace(compiled_variants[0], accepted_inputs[0])
+    for compiled in compiled_variants[1:]:
+        actual_trace = _mask_trace(compiled, accepted_inputs[0])
+        assert len(actual_trace) == len(expected_trace)
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(
+            expected_trace, actual_trace
+        ):
+            assert actual_apply == expected_apply
+            torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_sharded_rule_cache_concurrent_compilation():
+    """Propagate worker failures while exercising concurrent cache lookup and insertion."""
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c", "d", "x", "y", "z", "ab", "bc"])
+    cache_limit = 4 * 1024 * 1024
+    compiler = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=4, cache_enabled=True, cache_limit_bytes=cache_limit
+    )
+    cases = HASHER_GRAPH_CASES[:5]
+
+    def compile_and_check(index: int) -> None:
+        grammar_str, accepted_inputs, rejected_inputs = cases[index % len(cases)]
+        compiled = compiler.compile_grammar(grammar_str)
+        assert _compiled_accepts(compiled, accepted_inputs[0])
+        assert not _compiled_accepts(compiled, rejected_inputs[0])
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = [executor.submit(compile_and_check, i) for i in range(32)]
+        for future in futures:
+            future.result()
+
+    assert 0 < compiler.get_cache_size_bytes() <= cache_limit
+    size_before_reuse = compiler.get_cache_size_bytes()
+    for index in range(len(cases)):
+        compile_and_check(index)
+    assert compiler.get_cache_size_bytes() == size_before_reuse
+
+    compiler.clear_cache()
+    assert compiler.get_cache_size_bytes() == 0
 
 
 if __name__ == "__main__":

--- a/tests/python/test_grammar_matcher_ebnf.py
+++ b/tests/python/test_grammar_matcher_ebnf.py
@@ -955,5 +955,31 @@ def test_repeat_ref_complex_nested():
     assert not _is_grammar_accept_string(grammar, "[" + body_few + "]")
 
 
+@pytest.mark.parametrize(
+    "grammar_str,accepted_inputs,rejected_inputs",
+    [
+        ('root ::= ("a" | "bc")? "z"', ["z", "az", "bcz"], ["", "a", "bc", "bz", "abcz"]),
+        ('root ::= ("a" | "bc")*', ["", "a", "bc", "abc", "bca", "bcbca"], ["b", "c", "ac", "ab"]),
+        ('root ::= ("a" | "bc")+', ["a", "bc", "abc", "bca", "bcbc"], ["", "b", "c", "ac"]),
+        ("root ::= [^a-cx-z]+", ["d", "w", "dw"], ["a", "x", "da", "wy"]),
+        (
+            'root ::= ("ab" | "ac" | "db" | "dc") ("x" | "yz")',
+            ["abx", "abyz", "acx", "dbyz", "dcx"],
+            ["ab", "x", "adx", "dcy", "abxyz"],
+        ),
+    ],
+    ids=["optional", "star", "plus", "complement", "state-remapping"],
+)
+def test_sparse_end_state_fsm_operations(
+    grammar_str: str, accepted_inputs: List[str], rejected_inputs: List[str]
+):
+    """Exercise FSM operations that create, combine, invert, or remap multiple end states."""
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    for input_str in accepted_inputs:
+        assert _is_grammar_accept_string(grammar, input_str)
+    for input_str in rejected_inputs:
+        assert not _is_grammar_accept_string(grammar, input_str)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import sys
 import threading
@@ -291,6 +292,42 @@ def test_empty_tag_dispatch():
     assert _is_grammar_accept_string(grammar_with_excludes, "好")
     assert not _is_grammar_accept_string(grammar_with_excludes, "any stringend")
     assert not _is_grammar_accept_string(grammar_with_excludes, "endaaa")
+
+
+@pytest.mark.parametrize("loop", [False, True])
+def test_dense_tag_dispatch_end_states(loop: bool):
+    """Exercise dense accepting states and the post-dispatch final state."""
+    patterns = ["@" + hashlib.sha1(f"sparse-end-{i}".encode()).hexdigest()[:12] for i in range(32)]
+    dispatch = {
+        "type": "structural_tag",
+        "format": {
+            "type": "dispatch",
+            "rules": [
+                [pattern, {"type": "const_string", "value": f"X{i:02d}"}]
+                for i, pattern in enumerate(patterns)
+            ],
+            "loop": loop,
+            "excludes": [],
+        },
+    }
+    compiled = xgr.GrammarCompiler(
+        xgr.TokenizerInfo([]), cache_enabled=False
+    ).compile_structural_tag(dispatch)
+
+    def accepts(input_str: str) -> bool:
+        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        return matcher.accept_string(input_str) and matcher.is_terminated()
+
+    for index in [0, 15, 31]:
+        assert accepts(f"free{patterns[index]}X{index:02d}")
+        assert not accepts(f"free{patterns[index]}WRONG")
+
+    repeated = f"free{patterns[0]}X00tail{patterns[31]}X31"
+    if loop:
+        assert accepts(repeated)
+    else:
+        assert not accepts(repeated)
+        assert not accepts(f"free{patterns[0]}X00tail")
 
 
 def test_excludes_overlapping_prefixes():

--- a/tests/python/test_grammar_union_concat.py
+++ b/tests/python/test_grammar_union_concat.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 
 import xgrammar as xgr
+from xgrammar.testing import _is_grammar_accept_string
 
 
 def test_grammar_union():
@@ -158,6 +159,25 @@ root_2 ::= (([a-z] root_2) | ([a-z]))
     assert str(grammar_union) == expected_grammar_union
     grammar_concat = xgr.Grammar.concat(stag_grammar, start_grammar)
     assert str(grammar_concat) == expected_grammar_concat
+
+
+def test_grammar_union_concat_compiled_semantics():
+    """Check end-state mapping after union and concatenation are optimized into FSMs."""
+    nullable = xgr.Grammar.from_ebnf('root ::= "a" | ""')
+    alternatives = xgr.Grammar.from_ebnf('root ::= "bc" | "d"')
+    repeated = xgr.Grammar.from_ebnf("root ::= [x-z]+")
+
+    union = xgr.Grammar.union(nullable, alternatives, repeated)
+    for input_str in ["", "a", "bc", "d", "x", "xyz"]:
+        assert _is_grammar_accept_string(union, input_str)
+    for input_str in ["ab", "bd", "1", "ax"]:
+        assert not _is_grammar_accept_string(union, input_str)
+
+    concatenated = xgr.Grammar.concat(nullable, alternatives, repeated)
+    for input_str in ["bcx", "dxyz", "abcx", "adxyz"]:
+        assert _is_grammar_accept_string(concatenated, input_str)
+    for input_str in ["", "a", "bc", "x", "abdx", "abc"]:
+        assert not _is_grammar_accept_string(concatenated, input_str)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_pressure.py
+++ b/tests/python/test_pressure.py
@@ -1,0 +1,204 @@
+"""Local pressure tests for representative large-grammar workloads."""
+
+import hashlib
+import json
+import math
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, List
+
+import pytest
+from transformers import AutoTokenizer
+
+import xgrammar as xgr
+
+
+def _running_in_ci() -> bool:
+    true_values = {"1", "true", "yes", "on"}
+    return any(
+        os.environ.get(name, "").strip().lower() in true_values for name in ("CI", "GITHUB_ACTIONS")
+    )
+
+
+pytestmark = [
+    pytest.mark.skipif(_running_in_ci(), reason="Pressure tests are intended for local runs"),
+    pytest.mark.hf_token_required,
+]
+
+
+@dataclass
+class Workload:
+    name: str
+    compile_kind: str
+    source: Any
+    valid_input: str
+
+
+def _make_flat_json_workload(size: int) -> Workload:
+    names = [f"field_{i:05d}" for i in range(size)]
+    schema = {
+        "type": "object",
+        "properties": {name: {"type": "string"} for name in names},
+        "required": names,
+        "additionalProperties": False,
+    }
+    instance = dict.fromkeys(names, "x")
+    return Workload(
+        name=f"flat_json_{size}",
+        compile_kind="json",
+        source=json.dumps(schema, separators=(",", ":")),
+        valid_input=json.dumps(instance, separators=(",", ":")),
+    )
+
+
+def _make_dense_patterns(size: int) -> List[str]:
+    return ["@" + hashlib.sha1(f"dispatch-{i}".encode()).hexdigest()[:15] for i in range(size)]
+
+
+def _make_shared_prefix_patterns(size: int) -> List[str]:
+    return [f"<function=namespace.deep.tool_{i:05d}>" for i in range(size)]
+
+
+def _make_dispatch_workload(
+    name: str, patterns: List[str], *, unique_content: bool = False
+) -> Workload:
+    rules = [
+        [pattern, {"type": "const_string", "value": f"X{i:05d}" if unique_content else "X"}]
+        for i, pattern in enumerate(patterns)
+    ]
+    selected = len(patterns) - 269
+    content = f"X{selected:05d}" if unique_content else "X"
+    valid_input = ("free" + patterns[selected] + content) * 16 + "tail"
+    return Workload(
+        name=name,
+        compile_kind="structural_tag",
+        source={
+            "type": "structural_tag",
+            "format": {"type": "dispatch", "rules": rules, "loop": True, "excludes": []},
+        },
+        valid_input=valid_input,
+    )
+
+
+def _make_ring_workload(size: int) -> Workload:
+    lines = ["root ::= rule_00000"]
+    for index in range(size):
+        next_index = (index + 1) % size
+        lines.append(f'rule_{index:05d} ::= "a{index:05d}" rule_{next_index:05d} | "z{index:05d}"')
+    return Workload(
+        name=f"ring_ebnf_{size}",
+        compile_kind="grammar",
+        source="\n".join(lines) + "\n",
+        valid_input="z00000",
+    )
+
+
+def _get_workload(name: str) -> Workload:
+    if name == "flat_json_20000":
+        return _make_flat_json_workload(20_000)
+    if name == "flat_json_50000":
+        return _make_flat_json_workload(50_000)
+    if name == "ac_dense_4000":
+        return _make_dispatch_workload(name, _make_dense_patterns(4_000))
+    if name == "ac_dense_unique_4000":
+        return _make_dispatch_workload(name, _make_dense_patterns(4_000), unique_content=True)
+    if name == "ac_shared_prefix_4000":
+        return _make_dispatch_workload(name, _make_shared_prefix_patterns(4_000))
+    if name == "ring_ebnf_4000":
+        return _make_ring_workload(4_000)
+    raise ValueError(f"Unknown pressure workload: {name}")
+
+
+def _compile_workload(compiler: xgr.GrammarCompiler, workload: Workload) -> xgr.CompiledGrammar:
+    if workload.compile_kind == "json":
+        return compiler.compile_json_schema(
+            workload.source, any_whitespace=True, max_whitespace_cnt=4
+        )
+    if workload.compile_kind == "grammar":
+        return compiler.compile_grammar(workload.source)
+    if workload.compile_kind == "structural_tag":
+        return compiler.compile_structural_tag(workload.source)
+    raise ValueError(f"Unknown compile kind: {workload.compile_kind}")
+
+
+def _nearest_rank_percentile(samples: List[float], percentile: float) -> float:
+    ordered = sorted(samples)
+    index = max(0, math.ceil(percentile * len(ordered)) - 1)
+    return ordered[index]
+
+
+def _token_is_allowed(bitmask, token_id: int) -> bool:
+    word = int(bitmask[0, token_id // 32])
+    return ((word >> (token_id % 32)) & 1) == 1
+
+
+def _measure_mask_calls(
+    compiled: xgr.CompiledGrammar, tokenizer: Any, valid_input: str
+) -> List[float]:
+    token_ids = tokenizer.encode(valid_input, add_special_tokens=False)[:96]
+    assert token_ids
+    measured_repeats = max(5, math.ceil(512 / len(token_ids)))
+    samples = []
+    for repeat in range(measured_repeats + 1):
+        matcher = xgr.GrammarMatcher(compiled)
+        bitmask = xgr.allocate_token_bitmask(1, compiled.tokenizer_info.vocab_size)
+        for token_id in token_ids:
+            xgr.reset_token_bitmask(bitmask)
+            start = time.perf_counter_ns()
+            matcher.fill_next_token_bitmask(bitmask)
+            elapsed_us = (time.perf_counter_ns() - start) / 1_000
+            assert _token_is_allowed(bitmask, token_id)
+            assert matcher.accept_token(token_id)
+            if repeat > 0:
+                samples.append(elapsed_us)
+    return samples
+
+
+@pytest.fixture(scope="module")
+def glm_tokenizer():
+    return AutoTokenizer.from_pretrained("zai-org/GLM-5.2", trust_remote_code=True)
+
+
+@pytest.fixture(scope="module")
+def glm_tokenizer_info(glm_tokenizer):
+    return xgr.TokenizerInfo.from_huggingface(glm_tokenizer)
+
+
+@pytest.mark.parametrize(
+    "workload_name",
+    [
+        "flat_json_20000",
+        "flat_json_50000",
+        "ac_dense_4000",
+        "ac_dense_unique_4000",
+        "ac_shared_prefix_4000",
+        "ring_ebnf_4000",
+    ],
+)
+def test_pressure_workload(workload_name: str, glm_tokenizer, glm_tokenizer_info):
+    workload = _get_workload(workload_name)
+    compiler = xgr.GrammarCompiler(
+        glm_tokenizer_info, max_threads=8, cache_enabled=True, cache_limit_bytes=512 * 1024 * 1024
+    )
+
+    cpu_start = time.process_time()
+    wall_start = time.perf_counter()
+    compiled = _compile_workload(compiler, workload)
+    compile_wall_ms = (time.perf_counter() - wall_start) * 1_000
+    compile_cpu_ms = (time.process_time() - cpu_start) * 1_000
+
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_string(workload.valid_input)
+    assert matcher.is_terminated()
+
+    mask_samples = _measure_mask_calls(compiled, glm_tokenizer, workload.valid_input)
+    result = {
+        "workload": workload.name,
+        "compile_wall_ms": compile_wall_ms,
+        "compile_cpu_ms": compile_cpu_ms,
+        "mask_p50_us": _nearest_rank_percentile(mask_samples, 0.50),
+        "mask_p99_us": _nearest_rank_percentile(mask_samples, 0.99),
+        "mask_samples": len(mask_samples),
+    }
+    print("PRESSURE_RESULT " + json.dumps(result, sort_keys=True))


### PR DESCRIPTION
## Summary

Follow-up to #691. This PR removes the remaining bottlenecks when compiling very large grammars. Together the three commits bring the flat 50k-property schema (`any_whitespace=True`, `max_whitespace_cnt=4`, vocab 154,856, 8 threads, cache enabled) from **18.5s / 6.6GB peak RSS on main to 3.6s / 2.0GB** (~1.3GB of the RSS is the Python/torch/tokenizer process baseline, so the grammar-side footprint is ~0.7GB).

### 1. Sparse FSM end states (main change)

`FSMWithStartEndBase` stored end states as a `std::vector<bool>` over the whole state id space, so every per-rule FSM view over the grammar's complete FSM carried a bitvector sized to the **entire** complete FSM. That is O(num_rules × num_total_states) time and memory in `GrammarFSMBuilder` — for the 50k schema, ~5GB of almost-all-zero bitvectors, allocated per rule in `AddToCompleteFSM` and persisted in `per_rule_fsms`.

End states are now a **sorted, deduplicated `std::vector<int32_t>` of state ids** (FSM views typically have 1–3 end states). `IsEndState` becomes a binary search over a tiny array; loops of the form `for (state : 0..NumStates()) if (IsEndState(state))` now iterate the end list directly. The **serialization format is unchanged**: end states were already serialized sparsely (`end_index`), so no version bump is needed and old blobs still roundtrip.

### 2. O(V+E) hashing loop in GrammarFSMHasher

With `cache_enabled=True`, `GrammarFSMHasher` rescanned all rules after every hashed fsm to find the next hashable one (`FindSimpleFsmCanBeHashed`), which is O(V²) and took ~45% of `compile_grammar` time at 50k rules (profiled). The rescan is replaced with an incrementally maintained ready queue, making the hashing loop O(V + E) over the rule reference graph.

### 3. Sharded RuleLevelCache lock

The rule-level cache used one global mutex; mask-cache generation issues millions of cache lookups/insertions from all compilation threads, which the global lock serialized. The cache is now sharded into 16 independently locked shards keyed by fsm hash, with per-shard eviction budgets.

### Also fixed: memory accounting

`CompiledGrammar.memory_size_bytes` was wildly over-reported (662GB reported vs ~0.3GB actual for the 50k schema), effectively breaking `cache_limit_bytes`-based cache admission:

- `MemorySize(std::vector<bool>)` counted 1 byte per bit-packed element (8× over-count).
- `MemorySize(CompactFSMWithStartEnd)` counted the underlying shared `CompactFSM` once **per view**, while the complete FSM is already counted by the grammar itself.

## Results

Flat 50k-property schema, end-to-end `compile_json_schema` (cache enabled):

| Metric | main | this PR |
|---|---|---|
| compile time | 18.5s | **3.6s** |
| peak RSS | 6.6GB | **2.0GB** (1.3GB process baseline) |
| `memory_size_bytes` reported | 662GB | 0.12GB |

`compile_grammar` with `cache_enabled=False` is 1.9s; the remaining gap to the cache-enabled path is the inherent cost of hashing all rule FSMs and populating the cross-grammar cache. After these changes no single function exceeds ~2% of the profile (the remainder is spread across the Earley parser inner loops of mask generation).

For context, the same schema was >30 minutes and hundreds of GB of RSS before #691.

## Test plan

- [x] C++ unit tests: 47/47 pass
- [x] Python: `test_grammar_parser`, `test_json_schema_converter`, `test_regex_converter`, `test_grammar_matcher_basic`, `test_grammar_matcher_ebnf`: 770 pass
- [x] Python: `test_grammar_matcher_json_schema`, `test_grammar_matcher_regex`, `test_grammar_compiler`, `test_serialization`, `test_grammar_matcher_structural_tag`, `test_token_edge`: 274 pass
- [x] Serialization literal-string tests unchanged except the `GetEnds()` type expectation (JSON output identical)
- [x] End-to-end perf/memory measurements above (all re-run after each commit)

## Alternative evaluated: independently compacted per-rule FSMs

We also prototyped a broader layout where every rule owns a local compact FSM and a local `std::vector<bool>` end-state bitmap, instead of viewing one fused FSM through global state ids. This keeps end-state checks O(1), improves locality for rule-level operations, and could simplify future per-rule caching or parallel construction.

The prototype showed modest additional gains. On flat JSON 20k with #691, fused sparse ends reduced compile wall time / CPU time / FSM-build wall time / peak RSS by 22.9% / 10.2% / 41.3% / 50.6%; independent compact FSMs reduced them by 30.1% / 15.5% / 44.9% / 50.5%. On the four target GLM-5.2 Aho-Corasick workloads, its single-call mask p99 changes were -1.9%, -0.1%, -29.7%, and -12.6%, and it delayed the isolated extreme compile-scaling regression from 20k to 50k triggers. It also regressed mask p99 on several non-target workloads.

Adopting this layout requires substantially broader changes to FSM ownership, the optimizer, parser, hashing, memory accounting, and serialization; the current format assumes a fused FSM for repeat-edge information. Given the limited incremental benefit and larger compatibility risk, this PR keeps the fused FSM with sparse ends. The independent layout remains an experimental prototype and is not included in the production implementation.
