### PR TITLE
Cache parser state properties

### DIFF
--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -263,12 +263,11 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
   // Check if the rule has a corresponding FSM.
   if (state.rule_id != -1) {
     XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
-    // Try to expand the fsm.
-    ExpandNextRuleRefElementOnFSM(state, debug_print);
-    const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
-    return std::make_pair(
-        fsm.GetFsm().IsScanableState(state.element_id), fsm.GetFsm().IsEndState(state.element_id)
-    );
+    const uint8_t flags = GetFsmStateFlags(state.rule_id, state.element_id);
+    if (flags & kFsmStateNonTerminal) {
+      ExpandNextRuleRefElementOnFSM(state, debug_print);
+    }
+    return std::make_pair(flags & kFsmStateScanable, flags & kFsmStateEnd);
   }
   const GrammarExpr& grammar_expr = grammar_->GetGrammarExpr(state.sequence_id);
   XGRAMMAR_DCHECK(
@@ -456,7 +455,9 @@ void EarleyParser::RemoveCommittedLazyStates() {
 }
 
 EarleyParser::EarleyParser(const Grammar& grammar, std::optional<ParserState> initial_state)
-    : grammar_(grammar) {
+    : grammar_(grammar),
+      fsm_state_flags_cache_(grammar->NumRules()),
+      rule_is_nullable_(grammar->NumRules(), 0) {
   if (!grammar->optimized) {
     XGRAMMAR_LOG(FATAL) << "The grammar is not optimized. Please optimize the grammar before using "
                            "the Earley parser.";
@@ -482,7 +483,41 @@ EarleyParser::EarleyParser(const Grammar& grammar, std::optional<ParserState> in
       break;
     }
   }
+  for (int32_t rule_id : grammar_->allow_empty_rule_ids) {
+    rule_is_nullable_[rule_id] = true;
+  }
   PushStateAndExpand(initial_state.has_value() ? *initial_state : RootInitialState());
+}
+
+uint8_t EarleyParser::InitializeFsmStateFlags(int32_t rule_id, int32_t state_id) {
+  XGRAMMAR_DCHECK(grammar_->per_rule_fsms[rule_id].has_value());
+  const auto& fsm = grammar_->per_rule_fsms[rule_id]->GetFsm();
+  auto& flags_cache = fsm_state_flags_cache_[rule_id];
+  if (flags_cache.empty()) {
+    flags_cache.resize(fsm.NumStates());
+  }
+  XGRAMMAR_DCHECK(state_id >= 0 && state_id < static_cast<int32_t>(flags_cache.size()));
+  uint8_t& flags = flags_cache[state_id];
+  if (flags & kFsmStateInitialized) {
+    return flags;
+  }
+
+  flags = kFsmStateInitialized;
+  if (fsm.IsEndState(state_id)) {
+    flags |= kFsmStateEnd;
+  }
+  const auto& edges = fsm.GetFsm().GetEdges(state_id);
+  if (edges.size() != 0) {
+    flags |= kFsmStateHasEdges;
+  }
+  for (const auto& edge : edges) {
+    if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken()) {
+      flags |= kFsmStateScanable;
+    } else if (edge.IsRuleRef() || edge.IsEpsilon() || edge.IsRepeatRef()) {
+      flags |= kFsmStateNonTerminal;
+    }
+  }
+  return flags;
 }
 
 ParserState EarleyParser::RootInitialState() const {
@@ -610,9 +645,7 @@ void EarleyParser::ExpandNextRuleRefElement(
     }
   }
 
-  if (std::find(
-          grammar_->allow_empty_rule_ids.begin(), grammar_->allow_empty_rule_ids.end(), ref_rule_id
-      ) != grammar_->allow_empty_rule_ids.end()) {
+  if (IsRuleNullable(ref_rule_id)) {
     XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kSequence);
     Enqueue(ParserState{
         state.rule_id,
@@ -714,8 +747,8 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
                          << grammar_->GetRule(state.rule_id).name << " predict the new rule "
                          << ref_rule_id << ": " << grammar_->GetRule(ref_rule_id).name << ".";
     }
-    if (!is_repeat && (fsm.GetFsm().GetFsm().GetEdges(target).size() == 0) &&
-        fsm.GetFsm().IsEndState(target) &&
+    const uint8_t target_flags = GetFsmStateFlags(state.rule_id, target);
+    if (!is_repeat && !(target_flags & kFsmStateHasEdges) && (target_flags & kFsmStateEnd) &&
         state.rule_start_pos != static_cast<int32_t>(rule_id_to_completable_states_.size() - 1) &&
         !RuleNeedsCaptureEvent(state.rule_id) && !RuleNeedsCaptureEvent(ref_rule_id)) {
       // It's a right recursion. We can optimize it. The optimization elides the completion of
@@ -786,11 +819,7 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
     }
 
     // Check if the reference rule can be empty.
-    if (!is_repeat && std::binary_search(
-                          grammar_->allow_empty_rule_ids.begin(),
-                          grammar_->allow_empty_rule_ids.end(),
-                          ref_rule_id
-                      )) {
+    if (!is_repeat && IsRuleNullable(ref_rule_id)) {
       Enqueue(ParserState{
           state.rule_id,
           state.sequence_id,
@@ -1121,9 +1150,8 @@ void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
     }
     auto new_state = state;
     new_state.element_id = edge.target;
-    if ((!current_fsm.GetFsm().IsNonTerminalState(edge.target)) &&
-        (!current_fsm.GetFsm().IsEndState(edge.target) &&
-         current_fsm.GetFsm().IsScanableState(edge.target))) {
+    const uint8_t flags = GetFsmStateFlags(state.rule_id, edge.target);
+    if (!(flags & kFsmStateNonTerminal) && !(flags & kFsmStateEnd) && (flags & kFsmStateScanable)) {
       EnqueueWithoutProcessing(std::move(new_state));
     } else {
       Enqueue(std::move(new_state));
@@ -1147,9 +1175,8 @@ void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
     if (!matched) continue;
     auto new_state = state;
     new_state.element_id = edge.target;
-    if ((!current_fsm.GetFsm().IsNonTerminalState(edge.target)) &&
-        (!current_fsm.GetFsm().IsEndState(edge.target) &&
-         current_fsm.GetFsm().IsScanableState(edge.target))) {
+    const uint8_t flags = GetFsmStateFlags(state.rule_id, edge.target);
+    if (!(flags & kFsmStateNonTerminal) && !(flags & kFsmStateEnd) && (flags & kFsmStateScanable)) {
       EnqueueWithoutProcessing(std::move(new_state));
     } else {
       Enqueue(std::move(new_state));

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -359,6 +359,38 @@ class EarleyParser {
   /*! \brief Check if the stop token is accepted. */
   bool stop_token_is_accepted_ = false;
 
+  enum FsmStateFlag : uint8_t {
+    kFsmStateInitialized = 1 << 0,
+    kFsmStateScanable = 1 << 1,
+    kFsmStateNonTerminal = 1 << 2,
+    kFsmStateEnd = 1 << 3,
+    kFsmStateHasEdges = 1 << 4,
+  };
+
+  /*! \brief Lazily-computed FSM state properties, indexed by rule id and state id. */
+  std::vector<std::vector<uint8_t>> fsm_state_flags_cache_;
+
+  /*! \brief Whether each rule can match the empty string. */
+  std::vector<uint8_t> rule_is_nullable_;
+
+  /*! \brief Compute and cache properties for a state in a per-rule FSM. */
+  uint8_t InitializeFsmStateFlags(int32_t rule_id, int32_t state_id);
+
+  /*! \brief Return cached properties for a state in a per-rule FSM. */
+  uint8_t GetFsmStateFlags(int32_t rule_id, int32_t state_id) {
+    XGRAMMAR_DCHECK(rule_id >= 0 && rule_id < static_cast<int32_t>(fsm_state_flags_cache_.size()));
+    auto& flags_cache = fsm_state_flags_cache_[rule_id];
+    if (!flags_cache.empty()) {
+      XGRAMMAR_DCHECK(state_id >= 0 && state_id < static_cast<int32_t>(flags_cache.size()));
+      if (flags_cache[state_id] != 0) {
+        return flags_cache[state_id];
+      }
+    }
+    return InitializeFsmStateFlags(rule_id, state_id);
+  }
+
+  bool IsRuleNullable(int32_t rule_id) const { return rule_is_nullable_[rule_id] != 0; }
+
   /*! \brief The index of the LLM token currently being accepted, set by the matcher; -1
    * before any token. budget_deadline values are compared against it. */
   int32_t current_token_index_ = -1;


### PR DESCRIPTION
## What changed

Cache immutable Earley FSM-state properties lazily, use a dense nullable-rule lookup, and reuse both in character and atomic-token transitions. The cache stays matcher-local; compiled grammars remain immutable.

This commit is based on main at 7a5057ed and changes 2 files, +82/-23.

## Why

Mask generation revisits the same states through shared vocabulary prefixes. These queries previously rescanned edges and nullable-rule lists on every visit.

## Correctness

Release C++: 61 passed. Isolated-wheel targeted Python: 131 passed, with 26 credential-dependent cases deselected. The suite covers nullable and repetition edges, UTF-8, structural tags, token and character budgets, fork, rollback, reset, and transactional failures. After #773 merged, the isolated wheel also passed all 15 max_chars tests. All four benchmark workloads have zero before/after behavior differences.

## Performance

Compile time is in milliseconds and mask time is mean per-step latency in microseconds. Before is this commit's direct parent. A ratio above 1.00x means After is faster than Before.

| Workload | Metric | Before | After | After vs Before |
|---|---|---:|---:|---:|
| Large structural tags | Compile (ms) | 359.646 | 353.207 | 1.02x |
| Large structural tags | Mask (us) | 5.310 | 4.838 | 1.10x |
| Small structural tags | Compile (ms) | 4.897 | 4.617 | 1.06x |
| Small structural tags | Mask (us) | 5.828 | 5.337 | 1.09x |
| Large JSON Schema | Compile (ms) | 93.120 | 45.495 | 2.05x |
| Large JSON Schema | Mask (us) | 19.156 | 15.119 | 1.27x |
| Small JSON Schema | Compile (ms) | 55.686 | 45.460 | 1.22x |
| Small JSON Schema | Mask (us) | 121.696 | 93.191 | 1.31x |

Before/after exact behavior differences in these workloads: 0.
