### PR TITLE
add Lark grammar frontend

### DIFF
--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -76,9 +76,11 @@ Grammar Grammar::FromRegex(const std::string& regex, bool print_converted_ebnf) 
 }
 
 Grammar Grammar::FromLark(
-    const std::string& lark_string, const std::optional<TokenizerInfo>& tokenizer_info
+    const std::string& lark_string,
+    const std::optional<TokenizerInfo>& tokenizer_info,
+    const std::vector<NamedGrammar>& named_grammars
 ) {
-  return LarkToGrammar(lark_string, tokenizer_info);
+  return LarkToGrammar(lark_string, tokenizer_info, named_grammars);
 }
 
 std::variant<Grammar, StructuralTagError> Grammar::FromStructuralTag(

--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -11,6 +11,7 @@
 #include "grammar_parser.h"
 #include "grammar_printer.h"
 #include "json_schema_converter.h"
+#include "lark_converter.h"
 #include "regex_converter.h"
 #include "structural_tag.h"
 #include "support/json_serializer.h"
@@ -72,6 +73,12 @@ Grammar Grammar::FromRegex(const std::string& regex, bool print_converted_ebnf) 
     XGRAMMAR_LOG(INFO) << "Converted EBNF: " << ebnf_string << std::endl;
   }
   return FromEBNF(ebnf_string);
+}
+
+Grammar Grammar::FromLark(
+    const std::string& lark_string, const std::optional<TokenizerInfo>& tokenizer_info
+) {
+  return LarkToGrammar(lark_string, tokenizer_info);
 }
 
 std::variant<Grammar, StructuralTagError> Grammar::FromStructuralTag(

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -2012,15 +2012,16 @@ class RootRuleRenamerImpl {
     grammar_copy->GetRule(grammar_copy->GetRootRuleId()).name = "root";
     if (root_name_rule_id != -1) {
       std::string rule_prefix = "root_";
+      bool renamed = false;
       for (int i = 0; i <= grammar_copy->NumRules(); i++) {
         std::string new_rule_name = rule_prefix + std::to_string(i);
         if (rule_names.find(new_rule_name) == rule_names.end()) {
           grammar_copy->GetRule(root_name_rule_id).name = new_rule_name;
+          renamed = true;
           break;
         }
-        XGRAMMAR_DCHECK(false
-        ) << "The rule must be renamed successfully after (n + 1) times of iterations.";
       }
+      XGRAMMAR_DCHECK(renamed) << "Rule renaming must succeed within (n + 1) attempts.";
     }
     return grammar_copy;
   }

--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -71,7 +71,7 @@ enum class TokenType {
   kGrammarRef,
   kJson,
   kRegexExt,
-  kLLGuidance,
+  kGrammarOptions,
   kImport,
   kIgnore,
   kLark,
@@ -439,8 +439,8 @@ class LarkLexer {
     if (directive == "%regex") {
       return LexJSONValue(TokenType::kRegexExt, location, directive);
     }
-    if (directive == "%llguidance") {
-      return LexJSONValue(TokenType::kLLGuidance, location, directive);
+    if (directive == "%grammar_options") {
+      return LexJSONValue(TokenType::kGrammarOptions, location, directive);
     }
     if (directive == "%import") {
       return {TokenType::kImport, directive, "", location};
@@ -517,6 +517,8 @@ struct Definition {
   std::string name;
   bool is_terminal = false;
   bool lazy = false;
+  std::optional<std::string> suffix;
+  Location suffix_location;
   Node body;
   Location location;
 };
@@ -579,7 +581,7 @@ class LarkParser {
         case TokenType::kIgnore:
           ParseIgnore(&document);
           break;
-        case TokenType::kLLGuidance:
+        case TokenType::kGrammarOptions:
           ParseOptions(&document);
           break;
         case TokenType::kUnsupportedDirective:
@@ -647,11 +649,11 @@ class LarkParser {
   }
 
   void ParseOptions(Document* document) {
-    Token token = Consume(TokenType::kLLGuidance, "expected %llguidance");
+    Token token = Consume(TokenType::kGrammarOptions, "expected %grammar_options");
     picojson::value value;
     std::string error = picojson::parse(value, token.text);
     if (!error.empty()) {
-      RaiseLarkError(source_, token.location, "invalid %llguidance value: " + error);
+      RaiseLarkError(source_, token.location, "invalid %grammar_options value: " + error);
     }
     document->options.push_back({std::move(value), token.location});
   }
@@ -689,6 +691,23 @@ class LarkParser {
       Token key = Consume(TokenType::kName, "expected rule attribute");
       if (key.text == "lazy" && Peek().type != TokenType::kEquals) {
         definition->lazy = true;
+      } else if (key.text == "suffix") {
+        Consume(TokenType::kEquals, "expected '=' after suffix attribute");
+        Token suffix_token = Consume(TokenType::kString, "expected string literal after suffix=");
+        Node suffix = ParseStringNode(suffix_token);
+        if (!suffix.flags.empty()) {
+          RaiseLarkError(
+              source_, suffix.location, "case-insensitive flags are not supported on suffix"
+          );
+        }
+        if (suffix.text.empty()) {
+          RaiseLarkError(source_, suffix.location, "suffix must not be empty");
+        }
+        if (definition->suffix.has_value()) {
+          RaiseLarkError(source_, key.location, "suffix attribute is specified more than once");
+        }
+        definition->suffix = std::move(suffix.text);
+        definition->suffix_location = suffix.location;
       } else {
         RaiseLarkError(
             source_,
@@ -855,11 +874,18 @@ class LarkParser {
       Node result = ParseStringNode(token);
       if (Match(TokenType::kDotDot)) {
         Token end = Consume(TokenType::kString, "expected string after '..'");
+        Node end_node = ParseStringNode(end);
+        if (!result.flags.empty()) {
+          RaiseLarkError(source_, token.location, "flags are not allowed on character ranges");
+        }
+        if (!end_node.flags.empty()) {
+          RaiseLarkError(source_, end.location, "flags are not allowed on character ranges");
+        }
         Node range;
         range.kind = Node::Kind::kRange;
         range.location = token.location;
         range.text = result.text;
-        range.text2 = ParseStringNode(end).text;
+        range.text2 = end_node.text;
         return range;
       }
       return result;
@@ -1001,14 +1027,148 @@ std::string Trim(std::string value) {
   return value.substr(begin, end - begin);
 }
 
+std::string RewriteRegexDots(const std::string& pattern, bool dot_matches_newline) {
+  if (dot_matches_newline) {
+    return pattern;
+  }
+  std::string result;
+  result.reserve(pattern.size());
+  bool escaped = false;
+  bool in_character_class = false;
+  for (char c : pattern) {
+    if (escaped) {
+      result.push_back(c);
+      escaped = false;
+      continue;
+    }
+    if (c == '\\') {
+      result.push_back(c);
+      escaped = true;
+    } else if (c == '[') {
+      result.push_back(c);
+      in_character_class = true;
+    } else if (c == ']' && in_character_class) {
+      result.push_back(c);
+      in_character_class = false;
+    } else if (c == '.' && !in_character_class) {
+      result += "[^\\n]";
+    } else {
+      result.push_back(c);
+    }
+  }
+  return result;
+}
+
+std::optional<std::string> ParseFixedRegexLiteral(const std::string& pattern) {
+  std::string result;
+  for (size_t i = 0; i < pattern.size();) {
+    char c = pattern[i++];
+    if (c != '\\') {
+      if (std::string(".^$*+?()[]{}|").find(c) != std::string::npos) {
+        return std::nullopt;
+      }
+      result.push_back(c);
+      continue;
+    }
+    if (i == pattern.size()) {
+      return std::nullopt;
+    }
+    char escaped = pattern[i++];
+    switch (escaped) {
+      case 'n':
+        result.push_back('\n');
+        break;
+      case 'r':
+        result.push_back('\r');
+        break;
+      case 't':
+        result.push_back('\t');
+        break;
+      case 'f':
+        result.push_back('\f');
+        break;
+      case 'v':
+        result.push_back('\v');
+        break;
+      case '0':
+        result.push_back('\0');
+        break;
+      case '^':
+      case '$':
+      case '.':
+      case '*':
+      case '+':
+      case '?':
+      case '(':
+      case ')':
+      case '[':
+      case ']':
+      case '{':
+      case '}':
+      case '|':
+      case '\\':
+      case '/':
+      case '-':
+        result.push_back(escaped);
+        break;
+      case 'x':
+      case 'u': {
+        bool braced = escaped == 'u' && i < pattern.size() && pattern[i] == '{';
+        TCodepoint codepoint = 0;
+        if (braced) {
+          ++i;
+          int digit_count = 0;
+          while (i < pattern.size() && HexCharToInt(pattern[i]) != -1 && digit_count < 6) {
+            codepoint = codepoint * 16 + HexCharToInt(pattern[i++]);
+            ++digit_count;
+          }
+          if (digit_count == 0 || i >= pattern.size() || pattern[i++] != '}') {
+            return std::nullopt;
+          }
+        } else {
+          int digit_count = escaped == 'x' ? 2 : 4;
+          if (i + static_cast<size_t>(digit_count) > pattern.size()) {
+            return std::nullopt;
+          }
+          for (int digit = 0; digit < digit_count; ++digit) {
+            int value = HexCharToInt(pattern[i++]);
+            if (value == -1) {
+              return std::nullopt;
+            }
+            codepoint = codepoint * 16 + value;
+          }
+        }
+        if (codepoint > 0x10FFFF || (codepoint >= 0xD800 && codepoint <= 0xDFFF)) {
+          return std::nullopt;
+        }
+        result += CharToUTF8(codepoint);
+        break;
+      }
+      default:
+        return std::nullopt;
+    }
+  }
+  return result;
+}
+
+struct NamedGrammarRegistry {
+  std::unordered_map<std::string, std::variant<Grammar, std::string>> inputs;
+  std::unordered_map<std::string, Grammar> compiled;
+  std::vector<std::string> active;
+};
+
 class LarkCompiler {
  public:
   LarkCompiler(
       const std::string& source,
       Document document,
-      const std::optional<TokenizerInfo>& tokenizer_info
+      const std::optional<TokenizerInfo>& tokenizer_info,
+      NamedGrammarRegistry& named_grammars
   )
-      : source_(source), document_(std::move(document)), tokenizer_info_(tokenizer_info) {}
+      : source_(source),
+        document_(std::move(document)),
+        tokenizer_info_(tokenizer_info),
+        named_grammars_(named_grammars) {}
 
   Grammar Compile() {
     ExpandImports();
@@ -1045,7 +1205,7 @@ class LarkCompiler {
       if (definition.name == "start") {
         if (dynamic_start_body.has_value()) {
           body_expr_id = dynamic_start_body.value();
-        } else if (definition.lazy) {
+        } else if (HasLazySemantics(definition)) {
           body_expr_id = CompileLazyRule(definition);
         } else {
           body_expr_id = CompileNode(definition.body, definition.name, false);
@@ -1053,7 +1213,7 @@ class LarkCompiler {
         if (allow_initial_skip_ && skip_rule_id_ != -1) {
           body_expr_id = builder_.AddSequence({builder_.AddRuleRef(skip_rule_id_), body_expr_id});
         }
-      } else if (definition.lazy) {
+      } else if (HasLazySemantics(definition)) {
         body_expr_id = CompileLazyRule(definition);
       } else {
         body_expr_id = CompileNode(definition.body, definition.name, false);
@@ -1086,6 +1246,10 @@ class LarkCompiler {
     Node remainder;
   };
 
+  static bool HasLazySemantics(const Definition& definition) {
+    return definition.lazy || definition.suffix.has_value();
+  }
+
   void ExpandImports() {
     for (const auto& import : document_.imports) {
       auto it = CommonRegexes().find(import.path);
@@ -1108,7 +1272,7 @@ class LarkCompiler {
   void ParseOptions() {
     for (const auto& [value, location] : document_.options) {
       if (!value.is<picojson::object>()) {
-        RaiseLarkError(source_, location, "%llguidance value must be an object");
+        RaiseLarkError(source_, location, "%grammar_options value must be an object");
       }
       for (const auto& [key, option] : value.get<picojson::object>()) {
         if (key == "allow_initial_skip") {
@@ -1121,10 +1285,12 @@ class LarkCompiler {
             RaiseLarkError(source_, location, key + " must be a boolean");
           }
           if (option.get<bool>()) {
-            RaiseLarkError(source_, location, "%llguidance option '" + key + "' is not supported");
+            RaiseLarkError(
+                source_, location, "%grammar_options option '" + key + "' is not supported"
+            );
           }
         } else {
-          RaiseLarkError(source_, location, "unknown %llguidance option '" + key + "'");
+          RaiseLarkError(source_, location, "unknown %grammar_options option '" + key + "'");
         }
       }
     }
@@ -1208,6 +1374,110 @@ class LarkCompiler {
     skip_rule_id_ = builder_.AddRuleWithHint("lark_ignore", ignore_repeat);
   }
 
+  int32_t CompileStringLiteral(const Node& node) {
+    if (node.flags.empty()) {
+      return node.text.empty() ? builder_.AddEmptyStr() : builder_.AddByteString(node.text);
+    }
+    if (node.flags != "i") {
+      RaiseLarkError(
+          source_, node.location, "unsupported string literal flags '" + node.flags + "'"
+      );
+    }
+    std::vector<TCodepoint> codepoints = ParseUTF8(node.text.c_str());
+    if (!node.text.empty() &&
+        (codepoints.empty() || codepoints[0] == CharHandlingError::kInvalidUTF8)) {
+      RaiseLarkError(source_, node.location, "case-insensitive string is not valid UTF-8");
+    }
+    std::vector<int32_t> elements;
+    elements.reserve(codepoints.size());
+    for (TCodepoint codepoint : codepoints) {
+      if (codepoint > 0x7F) {
+        RaiseLarkError(
+            source_,
+            node.location,
+            "case-insensitive string literals currently support ASCII characters only"
+        );
+      }
+      if ((codepoint >= 'a' && codepoint <= 'z') || (codepoint >= 'A' && codepoint <= 'Z')) {
+        TCodepoint lowercase =
+            static_cast<TCodepoint>(std::tolower(static_cast<unsigned char>(codepoint)));
+        TCodepoint uppercase =
+            static_cast<TCodepoint>(std::toupper(static_cast<unsigned char>(codepoint)));
+        elements.push_back(
+            builder_.AddCharacterClass({{lowercase, lowercase}, {uppercase, uppercase}})
+        );
+      } else {
+        elements.push_back(builder_.AddByteString(CharToUTF8(codepoint)));
+      }
+    }
+    if (elements.empty()) {
+      return builder_.AddEmptyStr();
+    }
+    return elements.size() == 1 ? elements[0] : builder_.AddSequence(elements);
+  }
+
+  std::string PrepareRegexPattern(const Node& node) const {
+    if (node.flags.empty()) {
+      return RewriteRegexDots(node.text, false);
+    }
+    if (node.flags == "s") {
+      return RewriteRegexDots(node.text, true);
+    }
+    if (node.flags.find('l') != std::string::npos) {
+      RaiseLarkError(source_, node.location, "regular-expression flag 'l' is not supported");
+    }
+    RaiseLarkError(
+        source_, node.location, "only the regular-expression flag 's' is currently supported"
+    );
+  }
+
+  const Grammar& ResolveNamedGrammar(const std::string& name, const Location& location) {
+    auto input_it = named_grammars_.inputs.find(name);
+    if (input_it == named_grammars_.inputs.end()) {
+      RaiseLarkError(source_, location, "unknown named grammar '@" + name + "'");
+    }
+    if (std::holds_alternative<Grammar>(input_it->second)) {
+      return std::get<Grammar>(input_it->second);
+    }
+    auto compiled_it = named_grammars_.compiled.find(name);
+    if (compiled_it != named_grammars_.compiled.end()) {
+      return compiled_it->second;
+    }
+
+    auto active_it = std::find(named_grammars_.active.begin(), named_grammars_.active.end(), name);
+    if (active_it != named_grammars_.active.end()) {
+      std::ostringstream cycle;
+      for (auto it = active_it; it != named_grammars_.active.end(); ++it) {
+        if (it != active_it) {
+          cycle << " -> ";
+        }
+        cycle << "@" << *it;
+      }
+      cycle << " -> @" << name;
+      RaiseLarkError(source_, location, "circular named grammar reference: " + cycle.str());
+    }
+
+    named_grammars_.active.push_back(name);
+    try {
+      const std::string& named_source = std::get<std::string>(input_it->second);
+      auto tokens = LarkLexer(named_source).Tokenize();
+      auto document = LarkParser(named_source, std::move(tokens)).Parse();
+      Grammar compiled =
+          LarkCompiler(named_source, std::move(document), tokenizer_info_, named_grammars_)
+              .Compile();
+      auto compiled_it = named_grammars_.compiled.emplace(name, std::move(compiled)).first;
+      named_grammars_.active.pop_back();
+      return compiled_it->second;
+    } catch (const std::exception& error) {
+      named_grammars_.active.pop_back();
+      RaiseLarkError(
+          source_,
+          location,
+          "failed to compile named grammar '@" + name + "': " + std::string(error.what())
+      );
+    }
+  }
+
   int32_t CompileNode(const Node& node, const std::string& rule_hint, bool terminal_mode) {
     switch (node.kind) {
       case Node::Kind::kSequence: {
@@ -1249,11 +1519,7 @@ class LarkCompiler {
         return !terminal_mode && definition_it->second->is_terminal ? AppendSkip(result) : result;
       }
       case Node::Kind::kString: {
-        if (!node.flags.empty()) {
-          RaiseLarkError(source_, node.location, "case-insensitive string flags are not supported");
-        }
-        int32_t result =
-            node.text.empty() ? builder_.AddEmptyStr() : builder_.AddByteString(node.text);
+        int32_t result = CompileStringLiteral(node);
         return !terminal_mode && !node.text.empty() ? AppendSkip(result) : result;
       }
       case Node::Kind::kRange: {
@@ -1270,11 +1536,9 @@ class LarkCompiler {
         return terminal_mode ? result : AppendSkip(result);
       }
       case Node::Kind::kRegex: {
-        if (!node.flags.empty()) {
-          RaiseLarkError(source_, node.location, "regular-expression flags are not supported");
-        }
+        std::string pattern = PrepareRegexPattern(node);
         try {
-          int32_t root = SubGrammarAdder::Apply(&builder_, Grammar::FromRegex(node.text));
+          int32_t root = SubGrammarAdder::Apply(&builder_, Grammar::FromRegex(pattern));
           int32_t result = builder_.AddRuleRef(root);
           return terminal_mode ? result : AppendSkip(result);
         } catch (const std::exception& error) {
@@ -1286,6 +1550,9 @@ class LarkCompiler {
         }
       }
       case Node::Kind::kJson: {
+        if (terminal_mode) {
+          RaiseLarkError(source_, node.location, "%json cannot be used in terminals");
+        }
         try {
           int32_t root = SubGrammarAdder::Apply(&builder_, Grammar::FromJSONSchema(node.text));
           int32_t result = builder_.AddRuleRef(root);
@@ -1299,8 +1566,11 @@ class LarkCompiler {
         }
       }
       case Node::Kind::kNestedLark: {
+        if (terminal_mode) {
+          RaiseLarkError(source_, node.location, "nested %lark cannot be used in terminals");
+        }
         try {
-          LarkCompiler compiler(source_, *node.nested, tokenizer_info_);
+          LarkCompiler compiler(source_, *node.nested, tokenizer_info_, named_grammars_);
           int32_t root = SubGrammarAdder::Apply(&builder_, compiler.Compile());
           int32_t result = builder_.AddRuleRef(root);
           return terminal_mode ? result : AppendSkip(result);
@@ -1323,8 +1593,19 @@ class LarkCompiler {
       }
       case Node::Kind::kRegexExt:
         RaiseLarkError(source_, node.location, "structured %regex is not supported");
-      case Node::Kind::kGrammarRef:
-        RaiseLarkError(source_, node.location, "multiple grammar references are not supported");
+      case Node::Kind::kGrammarRef: {
+        if (terminal_mode) {
+          RaiseLarkError(source_, node.location, "named grammars cannot be used in terminals");
+        }
+        std::string name = node.text.substr(1);
+        auto root_it = named_grammar_roots_.find(name);
+        if (root_it == named_grammar_roots_.end()) {
+          int32_t root =
+              SubGrammarAdder::Apply(&builder_, ResolveNamedGrammar(name, node.location));
+          root_it = named_grammar_roots_.emplace(name, root).first;
+        }
+        return AppendSkip(builder_.AddRuleRef(root_it->second));
+      }
       case Node::Kind::kNot:
         RaiseLarkError(
             source_, node.location, "regular-expression complement '~' is not supported"
@@ -1439,16 +1720,29 @@ class LarkCompiler {
     return result;
   }
 
+  static const Node* UnwrapSingle(const Node* node) {
+    while (node->kind == Node::Kind::kSequence && node->children.size() == 1) {
+      node = &node->children[0];
+    }
+    return node;
+  }
+
   bool IsAnyText(const Node& node, std::unordered_set<std::string>* visiting = nullptr) const {
-    if (node.kind == Node::Kind::kRegex && node.flags.empty()) {
+    if (node.kind == Node::Kind::kRegex) {
       std::string pattern;
       for (char c : node.text) {
         if (c != ' ' && c != '\t' && c != '\r') {
           pattern.push_back(c);
         }
       }
+      if (node.flags == "s") {
+        return pattern == ".*";
+      }
+      if (!node.flags.empty()) {
+        return false;
+      }
       return pattern == "(.|\\n)*" || pattern == "(\\n|.)*" || pattern == "(?s:.*)" ||
-             pattern == "[\\s\\S]*";
+             pattern == "(?:.|\\n)*" || pattern == "(?:\\n|.)*" || pattern == "[\\s\\S]*";
     }
     if (node.kind == Node::Kind::kSequence && node.children.size() == 1) {
       return IsAnyText(node.children[0], visiting);
@@ -1473,9 +1767,51 @@ class LarkCompiler {
     return false;
   }
 
+  std::optional<Trigger> ExtractLazyRegexTrigger(const Node& node) const {
+    if (node.kind != Node::Kind::kRegex) {
+      return std::nullopt;
+    }
+    std::vector<std::string> prefixes;
+    if (node.flags.empty()) {
+      prefixes = {"(.|\\n)*", "(\\n|.)*", "(?:.|\\n)*", "(?:\\n|.)*", "[\\s\\S]*", "(?s:.*)"};
+    } else if (node.flags == "s") {
+      prefixes = {".*"};
+    } else {
+      return std::nullopt;
+    }
+    for (const std::string& prefix : prefixes) {
+      if (node.text.size() <= prefix.size() || node.text.compare(0, prefix.size(), prefix) != 0) {
+        continue;
+      }
+      auto trigger = ParseFixedRegexLiteral(node.text.substr(prefix.size()));
+      if (trigger.has_value() && !trigger->empty()) {
+        return Trigger{Trigger::Level::kString, std::move(trigger.value()), {}, node.location};
+      }
+    }
+    return std::nullopt;
+  }
+
   std::optional<Trigger> ExtractLazyTrigger(const Definition& definition) const {
-    if (!definition.lazy || definition.body.kind != Node::Kind::kSequence ||
-        definition.body.children.size() != 2 || !IsAnyText(definition.body.children[0])) {
+    if (definition.suffix.has_value()) {
+      if (!IsAnyText(definition.body)) {
+        return std::nullopt;
+      }
+      return Trigger{
+          Trigger::Level::kString, definition.suffix.value(), {}, definition.suffix_location
+      };
+    }
+    if (!definition.lazy) {
+      return std::nullopt;
+    }
+    const Node* body = UnwrapSingle(&definition.body);
+    if (body->kind == Node::Kind::kRegex) {
+      auto regex_trigger = ExtractLazyRegexTrigger(*body);
+      if (regex_trigger.has_value()) {
+        return regex_trigger;
+      }
+    }
+    if (definition.body.kind != Node::Kind::kSequence || definition.body.children.size() != 2 ||
+        !IsAnyText(definition.body.children[0])) {
       return std::nullopt;
     }
     const Node& trigger = definition.body.children[1];
@@ -1493,12 +1829,28 @@ class LarkCompiler {
   }
 
   int32_t CompileLazyRule(const Definition& definition) {
+    if (definition.suffix.has_value()) {
+      RaiseLarkError(
+          source_,
+          definition.location,
+          "suffix is only supported on an ANY_TEXT head used by dynamic dispatch"
+      );
+    }
+    const Node* body = UnwrapSingle(&definition.body);
+    if (body->kind == Node::Kind::kRegex && ExtractLazyRegexTrigger(*body).has_value()) {
+      RaiseLarkError(
+          source_,
+          definition.location,
+          "lazy regex suffix is only supported on a head used by dynamic dispatch"
+      );
+    }
     auto trigger = ExtractLazyTrigger(definition);
     if (!trigger.has_value()) {
       RaiseLarkError(
           source_,
           definition.location,
-          "general lazy rules are not supported; expected ANY_TEXT followed by a fixed trigger"
+          "general lazy rules are not supported; expected ANY_TEXT with a fixed string, token, "
+          "regex suffix, or suffix attribute"
       );
     }
     int32_t empty_rule = builder_.AddRuleWithHint("lark_lazy_end", builder_.AddEmptyStr());
@@ -1514,13 +1866,6 @@ class LarkCompiler {
       result = builder_.AddTokenTagDispatch(dispatch);
     }
     return AppendSkip(result);
-  }
-
-  static const Node* UnwrapSingle(const Node* node) {
-    while (node->kind == Node::Kind::kSequence && node->children.size() == 1) {
-      node = &node->children[0];
-    }
-    return node;
   }
 
   static std::vector<Node> FlattenSequence(const Node& node) {
@@ -1691,9 +2036,11 @@ class LarkCompiler {
   const std::string& source_;
   Document document_;
   const std::optional<TokenizerInfo>& tokenizer_info_;
+  NamedGrammarRegistry& named_grammars_;
   GrammarBuilder builder_;
   std::unordered_map<std::string, Definition*> definition_by_name_;
   std::unordered_map<std::string, int32_t> rule_ids_;
+  std::unordered_map<std::string, int32_t> named_grammar_roots_;
   int32_t skip_rule_id_ = -1;
   bool allow_initial_skip_ = false;
   std::unordered_set<std::string> dynamic_unused_rules_;
@@ -1702,11 +2049,31 @@ class LarkCompiler {
 }  // namespace
 
 Grammar LarkToGrammar(
-    const std::string& lark_string, const std::optional<TokenizerInfo>& tokenizer_info
+    const std::string& lark_string,
+    const std::optional<TokenizerInfo>& tokenizer_info,
+    const std::vector<NamedGrammar>& named_grammars
 ) {
+  NamedGrammarRegistry named_grammar_registry;
+  for (const auto& [name, grammar_or_source] : named_grammars) {
+    if (name.empty()) {
+      throw XGrammarError("Named grammar names must not be empty");
+    }
+    if (!std::all_of(name.begin(), name.end(), [](unsigned char character) {
+          return std::isalnum(character) || character == '_' || character == '-';
+        })) {
+      throw XGrammarError(
+          "Invalid named grammar name '" + name +
+          "': names may contain only letters, digits, underscores, and hyphens"
+      );
+    }
+    if (!named_grammar_registry.inputs.emplace(name, grammar_or_source).second) {
+      throw XGrammarError("Duplicate named grammar '" + name + "'");
+    }
+  }
   auto tokens = LarkLexer(lark_string).Tokenize();
   auto document = LarkParser(lark_string, std::move(tokens)).Parse();
-  return LarkCompiler(lark_string, std::move(document), tokenizer_info).Compile();
+  return LarkCompiler(lark_string, std::move(document), tokenizer_info, named_grammar_registry)
+      .Compile();
 }
 
 }  // namespace xgrammar

--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -1,0 +1,1712 @@
+/*!
+ *  Copyright (c) 2026 by Contributors
+ * \file xgrammar/lark_converter.cc
+ */
+
+#include "lark_converter.h"
+
+#include <picojson.h>
+#include <xgrammar/exception.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "grammar_builder.h"
+#include "grammar_functor.h"
+#include "support/encoding.h"
+
+namespace xgrammar {
+namespace {
+
+struct Location {
+  int line = 1;
+  int column = 1;
+};
+
+[[noreturn]] void RaiseLarkError(
+    const std::string& source, const Location& location, const std::string& message
+) {
+  size_t line_start = 0;
+  int current_line = 1;
+  while (current_line < location.line && line_start < source.size()) {
+    size_t newline = source.find('\n', line_start);
+    if (newline == std::string::npos) {
+      line_start = source.size();
+      break;
+    }
+    line_start = newline + 1;
+    ++current_line;
+  }
+  size_t line_end = source.find('\n', line_start);
+  if (line_end == std::string::npos) {
+    line_end = source.size();
+  }
+  std::string line_text = source.substr(line_start, line_end - line_start);
+  std::ostringstream os;
+  os << "Lark error at line " << location.line << ", column " << location.column << ": " << message;
+  if (!line_text.empty()) {
+    os << "\n" << line_text << "\n" << std::string(std::max(0, location.column - 1), ' ') << "^";
+  }
+  throw XGrammarError(os.str());
+}
+
+enum class TokenType {
+  kName,
+  kString,
+  kRegex,
+  kNumber,
+  kSpecialToken,
+  kGrammarRef,
+  kJson,
+  kRegexExt,
+  kLLGuidance,
+  kImport,
+  kIgnore,
+  kLark,
+  kIf,
+  kUnsupportedDirective,
+  kColon,
+  kDoubleColon,
+  kComma,
+  kDot,
+  kDotDot,
+  kArrow,
+  kEquals,
+  kLParen,
+  kRParen,
+  kLBracket,
+  kRBracket,
+  kLBrace,
+  kRBrace,
+  kPipe,
+  kAnd,
+  kTilde,
+  kQuestion,
+  kStar,
+  kPlus,
+  kNewline,
+  kEnd,
+};
+
+struct Token {
+  TokenType type;
+  std::string text;
+  std::string flags;
+  Location location;
+};
+
+class LarkLexer {
+ public:
+  explicit LarkLexer(const std::string& source) : source_(source) {}
+
+  std::vector<Token> Tokenize() {
+    std::vector<Token> result;
+    while (position_ < source_.size()) {
+      char c = source_[position_];
+      if (c == ' ' || c == '\t' || c == '\f') {
+        Advance();
+        continue;
+      }
+      if (c == '\r' || c == '\n') {
+        Location location = CurrentLocation();
+        if (c == '\r') {
+          Advance();
+          if (position_ < source_.size() && source_[position_] == '\n') {
+            Advance();
+          }
+        } else {
+          Advance();
+        }
+        result.push_back({TokenType::kNewline, "\n", "", location});
+        continue;
+      }
+      if (c == '#') {
+        SkipComment();
+        continue;
+      }
+      if (c == '/' && PeekChar(1) == '/') {
+        SkipComment();
+        continue;
+      }
+
+      Location location = CurrentLocation();
+      switch (c) {
+        case ':':
+          if (PeekChar(1) == ':') {
+            result.push_back(SimpleToken(TokenType::kDoubleColon, 2));
+          } else {
+            result.push_back(SimpleToken(TokenType::kColon, 1));
+          }
+          break;
+        case ',':
+          result.push_back(SimpleToken(TokenType::kComma, 1));
+          break;
+        case '.':
+          if (PeekChar(1) == '.') {
+            result.push_back(SimpleToken(TokenType::kDotDot, 2));
+          } else {
+            result.push_back(SimpleToken(TokenType::kDot, 1));
+          }
+          break;
+        case '-':
+          if (PeekChar(1) == '>') {
+            result.push_back(SimpleToken(TokenType::kArrow, 2));
+          } else if (std::isdigit(static_cast<unsigned char>(PeekChar(1)))) {
+            result.push_back(LexNumber());
+          } else {
+            RaiseLarkError(source_, location, "unexpected '-' character");
+          }
+          break;
+        case '+':
+          if (std::isdigit(static_cast<unsigned char>(PeekChar(1)))) {
+            result.push_back(LexNumber());
+          } else {
+            result.push_back(SimpleToken(TokenType::kPlus, 1));
+          }
+          break;
+        case '=':
+          result.push_back(SimpleToken(TokenType::kEquals, 1));
+          break;
+        case '(':
+          result.push_back(SimpleToken(TokenType::kLParen, 1));
+          break;
+        case ')':
+          result.push_back(SimpleToken(TokenType::kRParen, 1));
+          break;
+        case '[':
+          result.push_back(SimpleToken(TokenType::kLBracket, 1));
+          break;
+        case ']':
+          result.push_back(SimpleToken(TokenType::kRBracket, 1));
+          break;
+        case '{':
+          result.push_back(SimpleToken(TokenType::kLBrace, 1));
+          break;
+        case '}':
+          result.push_back(SimpleToken(TokenType::kRBrace, 1));
+          break;
+        case '|':
+          result.push_back(SimpleToken(TokenType::kPipe, 1));
+          break;
+        case '&':
+          result.push_back(SimpleToken(TokenType::kAnd, 1));
+          break;
+        case '~':
+          result.push_back(SimpleToken(TokenType::kTilde, 1));
+          break;
+        case '?':
+          if (std::isalpha(static_cast<unsigned char>(PeekChar(1))) || PeekChar(1) == '_') {
+            result.push_back(LexName());
+          } else {
+            result.push_back(SimpleToken(TokenType::kQuestion, 1));
+          }
+          break;
+        case '*':
+          result.push_back(SimpleToken(TokenType::kStar, 1));
+          break;
+        case '!':
+          if (std::isalpha(static_cast<unsigned char>(PeekChar(1))) || PeekChar(1) == '_') {
+            result.push_back(LexName());
+          } else {
+            RaiseLarkError(source_, location, "unexpected '!' character");
+          }
+          break;
+        case '"':
+          result.push_back(LexString());
+          break;
+        case '/':
+          result.push_back(LexRegex());
+          break;
+        case '<':
+          result.push_back(LexSpecialToken());
+          break;
+        case '@':
+          result.push_back(LexGrammarRef());
+          break;
+        case '%':
+          result.push_back(LexDirective());
+          break;
+        default:
+          if (std::isalpha(static_cast<unsigned char>(c)) || c == '_') {
+            result.push_back(LexName());
+          } else if (std::isdigit(static_cast<unsigned char>(c))) {
+            result.push_back(LexNumber());
+          } else {
+            RaiseLarkError(source_, location, std::string("unexpected character '") + c + "'");
+          }
+      }
+    }
+    result.push_back({TokenType::kEnd, "", "", CurrentLocation()});
+    return result;
+  }
+
+ private:
+  char PeekChar(size_t offset) const {
+    size_t index = position_ + offset;
+    return index < source_.size() ? source_[index] : '\0';
+  }
+
+  Location CurrentLocation() const { return {line_, column_}; }
+
+  void Advance() {
+    if (position_ >= source_.size()) {
+      return;
+    }
+    char c = source_[position_++];
+    if (c == '\n') {
+      ++line_;
+      column_ = 1;
+    } else {
+      ++column_;
+    }
+  }
+
+  void AdvanceTo(size_t end_position) {
+    while (position_ < end_position) {
+      Advance();
+    }
+  }
+
+  Token SimpleToken(TokenType type, size_t length) {
+    Location location = CurrentLocation();
+    std::string text = source_.substr(position_, length);
+    AdvanceTo(position_ + length);
+    return {type, std::move(text), "", location};
+  }
+
+  void SkipComment() {
+    while (position_ < source_.size() && source_[position_] != '\n' && source_[position_] != '\r') {
+      Advance();
+    }
+  }
+
+  Token LexName() {
+    Location location = CurrentLocation();
+    size_t start = position_;
+    if (source_[position_] == '!' || source_[position_] == '?') {
+      Advance();
+    }
+    while (position_ < source_.size()) {
+      char c = source_[position_];
+      if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_' && c != '-') {
+        break;
+      }
+      Advance();
+    }
+    return {TokenType::kName, source_.substr(start, position_ - start), "", location};
+  }
+
+  Token LexNumber() {
+    Location location = CurrentLocation();
+    size_t start = position_;
+    if (source_[position_] == '+' || source_[position_] == '-') {
+      Advance();
+    }
+    while (std::isdigit(static_cast<unsigned char>(PeekChar(0)))) {
+      Advance();
+    }
+    if (PeekChar(0) == '.' && PeekChar(1) != '.') {
+      Advance();
+      while (std::isdigit(static_cast<unsigned char>(PeekChar(0)))) {
+        Advance();
+      }
+    }
+    if (PeekChar(0) == 'e' || PeekChar(0) == 'E') {
+      Advance();
+      if (PeekChar(0) == '+' || PeekChar(0) == '-') {
+        Advance();
+      }
+      while (std::isdigit(static_cast<unsigned char>(PeekChar(0)))) {
+        Advance();
+      }
+    }
+    return {TokenType::kNumber, source_.substr(start, position_ - start), "", location};
+  }
+
+  Token LexString() {
+    Location location = CurrentLocation();
+    size_t start = position_;
+    Advance();
+    bool escaped = false;
+    while (position_ < source_.size()) {
+      char c = source_[position_];
+      if (!escaped && c == '"') {
+        Advance();
+        if (PeekChar(0) == 'i') {
+          Advance();
+        }
+        return {TokenType::kString, source_.substr(start, position_ - start), "", location};
+      }
+      if (c == '\n' || c == '\r') {
+        RaiseLarkError(source_, location, "unterminated string literal");
+      }
+      if (!escaped && c == '\\') {
+        escaped = true;
+      } else {
+        escaped = false;
+      }
+      Advance();
+    }
+    RaiseLarkError(source_, location, "unterminated string literal");
+  }
+
+  Token LexRegex() {
+    Location location = CurrentLocation();
+    Advance();
+    size_t pattern_start = position_;
+    bool escaped = false;
+    while (position_ < source_.size()) {
+      char c = source_[position_];
+      if (!escaped && c == '/') {
+        std::string pattern = source_.substr(pattern_start, position_ - pattern_start);
+        Advance();
+        size_t flags_start = position_;
+        while (std::isalpha(static_cast<unsigned char>(PeekChar(0)))) {
+          Advance();
+        }
+        return {
+            TokenType::kRegex,
+            std::move(pattern),
+            source_.substr(flags_start, position_ - flags_start),
+            location
+        };
+      }
+      if (!escaped && c == '\\') {
+        escaped = true;
+      } else {
+        escaped = false;
+      }
+      Advance();
+    }
+    RaiseLarkError(source_, location, "unterminated regular expression");
+  }
+
+  Token LexSpecialToken() {
+    Location location = CurrentLocation();
+    size_t start = position_;
+    Advance();
+    while (position_ < source_.size() && source_[position_] != '>') {
+      char c = source_[position_];
+      if (std::isspace(static_cast<unsigned char>(c)) || c == '<') {
+        RaiseLarkError(source_, location, "invalid special token");
+      }
+      Advance();
+    }
+    if (position_ == source_.size()) {
+      RaiseLarkError(source_, location, "unterminated special token");
+    }
+    Advance();
+    return {TokenType::kSpecialToken, source_.substr(start, position_ - start), "", location};
+  }
+
+  Token LexGrammarRef() {
+    Location location = CurrentLocation();
+    size_t start = position_;
+    Advance();
+    while (std::isalnum(static_cast<unsigned char>(PeekChar(0))) || PeekChar(0) == '_' ||
+           PeekChar(0) == '-') {
+      Advance();
+    }
+    if (position_ == start + 1) {
+      RaiseLarkError(source_, location, "empty grammar reference");
+    }
+    return {TokenType::kGrammarRef, source_.substr(start, position_ - start), "", location};
+  }
+
+  Token LexDirective() {
+    Location location = CurrentLocation();
+    size_t start = position_;
+    Advance();
+    while (std::isalpha(static_cast<unsigned char>(PeekChar(0))) || PeekChar(0) == '_') {
+      Advance();
+    }
+    std::string directive = source_.substr(start, position_ - start);
+    if (directive == "%json") {
+      return LexJSONValue(TokenType::kJson, location, directive);
+    }
+    if (directive == "%regex") {
+      return LexJSONValue(TokenType::kRegexExt, location, directive);
+    }
+    if (directive == "%llguidance") {
+      return LexJSONValue(TokenType::kLLGuidance, location, directive);
+    }
+    if (directive == "%import") {
+      return {TokenType::kImport, directive, "", location};
+    }
+    if (directive == "%ignore") {
+      return {TokenType::kIgnore, directive, "", location};
+    }
+    if (directive == "%lark") {
+      return {TokenType::kLark, directive, "", location};
+    }
+    if (directive == "%if") {
+      return {TokenType::kIf, directive, "", location};
+    }
+    return {TokenType::kUnsupportedDirective, directive, "", location};
+  }
+
+  Token LexJSONValue(TokenType type, const Location& location, const std::string& directive) {
+    while (position_ < source_.size() &&
+           std::isspace(static_cast<unsigned char>(source_[position_]))) {
+      Advance();
+    }
+    auto begin = source_.begin() + static_cast<std::ptrdiff_t>(position_);
+    auto end = source_.end();
+    picojson::value value;
+    std::string error;
+    auto parsed_end = picojson::parse(value, begin, end, &error);
+    if (!error.empty() || parsed_end == begin) {
+      RaiseLarkError(
+          source_, location, "failed to parse JSON value after " + directive + ": " + error
+      );
+    }
+    size_t new_position = static_cast<size_t>(parsed_end - source_.begin());
+    AdvanceTo(new_position);
+    return {type, value.serialize(), "", location};
+  }
+
+  const std::string& source_;
+  size_t position_ = 0;
+  int line_ = 1;
+  int column_ = 1;
+};
+
+struct Document;
+
+struct Node {
+  enum class Kind {
+    kSequence,
+    kChoice,
+    kRepeat,
+    kString,
+    kRegex,
+    kRange,
+    kName,
+    kJson,
+    kRegexExt,
+    kNestedLark,
+    kSpecialToken,
+    kGrammarRef,
+    kNot,
+  };
+
+  Kind kind = Kind::kSequence;
+  Location location;
+  std::string text;
+  std::string text2;
+  std::string flags;
+  int32_t min_repeat = 0;
+  int32_t max_repeat = 0;
+  std::vector<Node> children;
+  std::shared_ptr<Document> nested;
+};
+
+struct Definition {
+  std::string name;
+  bool is_terminal = false;
+  bool lazy = false;
+  Node body;
+  Location location;
+};
+
+struct Import {
+  std::string path;
+  std::string local_name;
+  Location location;
+};
+
+struct Document {
+  std::vector<Definition> definitions;
+  std::vector<Node> ignores;
+  std::vector<Import> imports;
+  std::vector<std::pair<picojson::value, Location>> options;
+};
+
+class LarkParser {
+ public:
+  LarkParser(const std::string& source, std::vector<Token> tokens)
+      : source_(source), tokens_(std::move(tokens)) {}
+
+  Document Parse() { return ParseDocument(false); }
+
+ private:
+  const Token& Peek(size_t offset = 0) const {
+    size_t index = std::min(position_ + offset, tokens_.size() - 1);
+    return tokens_[index];
+  }
+
+  bool Match(TokenType type) {
+    if (Peek().type != type) {
+      return false;
+    }
+    ++position_;
+    return true;
+  }
+
+  Token Consume(TokenType type, const std::string& message) {
+    if (Peek().type != type) {
+      RaiseLarkError(source_, Peek().location, message);
+    }
+    return tokens_[position_++];
+  }
+
+  void ConsumeNewlines() {
+    while (Match(TokenType::kNewline)) {
+    }
+  }
+
+  Document ParseDocument(bool stop_at_rbrace) {
+    Document document;
+    ConsumeNewlines();
+    while (Peek().type != TokenType::kEnd && !(stop_at_rbrace && Peek().type == TokenType::kRBrace)
+    ) {
+      switch (Peek().type) {
+        case TokenType::kImport:
+          ParseImport(&document);
+          break;
+        case TokenType::kIgnore:
+          ParseIgnore(&document);
+          break;
+        case TokenType::kLLGuidance:
+          ParseOptions(&document);
+          break;
+        case TokenType::kUnsupportedDirective:
+          RaiseLarkError(
+              source_, Peek().location, "directive " + Peek().text + " is not supported"
+          );
+        default:
+          document.definitions.push_back(ParseDefinition());
+          break;
+      }
+      if (Peek().type != TokenType::kNewline && Peek().type != TokenType::kEnd &&
+          !(stop_at_rbrace && Peek().type == TokenType::kRBrace)) {
+        RaiseLarkError(source_, Peek().location, "expected end of grammar item");
+      }
+      ConsumeNewlines();
+    }
+    return document;
+  }
+
+  static bool IsTerminalName(const std::string& raw_name) {
+    size_t index = 0;
+    if (!raw_name.empty() && (raw_name[0] == '!' || raw_name[0] == '?')) {
+      index = 1;
+    }
+    if (index < raw_name.size() && raw_name[index] == '_') {
+      ++index;
+    }
+    return index < raw_name.size() && std::isupper(static_cast<unsigned char>(raw_name[index]));
+  }
+
+  static std::string NormalizeRuleName(std::string name) {
+    if (!name.empty() && (name[0] == '!' || name[0] == '?')) {
+      name.erase(name.begin());
+    }
+    return name;
+  }
+
+  void ParseImport(Document* document) {
+    Location location = Consume(TokenType::kImport, "expected %import").location;
+    Token first = Consume(TokenType::kName, "expected import path");
+    std::string path = first.text;
+    while (Match(TokenType::kDot)) {
+      path += "." + Consume(TokenType::kName, "expected name after '.'").text;
+    }
+
+    if (Match(TokenType::kLParen)) {
+      do {
+        Token name = Consume(TokenType::kName, "expected imported terminal name");
+        document->imports.push_back({path + "." + name.text, name.text, location});
+      } while (Match(TokenType::kComma));
+      Consume(TokenType::kRParen, "expected ')' after import list");
+      return;
+    }
+
+    std::string local_name = path.substr(path.find_last_of('.') + 1);
+    if (Match(TokenType::kArrow)) {
+      local_name = Consume(TokenType::kName, "expected import alias").text;
+    }
+    document->imports.push_back({path, local_name, location});
+  }
+
+  void ParseIgnore(Document* document) {
+    Consume(TokenType::kIgnore, "expected %ignore");
+    document->ignores.push_back(ParseChoice());
+  }
+
+  void ParseOptions(Document* document) {
+    Token token = Consume(TokenType::kLLGuidance, "expected %llguidance");
+    picojson::value value;
+    std::string error = picojson::parse(value, token.text);
+    if (!error.empty()) {
+      RaiseLarkError(source_, token.location, "invalid %llguidance value: " + error);
+    }
+    document->options.push_back({std::move(value), token.location});
+  }
+
+  Definition ParseDefinition() {
+    Token name_token = Consume(TokenType::kName, "expected rule or terminal name");
+    Definition result;
+    result.name = NormalizeRuleName(name_token.text);
+    result.is_terminal = IsTerminalName(name_token.text);
+    result.location = name_token.location;
+
+    if (Peek().type == TokenType::kLBracket) {
+      if (result.is_terminal) {
+        RaiseLarkError(source_, Peek().location, "attributes are only supported on rules");
+      }
+      ParseAttributes(&result);
+    }
+    if (Peek().type == TokenType::kDot) {
+      RaiseLarkError(source_, Peek().location, "rule and terminal priorities are not supported");
+    }
+    if (Peek().type == TokenType::kDoubleColon) {
+      RaiseLarkError(source_, Peek().location, "parametric grammar is not supported");
+    }
+    if (Peek().type == TokenType::kLBrace) {
+      RaiseLarkError(source_, Peek().location, "Lark templates are not supported");
+    }
+    Consume(TokenType::kColon, "expected ':' after rule name");
+    result.body = ParseChoice();
+    return result;
+  }
+
+  void ParseAttributes(Definition* definition) {
+    Consume(TokenType::kLBracket, "expected '['");
+    while (Peek().type != TokenType::kRBracket) {
+      Token key = Consume(TokenType::kName, "expected rule attribute");
+      if (key.text == "lazy" && Peek().type != TokenType::kEquals) {
+        definition->lazy = true;
+      } else {
+        RaiseLarkError(
+            source_,
+            key.location,
+            "rule attribute '" + key.text + "' is not supported by XGrammar Lark"
+        );
+      }
+      if (!Match(TokenType::kComma)) {
+        break;
+      }
+    }
+    Consume(TokenType::kRBracket, "expected ']' after rule attributes");
+  }
+
+  Node ParseChoice() {
+    Location location = Peek().location;
+    std::vector<Node> alternatives;
+    alternatives.push_back(ParseSequence());
+    while (MatchAlternativeSeparator()) {
+      alternatives.push_back(ParseSequence());
+    }
+    if (alternatives.size() == 1) {
+      return std::move(alternatives[0]);
+    }
+    Node result;
+    result.kind = Node::Kind::kChoice;
+    result.location = location;
+    result.children = std::move(alternatives);
+    return result;
+  }
+
+  bool MatchAlternativeSeparator() {
+    if (Match(TokenType::kPipe)) {
+      return true;
+    }
+    size_t saved_position = position_;
+    ConsumeNewlines();
+    if (Match(TokenType::kPipe)) {
+      return true;
+    }
+    if (Peek().type == TokenType::kRParen || Peek().type == TokenType::kRBracket ||
+        Peek().type == TokenType::kRBrace) {
+      return false;
+    }
+    position_ = saved_position;
+    return false;
+  }
+
+  Node ParseSequence() {
+    Location location = Peek().location;
+    std::vector<Node> elements;
+    while (!IsSequenceEnd(Peek().type)) {
+      elements.push_back(ParseExpr());
+    }
+    if (Match(TokenType::kArrow)) {
+      Consume(TokenType::kName, "expected alias name after '->'");
+    }
+    if (Peek().type == TokenType::kAnd) {
+      RaiseLarkError(source_, Peek().location, "terminal intersection '&' is not supported");
+    }
+    if (Peek().type == TokenType::kIf) {
+      RaiseLarkError(source_, Peek().location, "parametric %if conditions are not supported");
+    }
+    Node result;
+    result.kind = Node::Kind::kSequence;
+    result.location = location;
+    result.children = std::move(elements);
+    return result;
+  }
+
+  static bool IsSequenceEnd(TokenType type) {
+    return type == TokenType::kNewline || type == TokenType::kPipe || type == TokenType::kRParen ||
+           type == TokenType::kRBracket || type == TokenType::kRBrace || type == TokenType::kEnd ||
+           type == TokenType::kArrow || type == TokenType::kAnd || type == TokenType::kIf;
+  }
+
+  int32_t ParseInteger() {
+    Token token = Consume(TokenType::kNumber, "expected integer");
+    try {
+      size_t parsed = 0;
+      long long value = std::stoll(token.text, &parsed);
+      if (parsed != token.text.size() || value < 0 || value > std::numeric_limits<int32_t>::max()) {
+        RaiseLarkError(source_, token.location, "invalid non-negative repetition count");
+      }
+      return static_cast<int32_t>(value);
+    } catch (const std::exception&) {
+      RaiseLarkError(source_, token.location, "invalid repetition count");
+    }
+  }
+
+  Node ParseExpr() {
+    Location location = Peek().location;
+    bool negated = Match(TokenType::kTilde);
+    Node atom = ParseAtom();
+    if (negated) {
+      Node not_node;
+      not_node.kind = Node::Kind::kNot;
+      not_node.location = location;
+      not_node.children.push_back(std::move(atom));
+      atom = std::move(not_node);
+    }
+
+    int32_t min_repeat = -1;
+    int32_t max_repeat = -1;
+    if (Match(TokenType::kQuestion)) {
+      min_repeat = 0;
+      max_repeat = 1;
+    } else if (Match(TokenType::kStar)) {
+      min_repeat = 0;
+      max_repeat = -1;
+    } else if (Match(TokenType::kPlus)) {
+      min_repeat = 1;
+      max_repeat = -1;
+    } else if (Match(TokenType::kTilde)) {
+      min_repeat = ParseInteger();
+      max_repeat = min_repeat;
+      if (Match(TokenType::kDotDot)) {
+        max_repeat = ParseInteger();
+      }
+    } else if (Match(TokenType::kLBrace)) {
+      min_repeat = Peek().type == TokenType::kComma ? 0 : ParseInteger();
+      if (Match(TokenType::kComma)) {
+        max_repeat = Peek().type == TokenType::kRBrace ? -1 : ParseInteger();
+      } else {
+        max_repeat = min_repeat;
+      }
+      Consume(TokenType::kRBrace, "expected '}' after repetition range");
+    }
+
+    if (min_repeat == -1) {
+      return atom;
+    }
+    if (max_repeat != -1 && max_repeat < min_repeat) {
+      RaiseLarkError(source_, location, "repetition end must be greater than or equal to start");
+    }
+    Node repeat;
+    repeat.kind = Node::Kind::kRepeat;
+    repeat.location = location;
+    repeat.min_repeat = min_repeat;
+    repeat.max_repeat = max_repeat;
+    repeat.children.push_back(std::move(atom));
+    return repeat;
+  }
+
+  Node ParseAtom() {
+    Token token = Peek();
+    if (Match(TokenType::kLParen)) {
+      Node result = ParseChoice();
+      Consume(TokenType::kRParen, "expected ')' after group");
+      return result;
+    }
+    if (Match(TokenType::kLBracket)) {
+      Node inner = ParseChoice();
+      Consume(TokenType::kRBracket, "expected ']' after optional group");
+      Node result;
+      result.kind = Node::Kind::kRepeat;
+      result.location = token.location;
+      result.min_repeat = 0;
+      result.max_repeat = 1;
+      result.children.push_back(std::move(inner));
+      return result;
+    }
+    if (Match(TokenType::kString)) {
+      Node result = ParseStringNode(token);
+      if (Match(TokenType::kDotDot)) {
+        Token end = Consume(TokenType::kString, "expected string after '..'");
+        Node range;
+        range.kind = Node::Kind::kRange;
+        range.location = token.location;
+        range.text = result.text;
+        range.text2 = ParseStringNode(end).text;
+        return range;
+      }
+      return result;
+    }
+    if (Match(TokenType::kRegex)) {
+      Node result;
+      result.kind = Node::Kind::kRegex;
+      result.location = token.location;
+      result.text = token.text;
+      result.flags = token.flags;
+      return result;
+    }
+    if (Match(TokenType::kName)) {
+      Node result;
+      result.kind = Node::Kind::kName;
+      result.location = token.location;
+      result.text = NormalizeRuleName(token.text);
+      if (Peek().type == TokenType::kDoubleColon) {
+        RaiseLarkError(source_, Peek().location, "parametric grammar is not supported");
+      }
+      if (Peek().type == TokenType::kLBrace && Peek(1).type != TokenType::kComma &&
+          Peek(1).type != TokenType::kNumber) {
+        RaiseLarkError(source_, Peek().location, "Lark templates are not supported");
+      }
+      return result;
+    }
+    if (Match(TokenType::kJson)) {
+      Node result;
+      result.kind = Node::Kind::kJson;
+      result.location = token.location;
+      result.text = token.text;
+      return result;
+    }
+    if (Match(TokenType::kRegexExt)) {
+      Node result;
+      result.kind = Node::Kind::kRegexExt;
+      result.location = token.location;
+      result.text = token.text;
+      return result;
+    }
+    if (Match(TokenType::kSpecialToken)) {
+      Node result;
+      result.kind = Node::Kind::kSpecialToken;
+      result.location = token.location;
+      result.text = token.text;
+      return result;
+    }
+    if (Match(TokenType::kGrammarRef)) {
+      Node result;
+      result.kind = Node::Kind::kGrammarRef;
+      result.location = token.location;
+      result.text = token.text;
+      return result;
+    }
+    if (Match(TokenType::kLark)) {
+      Consume(TokenType::kLBrace, "expected '{' after %lark");
+      Node result;
+      result.kind = Node::Kind::kNestedLark;
+      result.location = token.location;
+      result.nested = std::make_shared<Document>(ParseDocument(true));
+      Consume(TokenType::kRBrace, "expected '}' after nested Lark grammar");
+      return result;
+    }
+    if (token.type == TokenType::kUnsupportedDirective) {
+      RaiseLarkError(source_, token.location, "directive " + token.text + " is not supported");
+    }
+    RaiseLarkError(source_, token.location, "expected grammar expression");
+  }
+
+  Node ParseStringNode(const Token& token) {
+    std::string json_string = token.text;
+    std::string flags;
+    if (!json_string.empty() && json_string.back() == 'i') {
+      flags = "i";
+      json_string.pop_back();
+    }
+    picojson::value value;
+    std::string error = picojson::parse(value, json_string);
+    if (!error.empty() || !value.is<std::string>()) {
+      RaiseLarkError(source_, token.location, "invalid string literal: " + error);
+    }
+    Node result;
+    result.kind = Node::Kind::kString;
+    result.location = token.location;
+    result.text = value.get<std::string>();
+    result.flags = std::move(flags);
+    return result;
+  }
+
+  const std::string& source_;
+  std::vector<Token> tokens_;
+  size_t position_ = 0;
+};
+
+const std::unordered_map<std::string, std::string>& CommonRegexes() {
+  static const std::unordered_map<std::string, std::string> regexes = {
+      {"common.DIGIT", "[0-9]"},
+      {"common.HEXDIGIT", "[a-fA-F0-9]"},
+      {"common.INT", "[0-9]+"},
+      {"common.SIGNED_INT", "(\\+|-)?[0-9]+"},
+      {"common.DECIMAL", "([0-9]+\\.[0-9]*)|(\\.[0-9]+)"},
+      {"common._EXP", "[eE](\\+|-)?[0-9]+"},
+      {"common.FLOAT", "([0-9]+\\.[0-9]*|\\.[0-9]+)([eE](\\+|-)?[0-9]+)?|[0-9]+[eE](\\+|-)?[0-9]+"},
+      {"common.SIGNED_FLOAT",
+       "(\\+|-)?(([0-9]+\\.[0-9]*|\\.[0-9]+)([eE](\\+|-)?[0-9]+)?|[0-9]+[eE](\\+|-)?[0-9]+)"},
+      {"common.NUMBER",
+       "([0-9]+)|([0-9]+\\.[0-9]*|\\.[0-9]+)([eE](\\+|-)?[0-9]+)?|[0-9]+[eE](\\+|-)?[0-9]+"},
+      {"common.SIGNED_NUMBER",
+       "(\\+|-)?(([0-9]+)|([0-9]+\\.[0-9]*|\\.[0-9]+)([eE](\\+|-)?[0-9]+)?|[0-9]+[eE](\\+|-)?[0-9]+"
+       ")"},
+      {"common.ESCAPED_STRING", "\\\"([^\\\"\\\\]|\\\\.)*\\\""},
+      {"common.LCASE_LETTER", "[a-z]"},
+      {"common.UCASE_LETTER", "[A-Z]"},
+      {"common.LETTER", "[A-Za-z]"},
+      {"common.WORD", "[A-Za-z]+"},
+      {"common.CNAME", "[_A-Za-z][_A-Za-z0-9]*"},
+      {"common.WS_INLINE", "[ \\t]+"},
+      {"common.WS", "[ \\t\\f\\r\\n]+"},
+      {"common.CR", "\\r"},
+      {"common.LF", "\\n"},
+      {"common.NEWLINE", "(\\r?\\n)+"},
+      {"common.SH_COMMENT", "#[^\\n]*"},
+      {"common.CPP_COMMENT", "//[^\\n]*"},
+      {"common.C_COMMENT", "\\/\\*[^*]*\\*+(?:[^/*][^*]*\\*+)*\\/"},
+      {"common.SQL_COMMENT", "--[^\\n]*"},
+  };
+  return regexes;
+}
+
+std::string Trim(std::string value) {
+  size_t begin = 0;
+  while (begin < value.size() && std::isspace(static_cast<unsigned char>(value[begin]))) {
+    ++begin;
+  }
+  size_t end = value.size();
+  while (end > begin && std::isspace(static_cast<unsigned char>(value[end - 1]))) {
+    --end;
+  }
+  return value.substr(begin, end - begin);
+}
+
+class LarkCompiler {
+ public:
+  LarkCompiler(
+      const std::string& source,
+      Document document,
+      const std::optional<TokenizerInfo>& tokenizer_info
+  )
+      : source_(source), document_(std::move(document)), tokenizer_info_(tokenizer_info) {}
+
+  Grammar Compile() {
+    ExpandImports();
+    ParseOptions();
+    IndexDefinitions();
+    ValidateTerminalCycles();
+
+    for (const auto& definition : document_.definitions) {
+      rule_ids_[definition.name] = builder_.AddEmptyRule(definition.name);
+    }
+
+    for (const auto& definition : document_.definitions) {
+      if (definition.is_terminal) {
+        builder_.UpdateRuleBody(
+            rule_ids_.at(definition.name), CompileNode(definition.body, definition.name, true)
+        );
+      }
+    }
+
+    CompileIgnore();
+
+    const Definition& start_definition = *definition_by_name_.at("start");
+    std::optional<int32_t> dynamic_start_body = CompileDynamicStart(start_definition);
+
+    for (const auto& definition : document_.definitions) {
+      if (definition.is_terminal) {
+        continue;
+      }
+      if (dynamic_unused_rules_.count(definition.name)) {
+        builder_.UpdateRuleBody(rule_ids_.at(definition.name), builder_.AddEmptyStr());
+        continue;
+      }
+      int32_t body_expr_id;
+      if (definition.name == "start") {
+        if (dynamic_start_body.has_value()) {
+          body_expr_id = dynamic_start_body.value();
+        } else if (definition.lazy) {
+          body_expr_id = CompileLazyRule(definition);
+        } else {
+          body_expr_id = CompileNode(definition.body, definition.name, false);
+        }
+        if (allow_initial_skip_ && skip_rule_id_ != -1) {
+          body_expr_id = builder_.AddSequence({builder_.AddRuleRef(skip_rule_id_), body_expr_id});
+        }
+      } else if (definition.lazy) {
+        body_expr_id = CompileLazyRule(definition);
+      } else {
+        body_expr_id = CompileNode(definition.body, definition.name, false);
+      }
+      builder_.UpdateRuleBody(rule_ids_.at(definition.name), body_expr_id);
+    }
+
+    auto start_it = rule_ids_.find("start");
+    if (start_it == rule_ids_.end()) {
+      RaiseLarkError(source_, {1, 1}, "no start rule found");
+    }
+    return DeadCodeEliminator::Apply(GrammarNormalizer().Apply(builder_.Get(start_it->second)));
+  }
+
+ private:
+  struct SpecialTokenSet {
+    bool excluded = false;
+    std::vector<int32_t> token_ids;
+  };
+
+  struct Trigger {
+    enum class Level { kString, kToken } level;
+    std::string string;
+    std::vector<int32_t> token_ids;
+    Location location;
+  };
+
+  struct DynamicAlternative {
+    Trigger trigger;
+    Node remainder;
+  };
+
+  void ExpandImports() {
+    for (const auto& import : document_.imports) {
+      auto it = CommonRegexes().find(import.path);
+      if (it == CommonRegexes().end()) {
+        RaiseLarkError(source_, import.location, "unknown common import '" + import.path + "'");
+      }
+      Node regex;
+      regex.kind = Node::Kind::kRegex;
+      regex.location = import.location;
+      regex.text = it->second;
+      Definition definition;
+      definition.name = import.local_name;
+      definition.is_terminal = true;
+      definition.body = std::move(regex);
+      definition.location = import.location;
+      document_.definitions.push_back(std::move(definition));
+    }
+  }
+
+  void ParseOptions() {
+    for (const auto& [value, location] : document_.options) {
+      if (!value.is<picojson::object>()) {
+        RaiseLarkError(source_, location, "%llguidance value must be an object");
+      }
+      for (const auto& [key, option] : value.get<picojson::object>()) {
+        if (key == "allow_initial_skip") {
+          if (!option.is<bool>()) {
+            RaiseLarkError(source_, location, "allow_initial_skip must be a boolean");
+          }
+          allow_initial_skip_ = allow_initial_skip_ || option.get<bool>();
+        } else if (key == "no_forcing" || key == "allow_invalid_utf8") {
+          if (!option.is<bool>()) {
+            RaiseLarkError(source_, location, key + " must be a boolean");
+          }
+          if (option.get<bool>()) {
+            RaiseLarkError(source_, location, "%llguidance option '" + key + "' is not supported");
+          }
+        } else {
+          RaiseLarkError(source_, location, "unknown %llguidance option '" + key + "'");
+        }
+      }
+    }
+  }
+
+  void IndexDefinitions() {
+    for (auto& definition : document_.definitions) {
+      if (definition_by_name_.count(definition.name)) {
+        RaiseLarkError(
+            source_, definition.location, "duplicate rule or terminal '" + definition.name + "'"
+        );
+      }
+      definition_by_name_[definition.name] = &definition;
+    }
+    if (!definition_by_name_.count("start")) {
+      RaiseLarkError(source_, {1, 1}, "no start rule found");
+    }
+    if (definition_by_name_.at("start")->is_terminal) {
+      RaiseLarkError(source_, definition_by_name_.at("start")->location, "start must be a rule");
+    }
+  }
+
+  void CollectReferencedNames(const Node& node, std::vector<std::string>* names) const {
+    if (node.kind == Node::Kind::kName) {
+      names->push_back(node.text);
+    }
+    for (const Node& child : node.children) {
+      CollectReferencedNames(child, names);
+    }
+  }
+
+  void ValidateTerminalCycles() {
+    std::unordered_map<std::string, int> states;
+    for (const auto& definition : document_.definitions) {
+      if (definition.is_terminal && states[definition.name] == 0) {
+        VisitTerminal(definition, &states);
+      }
+    }
+  }
+
+  void VisitTerminal(const Definition& definition, std::unordered_map<std::string, int>* states) {
+    (*states)[definition.name] = 1;
+    std::vector<std::string> names;
+    CollectReferencedNames(definition.body, &names);
+    for (const std::string& name : names) {
+      auto it = definition_by_name_.find(name);
+      if (it == definition_by_name_.end()) {
+        RaiseLarkError(source_, definition.location, "unknown name '" + name + "'");
+      }
+      if (!it->second->is_terminal) {
+        RaiseLarkError(
+            source_,
+            definition.location,
+            "terminal '" + definition.name + "' cannot reference rule '" + name + "'"
+        );
+      }
+      if ((*states)[name] == 1) {
+        RaiseLarkError(
+            source_, definition.location, "circular reference in terminal '" + name + "'"
+        );
+      }
+      if ((*states)[name] == 0) {
+        VisitTerminal(*it->second, states);
+      }
+    }
+    (*states)[definition.name] = 2;
+  }
+
+  void CompileIgnore() {
+    if (document_.ignores.empty()) {
+      return;
+    }
+    std::vector<int32_t> ignore_choices;
+    for (const Node& ignore : document_.ignores) {
+      ignore_choices.push_back(CompileNode(ignore, "lark_ignore", true));
+    }
+    int32_t ignore_body =
+        ignore_choices.size() == 1 ? ignore_choices[0] : builder_.AddChoices(ignore_choices);
+    int32_t ignore_item_rule = builder_.AddRuleWithHint("lark_ignore_item", ignore_body);
+    int32_t ignore_repeat = builder_.AddRepeat(ignore_item_rule, 0, -1);
+    skip_rule_id_ = builder_.AddRuleWithHint("lark_ignore", ignore_repeat);
+  }
+
+  int32_t CompileNode(const Node& node, const std::string& rule_hint, bool terminal_mode) {
+    switch (node.kind) {
+      case Node::Kind::kSequence: {
+        if (node.children.empty()) {
+          return builder_.AddEmptyStr();
+        }
+        std::vector<int32_t> elements;
+        elements.reserve(node.children.size());
+        for (const Node& child : node.children) {
+          elements.push_back(CompileNode(child, rule_hint, terminal_mode));
+        }
+        return elements.size() == 1 ? elements[0] : builder_.AddSequence(elements);
+      }
+      case Node::Kind::kChoice: {
+        std::vector<int32_t> choices;
+        choices.reserve(node.children.size());
+        for (const Node& child : node.children) {
+          choices.push_back(CompileNode(child, rule_hint, terminal_mode));
+        }
+        return choices.size() == 1 ? choices[0] : builder_.AddChoices(choices);
+      }
+      case Node::Kind::kRepeat: {
+        int32_t child = CompileNode(node.children[0], rule_hint + "_repeat", terminal_mode);
+        return builder_.AddRepeatFromExpr(
+            rule_hint + "_repeat", child, node.min_repeat, node.max_repeat
+        );
+      }
+      case Node::Kind::kName: {
+        auto definition_it = definition_by_name_.find(node.text);
+        if (definition_it == definition_by_name_.end()) {
+          RaiseLarkError(source_, node.location, "unknown name '" + node.text + "'");
+        }
+        if (terminal_mode && !definition_it->second->is_terminal) {
+          RaiseLarkError(
+              source_, node.location, "terminal cannot reference rule '" + node.text + "'"
+          );
+        }
+        int32_t result = builder_.AddRuleRef(rule_ids_.at(node.text));
+        return !terminal_mode && definition_it->second->is_terminal ? AppendSkip(result) : result;
+      }
+      case Node::Kind::kString: {
+        if (!node.flags.empty()) {
+          RaiseLarkError(source_, node.location, "case-insensitive string flags are not supported");
+        }
+        int32_t result =
+            node.text.empty() ? builder_.AddEmptyStr() : builder_.AddByteString(node.text);
+        return !terminal_mode && !node.text.empty() ? AppendSkip(result) : result;
+      }
+      case Node::Kind::kRange: {
+        auto begin = ParseUTF8(node.text.c_str());
+        auto end = ParseUTF8(node.text2.c_str());
+        if (begin.size() != 1 || end.size() != 1 || begin[0] == CharHandlingError::kInvalidUTF8 ||
+            end[0] == CharHandlingError::kInvalidUTF8) {
+          RaiseLarkError(source_, node.location, "character range endpoints must be one character");
+        }
+        if (begin[0] > end[0]) {
+          RaiseLarkError(source_, node.location, "character range start must not exceed end");
+        }
+        int32_t result = builder_.AddCharacterClass({{begin[0], end[0]}});
+        return terminal_mode ? result : AppendSkip(result);
+      }
+      case Node::Kind::kRegex: {
+        if (!node.flags.empty()) {
+          RaiseLarkError(source_, node.location, "regular-expression flags are not supported");
+        }
+        try {
+          int32_t root = SubGrammarAdder::Apply(&builder_, Grammar::FromRegex(node.text));
+          int32_t result = builder_.AddRuleRef(root);
+          return terminal_mode ? result : AppendSkip(result);
+        } catch (const std::exception& error) {
+          RaiseLarkError(
+              source_,
+              node.location,
+              "failed to compile regular expression: " + std::string(error.what())
+          );
+        }
+      }
+      case Node::Kind::kJson: {
+        try {
+          int32_t root = SubGrammarAdder::Apply(&builder_, Grammar::FromJSONSchema(node.text));
+          int32_t result = builder_.AddRuleRef(root);
+          return terminal_mode ? result : AppendSkip(result);
+        } catch (const std::exception& error) {
+          RaiseLarkError(
+              source_,
+              node.location,
+              "failed to compile inline JSON schema: " + std::string(error.what())
+          );
+        }
+      }
+      case Node::Kind::kNestedLark: {
+        try {
+          LarkCompiler compiler(source_, *node.nested, tokenizer_info_);
+          int32_t root = SubGrammarAdder::Apply(&builder_, compiler.Compile());
+          int32_t result = builder_.AddRuleRef(root);
+          return terminal_mode ? result : AppendSkip(result);
+        } catch (const std::exception& error) {
+          RaiseLarkError(
+              source_,
+              node.location,
+              "failed to compile nested Lark grammar: " + std::string(error.what())
+          );
+        }
+      }
+      case Node::Kind::kSpecialToken: {
+        if (terminal_mode) {
+          RaiseLarkError(source_, node.location, "special tokens cannot be used in terminals");
+        }
+        SpecialTokenSet token_set = ResolveSpecialToken(node.text, node.location);
+        int32_t result = token_set.excluded ? builder_.AddExcludeTokenSet(token_set.token_ids)
+                                            : builder_.AddTokenSet(token_set.token_ids);
+        return AppendSkip(result);
+      }
+      case Node::Kind::kRegexExt:
+        RaiseLarkError(source_, node.location, "structured %regex is not supported");
+      case Node::Kind::kGrammarRef:
+        RaiseLarkError(source_, node.location, "multiple grammar references are not supported");
+      case Node::Kind::kNot:
+        RaiseLarkError(
+            source_, node.location, "regular-expression complement '~' is not supported"
+        );
+    }
+    RaiseLarkError(source_, node.location, "unsupported grammar node");
+  }
+
+  int32_t AppendSkip(int32_t expression) {
+    if (skip_rule_id_ == -1) {
+      return expression;
+    }
+    return builder_.AddSequence({expression, builder_.AddRuleRef(skip_rule_id_)});
+  }
+
+  SpecialTokenSet ResolveSpecialToken(const std::string& token, const Location& location) const {
+    if (token.size() >= 4 && token.substr(0, 2) == "<[" && token.substr(token.size() - 2) == "]>") {
+      std::string contents = token.substr(2, token.size() - 4);
+      SpecialTokenSet result;
+      if (!contents.empty() && contents[0] == '^') {
+        result.excluded = true;
+        contents.erase(contents.begin());
+      }
+      if (contents == "*") {
+        if (result.excluded) {
+          RaiseLarkError(source_, location, "negated wildcard special token is not supported");
+        }
+        if (!tokenizer_info_.has_value()) {
+          RaiseLarkError(source_, location, "wildcard special token requires tokenizer_info");
+        }
+        result.token_ids.reserve(tokenizer_info_->GetVocabSize());
+        for (int32_t token_id = 0; token_id < tokenizer_info_->GetVocabSize(); ++token_id) {
+          result.token_ids.push_back(token_id);
+        }
+        return result;
+      }
+      if (contents.find('*') != std::string::npos) {
+        RaiseLarkError(source_, location, "wildcard cannot be mixed with token ranges");
+      }
+      size_t offset = 0;
+      while (offset <= contents.size()) {
+        size_t comma = contents.find(',', offset);
+        std::string range = Trim(contents.substr(offset, comma - offset));
+        if (!range.empty()) {
+          size_t dash = range.find('-');
+          if (dash != std::string::npos && range.find('-', dash + 1) != std::string::npos) {
+            RaiseLarkError(
+                source_, location, "invalid numeric special-token range '" + range + "'"
+            );
+          }
+          int64_t first;
+          int64_t last;
+          try {
+            auto parse_token_id = [](const std::string& value) {
+              std::string trimmed = Trim(value);
+              size_t parsed = 0;
+              int64_t result = std::stoll(trimmed, &parsed);
+              if (parsed != trimmed.size()) {
+                throw std::invalid_argument("trailing characters");
+              }
+              return result;
+            };
+            first = parse_token_id(range.substr(0, dash));
+            last = dash == std::string::npos ? first : parse_token_id(range.substr(dash + 1));
+          } catch (const std::exception&) {
+            RaiseLarkError(
+                source_, location, "invalid numeric special-token range '" + range + "'"
+            );
+          }
+          if (first < 0 || last < first || last > std::numeric_limits<int32_t>::max()) {
+            RaiseLarkError(
+                source_, location, "invalid numeric special-token range '" + range + "'"
+            );
+          }
+          if (last - first > 1'000'000) {
+            RaiseLarkError(source_, location, "special-token range is too large");
+          }
+          for (int64_t token_id = first; token_id <= last; ++token_id) {
+            result.token_ids.push_back(static_cast<int32_t>(token_id));
+          }
+        }
+        if (comma == std::string::npos) {
+          break;
+        }
+        offset = comma + 1;
+      }
+      if (result.token_ids.empty()) {
+        RaiseLarkError(source_, location, "empty numeric special-token range");
+      }
+      std::sort(result.token_ids.begin(), result.token_ids.end());
+      result.token_ids.erase(
+          std::unique(result.token_ids.begin(), result.token_ids.end()), result.token_ids.end()
+      );
+      return result;
+    }
+
+    if (!tokenizer_info_.has_value()) {
+      RaiseLarkError(
+          source_, location, "named special token " + token + " requires tokenizer_info"
+      );
+    }
+    SpecialTokenSet result;
+    const auto& decoded_vocab = tokenizer_info_->GetDecodedVocab();
+    for (int32_t token_id = 0; token_id < static_cast<int32_t>(decoded_vocab.size()); ++token_id) {
+      if (decoded_vocab[token_id] == token) {
+        result.token_ids.push_back(token_id);
+      }
+    }
+    if (result.token_ids.empty()) {
+      RaiseLarkError(source_, location, "unknown special token " + token);
+    }
+    return result;
+  }
+
+  bool IsAnyText(const Node& node, std::unordered_set<std::string>* visiting = nullptr) const {
+    if (node.kind == Node::Kind::kRegex && node.flags.empty()) {
+      std::string pattern;
+      for (char c : node.text) {
+        if (c != ' ' && c != '\t' && c != '\r') {
+          pattern.push_back(c);
+        }
+      }
+      return pattern == "(.|\\n)*" || pattern == "(\\n|.)*" || pattern == "(?s:.*)" ||
+             pattern == "[\\s\\S]*";
+    }
+    if (node.kind == Node::Kind::kSequence && node.children.size() == 1) {
+      return IsAnyText(node.children[0], visiting);
+    }
+    if (node.kind == Node::Kind::kName) {
+      std::unordered_set<std::string> local_visiting;
+      if (visiting == nullptr) {
+        visiting = &local_visiting;
+      }
+      if (visiting->count(node.text)) {
+        return false;
+      }
+      auto it = definition_by_name_.find(node.text);
+      if (it == definition_by_name_.end()) {
+        return false;
+      }
+      visiting->insert(node.text);
+      bool result = IsAnyText(it->second->body, visiting);
+      visiting->erase(node.text);
+      return result;
+    }
+    return false;
+  }
+
+  std::optional<Trigger> ExtractLazyTrigger(const Definition& definition) const {
+    if (!definition.lazy || definition.body.kind != Node::Kind::kSequence ||
+        definition.body.children.size() != 2 || !IsAnyText(definition.body.children[0])) {
+      return std::nullopt;
+    }
+    const Node& trigger = definition.body.children[1];
+    if (trigger.kind == Node::Kind::kString && !trigger.text.empty() && trigger.flags.empty()) {
+      return Trigger{Trigger::Level::kString, trigger.text, {}, trigger.location};
+    }
+    if (trigger.kind == Node::Kind::kSpecialToken) {
+      SpecialTokenSet token_set = ResolveSpecialToken(trigger.text, trigger.location);
+      if (token_set.excluded) {
+        RaiseLarkError(source_, trigger.location, "lazy special-token trigger cannot be negated");
+      }
+      return Trigger{Trigger::Level::kToken, "", token_set.token_ids, trigger.location};
+    }
+    return std::nullopt;
+  }
+
+  int32_t CompileLazyRule(const Definition& definition) {
+    auto trigger = ExtractLazyTrigger(definition);
+    if (!trigger.has_value()) {
+      RaiseLarkError(
+          source_,
+          definition.location,
+          "general lazy rules are not supported; expected ANY_TEXT followed by a fixed trigger"
+      );
+    }
+    int32_t empty_rule = builder_.AddRuleWithHint("lark_lazy_end", builder_.AddEmptyStr());
+    int32_t result;
+    if (trigger->level == Trigger::Level::kString) {
+      result = builder_.AddTagDispatch({{{trigger->string, empty_rule}}, false, {}});
+    } else {
+      Grammar::Impl::TokenTagDispatch dispatch;
+      for (int32_t token_id : trigger->token_ids) {
+        dispatch.trigger_rule_pairs.push_back({token_id, empty_rule});
+      }
+      dispatch.loop_after_dispatch = false;
+      result = builder_.AddTokenTagDispatch(dispatch);
+    }
+    return AppendSkip(result);
+  }
+
+  static const Node* UnwrapSingle(const Node* node) {
+    while (node->kind == Node::Kind::kSequence && node->children.size() == 1) {
+      node = &node->children[0];
+    }
+    return node;
+  }
+
+  static std::vector<Node> FlattenSequence(const Node& node) {
+    if (node.kind == Node::Kind::kSequence) {
+      return node.children;
+    }
+    return {node};
+  }
+
+  std::optional<int32_t> CompileDynamicStart(const Definition& start) {
+    std::unordered_set<std::string> unused_rules;
+    std::vector<Node> start_elements = FlattenSequence(start.body);
+    if (start_elements.size() != 2) {
+      return std::nullopt;
+    }
+    const Node* loop = UnwrapSingle(&start_elements[0]);
+    if (loop->kind != Node::Kind::kRepeat || loop->min_repeat != 0 || loop->max_repeat != -1) {
+      return std::nullopt;
+    }
+    const Node* loop_body = UnwrapSingle(&loop->children[0]);
+    std::vector<std::string> tool_names;
+    if (loop_body->kind == Node::Kind::kChoice) {
+      for (const Node& alternative : loop_body->children) {
+        const Node* name = UnwrapSingle(&alternative);
+        if (name->kind != Node::Kind::kName) {
+          return std::nullopt;
+        }
+        tool_names.push_back(name->text);
+      }
+    } else if (loop_body->kind == Node::Kind::kName) {
+      tool_names.push_back(loop_body->text);
+    } else {
+      return std::nullopt;
+    }
+
+    const Node* tail_name = UnwrapSingle(&start_elements[1]);
+    if (tail_name->kind != Node::Kind::kName) {
+      return std::nullopt;
+    }
+    auto tail_it = definition_by_name_.find(tail_name->text);
+    if (tail_it == definition_by_name_.end() || !IsAnyText(tail_it->second->body)) {
+      return std::nullopt;
+    }
+    unused_rules.insert(tail_name->text);
+
+    std::vector<DynamicAlternative> alternatives;
+    for (const std::string& tool_name : tool_names) {
+      auto tool_it = definition_by_name_.find(tool_name);
+      if (tool_it == definition_by_name_.end() || tool_it->second->is_terminal) {
+        return std::nullopt;
+      }
+      unused_rules.insert(tool_name);
+      std::vector<Node> tool_elements = FlattenSequence(tool_it->second->body);
+      if (tool_elements.empty()) {
+        return std::nullopt;
+      }
+
+      std::optional<Trigger> trigger;
+      size_t remainder_begin = 0;
+      const Node* first = UnwrapSingle(&tool_elements[0]);
+      if (first->kind == Node::Kind::kName) {
+        auto head_it = definition_by_name_.find(first->text);
+        if (head_it != definition_by_name_.end()) {
+          trigger = ExtractLazyTrigger(*head_it->second);
+          if (trigger.has_value()) {
+            unused_rules.insert(first->text);
+            remainder_begin = 1;
+          }
+        }
+      }
+      if (!trigger.has_value() && tool_elements.size() >= 2 && IsAnyText(tool_elements[0])) {
+        const Node* token_trigger = UnwrapSingle(&tool_elements[1]);
+        if (token_trigger->kind == Node::Kind::kSpecialToken) {
+          SpecialTokenSet token_set =
+              ResolveSpecialToken(token_trigger->text, token_trigger->location);
+          if (token_set.excluded) {
+            RaiseLarkError(
+                source_, token_trigger->location, "dynamic special-token trigger cannot be negated"
+            );
+          }
+          trigger =
+              Trigger{Trigger::Level::kToken, "", token_set.token_ids, token_trigger->location};
+          remainder_begin = 2;
+        }
+      }
+      if (!trigger.has_value()) {
+        return std::nullopt;
+      }
+
+      Node remainder;
+      remainder.kind = Node::Kind::kSequence;
+      remainder.location = tool_it->second->location;
+      remainder.children.assign(
+          tool_elements.begin() + static_cast<std::ptrdiff_t>(remainder_begin), tool_elements.end()
+      );
+      alternatives.push_back({std::move(trigger.value()), std::move(remainder)});
+    }
+
+    if (alternatives.empty()) {
+      return std::nullopt;
+    }
+    Trigger::Level level = alternatives[0].trigger.level;
+    for (const auto& alternative : alternatives) {
+      if (alternative.trigger.level != level) {
+        RaiseLarkError(
+            source_,
+            start.location,
+            "a dynamic Lark start rule cannot mix string and token triggers"
+        );
+      }
+    }
+
+    if (level == Trigger::Level::kString) {
+      std::unordered_map<std::string, std::vector<const DynamicAlternative*>> grouped;
+      std::vector<std::string> trigger_order;
+      for (const auto& alternative : alternatives) {
+        if (!grouped.count(alternative.trigger.string)) {
+          trigger_order.push_back(alternative.trigger.string);
+        }
+        grouped[alternative.trigger.string].push_back(&alternative);
+      }
+      Grammar::Impl::TagDispatch dispatch;
+      dispatch.loop_after_dispatch = true;
+      for (const std::string& trigger : trigger_order) {
+        std::vector<int32_t> remainder_choices;
+        for (const DynamicAlternative* alternative : grouped.at(trigger)) {
+          remainder_choices.push_back(
+              CompileNode(alternative->remainder, "lark_dynamic_body", false)
+          );
+        }
+        int32_t body = remainder_choices.size() == 1 ? remainder_choices[0]
+                                                     : builder_.AddChoices(remainder_choices);
+        int32_t body_rule = builder_.AddRuleWithHint("lark_dynamic_body", body);
+        dispatch.tag_rule_pairs.push_back({trigger, body_rule});
+      }
+      dynamic_unused_rules_ = std::move(unused_rules);
+      return builder_.AddTagDispatch(dispatch);
+    }
+
+    std::unordered_map<int32_t, std::vector<const DynamicAlternative*>> grouped;
+    std::vector<int32_t> token_order;
+    for (const auto& alternative : alternatives) {
+      for (int32_t token_id : alternative.trigger.token_ids) {
+        if (!grouped.count(token_id)) {
+          token_order.push_back(token_id);
+        }
+        grouped[token_id].push_back(&alternative);
+      }
+    }
+    Grammar::Impl::TokenTagDispatch dispatch;
+    dispatch.loop_after_dispatch = true;
+    for (int32_t token_id : token_order) {
+      std::vector<int32_t> remainder_choices;
+      for (const DynamicAlternative* alternative : grouped.at(token_id)) {
+        remainder_choices.push_back(
+            CompileNode(alternative->remainder, "lark_dynamic_token_body", false)
+        );
+      }
+      int32_t body = remainder_choices.size() == 1 ? remainder_choices[0]
+                                                   : builder_.AddChoices(remainder_choices);
+      int32_t body_rule = builder_.AddRuleWithHint("lark_dynamic_token_body", body);
+      dispatch.trigger_rule_pairs.push_back({token_id, body_rule});
+    }
+    dynamic_unused_rules_ = std::move(unused_rules);
+    return builder_.AddTokenTagDispatch(dispatch);
+  }
+
+  const std::string& source_;
+  Document document_;
+  const std::optional<TokenizerInfo>& tokenizer_info_;
+  GrammarBuilder builder_;
+  std::unordered_map<std::string, Definition*> definition_by_name_;
+  std::unordered_map<std::string, int32_t> rule_ids_;
+  int32_t skip_rule_id_ = -1;
+  bool allow_initial_skip_ = false;
+  std::unordered_set<std::string> dynamic_unused_rules_;
+};
+
+}  // namespace
+
+Grammar LarkToGrammar(
+    const std::string& lark_string, const std::optional<TokenizerInfo>& tokenizer_info
+) {
+  auto tokens = LarkLexer(lark_string).Tokenize();
+  auto document = LarkParser(lark_string, std::move(tokens)).Parse();
+  return LarkCompiler(lark_string, std::move(document), tokenizer_info).Compile();
+}
+
+}  // namespace xgrammar

--- a/cpp/lark_converter.h
+++ b/cpp/lark_converter.h
@@ -1,0 +1,24 @@
+/*!
+ *  Copyright (c) 2026 by Contributors
+ * \file xgrammar/lark_converter.h
+ * \brief Convert LLGuidance-compatible Lark syntax to XGrammar Grammar IR.
+ */
+
+#ifndef XGRAMMAR_LARK_CONVERTER_H_
+#define XGRAMMAR_LARK_CONVERTER_H_
+
+#include <xgrammar/grammar.h>
+
+#include <optional>
+#include <string>
+
+namespace xgrammar {
+
+Grammar LarkToGrammar(
+    const std::string& lark_string,
+    const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt
+);
+
+}  // namespace xgrammar
+
+#endif  // XGRAMMAR_LARK_CONVERTER_H_

--- a/cpp/lark_converter.h
+++ b/cpp/lark_converter.h
@@ -1,7 +1,7 @@
 /*!
  *  Copyright (c) 2026 by Contributors
  * \file xgrammar/lark_converter.h
- * \brief Convert LLGuidance-compatible Lark syntax to XGrammar Grammar IR.
+ * \brief Convert Lark syntax to XGrammar Grammar IR.
  */
 
 #ifndef XGRAMMAR_LARK_CONVERTER_H_
@@ -11,12 +11,14 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace xgrammar {
 
 Grammar LarkToGrammar(
     const std::string& lark_string,
-    const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt
+    const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt,
+    const std::vector<NamedGrammar>& named_grammars = {}
 );
 
 }  // namespace xgrammar

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -383,6 +383,21 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           }
       )
       .def_static(
+          "from_lark",
+          [](ffi::String lark_string, ffi::AnyView tokenizer_info_view) {
+            XGRAMMAR_FFI_TRY_BEGIN();
+            std::optional<TokenizerInfo> tokenizer_info = std::nullopt;
+            if (tokenizer_info_view != nullptr) {
+              tokenizer_info =
+                  tokenizer_info_view.cast<ffi::ObjectRef>().as<TokenizerInfoObj>()->value;
+            }
+            return ffi::ObjectRef(
+                ffi::make_object<GrammarObj>(Grammar::FromLark(lark_string, tokenizer_info))
+            );
+            XGRAMMAR_FFI_TRY_END();
+          }
+      )
+      .def_static(
           "from_structural_tag",
           [](ffi::String structural_tag_json) {
             XGRAMMAR_FFI_TRY_BEGIN();

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -384,16 +384,37 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       )
       .def_static(
           "from_lark",
-          [](ffi::String lark_string, ffi::AnyView tokenizer_info_view) {
+          [](ffi::String lark_string,
+             ffi::AnyView tokenizer_info_view,
+             ffi::AnyView named_grammar_names_view,
+             ffi::AnyView named_grammar_values_view) {
             XGRAMMAR_FFI_TRY_BEGIN();
             std::optional<TokenizerInfo> tokenizer_info = std::nullopt;
             if (tokenizer_info_view != nullptr) {
               tokenizer_info =
                   tokenizer_info_view.cast<ffi::ObjectRef>().as<TokenizerInfoObj>()->value;
             }
-            return ffi::ObjectRef(
-                ffi::make_object<GrammarObj>(Grammar::FromLark(lark_string, tokenizer_info))
-            );
+            auto named_grammar_names = named_grammar_names_view.cast<ffi::Array<ffi::Any>>();
+            auto named_grammar_values = named_grammar_values_view.cast<ffi::Array<ffi::Any>>();
+            if (named_grammar_names.size() != named_grammar_values.size()) {
+              throw XGrammarError("Named grammar names and values must have the same length");
+            }
+            std::vector<NamedGrammar> named_grammars;
+            named_grammars.reserve(static_cast<size_t>(named_grammar_names.size()));
+            for (int64_t i = 0; i < static_cast<int64_t>(named_grammar_names.size()); ++i) {
+              std::string name = named_grammar_names[i].cast<ffi::String>();
+              ffi::AnyView value = named_grammar_values[i];
+              if (const auto* grammar_obj = value.as<GrammarObj>()) {
+                named_grammars.push_back({std::move(name), grammar_obj->value});
+              } else if (value.as<ffi::String>()) {
+                named_grammars.push_back({std::move(name), std::string(value.cast<ffi::String>())});
+              } else {
+                throw XGrammarError("Named grammar values must be Grammar or Lark strings");
+              }
+            }
+            return ffi::ObjectRef(ffi::make_object<GrammarObj>(
+                Grammar::FromLark(lark_string, tokenizer_info, named_grammars)
+            ));
             XGRAMMAR_FFI_TRY_END();
           }
       )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ The mission of this project is to bring flexible zero-overhead structure generat
 
    xgrammar_features/runtime_safeguards
    xgrammar_features/serialization
+   xgrammar_features/lark_grammar
    xgrammar_features/javascript_api
 
 .. toctree::

--- a/docs/xgrammar_features/lark_grammar.md
+++ b/docs/xgrammar_features/lark_grammar.md
@@ -1,0 +1,146 @@
+# Lark Grammar Frontend
+
+XGrammar can compile a practical subset of the Lark grammar syntax used by LLGuidance. The result
+is a normal `Grammar`, so it works with the existing compiler, matcher, serialization, and engine
+integrations.
+
+```python
+import xgrammar as xgr
+
+grammar = xgr.Grammar.from_lark(
+    r'''
+    %import common.INT
+    %import common.WS
+    %ignore WS
+
+    start: item ("," item)*
+    item: "id=" INT
+    '''
+)
+```
+
+The root rule must be named `start`.
+
+## Supported Syntax
+
+- lowercase rules and uppercase terminals
+- string and regular-expression literals
+- sequences, alternatives, groups, and optional groups
+- `?`, `*`, `+`, `~M..N`, `{M}`, `{M,N}`, `{M,}`, and `{,N}` repetitions
+- single-character ranges such as `"a".."z"`
+- recursive rules and forward references
+- `#` and `//` comments
+- multiline alternatives beginning with `|`
+- hyphens in identifiers
+- `%import common.X`, import aliases, and multi-imports
+- `%ignore`
+- inline `%json { ... }`
+- nested `%lark { ... }`
+- numeric token sets such as `<[1,3-8]>`, exclusions such as `<[^1,3]>`, and `<[*]>`
+- named special tokens when `tokenizer_info` is supplied
+- `%llguidance {"allow_initial_skip": true}`
+
+String and regex flags are not currently supported.
+
+## Inline JSON
+
+`%json` behaves like a nonterminal and compiles through XGrammar's JSON Schema converter.
+
+```python
+grammar = xgr.Grammar.from_lark(
+    r'''
+    start: "<tool_call>" arguments "</tool_call>"
+    arguments: %json {
+      "type": "object",
+      "properties": {"city": {"type": "string"}},
+      "required": ["city"],
+      "additionalProperties": false
+    }
+    '''
+)
+```
+
+Whitespace outside the JSON value is controlled by the surrounding Lark grammar. Whitespace inside
+the value follows the JSON Schema converter's normal behavior.
+
+## Dynamic Tool Calls
+
+LLGuidance uses a lazy text lexeme to allow arbitrary text until a tool-call trigger appears. The
+grammar remains static; the trigger changes the active parser state rather than replacing the
+grammar at runtime.
+
+XGrammar recognizes the LLGuidance structural-tag pattern below and lowers the complete `start`
+rule to `TagDispatch`:
+
+```python
+grammar = xgr.Grammar.from_lark(
+    r'''
+    start: tool* tail
+    tail: TEXT
+
+    tool_head[lazy]: TEXT "<tool_call>"
+    tool: tool_head %json {
+      "type": "object",
+      "properties": {"x": {"type": "integer"}},
+      "required": ["x"],
+      "additionalProperties": false
+    } "</tool_call>"
+
+    TEXT: /(\n|.)*/
+    '''
+)
+```
+
+This accepts plain text, one tool call, or multiple tool calls. Once the complete trigger is seen,
+the payload and end tag are mandatory. After the end tag, free text is allowed again.
+
+Multiple tool forms may share a trigger prefix:
+
+```text
+start: (foo | bar)* tail
+tail: TEXT
+
+foo_head[lazy]: TEXT "<function"
+foo: foo_head "=foo>" /[a-z]+/ "</function>"
+
+bar_head[lazy]: TEXT "<function"
+bar: bar_head "=bar>" /[A-Z]+/ "</function>"
+
+TEXT: /(\n|.)*/
+```
+
+The supported lazy form is deliberately narrow: an arbitrary-text terminal followed by one fixed
+string or special-token trigger. General shortest-match regex semantics are not approximated.
+
+## Special Tokens
+
+Numeric token references do not require tokenizer metadata:
+
+```python
+grammar = xgr.Grammar.from_lark("start: <[128000-128010]>")
+```
+
+Named references are resolved by exact match against the decoded vocabulary:
+
+```python
+tokenizer_info = xgr.TokenizerInfo(["a", "<|tool|>", "b"])
+grammar = xgr.Grammar.from_lark("start: <|tool|>", tokenizer_info=tokenizer_info)
+```
+
+## Unsupported LLGuidance Extensions
+
+The following features require regular-language or generation-runtime state that is not represented
+by XGrammar's current `Grammar` API. The frontend rejects them with a source-located error:
+
+- captures
+- general `lazy`, `stop`, `suffix`, and stop captures
+- rule-level `max_tokens` and `temperature`
+- terminal intersection and complement (`&` and `~`)
+- structured `%regex` substring nodes
+- multiple named grammars referenced with `@name`
+- parametric grammar rules and `%if`
+- templates, priorities, `%declare`, and `%override`
+- `%llguidance` options other than `allow_initial_skip`
+
+Rejecting these constructs is intentional. Ignoring them would silently accept a different language
+or drop generation-time behavior.

--- a/docs/xgrammar_features/lark_grammar.md
+++ b/docs/xgrammar_features/lark_grammar.md
@@ -1,58 +1,253 @@
-# Lark Grammar Frontend
+# Lark Grammar
 
-XGrammar's Lark frontend is compatible with the Lark dialect used by LLGuidance. The result is a
-normal `Grammar`, so it works with the existing compiler, matcher, serialization, and engine
+XGrammar can build grammars from a dialect of the
+[Lark grammar language](https://lark-parser.readthedocs.io/en/latest/grammar.html) through
+[`xgr.Grammar.from_lark`](xgrammar.Grammar.from_lark). Lark is a compact, readable notation for
+describing structured text: fixed strings, alternatives, repetition, recursion, and regular
+expressions. The result is a normal [`xgr.Grammar`](xgrammar.Grammar), so it works with the
+existing compiler, matcher, serialization, `Grammar.union` / `Grammar.concat`, and all engine
 integrations.
 
 ```python
 import xgrammar as xgr
 
 grammar = xgr.Grammar.from_lark(
-    r'''
+    r"""
     %import common.INT
     %import common.WS
     %ignore WS
 
     start: item ("," item)*
     item: "id=" INT
-    '''
+    """
 )
 ```
 
-The root rule must be named `start`.
+This grammar accepts strings such as `id=1`, `id=1, id=42`, or `id=1 ,id=2 , id=3`.
 
-## Supported Syntax
+XGrammar's Lark dialect is compatible with the dialect used by
+[llguidance](https://github.com/guidance-ai/llguidance).
 
-- lowercase rules and uppercase terminals
-- string and regular-expression literals
-- ASCII case-insensitive string literals such as `"yes"i`
-- the regex `s` flag, such as `/.*/s`; without `s`, `.` does not match newline
-- sequences, alternatives, groups, and optional groups
-- `?`, `*`, `+`, `~M..N`, `{M}`, `{M,N}`, `{M,}`, and `{,N}` repetitions
-- single-character ranges such as `"a".."z"`
-- recursive rules and forward references
-- `#` and `//` comments
-- multiline alternatives beginning with `|`
-- hyphens in identifiers
-- `%import common.X`, import aliases, and multi-imports
-- `%ignore`
-- inline `%json { ... }`
-- nested `%lark { ... }`
-- numeric token sets such as `<[1,3-8]>`, exclusions such as `<[^1,3]>`, and `<[*]>`
-- named special tokens when `tokenizer_info` is supplied
-- named grammars referenced with `@name`
-- `%grammar_options {"allow_initial_skip": true}`
+## Usage
 
-Case-insensitive string literals containing non-ASCII characters are rejected. Regex flags other
-than `s` are not currently supported.
+```python
+xgr.Grammar.from_lark(
+    lark_string: str,
+    *,
+    tokenizer_info: Optional[xgr.TokenizerInfo] = None,
+    named_grammars: Optional[Dict[str, Union[xgr.Grammar, str]]] = None,
+) -> xgr.Grammar
+```
 
-## Inline JSON
+- `lark_string` is the grammar source. It must define a rule named `start`, which is the entry
+  point of the grammar.
+- `tokenizer_info` is only required when the grammar uses named special tokens (such as
+  `<|tool_call|>`) or the all-token wildcard `<[*]>`. See [Special Tokens](#special-tokens).
+- `named_grammars` supplies external grammars referenced with `@name` in the Lark source. See
+  [Named Grammars](#named-grammars).
 
-`%json` behaves like a nonterminal and compiles through XGrammar's JSON Schema converter.
+The returned grammar is compiled and matched like any other grammar:
+
+```python
+tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
+compiler = xgr.GrammarCompiler(tokenizer_info)
+compiled = compiler.compile_grammar(xgr.Grammar.from_lark('start: "a" | "b"'))
+matcher = xgr.GrammarMatcher(compiled)
+```
+
+Errors in the grammar raise `RuntimeError` with the line, the column, and the offending source
+line:
+
+```text
+Lark error at line 3, column 6: expected ':' after rule name
+item missing
+     ^
+```
+
+## Grammar Structure
+
+A grammar is a sequence of items separated by newlines. Each item is one of:
+
+- a rule definition: `name: expression`
+- a terminal definition: `NAME: expression`
+- a directive: `%import`, `%ignore`, or `%grammar_options`
+
+Comments start with `#` or `//` and run to the end of the line. Blank lines are ignored. An
+alternative may continue on the next line when that line starts with `|`:
+
+```text
+start: "a"
+     | "b"
+     | "c"
+```
+
+### Rules and Terminals
+
+Names consist of letters, digits, underscores, and hyphens. A definition whose name starts with a
+lowercase letter (ignoring a leading underscore) is a **rule**; one that starts with an uppercase
+letter is a **terminal**.
+
+```text
+start: value (";" value)*     // rule
+value: INT | NAME             // rule referencing terminals
+INT: /[0-9]+/                 // terminal
+NAME: /[a-z]+/                // terminal
+```
+
+Rules may reference each other freely, including forward references, direct recursion, and
+indirect recursion:
+
+```text
+start: value
+value: "x" | "(" value ")" | "[" (value ("," value)*)? "]"
+```
+
+Terminals are matched as one indivisible unit:
+
+- A terminal may be composed of strings, character ranges, regular expressions, repetition, and
+  other terminals, but it cannot reference rules and cannot be recursive.
+- Content skipped by `%ignore` is never inserted inside a terminal. In the first example above,
+  with `%ignore WS`, spaces may appear around an `INT` but not between its digits.
+- `%json`, `%lark`, special tokens, and `@name` references cannot appear inside terminals.
+
+For compatibility with grammars written for parse-tree-producing parsers, XGrammar accepts and
+ignores the rule prefixes `?` and `!` (as in `?value: ...`) and alternative aliases
+(`"a" -> first`). These constructs only affect parse-tree shaping and have no effect on which
+strings the grammar accepts.
+
+### String Literals
+
+String literals use double quotes and JSON escape syntax: `\"`, `\\`, `\/`, `\b`, `\f`, `\n`,
+`\r`, `\t`, and `\uXXXX`. Non-ASCII characters may be written directly (`"中文"`, `"😀"`) or with
+Unicode escapes (`"\u03bb"` matches `λ`).
+
+A trailing `i` makes the literal case-insensitive: `"yes"i` matches `yes`, `YES`, `Yes`, and so
+on. Case-insensitive literals currently support ASCII characters only; a case-insensitive literal
+containing non-ASCII characters is rejected.
+
+### Character Ranges
+
+`"a".."z"` matches one character between the two endpoints, inclusive. Both endpoints must be
+exactly one character and may be any Unicode character: `"α".."γ"` matches `α`, `β`, or `γ`. The
+`i` flag is not allowed on range endpoints.
+
+### Regular Expressions
+
+`/pattern/` matches text against a regular expression. The pattern is compiled through XGrammar's
+regex converter (the same engine as [`xgr.Grammar.from_regex`](xgrammar.Grammar.from_regex)) and
+supports character classes, alternation, groups, repetition (`*`, `+`, `?`, `{m,n}`), and the
+usual escapes. A `/` inside the pattern is written `\/`.
+
+`.` matches one Unicode character. By default it does not match newline; adding the `s` flag
+(`/pattern/s`) makes `.` match newline as well. `s` is currently the only supported regex flag.
+
+```text
+start: /a.b/      // accepts "acb", "a😀b"; rejects "a\nb"
+line: /a.b/s      // also accepts "a\nb"
+```
+
+### Sequences, Alternatives, and Groups
+
+| Form | Example | Meaning |
+| --- | --- | --- |
+| Sequence | `"a" "b"` | Match the elements in order. |
+| Alternative | `"a" \| "b"` | Match any one branch. |
+| Group | `("a" \| "b") "c"` | Group a sub-expression; may carry repetition. |
+| Optional group | `["a" "b"]` | The whole group appears zero or one time. |
+| Empty | `start:` or `start: \| "a"` or `""` | Matches the empty string. |
+
+### Repetition
+
+Repetition operators follow an element (a literal, a name, or a group):
+
+| Form | Meaning |
+| --- | --- |
+| `x?` | zero or one |
+| `x*` | zero or more |
+| `x+` | one or more |
+| `x~3` | exactly 3 |
+| `x~2..4` | 2 to 4, inclusive |
+| `x{3}` | exactly 3 |
+| `x{2,4}` | 2 to 4, inclusive |
+| `x{2,}` | 2 or more |
+| `x{,4}` | 0 to 4 |
+
+Zero counts such as `x{0}` are allowed and match the empty string. Ranges with the upper bound
+below the lower bound are rejected.
+
+## Directives
+
+### `%import common`
+
+XGrammar provides a built-in library of common terminals. `%import` brings one of them into scope
+as a terminal definition:
+
+```text
+%import common.INT                 // defines INT
+%import common.INT -> NUMBER       // defines NUMBER with INT's pattern
+%import common (INT, WS, CNAME)    // multiple imports in one line
+```
+
+Imports may appear anywhere in the grammar, including after the first use of the imported name.
+Importing a name that is already defined is an error. The available names:
+
+| Category | Names |
+| --- | --- |
+| Numbers | `DIGIT`, `HEXDIGIT`, `INT`, `SIGNED_INT`, `DECIMAL`, `_EXP`, `FLOAT`, `SIGNED_FLOAT`, `NUMBER`, `SIGNED_NUMBER` |
+| Strings and names | `ESCAPED_STRING`, `LCASE_LETTER`, `UCASE_LETTER`, `LETTER`, `WORD`, `CNAME` |
+| Whitespace | `WS_INLINE`, `WS`, `CR`, `LF`, `NEWLINE` |
+| Comments | `SH_COMMENT`, `CPP_COMMENT`, `C_COMMENT`, `SQL_COMMENT` |
+
+Only the `common` library can be imported.
+
+### `%ignore`
+
+`%ignore` declares content that may appear between terminals, typically whitespace:
+
+```text
+%import common.WS
+%ignore WS
+start: "a" DIGIT
+DIGIT: "0".."9"
+```
+
+This accepts `a1`, `a 1`, and `a\n1  `. The ignored content:
+
+- may appear between any two lexemes (terminals, string literals, character ranges, regexes) in a
+  rule, and after the last one;
+- may **not** appear before the first lexeme, unless `allow_initial_skip` is enabled (see below);
+- is never inserted inside a terminal.
+
+The `%ignore` expression may be a terminal name, a string, a regex, or a combination. Multiple
+`%ignore` declarations are merged:
+
+```text
+%import common (WS, CPP_COMMENT)
+%ignore WS
+%ignore CPP_COMMENT
+%ignore /;+/
+```
+
+### `%grammar_options`
+
+`%grammar_options` takes a JSON object that configures the whole grammar:
+
+```text
+%grammar_options {"allow_initial_skip": true}
+```
+
+`allow_initial_skip` (boolean, default `false`) allows `%ignore` content to appear before the
+first lexeme of the output. Multiple `%grammar_options` declarations are merged; unknown option
+names are rejected.
+
+## Inline JSON Schema
+
+`%json { ... }` embeds a JSON Schema and behaves like a rule reference: the element matches any
+JSON value conforming to the schema, converted through XGrammar's JSON Schema converter.
 
 ```python
 grammar = xgr.Grammar.from_lark(
-    r'''
+    r"""
     start: "<tool_call>" arguments "</tool_call>"
     arguments: %json {
       "type": "object",
@@ -60,17 +255,72 @@ grammar = xgr.Grammar.from_lark(
       "required": ["city"],
       "additionalProperties": false
     }
-    '''
+    """
 )
 ```
 
-Whitespace outside the JSON value is controlled by the surrounding Lark grammar. Whitespace inside
-the value follows the JSON Schema converter's normal behavior.
+`%json` may appear inside sequences, alternatives, and repetition. Whitespace outside the JSON
+value is controlled by the surrounding Lark grammar; whitespace inside the value follows the JSON
+Schema converter's normal behavior. `%json` cannot be used inside terminals.
+
+## Nested Grammars
+
+`%lark { ... }` embeds a complete Lark grammar as one element. The nested grammar has its own
+independent namespace: it must define its own `start` rule, and it may declare its own imports,
+`%ignore`, and `%grammar_options` without affecting the outer grammar. Rule names may be reused
+across the boundary.
+
+```python
+grammar = xgr.Grammar.from_lark(
+    r"""
+    start: "[" %lark {
+      %import common.WS
+      %ignore WS
+      start: item ":" %json {"type": "integer"}
+      item: "x" | "(" item ")"
+    } "]"
+    """
+)
+```
+
+Multiple `%lark` blocks may appear in the same rule. Nested grammars may use every feature of the
+top-level grammar, including further nesting and `@name` references.
+
+## Special Tokens
+
+Special-token elements match exactly one token from the model's vocabulary, rather than text.
+They may only be used in rules, not in terminals.
+
+**Numeric token sets** reference tokens by ID and do not require tokenizer metadata (except for
+the wildcard):
+
+```text
+start: <[128010]>            // exactly token 128010
+start: <[128000-128255]>     // one token in the inclusive range
+start: <[1,3-8,10]>          // union of IDs and ranges (duplicates are merged)
+start: <[^1,3-8]>            // any token NOT in the set
+start: <[*]>                 // any token (requires tokenizer_info)
+```
+
+A range whose endpoints differ by more than 1,000,000 is rejected, as is the negated wildcard
+`<[^*]>`.
+
+**Named special tokens** are resolved against the tokenizer's decoded vocabulary by exact string
+match and therefore require `tokenizer_info`:
+
+```python
+tokenizer_info = xgr.TokenizerInfo(["a", "<|tool|>", "b"])
+grammar = xgr.Grammar.from_lark("start: <|tool|>", tokenizer_info=tokenizer_info)
+```
+
+The reference matches every vocabulary entry whose decoded text equals the written form,
+including the angle brackets. A name that matches no vocabulary entry is an error.
 
 ## Named Grammars
 
-Pass existing `Grammar` objects or Lark grammar strings through `named_grammars` and reference them
-with `@name`. Dictionary keys do not include the leading `@`.
+`named_grammars` passes external grammars into the Lark source, referenced with `@name`.
+Dictionary keys do not include the leading `@`; values are either `Grammar` objects or Lark
+source strings.
 
 ```python
 arguments = xgr.Grammar.from_json_schema(
@@ -90,19 +340,24 @@ grammar = xgr.Grammar.from_lark(
 )
 ```
 
-String values are parsed as Lark grammars and may reference other entries in the same mapping. The
-same named grammar may be referenced more than once and from inside nested `%lark` blocks.
+- Names may contain letters, digits, underscores, and hyphens, and must be unique.
+- String values are complete Lark grammars with their own `start` rule, their own terminals, and
+  their own `%ignore` declarations. They may reference other entries of the same mapping with
+  `@name`; circular references are reported as errors with the reference chain.
+- The same named grammar may be referenced multiple times and from inside nested `%lark` blocks.
+  Each named grammar is compiled once and shared.
+- `@name` references may only appear in rules, not in terminals.
 
-## Dynamic Tool Calls
+## Dynamic Tool-Call Dispatch
 
-A lazy text lexeme can allow arbitrary text until a tool-call trigger appears. The grammar remains
-static; the trigger changes the active parser state rather than replacing the grammar at runtime.
-XGrammar recognizes the structural-tag pattern below and lowers the complete `start` rule to
-`TagDispatch`:
+A common pattern for tool calling lets the model produce free text until a trigger string (such
+as `<tool_call>`) appears, then switches to a strict argument grammar, and returns to free text
+after the call completes. XGrammar recognizes this pattern and compiles it into an efficient
+token-level dispatch structure:
 
 ```python
 grammar = xgr.Grammar.from_lark(
-    r'''
+    r"""
     start: tool* tail
     tail: TEXT
 
@@ -115,53 +370,80 @@ grammar = xgr.Grammar.from_lark(
     } "</tool_call>"
 
     TEXT: /(\n|.)*/
-    '''
+    """
 )
 ```
 
-This accepts plain text, one tool call, or multiple tool calls. Once the complete trigger is seen,
-the payload and end tag are mandatory. After the end tag, free text is allowed again.
+This accepts plain text with no tool call, one tool call, or several tool calls separated by free
+text. A partial trigger (for example a final `<tool_cal`) still counts as free text. Once the
+complete trigger has been produced, the payload and the end tag become mandatory.
 
-Multiple tool forms may share a trigger prefix:
+### The Recognized Pattern
+
+The `start` rule must have the shape
 
 ```text
-start: (foo | bar)* tail
+start: tool* tail            // or: start: (tool_a | tool_b | ...)* tail
 tail: TEXT
+```
 
-foo_head[lazy]: TEXT "<function"
-foo: foo_head "=foo>" /[a-z]+/ "</function>"
+where `TEXT` is an **any-text terminal**: a terminal whose body is one of the regexes
+`/(.|\n)*/`, `/(\n|.)*/`, `/(?:.|\n)*/`, `/(?:\n|.)*/`, `/[\s\S]*/`, `/(?s:.*)/`, or `/.*/s`
+(possibly through another terminal name).
 
-bar_head[lazy]: TEXT "<function"
-bar: bar_head "=bar>" /[A-Z]+/ "</function>"
+Each tool rule starts with a trigger and continues with an ordinary grammar for the payload. The
+trigger is written in one of these equivalent head forms:
 
+```text
+head[lazy]: TEXT "<tool>"          // any text, then a fixed trigger string
+head[lazy]: TEXT <|tool_token|>    // any text, then a special token (requires tokenizer_info)
+head[lazy]: /(\n|.)*<tool>/        // the same trigger written as a regex suffix
+head[suffix="<tool>"]: TEXT        // the same trigger written as a suffix attribute
+tool: TEXT <|tool_token|> ...      // token trigger written inline, without a head rule
+```
+
+For the regex-suffix form, the pattern must be one of the any-text regexes followed by a fixed
+literal (escapes such as `\n` or `\.` are allowed; alternation, repetition, and other variable
+constructs are not).
+
+### Multiple Tools
+
+Different tools may use different triggers, or share one trigger and differentiate on the text
+that follows:
+
+```python
+grammar = xgr.Grammar.from_lark(
+    r"""
+    start: (foo | bar)* tail
+    tail: TEXT
+
+    foo_head[lazy]: TEXT "<function"
+    foo: foo_head "=foo>" /[a-z]+/ "</function>"
+
+    bar_head[lazy]: TEXT "<function"
+    bar: bar_head "=bar>" /[0-9]+/ "</function>"
+
+    TEXT: /(\n|.)*/
+    """
+)
+```
+
+After `<function` is produced, the output must continue with `=foo>` or `=bar>` and the matching
+payload. All triggers within one grammar must be at the same level: either all trigger strings or
+all special tokens. Negated token sets cannot be used as triggers.
+
+### Standalone Lazy Rules
+
+Outside of the dispatch pattern, a lazy head of the form `head[lazy]: TEXT "<end>"` (or with a
+special-token trigger) may also be used on its own:
+
+```text
+start: head
+head[lazy]: TEXT "<end>"
 TEXT: /(\n|.)*/
 ```
 
-The supported lazy form is deliberately narrow: an arbitrary-text terminal followed by one fixed
-string or special-token trigger. Dynamic heads may also express the same fixed string trigger as a
-regex suffix or a `suffix` attribute:
-
-```text
-regex_head[lazy]: /(\n|.)*<tool>/
-suffix_head[suffix="<tool>"]: TEXT
-```
-
-For regex suffixes, the prefix must be one of the recognized arbitrary-text forms and the remainder
-must be a fixed regex literal. These forms are only enabled when the entire `start: tool* tail`
-pattern can be lowered to dispatch. General shortest-match regex and standalone suffix semantics
-are not approximated.
-
-## Special Tokens
-
-Numeric token references do not require tokenizer metadata:
-
-```python
-grammar = xgr.Grammar.from_lark("start: <[128000-128010]>")
-```
-
-Named references are resolved by exact match against the decoded vocabulary:
-
-```python
-tokenizer_info = xgr.TokenizerInfo(["a", "<|tool|>", "b"])
-grammar = xgr.Grammar.from_lark("start: <|tool|>", tokenizer_info=tokenizer_info)
-```
+This matches arbitrary text and completes as soon as the trigger appears; nothing may follow the
+trigger. Text that never produces the trigger is also accepted. The regex-suffix and
+`suffix="..."` head forms are only accepted inside the full dispatch pattern, and general lazy
+rules over other bodies (for example `value[lazy]: /[a-z]+/`) are rejected.

--- a/docs/xgrammar_features/lark_grammar.md
+++ b/docs/xgrammar_features/lark_grammar.md
@@ -1,7 +1,7 @@
 # Lark Grammar Frontend
 
-XGrammar can compile a practical subset of the Lark grammar syntax used by LLGuidance. The result
-is a normal `Grammar`, so it works with the existing compiler, matcher, serialization, and engine
+XGrammar's Lark frontend is compatible with the Lark dialect used by LLGuidance. The result is a
+normal `Grammar`, so it works with the existing compiler, matcher, serialization, and engine
 integrations.
 
 ```python
@@ -25,6 +25,8 @@ The root rule must be named `start`.
 
 - lowercase rules and uppercase terminals
 - string and regular-expression literals
+- ASCII case-insensitive string literals such as `"yes"i`
+- the regex `s` flag, such as `/.*/s`; without `s`, `.` does not match newline
 - sequences, alternatives, groups, and optional groups
 - `?`, `*`, `+`, `~M..N`, `{M}`, `{M,N}`, `{M,}`, and `{,N}` repetitions
 - single-character ranges such as `"a".."z"`
@@ -38,9 +40,11 @@ The root rule must be named `start`.
 - nested `%lark { ... }`
 - numeric token sets such as `<[1,3-8]>`, exclusions such as `<[^1,3]>`, and `<[*]>`
 - named special tokens when `tokenizer_info` is supplied
-- `%llguidance {"allow_initial_skip": true}`
+- named grammars referenced with `@name`
+- `%grammar_options {"allow_initial_skip": true}`
 
-String and regex flags are not currently supported.
+Case-insensitive string literals containing non-ASCII characters are rejected. Regex flags other
+than `s` are not currently supported.
 
 ## Inline JSON
 
@@ -63,14 +67,38 @@ grammar = xgr.Grammar.from_lark(
 Whitespace outside the JSON value is controlled by the surrounding Lark grammar. Whitespace inside
 the value follows the JSON Schema converter's normal behavior.
 
+## Named Grammars
+
+Pass existing `Grammar` objects or Lark grammar strings through `named_grammars` and reference them
+with `@name`. Dictionary keys do not include the leading `@`.
+
+```python
+arguments = xgr.Grammar.from_json_schema(
+    {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+        "additionalProperties": False,
+    }
+)
+grammar = xgr.Grammar.from_lark(
+    'start: "<tool_call>" @arguments "</tool_call>" ":" @status',
+    named_grammars={
+        "arguments": arguments,
+        "status": 'start: "ok" | "cancelled"',
+    },
+)
+```
+
+String values are parsed as Lark grammars and may reference other entries in the same mapping. The
+same named grammar may be referenced more than once and from inside nested `%lark` blocks.
+
 ## Dynamic Tool Calls
 
-LLGuidance uses a lazy text lexeme to allow arbitrary text until a tool-call trigger appears. The
-grammar remains static; the trigger changes the active parser state rather than replacing the
-grammar at runtime.
-
-XGrammar recognizes the LLGuidance structural-tag pattern below and lowers the complete `start`
-rule to `TagDispatch`:
+A lazy text lexeme can allow arbitrary text until a tool-call trigger appears. The grammar remains
+static; the trigger changes the active parser state rather than replacing the grammar at runtime.
+XGrammar recognizes the structural-tag pattern below and lowers the complete `start` rule to
+`TagDispatch`:
 
 ```python
 grammar = xgr.Grammar.from_lark(
@@ -110,7 +138,18 @@ TEXT: /(\n|.)*/
 ```
 
 The supported lazy form is deliberately narrow: an arbitrary-text terminal followed by one fixed
-string or special-token trigger. General shortest-match regex semantics are not approximated.
+string or special-token trigger. Dynamic heads may also express the same fixed string trigger as a
+regex suffix or a `suffix` attribute:
+
+```text
+regex_head[lazy]: /(\n|.)*<tool>/
+suffix_head[suffix="<tool>"]: TEXT
+```
+
+For regex suffixes, the prefix must be one of the recognized arbitrary-text forms and the remainder
+must be a fixed regex literal. These forms are only enabled when the entire `start: tool* tail`
+pattern can be lowered to dispatch. General shortest-match regex and standalone suffix semantics
+are not approximated.
 
 ## Special Tokens
 
@@ -126,21 +165,3 @@ Named references are resolved by exact match against the decoded vocabulary:
 tokenizer_info = xgr.TokenizerInfo(["a", "<|tool|>", "b"])
 grammar = xgr.Grammar.from_lark("start: <|tool|>", tokenizer_info=tokenizer_info)
 ```
-
-## Unsupported LLGuidance Extensions
-
-The following features require regular-language or generation-runtime state that is not represented
-by XGrammar's current `Grammar` API. The frontend rejects them with a source-located error:
-
-- captures
-- general `lazy`, `stop`, `suffix`, and stop captures
-- rule-level `max_tokens` and `temperature`
-- terminal intersection and complement (`&` and `~`)
-- structured `%regex` substring nodes
-- multiple named grammars referenced with `@name`
-- parametric grammar rules and `%if`
-- templates, priorities, `%declare`, and `%override`
-- `%llguidance` options other than `allow_initial_skip`
-
-Rejecting these constructs is intentional. Ignoring them would silently accept a different language
-or drop generation-time behavior.

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -131,6 +131,16 @@ class Grammar {
   static Grammar FromRegex(const std::string& regex, bool print_converted_ebnf = false);
 
   /*!
+   * \brief Construct a grammar from LLGuidance-compatible Lark syntax.
+   * \param lark_string The Lark grammar. The root rule must be named "start".
+   * \param tokenizer_info Optional tokenizer metadata used to resolve named special tokens.
+   */
+  static Grammar FromLark(
+      const std::string& lark_string,
+      const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt
+  );
+
+  /*!
    * \brief Construct a grammar from a structural tag string.
    * \param structural_tag_json The structural tag string.
    * \param tokenizer_info Optional tokenizer info for resolving string token references.

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -13,6 +13,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -29,6 +30,8 @@ struct StructuralTagItem {
     return begin == other.begin && schema == other.schema && end == other.end;
   }
 };
+
+struct NamedGrammar;
 
 /*!
  * \brief This class stores the abstract syntax tree (AST) of the Backus-Naur Form (BNF) grammar.
@@ -131,13 +134,15 @@ class Grammar {
   static Grammar FromRegex(const std::string& regex, bool print_converted_ebnf = false);
 
   /*!
-   * \brief Construct a grammar from LLGuidance-compatible Lark syntax.
+   * \brief Construct a grammar from Lark syntax.
    * \param lark_string The Lark grammar. The root rule must be named "start".
    * \param tokenizer_info Optional tokenizer metadata used to resolve named special tokens.
+   * \param named_grammars Grammar objects or Lark sources that can be referenced with `@name`.
    */
   static Grammar FromLark(
       const std::string& lark_string,
-      const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt
+      const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt,
+      const std::vector<NamedGrammar>& named_grammars = {}
   );
 
   /*!
@@ -195,6 +200,17 @@ class Grammar {
   static std::variant<Grammar, SerializationError> DeserializeJSON(const std::string& json_string);
 
   XGRAMMAR_DEFINE_PIMPL_METHODS(Grammar);
+};
+
+/*!
+ * \brief A grammar or Lark source that can be referenced by name from another Lark grammar.
+ */
+struct NamedGrammar {
+  /*! \brief The reference name, without the leading `@`. */
+  std::string name;
+
+  /*! \brief An existing grammar or a Lark source with its own `start` rule. */
+  std::variant<Grammar, std::string> grammar;
 };
 
 }  // namespace xgrammar

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -302,13 +302,17 @@ class Grammar(XGRObject):
 
     @staticmethod
     def from_lark(
-        lark_string: str, *, tokenizer_info: Optional["TokenizerInfo"] = None
+        lark_string: str,
+        *,
+        tokenizer_info: Optional["TokenizerInfo"] = None,
+        named_grammars: Optional[Dict[str, Union["Grammar", str]]] = None,
     ) -> "Grammar":
-        """Create a grammar from LLGuidance-compatible Lark syntax.
+        """Create a grammar from Lark syntax.
 
         The grammar must define a ``start`` rule. Core rules, terminals, regular
         expressions, repetition, ``%ignore``, ``%import common``, inline ``%json``,
-        special tokens, and the structural-tool-call lazy pattern are supported.
+        named grammar references, special tokens, and the structural-tool-call lazy
+        pattern are supported.
 
         Parameters
         ----------
@@ -317,9 +321,33 @@ class Grammar(XGRObject):
 
         tokenizer_info : Optional[TokenizerInfo]
             Tokenizer metadata used to resolve named special tokens.
+
+        named_grammars : Optional[Dict[str, Union[Grammar, str]]]
+            Grammars referenced by ``@name`` in the Lark source. String values
+            contain Lark grammar sources with their own ``start`` rules. Dictionary
+            keys are passed without the leading ``@``.
         """
         tokenizer_handle = None if tokenizer_info is None else tokenizer_info._handle
-        return Grammar._create_from_handle(_core.Grammar.from_lark(lark_string, tokenizer_handle))
+        if named_grammars is None:
+            named_grammars = {}
+        if not isinstance(named_grammars, dict):
+            raise TypeError("named_grammars must be a dictionary")
+        names: List[str] = []
+        values: List[Any] = []
+        for name, grammar_or_source in named_grammars.items():
+            if not isinstance(name, str):
+                raise TypeError("named grammar names must be strings")
+            if isinstance(grammar_or_source, Grammar):
+                value = grammar_or_source._handle
+            elif isinstance(grammar_or_source, str):
+                value = grammar_or_source
+            else:
+                raise TypeError("named grammar values must be Grammar instances or Lark strings")
+            names.append(name)
+            values.append(value)
+        return Grammar._create_from_handle(
+            _core.Grammar.from_lark(lark_string, tokenizer_handle, names, values)
+        )
 
     @overload
     @staticmethod

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -1,13 +1,16 @@
 """This module provides classes representing grammars."""
 
 import json
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, overload
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union, overload
 
 from pydantic import BaseModel
 from typing_extensions import deprecated
 
 from .base import XGRObject, _core
 from .structural_tag import StructuralTag, StructuralTagItem
+
+if TYPE_CHECKING:
+    from .tokenizer_info import TokenizerInfo
 
 
 def _convert_instance_to_str(instance: Union[str, Dict[str, Any], StructuralTag]) -> str:
@@ -296,6 +299,27 @@ class Grammar(XGRObject):
         return Grammar._create_from_handle(
             _core.Grammar.from_regex(regex_string, print_converted_ebnf)
         )
+
+    @staticmethod
+    def from_lark(
+        lark_string: str, *, tokenizer_info: Optional["TokenizerInfo"] = None
+    ) -> "Grammar":
+        """Create a grammar from LLGuidance-compatible Lark syntax.
+
+        The grammar must define a ``start`` rule. Core rules, terminals, regular
+        expressions, repetition, ``%ignore``, ``%import common``, inline ``%json``,
+        special tokens, and the structural-tool-call lazy pattern are supported.
+
+        Parameters
+        ----------
+        lark_string : str
+            The Lark grammar source.
+
+        tokenizer_info : Optional[TokenizerInfo]
+            Tokenizer metadata used to resolve named special tokens.
+        """
+        tokenizer_handle = None if tokenizer_info is None else tokenizer_info._handle
+        return Grammar._create_from_handle(_core.Grammar.from_lark(lark_string, tokenizer_handle))
 
     @overload
     @staticmethod

--- a/tests/cpp/test_lark_converter.cc
+++ b/tests/cpp/test_lark_converter.cc
@@ -38,6 +38,45 @@ TEST(LarkConverterTest, InlineAndNestedGrammar) {
   EXPECT_NE(printed.find("yes"), std::string::npos);
 }
 
+TEST(LarkConverterTest, NamedGrammars) {
+  auto word = Grammar::FromRegex("[a-z]+");
+  auto number = Grammar::FromLark(R"(start: /[0-9]+/)");
+  auto grammar = Grammar::FromLark(
+      R"(
+        start: "<" @word ":" @number ">" %lark {
+          start: "/" @word
+        }
+      )",
+      std::nullopt,
+      {{"word", word}, {"number", number}}
+  );
+  std::string printed = grammar.ToString();
+  EXPECT_NE(printed.find("[a-z]"), std::string::npos);
+  EXPECT_NE(printed.find("[0-9]"), std::string::npos);
+}
+
+TEST(LarkConverterTest, NamedGrammarSources) {
+  auto grammar = Grammar::FromLark(
+      "start: @pair",
+      std::nullopt,
+      {{"pair", std::string(R"(start: @item ":" @item)")},
+       {"item", std::string(R"(start: /[a-z]+/)")}}
+  );
+  std::string printed = grammar.ToString();
+  EXPECT_NE(printed.find("[a-z]"), std::string::npos);
+  EXPECT_NE(printed.find("\":\""), std::string::npos);
+
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark(
+          "start: @left",
+          std::nullopt,
+          {{"left", std::string("start: @right")}, {"right", std::string("start: @left")}}
+      ),
+      XGrammarError,
+      "circular named grammar reference: @left -> @right -> @left"
+  );
+}
+
 TEST(LarkConverterTest, DynamicToolCallLowersToTagDispatch) {
   auto grammar = Grammar::FromLark(R"(
     start: (foo | bar)* tail
@@ -65,6 +104,33 @@ TEST(LarkConverterTest, NumericAndNamedSpecialTokens) {
   EXPECT_NE(printed.find("Token(1)"), std::string::npos);
 }
 
+TEST(LarkConverterTest, StringAndRegexFlags) {
+  auto grammar = Grammar::FromLark(R"(
+    start: "Ab-1"i /a.b/s
+  )");
+  std::string printed = grammar.ToString();
+  EXPECT_NE(printed.find("root"), std::string::npos);
+}
+
+TEST(LarkConverterTest, DynamicRegexSuffixAndSuffixAttribute) {
+  auto grammar = Grammar::FromLark(R"(
+    start: (foo | bar)* tail
+    tail: TEXT
+
+    foo_head[lazy]: /(\n|.)*<foo>/
+    foo: foo_head /[a-z]+/ "</foo>"
+
+    bar_head[suffix="<bar>"]: TEXT
+    bar: bar_head /[0-9]+/ "</bar>"
+
+    TEXT: /.*/s
+  )");
+  std::string printed = grammar.ToString();
+  EXPECT_NE(printed.find("TagDispatch"), std::string::npos);
+  EXPECT_NE(printed.find("\"<foo>\""), std::string::npos);
+  EXPECT_NE(printed.find("\"<bar>\""), std::string::npos);
+}
+
 TEST(LarkConverterTest, ErrorsContainSourceLocations) {
   XGRAMMAR_EXPECT_THROW(
       Grammar::FromLark("item: \"a\""), XGrammarError, "line 1, column 1.*no start rule"
@@ -90,9 +156,39 @@ TEST(LarkConverterTest, ErrorsContainSourceLocations) {
   XGRAMMAR_EXPECT_THROW(
       Grammar::FromLark("start: /abc/i"),
       XGrammarError,
-      "regular-expression flags are not supported"
+      "only the regular-expression flag 's' is currently supported"
+  );
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark("start: \"\\u00c4\"i"),
+      XGrammarError,
+      "currently support ASCII characters only"
+  );
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark("start: TOKEN\nTOKEN: %json {}"),
+      XGrammarError,
+      "%json cannot be used in terminals"
+  );
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark("start: TOKEN\nTOKEN: %lark { start: \"a\" }"),
+      XGrammarError,
+      "nested %lark cannot be used in terminals"
   );
   XGRAMMAR_EXPECT_THROW(
       Grammar::FromLark("start: <[1-2-3]>"), XGrammarError, "invalid numeric special-token range"
+  );
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark("start: @missing"),
+      XGrammarError,
+      "line 1, column 8.*unknown named grammar '@missing'"
+  );
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark(
+          "start: @item",
+          std::nullopt,
+          {{"item", Grammar::FromLark(R"(start: "a")")},
+           {"item", Grammar::FromLark(R"(start: "b")")}}
+      ),
+      XGrammarError,
+      "Duplicate named grammar 'item'"
   );
 }

--- a/tests/cpp/test_lark_converter.cc
+++ b/tests/cpp/test_lark_converter.cc
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+#include <xgrammar/xgrammar.h>
+
+#include <string>
+
+#include "test_utils.h"
+
+using namespace xgrammar;
+
+TEST(LarkConverterTest, CoreSyntaxAndImports) {
+  auto grammar = Grammar::FromLark(R"(
+    %import common.INT
+    %import common (WS_INLINE, CNAME)
+    %ignore WS_INLINE
+    start: item{2,3}
+    item: CNAME ":" INT | "none"
+  )");
+  std::string printed = grammar.ToString();
+  EXPECT_NE(printed.find("root"), std::string::npos);
+  EXPECT_NE(printed.find("lark_ignore"), std::string::npos);
+  EXPECT_NE(printed.find("{2, 3}"), std::string::npos);
+}
+
+TEST(LarkConverterTest, InlineAndNestedGrammar) {
+  auto grammar = Grammar::FromLark(R"(
+    start: "payload=" %json {
+      "type": "object",
+      "properties": {"x": {"type": "integer"}},
+      "required": ["x"],
+      "additionalProperties": false
+    } ";" %lark {
+      start: "yes" | "no"
+    }
+  )");
+  std::string printed = grammar.ToString();
+  EXPECT_NE(printed.find("payload="), std::string::npos);
+  EXPECT_NE(printed.find("basic_integer"), std::string::npos);
+  EXPECT_NE(printed.find("yes"), std::string::npos);
+}
+
+TEST(LarkConverterTest, DynamicToolCallLowersToTagDispatch) {
+  auto grammar = Grammar::FromLark(R"(
+    start: (foo | bar)* tail
+    tail: TEXT
+
+    foo_head[lazy]: TEXT "<function"
+    foo: foo_head "=foo>" /[a-z]+/ "</function>"
+
+    bar_head[lazy]: TEXT "<function"
+    bar: bar_head "=bar>" /[A-Z]+/ "</function>"
+
+    TEXT: /(\n|.)*/
+  )");
+  std::string printed = grammar.ToString();
+  EXPECT_NE(printed.find("TagDispatch"), std::string::npos);
+  EXPECT_NE(printed.find("\"<function\""), std::string::npos);
+  EXPECT_NE(printed.find("loop_after_dispatch=true"), std::string::npos);
+}
+
+TEST(LarkConverterTest, NumericAndNamedSpecialTokens) {
+  TokenizerInfo tokenizer_info({"a", "<|tool|>", "b"}, VocabType::RAW, 3, std::vector<int32_t>{});
+  auto grammar = Grammar::FromLark("start: <[0,2]> | <|tool|>", tokenizer_info);
+  std::string printed = grammar.ToString();
+  EXPECT_NE(printed.find("Token(0, 2)"), std::string::npos);
+  EXPECT_NE(printed.find("Token(1)"), std::string::npos);
+}
+
+TEST(LarkConverterTest, ErrorsContainSourceLocations) {
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark("item: \"a\""), XGrammarError, "line 1, column 1.*no start rule"
+  );
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark("start: missing"), XGrammarError, "line 1, column 8.*unknown name"
+  );
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark("start: FOO\nFOO: BAR\nBAR: FOO"),
+      XGrammarError,
+      "circular reference in terminal"
+  );
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark("start[capture]: \"a\""),
+      XGrammarError,
+      "attribute 'capture' is not supported"
+  );
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark("start: A & B\nA: \"a\"\nB: \"b\""),
+      XGrammarError,
+      "intersection '&' is not supported"
+  );
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark("start: /abc/i"),
+      XGrammarError,
+      "regular-expression flags are not supported"
+  );
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark("start: <[1-2-3]>"), XGrammarError, "invalid numeric special-token range"
+  );
+}

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -1,124 +1,490 @@
-from typing import List
+import json
+from typing import Optional, Sequence
 
 import pytest
 
 import xgrammar as xgr
-from xgrammar.testing import _is_grammar_accept_string
 
 
-def _assert_language(grammar: str, accepted: List[str], rejected: List[str]) -> None:
-    compiled = xgr.Grammar.from_lark(grammar)
+def _compile_lark(
+    grammar: str, tokenizer_info: Optional[xgr.TokenizerInfo] = None
+) -> xgr.CompiledGrammar:
+    tokenizer_info = tokenizer_info or xgr.TokenizerInfo([])
+    grammar_obj = xgr.Grammar.from_lark(grammar, tokenizer_info=tokenizer_info)
+    return xgr.GrammarCompiler(tokenizer_info, cache_enabled=False).compile_grammar(grammar_obj)
+
+
+def _matches_string(compiled: xgr.CompiledGrammar, value: str) -> bool:
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    return matcher.accept_string(value) and matcher.is_terminated()
+
+
+def _assert_grammar_language(
+    grammar: xgr.Grammar,
+    accepted: Sequence[str],
+    rejected: Sequence[str],
+    tokenizer_info: Optional[xgr.TokenizerInfo] = None,
+) -> None:
+    tokenizer_info = tokenizer_info or xgr.TokenizerInfo([])
+    compiled = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False).compile_grammar(grammar)
     for value in accepted:
-        assert _is_grammar_accept_string(compiled, value), value
+        assert _matches_string(compiled, value), value
     for value in rejected:
-        assert not _is_grammar_accept_string(compiled, value), value
+        assert not _matches_string(compiled, value), value
+
+
+def _assert_language(
+    grammar: str,
+    accepted: Sequence[str],
+    rejected: Sequence[str],
+    tokenizer_info: Optional[xgr.TokenizerInfo] = None,
+) -> None:
+    grammar_obj = xgr.Grammar.from_lark(grammar, tokenizer_info=tokenizer_info)
+    _assert_grammar_language(grammar_obj, accepted, rejected, tokenizer_info)
+
+
+def _matches_token_sequence(compiled: xgr.CompiledGrammar, token_ids: Sequence[int]) -> bool:
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    for token_id in token_ids:
+        if not matcher.accept_token(token_id):
+            return False
+    return matcher.is_terminated()
+
+
+def _assert_token_language(
+    grammar: str,
+    tokenizer_info: xgr.TokenizerInfo,
+    accepted: Sequence[Sequence[int]],
+    rejected: Sequence[Sequence[int]],
+) -> None:
+    compiled = _compile_lark(grammar, tokenizer_info)
+    for token_ids in accepted:
+        assert _matches_token_sequence(compiled, token_ids), token_ids
+    for token_ids in rejected:
+        assert not _matches_token_sequence(compiled, token_ids), token_ids
+
+
+def _assert_lark_error(
+    grammar: str, message: str, tokenizer_info: Optional[xgr.TokenizerInfo] = None
+) -> str:
+    with pytest.raises(RuntimeError) as exc_info:
+        xgr.Grammar.from_lark(grammar, tokenizer_info=tokenizer_info)
+    error = str(exc_info.value)
+    assert message in error
+    assert "Lark error at line " in error
+    assert ", column " in error
+    return error
 
 
 @pytest.mark.parametrize(
     "grammar, accepted, rejected",
     [
-        ('start: item{2,3}\nitem: "a" | "b"', ["aa", "ab", "bbb"], ["", "a", "aaaa"]),
-        ('start: ["-"] DIGIT+\nDIGIT: "0".."9"', ["0", "123", "-42"], ["", "-", "+1", "1a"]),
-        (
-            'start: value ("," value)*\nvalue: "x" | "(" start ")"',
-            ["x", "x,x", "(x,x)", "x,(x,x)"],
-            ["", "x,", "(x", "y"],
+        pytest.param(
+            'start: "a" "b" | "c" ("d" | "e")',
+            ["ab", "cd", "ce"],
+            ["", "a", "c", "ade"],
+            id="sequence-choice-precedence",
         ),
-        ('start: ab~2..4\nab: "a" | "b"', ["aa", "aba", "bbbb"], ["", "a", "aaaaa"]),
-        ('start: foo-bar // comment\nfoo-bar: "ok" # another comment', ["ok"], ["foo-bar", ""]),
+        pytest.param(
+            'start: ("a" | "b") ["c"]',
+            ["a", "b", "ac", "bc"],
+            ["", "c", "abc"],
+            id="groups-and-optional-group",
+        ),
+        pytest.param(
+            'start: | "a" | "b"', ["", "a", "b"], ["ab", "c"], id="empty-left-alternative"
+        ),
+        pytest.param('start: "a" |', ["", "a"], ["aa", "b"], id="empty-right-alternative"),
+        pytest.param("start:", [""], ["a", " "], id="empty-rule"),
+        pytest.param('start: "" "a" ""', ["a"], ["", "aa"], id="empty-literals"),
+        pytest.param(
+            '?item: "a"\n!suffix: "b"\nstart: item suffix',
+            ["ab"],
+            ["", "a", "b"],
+            id="lark-rule-prefixes",
+        ),
+        pytest.param(
+            'start: _item _TOKEN\n_item: "a"\n_TOKEN: "b"',
+            ["ab"],
+            ["a", "b", "_item_TOKEN"],
+            id="hidden-rule-and-terminal-names",
+        ),
+        pytest.param(
+            'start: "a" -> first\n     | "b" -> second',
+            ["a", "b"],
+            ["", "first", "second"],
+            id="alternative-aliases",
+        ),
+        pytest.param(
+            'start: value\nvalue: "x" | "(" value ")" | "[" values? "]"\nvalues: value ("," value)*',
+            ["x", "(x)", "((x))", "[]", "[x]", "[x,(x),[x]]"],
+            ["", "()", "[", "[x,]", "[(])"],
+            id="forward-references-and-recursion",
+        ),
+        pytest.param(
+            'start: sequence\nsequence: "x" | "a" sequence "b"',
+            ["x", "axb", "aaxbb"],
+            ["", "ab", "aaxb"],
+            id="recursive-sequence",
+        ),
+        pytest.param(
+            'start: SIGNED\nSIGNED: SIGN? DIGIT+\nSIGN: "+" | "-"\nDIGIT: "0".."9"',
+            ["0", "123", "+7", "-42"],
+            ["", "+", "--1", "1a"],
+            id="terminal-composition",
+        ),
+        pytest.param(
+            "start: \"'foo'\" /a+/ | STRING /b+/\nSTRING: /'[^']*'/",
+            ["'foo'a", "'foo'aaa", "'bar'b", "'bar'bbb", "'foo'bb"],
+            ["'bar'a", "'bar'c", "foo"],
+            id="literal-terminal-ambiguity",
+        ),
+        pytest.param(
+            'start: /.../ "abc" /.../',
+            ["abcabcabc", "aaaabcccc", "🔵🟠✅abc❌🟠🔵"],
+            ["aaabcccc", "aaaaabcccc", "🔵🟠abc🟠🔵"],
+            id="regex-dot-counts-unicode-codepoints",
+        ),
+        pytest.param(
+            r"start: /a\/b/ /[0-9]{2,4}/",
+            ["a/b12", "a/b1234"],
+            ["a/b1", "a/b12345", "a-b12"],
+            id="regex-escaped-delimiter-and-repeat",
+        ),
+        pytest.param(
+            'start: "a".."z"+ "0".."9"?',
+            ["a", "xyz", "hello7"],
+            ["", "A", "7", "abc78"],
+            id="ascii-character-ranges",
+        ),
+        pytest.param(
+            'start: "α".."γ"+', ["α", "βγ", "γα"], ["", "δ", "a"], id="unicode-character-ranges"
+        ),
+        pytest.param(
+            'start: "😀" "é" "中文"',
+            ["😀é中文"],
+            ["", "😀é", "😀e中文"],
+            id="unicode-string-literals",
+        ),
+        pytest.param(
+            r'''start: "\n" "\t" "\\" "\"" "\u03bb"''',
+            ['\n\t\\"λ'],
+            [r"\n\t\"λ", "\n\tλ"],
+            id="json-style-string-escapes",
+        ),
+        pytest.param(
+            r'''start: "\b" "\f" "\r"''',
+            ["\b\f\r"],
+            ["bfr", "\b\f\n"],
+            id="control-character-string-escapes",
+        ),
+        pytest.param(
+            'start: foo-bar FOO-BAR\nfoo-bar: "a"\nFOO-BAR: "b"',
+            ["ab"],
+            ["", "a-b", "foo-barFOO-BAR"],
+            id="hyphenated-identifiers",
+        ),
+        pytest.param(
+            'start: item // top-level comment\nitem: "ok" # rule comment',
+            ["ok"],
+            ["", "item", "ok#"],
+            id="comment-styles",
+        ),
     ],
 )
-def test_lark_core_languages(grammar: str, accepted: List[str], rejected: List[str]) -> None:
+def test_lark_core_languages(
+    grammar: str, accepted: Sequence[str], rejected: Sequence[str]
+) -> None:
     _assert_language(grammar, accepted, rejected)
 
 
-def test_lark_import_ignore_and_initial_skip() -> None:
+@pytest.mark.parametrize(
+    "grammar, accepted, rejected",
+    [
+        pytest.param('start: "a"?', ["", "a"], ["aa"], id="question"),
+        pytest.param('start: "a"*', ["", "a", "aaaa"], ["b", "aaab"], id="star"),
+        pytest.param('start: "a"+', ["a", "aaaa"], ["", "b"], id="plus"),
+        pytest.param('start: "a"~2', ["aa"], ["", "a", "aaa"], id="tilde-exact"),
+        pytest.param(
+            'start: "a"~2..4', ["aa", "aaa", "aaaa"], ["", "a", "aaaaa"], id="tilde-range"
+        ),
+        pytest.param('start: "a"{2}', ["aa"], ["", "a", "aaa"], id="brace-exact"),
+        pytest.param(
+            'start: "a"{2,4}', ["aa", "aaa", "aaaa"], ["", "a", "aaaaa"], id="brace-range"
+        ),
+        pytest.param('start: "a"{2,}', ["aa", "aaaaaa"], ["", "a"], id="brace-open-end"),
+        pytest.param('start: "a"{,2}', ["", "a", "aa"], ["aaa"], id="brace-open-start"),
+        pytest.param('start: "a"{0}', [""], ["a"], id="zero-exact"),
+        pytest.param('start: "a"{0,0}', [""], ["a"], id="zero-range"),
+        pytest.param(
+            'start: ("a" | "bc"){2,3}',
+            ["aa", "abc", "bca", "bcbcbc"],
+            ["", "a", "bcbc bcbc", "aaaa"],
+            id="group-repeat",
+        ),
+        pytest.param(
+            'start: ITEM{2,3}\nITEM: "x" | "y"',
+            ["xx", "xy", "yyy"],
+            ["", "x", "xxxx"],
+            id="terminal-repeat",
+        ),
+        pytest.param(
+            'start: item{2,3}\nitem: "x" | "(" item ")"',
+            ["xx", "x(x)", "(x)(x)(x)"],
+            ["", "x", "xxxx"],
+            id="recursive-rule-repeat",
+        ),
+    ],
+)
+def test_lark_repetition_forms(
+    grammar: str, accepted: Sequence[str], rejected: Sequence[str]
+) -> None:
+    _assert_language(grammar, accepted, rejected)
+
+
+@pytest.mark.parametrize(
+    "common_name, accepted, rejected",
+    [
+        pytest.param("DIGIT", ["0", "9"], ["", "a", "10"], id="DIGIT"),
+        pytest.param("HEXDIGIT", ["0", "a", "F"], ["", "g", "ff"], id="HEXDIGIT"),
+        pytest.param("INT", ["0", "123"], ["", "-1", "1.0"], id="INT"),
+        pytest.param("SIGNED_INT", ["0", "+12", "-3"], ["", "+", "1.0"], id="SIGNED_INT"),
+        pytest.param("DECIMAL", ["1.", "1.5", ".25"], ["", "1", "."], id="DECIMAL"),
+        pytest.param("_EXP", ["e1", "E+12", "e-3"], ["", "1", "e"], id="_EXP"),
+        pytest.param("FLOAT", ["1.", ".5", "1e3", "1.2e-3"], ["", "1", "e3"], id="FLOAT"),
+        pytest.param(
+            "SIGNED_FLOAT", ["-1.", "+.5", "-1e3", "1.2e-3"], ["", "1", "+"], id="SIGNED_FLOAT"
+        ),
+        pytest.param("NUMBER", ["0", "12", ".5", "1e3"], ["", "-1", "x"], id="NUMBER"),
+        pytest.param(
+            "SIGNED_NUMBER", ["0", "-12", "+.5", "-1e3"], ["", "+", "x"], id="SIGNED_NUMBER"
+        ),
+        pytest.param(
+            "ESCAPED_STRING",
+            ['""', '"abc"', '"a\\"b"', '"a\\nb"'],
+            ["", "abc", '"unterminated'],
+            id="ESCAPED_STRING",
+        ),
+        pytest.param("LCASE_LETTER", ["a", "z"], ["", "A", "aa"], id="LCASE_LETTER"),
+        pytest.param("UCASE_LETTER", ["A", "Z"], ["", "a", "AA"], id="UCASE_LETTER"),
+        pytest.param("LETTER", ["a", "Z"], ["", "1", "ab"], id="LETTER"),
+        pytest.param("WORD", ["a", "AbCd"], ["", "a1", "a_b"], id="WORD"),
+        pytest.param("CNAME", ["a", "_a1", "A_2"], ["", "1a", "a-b"], id="CNAME"),
+        pytest.param("WS_INLINE", [" ", "\t", " \t "], ["", "\n", "a"], id="WS_INLINE"),
+        pytest.param("WS", [" ", "\n", "\t\f\r\n"], ["", "a"], id="WS"),
+        pytest.param("CR", ["\r"], ["", "\n", "\r\n"], id="CR"),
+        pytest.param("LF", ["\n"], ["", "\r", "\r\n"], id="LF"),
+        pytest.param("NEWLINE", ["\n", "\r\n", "\r\n\n"], ["", "\r", "a"], id="NEWLINE"),
+        pytest.param("SH_COMMENT", ["#", "# hello"], ["", "// hello", "# a\n"], id="SH_COMMENT"),
+        pytest.param(
+            "CPP_COMMENT", ["//", "// hello"], ["", "# hello", "// a\n"], id="CPP_COMMENT"
+        ),
+        pytest.param(
+            "C_COMMENT",
+            ["/**/", "/* hello */", "/* ** x **/"],
+            ["", "// hello", "/* open"],
+            id="C_COMMENT",
+        ),
+        pytest.param(
+            "SQL_COMMENT", ["--", "-- hello"], ["", "- hello", "-- a\n"], id="SQL_COMMENT"
+        ),
+    ],
+)
+def test_lark_common_imports(
+    common_name: str, accepted: Sequence[str], rejected: Sequence[str]
+) -> None:
+    _assert_language(f"%import common.{common_name}\nstart: {common_name}", accepted, rejected)
+
+
+def test_lark_multi_import_alias_and_forward_import() -> None:
     grammar = """
+        %ignore WS_INLINE
+        start: NAME "=" NUMBER
+        %import common (CNAME, WS_INLINE)
+        %import common.INT -> NUMBER
+        NAME: CNAME
+    """
+    _assert_language(grammar, ["x=1", "name = 42", "_x\t=\t0"], ["", "1x=2", "x=-1"])
+
+
+def test_lark_ignore_is_inserted_between_and_after_lexemes() -> None:
+    grammar = """
+        %import common.WS
+        %ignore WS
+        start: "a" DIGIT "c".."d"
+        DIGIT: "0".."9"
+    """
+    _assert_language(grammar, ["a1c", "a 1 d", "a\n1\n c  "], [" a1c", "a 1 e", "a x c"])
+
+
+def test_lark_multiple_ignore_declarations() -> None:
+    grammar = """
+        %import common (WS, CPP_COMMENT, SH_COMMENT)
+        %ignore WS
+        %ignore CPP_COMMENT
+        %ignore SH_COMMENT
+        start: "a" "b"
+    """
+    _assert_language(
+        grammar,
+        ["ab", "a // comment\n b", "a# comment\nb", "a b // trailing"],
+        [" // initial\na b", "a x b"],
+    )
+
+
+def test_lark_ignore_inline_regex() -> None:
+    grammar = r"""
+        %ignore /[ _]+/
+        start: "a" "b"
+    """
+    _assert_language(grammar, ["ab", "a_b", "a _ b___"], ["_ab", "a-b"])
+
+
+def test_lark_allow_initial_skip_options() -> None:
+    grammar = """
+        %llguidance {"allow_initial_skip": false}
+        %llguidance {"allow_initial_skip": true, "no_forcing": false, "allow_invalid_utf8": false}
         %import common.WS
         %ignore WS
         start: "a" "b"
     """
-    _assert_language(grammar, ["ab", "a b", "a\n b  "], [" ab", "a c"])
+    _assert_language(grammar, ["ab", " a b", "\n\ta\n b  "], ["a c", " xab"])
 
-    grammar_with_initial_skip = '%llguidance {"allow_initial_skip": true}\n' + grammar
-    _assert_language(grammar_with_initial_skip, [" ab", "\n a b"], [" a c"])
+
+def test_lark_default_disallows_initial_skip_but_allows_trailing_skip() -> None:
+    grammar = """
+        %import common.WS_INLINE
+        %ignore WS_INLINE
+        start: "a" "b"
+    """
+    _assert_language(grammar, ["ab", "a b", "ab  "], [" ab", "a\nb"])
+
+
+@pytest.mark.parametrize(
+    "schema, accepted, rejected",
+    [
+        pytest.param(
+            '{"type":"string"}',
+            ['""', '"hello"', '"λ"'],
+            ["hello", "1", '"unterminated'],
+            id="string",
+        ),
+        pytest.param('{"type":"integer"}', ["0", "-12", "123"], ["1.0", '"1"', "+1"], id="integer"),
+        pytest.param('{"const":"fixed"}', ['"fixed"'], ['"other"', "fixed"], id="const"),
+        pytest.param(
+            '{"enum":["red","green",3]}', ['"red"', '"green"', "3"], ['"blue"', "4"], id="enum"
+        ),
+        pytest.param(
+            '{"type":"array","items":{"type":"integer"},"minItems":1,"maxItems":3}',
+            ["[1]", "[1,2]", "[ 1, 2, 3 ]"],
+            ["[]", "[1,2,3,4]", '["1"]'],
+            id="array",
+        ),
+        pytest.param(
+            '{"type":"object","properties":{"x":{"type":"integer"}},"required":["x"],"additionalProperties":false}',
+            ['{"x":1}', '{ "x" : -2 }'],
+            ["{}", '{"x":"1"}', '{"x":1,"y":2}'],
+            id="object",
+        ),
+        pytest.param(
+            '{"anyOf":[{"type":"integer"},{"type":"boolean"}]}',
+            ["1", "-2", "true", "false"],
+            ['"1"', "null"],
+            id="any-of",
+        ),
+        pytest.param(
+            '{"type":"string","pattern":"^a[0-9]+$"}',
+            ['"a0"', '"a123"'],
+            ['"a"', '"ba1"', '"a1x"'],
+            id="string-pattern",
+        ),
+    ],
+)
+def test_lark_inline_json_schemas(
+    schema: str, accepted: Sequence[str], rejected: Sequence[str]
+) -> None:
+    _assert_language(f"start: %json {schema}", accepted, rejected)
+
+
+def test_lark_inline_json_inside_sequence_and_repeat() -> None:
+    grammar = r"""
+        start: "values=" value (";" value)* "."
+        value: %json {"type":"integer"}
+    """
+    _assert_language(
+        grammar, ["values=1.", "values=1;-2;3."], ["values=.", 'values="1".', "values=1;."]
+    )
+
+
+def test_lark_nested_lark_has_an_independent_namespace() -> None:
+    grammar = """
+        start: item %lark {
+          start: item
+          item: "b"
+        } item
+        item: "a"
+    """
+    _assert_language(grammar, ["aba"], ["aaa", "abb", "bbb"])
+
+
+def test_lark_nested_lark_supports_recursion_json_and_ignore() -> None:
+    grammar = r"""
+        start: "[" %lark {
+          %llguidance {"allow_initial_skip": true}
+          %import common.WS
+          %ignore WS
+          start: item ":" %json {"type":"integer"}
+          item: "x" | "(" item ")"
+        } "]"
+    """
+    _assert_language(grammar, ["[x:1]", "[ ((x)) : -2 ]"], ["[():1]", '[x:"1"]', "[x 1]"])
+
+
+def test_lark_multiple_nested_grammars() -> None:
+    grammar = """
+        start: %lark { start: "a" | "b" } %lark { start: "1" | "2" }
+    """
+    _assert_language(grammar, ["a1", "a2", "b1", "b2"], ["", "a", "1a", "c1"])
+
+
+def test_lark_numeric_and_named_special_tokens() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "<|tool|>", "b", "</s>"], stop_token_ids=[3])
+    _assert_token_language(
+        "start: <[0,2]> | <|tool|>",
+        tokenizer_info,
+        accepted=[[0], [1], [2]],
+        rejected=[[3], [0, 1], []],
+    )
 
 
 @pytest.mark.parametrize(
     "grammar, accepted, rejected",
     [
-        ('start: "a"? "b"* "c"+', ["c", "ac", "bbcc", "abbc"], ["", "a", "b"]),
-        ('start: "x"{2}', ["xx"], ["", "x", "xxx"]),
-        ('start: "x"{2,}', ["xx", "xxxx"], ["", "x"]),
-        ('start: "x"{,2}', ["", "x", "xx"], ["xxx"]),
+        pytest.param("start: <[0-2,1-3,3]>", [[0], [1], [2], [3]], [[4]], id="merged-ranges"),
+        pytest.param("start: <[^1,3]>", [[0], [2], [4]], [[1], [3]], id="excluded-set"),
+        pytest.param("start: <[*]>", [[0], [1], [2], [3], [4]], [], id="wildcard"),
+        pytest.param("start: <[0]> <[2-3]>", [[0, 2], [0, 3]], [[0], [2, 0]], id="token-sequence"),
     ],
 )
-def test_lark_repetition_forms(grammar: str, accepted: List[str], rejected: List[str]) -> None:
-    _assert_language(grammar, accepted, rejected)
-
-
-def test_lark_multiline_choice_and_import_alias() -> None:
-    grammar = """
-        %import common.INT -> NUMBER
-        start: "none"
-             | NUMBER
-    """
-    _assert_language(grammar, ["none", "0", "123"], ["", "number", "1.2"])
-
-
-def test_lark_inline_json_and_nested_lark() -> None:
-    grammar = r"""
-        start: "payload=" payload ";" %lark {
-          start: "yes" | "no"
-        }
-        payload: %json {
-          "type": "object",
-          "properties": {"x": {"type": "integer"}},
-          "required": ["x"],
-          "additionalProperties": false
-        }
-    """
-    _assert_language(
-        grammar,
-        ['payload={"x":1};yes', 'payload={ "x" : -2 };no'],
-        ['payload={"x":"bad"};yes', 'payload= {"x":1};yes', 'payload={"x":1};maybe'],
-    )
-
-
-def test_lark_numeric_and_named_special_tokens() -> None:
-    tokenizer_info = xgr.TokenizerInfo(
-        ["a", "<|tool|>", "b", "</s>"], vocab_size=4, stop_token_ids=[3]
-    )
-    grammar = xgr.Grammar.from_lark("start: <[0,2]> | <|tool|>", tokenizer_info=tokenizer_info)
-    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(grammar)
-
-    for token_id in [0, 1, 2]:
-        matcher = xgr.GrammarMatcher(compiled)
-        assert matcher.accept_token(token_id)
-        assert matcher.is_completed()
-
-    matcher = xgr.GrammarMatcher(compiled)
-    assert not matcher.accept_token(3)
-
-
-@pytest.mark.parametrize(
-    "lark, accepted, rejected",
-    [("start: <[^1,3]>", [0, 2], [1, 3]), ("start: <[*]>", [0, 1, 2, 3], [])],
-)
-def test_lark_special_token_exclusion_and_wildcard(
-    lark: str, accepted: List[int], rejected: List[int]
+def test_lark_numeric_special_token_sets(
+    grammar: str, accepted: Sequence[Sequence[int]], rejected: Sequence[Sequence[int]]
 ) -> None:
-    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c", "d"])
-    grammar = xgr.Grammar.from_lark(lark, tokenizer_info=tokenizer_info)
-    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(grammar)
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c", "d", "e"])
+    _assert_token_language(grammar, tokenizer_info, accepted, rejected)
 
-    for token_id in accepted:
-        matcher = xgr.GrammarMatcher(compiled)
-        assert matcher.accept_token(token_id), token_id
-        assert matcher.is_completed()
-    for token_id in rejected:
-        matcher = xgr.GrammarMatcher(compiled)
-        assert not matcher.accept_token(token_id), token_id
+
+def test_lark_named_special_token_matches_every_exact_vocab_entry() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["<dup>", "x", "<dup>", "dup", "<other>"])
+    _assert_token_language(
+        "start: <dup>", tokenizer_info, accepted=[[0], [2]], rejected=[[1], [3], [4]]
+    )
+
+
+def test_lark_special_token_and_literal_sequence() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["<|tool|>", "x", "y"])
+    _assert_token_language(
+        'start: <|tool|> "x"', tokenizer_info, accepted=[[0, 1]], rejected=[[0], [0, 2], [1]]
+    )
 
 
 TOOL_CALL_GRAMMAR = r"""
@@ -137,26 +503,46 @@ TOOL_CALL_GRAMMAR = r"""
 """
 
 
-def test_lark_dynamic_tool_call_optional_and_repeated() -> None:
+def test_lark_dynamic_tool_call_optional_repeated_and_committed() -> None:
     _assert_language(
         TOOL_CALL_GRAMMAR,
         [
             "",
             "plain text",
+            "text <tool_cal and more",
             '<tool_call>{"x":1}</tool_call>',
             'before<tool_call>{"x":1}</tool_call>after',
             '<tool_call>{"x":1}</tool_call><tool_call>{"x":2}</tool_call>',
             'line 1\nline 2<tool_call>{ "x" : -3 }</tool_call>tail',
-            # A trigger prefix is still ordinary text until the full trigger is present.
-            "text <tool_cal and more",
         ],
         [
+            "<tool_call>",
             '<tool_call>{"x":"bad"}</tool_call>',
             '<tool_call>{"x":1}',
             "before<tool_call>free text</tool_call>after",
             '<tool_call> {"x":1}</tool_call>',
             '<tool_call>{"x":1} </tool_call>',
         ],
+    )
+
+
+def test_lark_dynamic_distinct_string_triggers() -> None:
+    grammar = r"""
+        start: (foo | bar)* tail
+        tail: TEXT
+
+        foo_head[lazy]: TEXT "<foo>"
+        foo: foo_head /[a-z]+/ "</foo>"
+
+        bar_head[lazy]: TEXT "<bar>"
+        bar: bar_head /[0-9]+/ "</bar>"
+
+        TEXT: /(\n|.)*/
+    """
+    _assert_language(
+        grammar,
+        ["free text", "partial <fo remains text", "x<foo>abc</foo>y", "<bar>12</bar><foo>x</foo>"],
+        ["<foo>", "<foo>12</foo>", "<bar>x</bar>", "<bar>12"],
     )
 
 
@@ -181,6 +567,7 @@ def test_lark_dynamic_shared_trigger_dispatch() -> None:
             "<function=bar>ABC</function><function=foo>xyz</function>",
         ],
         [
+            "<function",
             "<function=baz>abc</function>",
             "<function=foo>ABC</function>",
             "<function=bar>abc</function>",
@@ -189,13 +576,37 @@ def test_lark_dynamic_shared_trigger_dispatch() -> None:
     )
 
 
+def test_lark_dynamic_any_text_can_be_referenced_through_terminals() -> None:
+    grammar = r"""
+        start: tool* tail
+        tail: FREE
+        head[lazy]: FREE "<call>"
+        tool: head /[0-9]+/ "</call>"
+        FREE: TEXT
+        TEXT: /(\n|.)*/
+    """
+    _assert_language(
+        grammar,
+        ["free", "x<call>12</call>y", "partial <cal"],
+        ["<call>", "<call>x</call>", "<call>12"],
+    )
+
+
+def test_lark_standalone_lazy_rule() -> None:
+    grammar = r"""
+        start: head
+        head[lazy]: TEXT "<end>"
+        TEXT: /(\n|.)*/
+    """
+    _assert_language(grammar, ["", "plain", "<end>", "plain<end>"], ["<end>x", "a<end>b"])
+
+
 def test_lark_dynamic_special_token_trigger() -> None:
     tokenizer_info = xgr.TokenizerInfo(
         ["plain", "<|tool|>", "{", '"x"', ":", "1", "}", "</tool>", "bad", "</s>"],
         stop_token_ids=[9],
     )
-    grammar = xgr.Grammar.from_lark(
-        r"""
+    grammar = r"""
         start: tool* tail
         tail: TEXT
         tool: TEXT <|tool|> %json {
@@ -205,52 +616,307 @@ def test_lark_dynamic_special_token_trigger() -> None:
           "additionalProperties": false
         } "</tool>"
         TEXT: /(\n|.)*/
+    """
+    _assert_token_language(
+        grammar,
+        tokenizer_info,
+        accepted=[[0], [1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7, 0]],
+        rejected=[[1], [1, 8], [1, 2, 3, 4, 8]],
+    )
+
+
+def test_lark_serialization_round_trip_for_core_and_dynamic_grammars() -> None:
+    core = xgr.Grammar.from_lark('start: "a" ("b" | "c")?')
+    restored_core = xgr.Grammar.deserialize_json(core.serialize_json())
+    _assert_grammar_language(restored_core, ["a", "ab", "ac"], ["", "abc"])
+
+    dynamic = xgr.Grammar.from_lark(TOOL_CALL_GRAMMAR)
+    restored_dynamic = xgr.Grammar.deserialize_json(dynamic.serialize_json())
+    _assert_grammar_language(
+        restored_dynamic,
+        ["text", '<tool_call>{"x":1}</tool_call>tail'],
+        ["<tool_call>", '<tool_call>{"x":"bad"}</tool_call>'],
+    )
+
+
+def test_lark_serialization_round_trip_for_token_dispatch() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["plain", "<|call|>", "x", "</call>"])
+    grammar = xgr.Grammar.from_lark(
+        r"""
+        start: call* tail
+        tail: TEXT
+        call: TEXT <|call|> "x" "</call>"
+        TEXT: /(\n|.)*/
         """,
         tokenizer_info=tokenizer_info,
     )
-    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(grammar)
-
-    matcher = xgr.GrammarMatcher(compiled)
-    for token_id in [0, 1, 2, 3, 4, 5, 6, 7, 0]:
-        assert matcher.accept_token(token_id), token_id
-
-    invalid_matcher = xgr.GrammarMatcher(compiled)
-    assert invalid_matcher.accept_token(1)
-    assert not invalid_matcher.accept_token(8)
-
-
-def test_lark_serialization_round_trip() -> None:
-    grammar = xgr.Grammar.from_lark('start: "a" ("b" | "c")?')
     restored = xgr.Grammar.deserialize_json(grammar.serialize_json())
-    for value in ["a", "ab", "ac"]:
-        assert _is_grammar_accept_string(restored, value)
-    assert not _is_grammar_accept_string(restored, "abc")
+    compiled = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False).compile_grammar(restored)
+    assert _matches_token_sequence(compiled, [0])
+    assert _matches_token_sequence(compiled, [1, 2, 3])
+    assert not _matches_token_sequence(compiled, [1, 3])
+
+
+def test_lark_grammar_union_and_concat_integration() -> None:
+    left = xgr.Grammar.from_lark('start: "a" | "b"')
+    right = xgr.Grammar.from_lark("start: /[0-9]+/")
+
+    _assert_grammar_language(xgr.Grammar.union(left, right), ["a", "b", "0", "123"], ["a1", "c"])
+    _assert_grammar_language(xgr.Grammar.concat(left, right), ["a0", "b123"], ["a", "1", "c1"])
+
+
+def test_lark_large_choice_grammar() -> None:
+    options = [f"option-{index:03d}" for index in range(256)]
+    choices = " | ".join(json.dumps(option) for option in options)
+    grammar = f"start: option\noption: {choices}"
+    _assert_language(
+        grammar, [options[0], options[127], options[-1]], ["", "option-256", "option-12"]
+    )
 
 
 @pytest.mark.parametrize(
     "grammar, message",
     [
-        ('item: "a"', "no start rule"),
-        ("start: missing", "unknown name 'missing'"),
-        ('start: foo\nfoo: "a"\nfoo: "b"', "duplicate rule or terminal 'foo'"),
-        ("start: FOO\nFOO: BAR\nBAR: FOO", "circular reference in terminal"),
-        ('start[capture]: "a"', "attribute 'capture' is not supported"),
-        ("start: /abc/i", "regular-expression flags are not supported"),
-        ('start: A & B\nA: "a"\nB: "b"', "intersection '&' is not supported"),
-        ('start: %regex {"substring_chars":"abc"}', "structured %regex is not supported"),
-        ("start: @other", "multiple grammar references are not supported"),
-        ("start: foo::0", "parametric grammar is not supported"),
-        ("start: <[1-2-3]>", "invalid numeric special-token range"),
-        ("start: <[,]>", "empty numeric special-token range"),
-        ('start: "unterminated', "unterminated string literal"),
+        pytest.param('item: "a"', "no start rule", id="missing-start"),
+        pytest.param("start: missing", "unknown name 'missing'", id="unknown-rule"),
+        pytest.param(
+            'start: foo\nfoo: "a"\nfoo: "b"',
+            "duplicate rule or terminal 'foo'",
+            id="duplicate-rule",
+        ),
+        pytest.param(
+            'start: FOO\nFOO: "a"\nFOO: "b"',
+            "duplicate rule or terminal 'FOO'",
+            id="duplicate-terminal",
+        ),
+        pytest.param(
+            "start: FOO\nFOO: BAR\nBAR: FOO", "circular reference in terminal", id="terminal-cycle"
+        ),
+        pytest.param(
+            'start: TOKEN\nTOKEN: rule\nrule: "a"',
+            "terminal 'TOKEN' cannot reference rule 'rule'",
+            id="terminal-references-rule",
+        ),
+        pytest.param(
+            'start[capture]: "a"', "attribute 'capture' is not supported", id="capture-attribute"
+        ),
+        pytest.param(
+            'start[stop="x"]: "a"', "attribute 'stop' is not supported", id="stop-attribute"
+        ),
+        pytest.param(
+            "TOKEN[lazy]: /a/\nstart: TOKEN",
+            "attributes are only supported on rules",
+            id="terminal-attribute",
+        ),
+        pytest.param('start.1: "a"', "priorities are not supported", id="priority"),
+        pytest.param('start{x}: "a"', "Lark templates are not supported", id="template-definition"),
+        pytest.param(
+            'start: foo{x}\nfoo: "a"', "Lark templates are not supported", id="template-reference"
+        ),
+        pytest.param(
+            'start::0: "a"', "parametric grammar is not supported", id="parametric-definition"
+        ),
+        pytest.param(
+            "start: foo::0", "parametric grammar is not supported", id="parametric-reference"
+        ),
+        pytest.param(
+            'start: "a" %if enabled',
+            "parametric %if conditions are not supported",
+            id="parametric-if",
+        ),
+        pytest.param(
+            'start: A & B\nA: "a"\nB: "b"', "intersection '&' is not supported", id="intersection"
+        ),
+        pytest.param("start: ~/[a]/", "complement '~' is not supported", id="complement"),
+        pytest.param(
+            'start: "a"i', "case-insensitive string flags are not supported", id="string-flag"
+        ),
+        pytest.param(
+            "start: /abc/i", "regular-expression flags are not supported", id="regex-flag"
+        ),
+        pytest.param("start: /[abc/", "failed to compile regular expression", id="invalid-regex"),
+        pytest.param('start: "\\q"', "invalid string literal", id="invalid-string-escape"),
+        pytest.param(
+            'start: "unterminated', "unterminated string literal", id="unterminated-string"
+        ),
+        pytest.param(
+            "start: /unterminated", "unterminated regular expression", id="unterminated-regex"
+        ),
+        pytest.param(
+            "start: <unterminated", "unterminated special token", id="unterminated-special-token"
+        ),
+        pytest.param("start: <bad token>", "invalid special token", id="special-token-whitespace"),
+        pytest.param("start: @", "empty grammar reference", id="empty-grammar-reference"),
+        pytest.param("start: $", "unexpected character '$'", id="unexpected-character"),
+        pytest.param("start: -", "unexpected '-' character", id="unexpected-minus"),
+        pytest.param("start: !", "unexpected '!' character", id="unexpected-bang"),
+        pytest.param('start "a"', "expected ':' after rule name", id="missing-colon"),
+        pytest.param('start: ("a"', "expected ')' after group", id="unclosed-group"),
+        pytest.param('start: ["a"', "expected ']' after optional group", id="unclosed-optional"),
+        pytest.param('start: "a" ->', "expected alias name after '->'", id="missing-alias-name"),
+        pytest.param(
+            "%declare TOKEN\nstart: TOKEN",
+            "directive %declare is not supported",
+            id="declare-directive",
+        ),
+        pytest.param(
+            '%override start\nstart: "a"',
+            "directive %override is not supported",
+            id="override-directive",
+        ),
+        pytest.param(
+            "%import common.UNKNOWN\nstart: UNKNOWN",
+            "unknown common import",
+            id="unknown-common-import",
+        ),
+        pytest.param(
+            '%import common.INT\nINT: "x"\nstart: INT',
+            "duplicate rule or terminal 'INT'",
+            id="import-name-conflict",
+        ),
+        pytest.param('start: "a"{3,2}', "repetition end must be greater", id="repetition-reversed"),
+        pytest.param('start: "a"{-1,}', "invalid repetition count", id="negative-repetition"),
+        pytest.param(
+            'start: "a"{999999999999999999999}',
+            "invalid repetition count",
+            id="repetition-overflow",
+        ),
+        pytest.param(
+            'start: "ab".."c"', "range endpoints must be one character", id="range-start-too-long"
+        ),
+        pytest.param(
+            'start: "a".."bc"', "range endpoints must be one character", id="range-end-too-long"
+        ),
+        pytest.param('start: "z".."a"', "range start must not exceed end", id="range-reversed"),
+        pytest.param(
+            "start: %json {",
+            "failed to parse JSON value after %json",
+            id="malformed-json-directive",
+        ),
+        pytest.param(
+            "start: %json []", "failed to compile inline JSON schema", id="invalid-json-schema"
+        ),
+        pytest.param(
+            'start: %lark { item: "a" }',
+            "failed to compile nested Lark grammar",
+            id="nested-no-start",
+        ),
+        pytest.param(
+            'start: %regex {"substring_chars":"abc"}',
+            "structured %regex is not supported",
+            id="structured-regex",
+        ),
+        pytest.param(
+            "start: @other",
+            "multiple grammar references are not supported",
+            id="named-grammar-reference",
+        ),
+        pytest.param(
+            "start: TOKEN\nTOKEN: <[1]>",
+            "special tokens cannot be used in terminals",
+            id="special-in-terminal",
+        ),
+        pytest.param(
+            "start: <[1-2-3]>", "invalid numeric special-token range", id="multiple-range-dashes"
+        ),
+        pytest.param(
+            "start: <[3-1]>", "invalid numeric special-token range", id="numeric-range-reversed"
+        ),
+        pytest.param("start: <[,]>", "empty numeric special-token range", id="empty-token-range"),
+        pytest.param(
+            "start: <[*]>",
+            "wildcard special token requires tokenizer_info",
+            id="wildcard-needs-tokenizer",
+        ),
+        pytest.param(
+            "start: <[^*]>",
+            "negated wildcard special token is not supported",
+            id="negated-wildcard",
+        ),
+        pytest.param("start: <[*,1]>", "wildcard cannot be mixed", id="mixed-wildcard-range"),
+        pytest.param(
+            "start: <|tool|>",
+            "named special token <|tool|> requires tokenizer_info",
+            id="named-needs-tokenizer",
+        ),
+        pytest.param(
+            "start: <[0-1000001]>", "special-token range is too large", id="token-range-too-large"
+        ),
+        pytest.param(
+            '%llguidance {"allow_initial_skip": 1}\nstart: "a"',
+            "allow_initial_skip must be a boolean",
+            id="initial-skip-type",
+        ),
+        pytest.param(
+            '%llguidance {"no_forcing": true}\nstart: "a"',
+            "%llguidance option 'no_forcing' is not supported",
+            id="no-forcing-option",
+        ),
+        pytest.param(
+            '%llguidance {"allow_invalid_utf8": true}\nstart: "a"',
+            "%llguidance option 'allow_invalid_utf8' is not supported",
+            id="invalid-utf8-option",
+        ),
+        pytest.param(
+            '%llguidance {"unknown": false}\nstart: "a"',
+            "unknown %llguidance option 'unknown'",
+            id="unknown-llguidance-option",
+        ),
+        pytest.param(
+            '%llguidance []\nstart: "a"',
+            "%llguidance value must be an object",
+            id="llguidance-not-object",
+        ),
+        pytest.param(
+            "start: thing\nthing[lazy]: /[a-z]+/",
+            "general lazy rules are not supported",
+            id="unsupported-general-lazy",
+        ),
+        pytest.param(
+            '%ignore MISSING\nstart: "a"', "unknown name 'MISSING'", id="unknown-ignore-name"
+        ),
     ],
 )
 def test_lark_errors_are_explicit_and_located(grammar: str, message: str) -> None:
-    with pytest.raises(RuntimeError, match=message):
-        xgr.Grammar.from_lark(grammar)
+    _assert_lark_error(grammar, message)
 
-    try:
-        xgr.Grammar.from_lark(grammar)
-    except RuntimeError as error:
-        assert "line " in str(error)
-        assert "column " in str(error)
+
+def test_lark_named_special_token_error_with_tokenizer() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["<known>", "text"])
+    _assert_lark_error("start: <unknown>", "unknown special token <unknown>", tokenizer_info)
+
+
+def test_lark_dynamic_trigger_levels_cannot_be_mixed() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["<|bar|>", "x"])
+    grammar = r"""
+        start: (foo | bar)* tail
+        tail: TEXT
+        foo_head[lazy]: TEXT "<foo>"
+        foo: foo_head "x"
+        bar: TEXT <|bar|> "x"
+        TEXT: /(\n|.)*/
+    """
+    _assert_lark_error(grammar, "cannot mix string and token triggers", tokenizer_info)
+
+
+def test_lark_lazy_and_dynamic_special_token_triggers_cannot_be_negated() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c"])
+    _assert_lark_error(
+        "start: head\nhead[lazy]: TEXT <[^1]>\nTEXT: /(\\n|.)*/",
+        "lazy special-token trigger cannot be negated",
+        tokenizer_info,
+    )
+    _assert_lark_error(
+        'start: tool* tail\ntail: TEXT\ntool: TEXT <[^1]> "x"\nTEXT: /(\\n|.)*/',
+        "dynamic special-token trigger cannot be negated",
+        tokenizer_info,
+    )
+
+
+def test_lark_error_reports_crlf_line_column_and_source_context() -> None:
+    error = _assert_lark_error(
+        '# comment\r\nstart: "a"\r\nitem missing', "expected ':' after rule name"
+    )
+    assert "line 3, column 6" in error
+    assert "item missing" in error
+    assert "     ^" in error

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -1,0 +1,256 @@
+from typing import List
+
+import pytest
+
+import xgrammar as xgr
+from xgrammar.testing import _is_grammar_accept_string
+
+
+def _assert_language(grammar: str, accepted: List[str], rejected: List[str]) -> None:
+    compiled = xgr.Grammar.from_lark(grammar)
+    for value in accepted:
+        assert _is_grammar_accept_string(compiled, value), value
+    for value in rejected:
+        assert not _is_grammar_accept_string(compiled, value), value
+
+
+@pytest.mark.parametrize(
+    "grammar, accepted, rejected",
+    [
+        ('start: item{2,3}\nitem: "a" | "b"', ["aa", "ab", "bbb"], ["", "a", "aaaa"]),
+        ('start: ["-"] DIGIT+\nDIGIT: "0".."9"', ["0", "123", "-42"], ["", "-", "+1", "1a"]),
+        (
+            'start: value ("," value)*\nvalue: "x" | "(" start ")"',
+            ["x", "x,x", "(x,x)", "x,(x,x)"],
+            ["", "x,", "(x", "y"],
+        ),
+        ('start: ab~2..4\nab: "a" | "b"', ["aa", "aba", "bbbb"], ["", "a", "aaaaa"]),
+        ('start: foo-bar // comment\nfoo-bar: "ok" # another comment', ["ok"], ["foo-bar", ""]),
+    ],
+)
+def test_lark_core_languages(grammar: str, accepted: List[str], rejected: List[str]) -> None:
+    _assert_language(grammar, accepted, rejected)
+
+
+def test_lark_import_ignore_and_initial_skip() -> None:
+    grammar = """
+        %import common.WS
+        %ignore WS
+        start: "a" "b"
+    """
+    _assert_language(grammar, ["ab", "a b", "a\n b  "], [" ab", "a c"])
+
+    grammar_with_initial_skip = '%llguidance {"allow_initial_skip": true}\n' + grammar
+    _assert_language(grammar_with_initial_skip, [" ab", "\n a b"], [" a c"])
+
+
+@pytest.mark.parametrize(
+    "grammar, accepted, rejected",
+    [
+        ('start: "a"? "b"* "c"+', ["c", "ac", "bbcc", "abbc"], ["", "a", "b"]),
+        ('start: "x"{2}', ["xx"], ["", "x", "xxx"]),
+        ('start: "x"{2,}', ["xx", "xxxx"], ["", "x"]),
+        ('start: "x"{,2}', ["", "x", "xx"], ["xxx"]),
+    ],
+)
+def test_lark_repetition_forms(grammar: str, accepted: List[str], rejected: List[str]) -> None:
+    _assert_language(grammar, accepted, rejected)
+
+
+def test_lark_multiline_choice_and_import_alias() -> None:
+    grammar = """
+        %import common.INT -> NUMBER
+        start: "none"
+             | NUMBER
+    """
+    _assert_language(grammar, ["none", "0", "123"], ["", "number", "1.2"])
+
+
+def test_lark_inline_json_and_nested_lark() -> None:
+    grammar = r"""
+        start: "payload=" payload ";" %lark {
+          start: "yes" | "no"
+        }
+        payload: %json {
+          "type": "object",
+          "properties": {"x": {"type": "integer"}},
+          "required": ["x"],
+          "additionalProperties": false
+        }
+    """
+    _assert_language(
+        grammar,
+        ['payload={"x":1};yes', 'payload={ "x" : -2 };no'],
+        ['payload={"x":"bad"};yes', 'payload= {"x":1};yes', 'payload={"x":1};maybe'],
+    )
+
+
+def test_lark_numeric_and_named_special_tokens() -> None:
+    tokenizer_info = xgr.TokenizerInfo(
+        ["a", "<|tool|>", "b", "</s>"], vocab_size=4, stop_token_ids=[3]
+    )
+    grammar = xgr.Grammar.from_lark("start: <[0,2]> | <|tool|>", tokenizer_info=tokenizer_info)
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(grammar)
+
+    for token_id in [0, 1, 2]:
+        matcher = xgr.GrammarMatcher(compiled)
+        assert matcher.accept_token(token_id)
+        assert matcher.is_completed()
+
+    matcher = xgr.GrammarMatcher(compiled)
+    assert not matcher.accept_token(3)
+
+
+@pytest.mark.parametrize(
+    "lark, accepted, rejected",
+    [("start: <[^1,3]>", [0, 2], [1, 3]), ("start: <[*]>", [0, 1, 2, 3], [])],
+)
+def test_lark_special_token_exclusion_and_wildcard(
+    lark: str, accepted: List[int], rejected: List[int]
+) -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c", "d"])
+    grammar = xgr.Grammar.from_lark(lark, tokenizer_info=tokenizer_info)
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(grammar)
+
+    for token_id in accepted:
+        matcher = xgr.GrammarMatcher(compiled)
+        assert matcher.accept_token(token_id), token_id
+        assert matcher.is_completed()
+    for token_id in rejected:
+        matcher = xgr.GrammarMatcher(compiled)
+        assert not matcher.accept_token(token_id), token_id
+
+
+TOOL_CALL_GRAMMAR = r"""
+    start: tool* tail
+    tail: TEXT
+
+    tool_head[lazy]: TEXT "<tool_call>"
+    tool: tool_head %json {
+      "type": "object",
+      "properties": {"x": {"type": "integer"}},
+      "required": ["x"],
+      "additionalProperties": false
+    } "</tool_call>"
+
+    TEXT: /(\n|.)*/
+"""
+
+
+def test_lark_dynamic_tool_call_optional_and_repeated() -> None:
+    _assert_language(
+        TOOL_CALL_GRAMMAR,
+        [
+            "",
+            "plain text",
+            '<tool_call>{"x":1}</tool_call>',
+            'before<tool_call>{"x":1}</tool_call>after',
+            '<tool_call>{"x":1}</tool_call><tool_call>{"x":2}</tool_call>',
+            'line 1\nline 2<tool_call>{ "x" : -3 }</tool_call>tail',
+            # A trigger prefix is still ordinary text until the full trigger is present.
+            "text <tool_cal and more",
+        ],
+        [
+            '<tool_call>{"x":"bad"}</tool_call>',
+            '<tool_call>{"x":1}',
+            "before<tool_call>free text</tool_call>after",
+            '<tool_call> {"x":1}</tool_call>',
+            '<tool_call>{"x":1} </tool_call>',
+        ],
+    )
+
+
+def test_lark_dynamic_shared_trigger_dispatch() -> None:
+    grammar = r"""
+        start: (foo | bar)* tail
+        tail: TEXT
+
+        foo_head[lazy]: TEXT "<function"
+        foo: foo_head "=foo>" /[a-z]+/ "</function>"
+
+        bar_head[lazy]: TEXT "<function"
+        bar: bar_head "=bar>" /[A-Z]+/ "</function>"
+
+        TEXT: /(\n|.)*/
+    """
+    _assert_language(
+        grammar,
+        [
+            "free text",
+            "a<function=foo>abc</function>b",
+            "<function=bar>ABC</function><function=foo>xyz</function>",
+        ],
+        [
+            "<function=baz>abc</function>",
+            "<function=foo>ABC</function>",
+            "<function=bar>abc</function>",
+            "<function=foo>abc",
+        ],
+    )
+
+
+def test_lark_dynamic_special_token_trigger() -> None:
+    tokenizer_info = xgr.TokenizerInfo(
+        ["plain", "<|tool|>", "{", '"x"', ":", "1", "}", "</tool>", "bad", "</s>"],
+        stop_token_ids=[9],
+    )
+    grammar = xgr.Grammar.from_lark(
+        r"""
+        start: tool* tail
+        tail: TEXT
+        tool: TEXT <|tool|> %json {
+          "type": "object",
+          "properties": {"x": {"const": 1}},
+          "required": ["x"],
+          "additionalProperties": false
+        } "</tool>"
+        TEXT: /(\n|.)*/
+        """,
+        tokenizer_info=tokenizer_info,
+    )
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(grammar)
+
+    matcher = xgr.GrammarMatcher(compiled)
+    for token_id in [0, 1, 2, 3, 4, 5, 6, 7, 0]:
+        assert matcher.accept_token(token_id), token_id
+
+    invalid_matcher = xgr.GrammarMatcher(compiled)
+    assert invalid_matcher.accept_token(1)
+    assert not invalid_matcher.accept_token(8)
+
+
+def test_lark_serialization_round_trip() -> None:
+    grammar = xgr.Grammar.from_lark('start: "a" ("b" | "c")?')
+    restored = xgr.Grammar.deserialize_json(grammar.serialize_json())
+    for value in ["a", "ab", "ac"]:
+        assert _is_grammar_accept_string(restored, value)
+    assert not _is_grammar_accept_string(restored, "abc")
+
+
+@pytest.mark.parametrize(
+    "grammar, message",
+    [
+        ('item: "a"', "no start rule"),
+        ("start: missing", "unknown name 'missing'"),
+        ('start: foo\nfoo: "a"\nfoo: "b"', "duplicate rule or terminal 'foo'"),
+        ("start: FOO\nFOO: BAR\nBAR: FOO", "circular reference in terminal"),
+        ('start[capture]: "a"', "attribute 'capture' is not supported"),
+        ("start: /abc/i", "regular-expression flags are not supported"),
+        ('start: A & B\nA: "a"\nB: "b"', "intersection '&' is not supported"),
+        ('start: %regex {"substring_chars":"abc"}', "structured %regex is not supported"),
+        ("start: @other", "multiple grammar references are not supported"),
+        ("start: foo::0", "parametric grammar is not supported"),
+        ("start: <[1-2-3]>", "invalid numeric special-token range"),
+        ("start: <[,]>", "empty numeric special-token range"),
+        ('start: "unterminated', "unterminated string literal"),
+    ],
+)
+def test_lark_errors_are_explicit_and_located(grammar: str, message: str) -> None:
+    with pytest.raises(RuntimeError, match=message):
+        xgr.Grammar.from_lark(grammar)
+
+    try:
+        xgr.Grammar.from_lark(grammar)
+    except RuntimeError as error:
+        assert "line " in str(error)
+        assert "column " in str(error)

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -152,6 +152,24 @@ def _assert_lark_error(
             id="regex-escaped-delimiter-and-repeat",
         ),
         pytest.param(
+            "start: /a.b/",
+            ["acb", "a b", "a😀b"],
+            ["ab", "a\nb", "a\n\nb"],
+            id="regex-dot-excludes-newline",
+        ),
+        pytest.param(
+            "start: /a.b/s", ["acb", "a\nb", "a😀b"], ["ab", "a\n\nb"], id="regex-dotall-flag"
+        ),
+        pytest.param(
+            r"start: /a\.b/s", ["a.b"], ["acb", "a\nb"], id="regex-dotall-preserves-escaped-dot"
+        ),
+        pytest.param(
+            "start: /a[.]b/s",
+            ["a.b"],
+            ["acb", "a\nb"],
+            id="regex-dotall-preserves-character-class-dot",
+        ),
+        pytest.param(
             'start: "a".."z"+ "0".."9"?',
             ["a", "xyz", "hello7"],
             ["", "A", "7", "abc78"],
@@ -165,6 +183,18 @@ def _assert_lark_error(
             ["😀é中文"],
             ["", "😀é", "😀e中文"],
             id="unicode-string-literals",
+        ),
+        pytest.param(
+            'start: "Ab-C9"i',
+            ["Ab-C9", "ab-c9", "AB-C9", "aB-c9"],
+            ["", "ab-c", "ab_c9", "äb-c9"],
+            id="ascii-case-insensitive-string",
+        ),
+        pytest.param(
+            'start: TOKEN\nTOKEN: "Yes"i | "no"',
+            ["yes", "YES", "YeS", "no"],
+            ["", "y", "No"],
+            id="case-insensitive-string-in-terminal",
         ),
         pytest.param(
             r'''start: "\n" "\t" "\\" "\"" "\u03bb"''',
@@ -342,8 +372,8 @@ def test_lark_ignore_inline_regex() -> None:
 
 def test_lark_allow_initial_skip_options() -> None:
     grammar = """
-        %llguidance {"allow_initial_skip": false}
-        %llguidance {"allow_initial_skip": true, "no_forcing": false, "allow_invalid_utf8": false}
+        %grammar_options {"allow_initial_skip": false}
+        %grammar_options {"allow_initial_skip": true, "no_forcing": false, "allow_invalid_utf8": false}
         %import common.WS
         %ignore WS
         start: "a" "b"
@@ -430,7 +460,7 @@ def test_lark_nested_lark_has_an_independent_namespace() -> None:
 def test_lark_nested_lark_supports_recursion_json_and_ignore() -> None:
     grammar = r"""
         start: "[" %lark {
-          %llguidance {"allow_initial_skip": true}
+          %grammar_options {"allow_initial_skip": true}
           %import common.WS
           %ignore WS
           start: item ":" %json {"type":"integer"}
@@ -543,6 +573,81 @@ def test_lark_dynamic_distinct_string_triggers() -> None:
         grammar,
         ["free text", "partial <fo remains text", "x<foo>abc</foo>y", "<bar>12</bar><foo>x</foo>"],
         ["<foo>", "<foo>12</foo>", "<bar>x</bar>", "<bar>12"],
+    )
+
+
+def test_lark_dynamic_lazy_regex_suffix() -> None:
+    grammar = r"""
+        start: tool* tail
+        tail: TEXT
+        head[lazy]: /(\n|.)*<call>/
+        tool: head /[0-9]+/ "</call>"
+        TEXT: /(\n|.)*/
+    """
+    _assert_language(
+        grammar,
+        ["", "free text", "partial <cal", "x<call>12</call>y"],
+        ["<call>", "<call>x</call>", "<call>12", "x<call>12</call><call>"],
+    )
+
+
+def test_lark_dynamic_lazy_dotall_regex_suffix() -> None:
+    grammar = r"""
+        start: tool* tail
+        tail: TEXT
+        head[lazy]: /.*<call>/s
+        tool: head "ok" "</call>"
+        TEXT: /.*/s
+    """
+    _assert_language(
+        grammar,
+        ["line 1\nline 2", "x\n<call>ok</call>tail"],
+        ["<call>", "<call>bad</call>", "x\n<call>ok"],
+    )
+
+
+def test_lark_dynamic_fixed_string_suffix_attribute() -> None:
+    grammar = r"""
+        start: tool* tail
+        tail: TEXT
+        head[suffix="<tool>"]: TEXT
+        tool: head /[a-z]+/ "</tool>"
+        TEXT: /(\n|.)*/
+    """
+    _assert_language(
+        grammar,
+        ["free", "x<tool>abc</tool>y", "partial <too"],
+        ["<tool>", "<tool>123</tool>", "<tool>abc"],
+    )
+
+
+def test_lark_dynamic_lazy_regex_escaped_newline_trigger() -> None:
+    grammar = r"""
+        start: tool* tail
+        tail: TEXT
+        head[lazy]: /(\n|.)*\n>>>>>>>/
+        tool: head "replacement"
+        TEXT: /(\n|.)*/
+    """
+    _assert_language(
+        grammar,
+        ["free >>>>>>> text", "before\n>>>>>>>replacementafter"],
+        ["\n>>>>>>>", "before\n>>>>>>>wrong"],
+    )
+
+
+def test_lark_dynamic_lazy_regex_escaped_metacharacter_trigger() -> None:
+    grammar = r"""
+        start: tool* tail
+        tail: TEXT
+        head[lazy]: /(\n|.)*END\./
+        tool: head "ok"
+        TEXT: /(\n|.)*/
+    """
+    _assert_language(
+        grammar,
+        ["free END text", "beforeEND.okafter"],
+        ["END.", "beforeEND.not-ok", "beforeEND.okEND."],
     )
 
 
@@ -665,6 +770,58 @@ def test_lark_grammar_union_and_concat_integration() -> None:
     _assert_grammar_language(xgr.Grammar.concat(left, right), ["a0", "b123"], ["a", "1", "c1"])
 
 
+def test_lark_named_grammar_references() -> None:
+    item = xgr.Grammar.from_lark('start: "x" | "y"')
+    grammar = xgr.Grammar.from_lark(
+        'start: "[" @item ("," @item)* "]"', named_grammars={"item": item}
+    )
+    _assert_grammar_language(grammar, ["[x]", "[y,x]", "[x,y,x]"], ["[]", "[z]", "[x,]"])
+
+
+def test_lark_named_grammar_reference_in_nested_lark() -> None:
+    value = xgr.Grammar.from_regex("[0-9]+")
+    grammar = xgr.Grammar.from_lark(
+        'start: "outer:" %lark { start: "inner:" @value }', named_grammars={"value": value}
+    )
+    _assert_grammar_language(grammar, ["outer:inner:0", "outer:inner:123"], ["inner:1", "outer:1"])
+
+
+def test_lark_named_grammar_string_references() -> None:
+    grammar = xgr.Grammar.from_lark(
+        "start: @pair", named_grammars={"pair": 'start: @item ":" @item', "item": "start: /[a-z]+/"}
+    )
+    _assert_grammar_language(grammar, ["a:b", "hello:world"], ["a:", ":b", "a:1"])
+
+
+def test_lark_named_grammar_string_can_reference_grammar_object() -> None:
+    item = xgr.Grammar.from_regex("[0-9]+")
+    grammar = xgr.Grammar.from_lark(
+        "start: @wrapper", named_grammars={"wrapper": 'start: "[" @item "]"', "item": item}
+    )
+    _assert_grammar_language(grammar, ["[0]", "[123]"], ["[]", "[x]"])
+
+
+def test_lark_named_grammar_string_cycle() -> None:
+    with pytest.raises(
+        RuntimeError, match=r"circular named grammar reference: @left -> @right -> @left"
+    ):
+        xgr.Grammar.from_lark(
+            "start: @left", named_grammars={"left": "start: @right", "right": "start: @left"}
+        )
+
+
+def test_lark_named_grammar_argument_validation() -> None:
+    item = xgr.Grammar.from_lark('start: "x"')
+    with pytest.raises(TypeError, match="must be a dictionary"):
+        xgr.Grammar.from_lark("start: @item", named_grammars=[item])  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="names must be strings"):
+        xgr.Grammar.from_lark("start: @item", named_grammars={1: item})  # type: ignore[dict-item]
+    with pytest.raises(TypeError, match="values must be Grammar instances or Lark strings"):
+        xgr.Grammar.from_lark("start: @item", named_grammars={"item": 1})  # type: ignore[dict-item]
+    with pytest.raises(RuntimeError, match="Invalid named grammar name"):
+        xgr.Grammar.from_lark("start: @item", named_grammars={"bad name": item})
+
+
 def test_lark_large_choice_grammar() -> None:
     options = [f"option-{index:03d}" for index in range(256)]
     choices = " | ".join(json.dumps(option) for option in options)
@@ -729,10 +886,23 @@ def test_lark_large_choice_grammar() -> None:
         ),
         pytest.param("start: ~/[a]/", "complement '~' is not supported", id="complement"),
         pytest.param(
-            'start: "a"i', "case-insensitive string flags are not supported", id="string-flag"
+            'start: "\\u00c4"i',
+            "case-insensitive string literals currently support ASCII characters only",
+            id="non-ascii-string-flag",
         ),
         pytest.param(
-            "start: /abc/i", "regular-expression flags are not supported", id="regex-flag"
+            "start: /abc/i",
+            "only the regular-expression flag 's' is currently supported",
+            id="unsupported-regex-flag",
+        ),
+        pytest.param(
+            "start: /abc/l", "regular-expression flag 'l' is not supported", id="unsupported-l-flag"
+        ),
+        pytest.param(
+            'start: "a"i.."z"', "flags are not allowed on character ranges", id="range-start-flag"
+        ),
+        pytest.param(
+            'start: "a".."z"i', "flags are not allowed on character ranges", id="range-end-flag"
         ),
         pytest.param("start: /[abc/", "failed to compile regular expression", id="invalid-regex"),
         pytest.param('start: "\\q"', "invalid string literal", id="invalid-string-escape"),
@@ -806,15 +976,21 @@ def test_lark_large_choice_grammar() -> None:
             "structured %regex is not supported",
             id="structured-regex",
         ),
-        pytest.param(
-            "start: @other",
-            "multiple grammar references are not supported",
-            id="named-grammar-reference",
-        ),
+        pytest.param("start: @other", "unknown named grammar '@other'", id="unknown-named-grammar"),
         pytest.param(
             "start: TOKEN\nTOKEN: <[1]>",
             "special tokens cannot be used in terminals",
             id="special-in-terminal",
+        ),
+        pytest.param(
+            "start: TOKEN\nTOKEN: %json {}",
+            "%json cannot be used in terminals",
+            id="json-in-terminal",
+        ),
+        pytest.param(
+            'start: TOKEN\nTOKEN: %lark { start: "a" }',
+            "nested %lark cannot be used in terminals",
+            id="nested-lark-in-terminal",
         ),
         pytest.param(
             "start: <[1-2-3]>", "invalid numeric special-token range", id="multiple-range-dashes"
@@ -843,34 +1019,64 @@ def test_lark_large_choice_grammar() -> None:
             "start: <[0-1000001]>", "special-token range is too large", id="token-range-too-large"
         ),
         pytest.param(
-            '%llguidance {"allow_initial_skip": 1}\nstart: "a"',
+            '%grammar_options {"allow_initial_skip": 1}\nstart: "a"',
             "allow_initial_skip must be a boolean",
             id="initial-skip-type",
         ),
         pytest.param(
-            '%llguidance {"no_forcing": true}\nstart: "a"',
-            "%llguidance option 'no_forcing' is not supported",
+            '%grammar_options {"no_forcing": true}\nstart: "a"',
+            "%grammar_options option 'no_forcing' is not supported",
             id="no-forcing-option",
         ),
         pytest.param(
-            '%llguidance {"allow_invalid_utf8": true}\nstart: "a"',
-            "%llguidance option 'allow_invalid_utf8' is not supported",
+            '%grammar_options {"allow_invalid_utf8": true}\nstart: "a"',
+            "%grammar_options option 'allow_invalid_utf8' is not supported",
             id="invalid-utf8-option",
         ),
         pytest.param(
-            '%llguidance {"unknown": false}\nstart: "a"',
-            "unknown %llguidance option 'unknown'",
-            id="unknown-llguidance-option",
+            '%grammar_options {"unknown": false}\nstart: "a"',
+            "unknown %grammar_options option 'unknown'",
+            id="unknown-grammar-options-option",
         ),
         pytest.param(
-            '%llguidance []\nstart: "a"',
-            "%llguidance value must be an object",
-            id="llguidance-not-object",
+            '%grammar_options []\nstart: "a"',
+            "%grammar_options value must be an object",
+            id="grammar-options-not-object",
         ),
         pytest.param(
             "start: thing\nthing[lazy]: /[a-z]+/",
             "general lazy rules are not supported",
             id="unsupported-general-lazy",
+        ),
+        pytest.param(
+            'start: head\nhead[suffix=""]: TEXT\nTEXT: /(\\n|.)*/',
+            "suffix must not be empty",
+            id="empty-suffix",
+        ),
+        pytest.param(
+            "start: head\nhead[suffix=/x/]: TEXT\nTEXT: /(\\n|.)*/",
+            "expected string literal after suffix=",
+            id="non-string-suffix",
+        ),
+        pytest.param(
+            'start: head\nhead[suffix="x",suffix="y"]: TEXT\nTEXT: /(\\n|.)*/',
+            "suffix attribute is specified more than once",
+            id="duplicate-suffix",
+        ),
+        pytest.param(
+            'start: head\nhead[suffix="x"i]: TEXT\nTEXT: /(\\n|.)*/',
+            "case-insensitive flags are not supported on suffix",
+            id="case-insensitive-suffix",
+        ),
+        pytest.param(
+            'start: head\nhead[suffix="x"]: /[a-z]+/',
+            "suffix is only supported on an ANY_TEXT head used by dynamic dispatch",
+            id="suffix-requires-any-text",
+        ),
+        pytest.param(
+            "start: head\nhead[lazy]: /(\\n|.)*END/",
+            "lazy regex suffix is only supported on a head used by dynamic dispatch",
+            id="standalone-lazy-regex-suffix",
         ),
         pytest.param(
             '%ignore MISSING\nstart: "a"', "unknown name 'MISSING'", id="unknown-ignore-name"


### PR DESCRIPTION
## Summary

- add `Grammar::FromLark` and `Grammar.from_lark` with source-located parsing errors and direct lowering into the existing `Grammar` IR
- support core Lark expressions, `%import common`, `%ignore`, inline `%json`, nested `%lark`, and numeric or tokenizer-resolved special-token sets
- support named grammar references such as `@payload`; C++ `NamedGrammar` values and Python mapping values may be existing `Grammar` objects or Lark grammar strings
- add the neutral `%grammar_options` directive, including `%grammar_options {"allow_initial_skip": true}`
- lower supported arbitrary-text/tool-call patterns to `TagDispatch` or `TokenTagDispatch`, so a complete trigger commits generation to the payload grammar
- support ASCII case-insensitive string literals (`"yes"i`) and Lark-compatible regex dot semantics, including the `s` flag
- document named grammars and the supported frontend behavior

## Named grammars

Existing `Grammar` objects and Lark grammar strings can be supplied by name and referenced from the Lark source:

```python
payload = xgr.Grammar.from_json_schema(schema)
grammar = xgr.Grammar.from_lark(
    "start: \"<tool>\" @payload \"</tool>\" \":\" @status",
    named_grammars={
        "payload": payload,
        "status": "start: \"ok\" | \"cancelled\"",
    },
)
```

String values are compiled lazily in C++ as Lark grammars with their own `start` rules. The C++ registry resolves references to other entries, caches compiled results, and detects circular references. A named grammar may also be referenced repeatedly and from nested `%lark` blocks. The Python layer only validates and packs mapping values for the FFI call.

## Dynamic grammar behavior

The frontend recognizes `start: tool* tail` grammars where `tail` is arbitrary text and each tool begins with a supported fixed string or special-token trigger. String triggers may be written as `ANY_TEXT "<tool>"`, a recognized arbitrary-text regex followed by a fixed regex literal, or `head[suffix="<tool>"]: ANY_TEXT`.

Plain text remains valid when no trigger appears. Once a complete trigger is consumed, the corresponding payload and closing syntax are mandatory; after that body completes, free text and later tool calls are allowed again.

## Validation

- pre-commit hooks on all changed files: passed
- Ruff on the changed Python implementation and tests: passed
- C++ test suite: 56 passed
- Python Lark suite: 192 passed
- Python suite with credential-gated tests excluded: 2695 passed, 1 skipped, 616 deselected
- Sphinx HTML build: succeeded with the repository existing 3 warnings
