### PR TITLE
perf: add `regex` AST to build more precise grammar.

### DIFF
--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -1267,14 +1267,18 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
     for (const auto& edge : edges) {
       in_degree[edge.target]++;
       if (edge.IsEpsilon()) {
-        if (edges.size() == 1 && !has_exclude_token[i] && !has_exclude_token[edge.target]) {
-          // a -- epsilon --> b, and a doesn't have other outward edges.
+        // a -- epsilon --> b, and a doesn't have other outward edges. Do not merge an
+        // accepting a into a non-accepting b: the merged state would be accepting, so other
+        // paths reaching b would be wrongly accepted. (If b is accepting, a effectively
+        // accepts already via the epsilon edge, so merging is safe.)
+        if (edges.size() == 1 && !has_exclude_token[i] && !has_exclude_token[edge.target] &&
+            (!IsEndState(i) || IsEndState(edge.target))) {
           union_find_set.Add(i);
           union_find_set.Add(edge.target);
           union_find_set.Union(i, edge.target);
           in_degree[edge.target]--;  // Remove the inward edge since a and b are merged.
         } else {
-          // a has other outward edges, we store it to check for another case.
+          // Otherwise, we store it to check for the second merge rule.
           epsilon_edges.emplace_back(i, edge.target);
         }
       }

--- a/cpp/fsm_builder.cc
+++ b/cpp/fsm_builder.cc
@@ -795,6 +795,45 @@ Result<FSMWithStartEnd> RegexFSMBuilder::Build(const std::string& regex) {
   return ir.Build();
 }
 
+Result<FSMWithStartEnd> RegexFSMBuilder::BuildWithForbiddenChars(
+    const std::string& regex, const std::bitset<256>& forbidden_chars
+) {
+  auto build_result = Build(regex);
+  if (build_result.IsErr() || forbidden_chars.none()) {
+    return build_result;
+  }
+  auto fsm_wse = std::move(build_result).Unwrap();
+  const auto& fsm = fsm_wse.GetFsm();
+  FSM new_fsm(fsm_wse.NumStates());
+  for (int state = 0; state < fsm_wse.NumStates(); ++state) {
+    for (const auto& edge : fsm.GetEdges(state)) {
+      if (!edge.IsCharRange()) {
+        new_fsm.AddEdge(state, edge.target, edge.min, edge.max);
+        continue;
+      }
+      // Split the character range into the maximal sub-ranges of allowed characters.
+      int range_start = -1;
+      for (int c = edge.min; c <= edge.max + 1; ++c) {
+        if (c <= edge.max && !forbidden_chars[c]) {
+          if (range_start == -1) {
+            range_start = c;
+          }
+        } else if (range_start != -1) {
+          new_fsm.AddEdge(state, edge.target, range_start, c - 1);
+          range_start = -1;
+        }
+      }
+    }
+  }
+  std::vector<bool> ends(fsm_wse.NumStates(), false);
+  for (int state = 0; state < fsm_wse.NumStates(); ++state) {
+    if (fsm_wse.IsEndState(state)) {
+      ends[state] = true;
+    }
+  }
+  return ResultOk(FSMWithStartEnd(new_fsm, fsm_wse.GetStart(), std::move(ends)));
+}
+
 class TrieFSMBuilderImpl {
  public:
   TrieFSMBuilderImpl() = default;

--- a/cpp/fsm_builder.cc
+++ b/cpp/fsm_builder.cc
@@ -287,8 +287,9 @@ Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Repeat& state) const {
   FSMWithStartEnd result = child.Copy();
   std::unordered_set<int> new_ends;
 
-  if (state.lower_bound == 1) {
-    // Insert the first end state.
+  bool has_upper_bound = state.upper_bound != RegexIR::kRepeatNoUpperBound;
+  if (state.lower_bound <= 1 && (!has_upper_bound || state.upper_bound >= 1)) {
+    // A single copy is accepting when the lower bound is at most 1.
     for (int end = 0; end < result.NumStates(); ++end) {
       if (result.IsEndState(end)) {
         new_ends.insert(end);
@@ -296,8 +297,18 @@ Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Repeat& state) const {
     }
   }
 
+  // Add a fresh accepting start state so that zero repetitions match. A fresh state is
+  // required: making the original start accepting would also accept strings that merely
+  // loop back to the start inside the first copy.
+  auto allow_zero_repetitions = [](FSMWithStartEnd* fsm) {
+    int new_start = fsm->AddState();
+    fsm->GetFsm().AddEpsilonEdge(new_start, fsm->GetStart());
+    fsm->SetStartState(new_start);
+    fsm->AddEndState(new_start);
+  };
+
   // Handling {n,}
-  if (state.upper_bound == RegexIR::kRepeatNoUpperBound) {
+  if (!has_upper_bound) {
     for (int i = 2; i < state.lower_bound; i++) {
       result = FSMWithStartEnd::Concat(std::vector<FSMWithStartEnd>{result, child});
     }
@@ -316,6 +327,12 @@ Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Repeat& state) const {
         result.GetFsm().AddEpsilonEdge(end, end_state_of_lower_bound_fsm);
       }
     }
+    for (const auto& end : new_ends) {
+      result.AddEndState(end);
+    }
+    if (state.lower_bound == 0) {
+      allow_zero_repetitions(&result);
+    }
     return ResultOk(std::move(result));
   }
   // Handling {n, m} or {n}
@@ -331,6 +348,9 @@ Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Repeat& state) const {
   }
   for (const auto& end : new_ends) {
     result.AddEndState(end);
+  }
+  if (state.lower_bound == 0) {
+    allow_zero_repetitions(&result);
   }
   return ResultOk(std::move(result));
 }

--- a/cpp/fsm_builder.cc
+++ b/cpp/fsm_builder.cc
@@ -180,6 +180,9 @@ Result<std::pair<int, int>> RegexIR::CheckRepeat(const std::string& regex, int& 
     return ResultErr("Invalid repeat format4");
   }
   upper_bound = std::stoi(num_str);
+  if (upper_bound < lower_bound) {
+    return ResultErr("Invalid repeat: the lower bound is larger than the upper bound");
+  }
   while (static_cast<size_t>(start) < regex.size() && regex[start] == ' ') {
     start++;
   }
@@ -279,6 +282,13 @@ Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Repeat& state) const {
   if (state.states.size() != 1) {
     return ResultErr("Invalid repeat");
   }
+  bool has_upper_bound = state.upper_bound != RegexIR::kRepeatNoUpperBound;
+  if (has_upper_bound && state.upper_bound == 0) {
+    // {0} / {0,0}: matches exactly the empty string. The general path below cannot express
+    // this: it starts from one copy of the child whose end states stay accepting.
+    FSM empty_fsm(1);
+    return ResultOk(FSMWithStartEnd(empty_fsm, 0, {0}, false));
+  }
   Result<FSMWithStartEnd> child_result =
       std::visit([&](auto&& arg) { return RegexIR::visit(arg); }, state.states[0]);
   if (child_result.IsErr()) {
@@ -288,7 +298,6 @@ Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Repeat& state) const {
   FSMWithStartEnd result = child.Copy();
   std::unordered_set<int> new_ends;
 
-  bool has_upper_bound = state.upper_bound != RegexIR::kRepeatNoUpperBound;
   if (state.lower_bound <= 1 && (!has_upper_bound || state.upper_bound >= 1)) {
     // A single copy is accepting when the lower bound is at most 1.
     for (int end = 0; end < result.NumStates(); ++end) {

--- a/cpp/fsm_builder.cc
+++ b/cpp/fsm_builder.cc
@@ -255,6 +255,7 @@ Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Symbol& state) const {
     }
     default: {
       XGRAMMAR_LOG(FATAL) << "Unknown regex symbol: " << static_cast<int>(state.symbol);
+      XGRAMMAR_UNREACHABLE();
     }
   }
 }
@@ -825,13 +826,7 @@ Result<FSMWithStartEnd> RegexFSMBuilder::BuildWithForbiddenChars(
       }
     }
   }
-  std::vector<bool> ends(fsm_wse.NumStates(), false);
-  for (int state = 0; state < fsm_wse.NumStates(); ++state) {
-    if (fsm_wse.IsEndState(state)) {
-      ends[state] = true;
-    }
-  }
-  return ResultOk(FSMWithStartEnd(new_fsm, fsm_wse.GetStart(), std::move(ends)));
+  return ResultOk(FSMWithStartEnd(new_fsm, fsm_wse.GetStart(), fsm_wse.GetEnds()));
 }
 
 class TrieFSMBuilderImpl {

--- a/cpp/fsm_builder.h
+++ b/cpp/fsm_builder.h
@@ -5,6 +5,7 @@
 #ifndef XGRAMMAR_FSM_BUILDER_H_
 #define XGRAMMAR_FSM_BUILDER_H_
 
+#include <bitset>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -25,6 +26,18 @@ class RegexFSMBuilder {
    * \return The FSM with start and end states.
    */
   static Result<FSMWithStartEnd> Build(const std::string& regex);
+
+  /*!
+   * \brief Converts a regex string to a FSM, then removes the forbidden characters from every
+   * character transition. The result accepts the intersection of the regex language and the
+   * set of strings that contain no forbidden character. The result language may be empty.
+   * \param regex The regex string.
+   * \param forbidden_chars The forbidden characters.
+   * \return The FSM with start and end states.
+   */
+  static Result<FSMWithStartEnd> BuildWithForbiddenChars(
+      const std::string& regex, const std::bitset<256>& forbidden_chars
+  );
 };
 
 /*!

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -68,6 +68,16 @@ int32_t GrammarBuilder::AddByteString(const std::string& str) {
   );
 }
 
+int32_t GrammarBuilder::AddRegex(const std::string& regex_str) {
+  std::vector<int32_t> bytes;
+  bytes.reserve(regex_str.size());
+  for (char c : regex_str) {
+    bytes.push_back(static_cast<int32_t>(static_cast<uint8_t>(c)));
+  }
+  return AddGrammarExpr({GrammarExprType::kRegex, bytes.data(), static_cast<int32_t>(bytes.size())}
+  );
+}
+
 int32_t GrammarBuilder::AddCharacterClass(
     const std::vector<CharacterClassElement>& elements, bool is_negative
 ) {

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -68,14 +68,14 @@ int32_t GrammarBuilder::AddByteString(const std::string& str) {
   );
 }
 
-int32_t GrammarBuilder::AddRegex(const std::string& regex_str) {
-  std::vector<int32_t> bytes;
-  bytes.reserve(regex_str.size());
+int32_t GrammarBuilder::AddRegex(const std::string& regex_str, bool json_string) {
+  std::vector<int32_t> data;
+  data.reserve(regex_str.size() + 1);
+  data.push_back(static_cast<int32_t>(json_string));
   for (char c : regex_str) {
-    bytes.push_back(static_cast<int32_t>(static_cast<uint8_t>(c)));
+    data.push_back(static_cast<int32_t>(static_cast<uint8_t>(c)));
   }
-  return AddGrammarExpr({GrammarExprType::kRegex, bytes.data(), static_cast<int32_t>(bytes.size())}
-  );
+  return AddGrammarExpr({GrammarExprType::kRegex, data.data(), static_cast<int32_t>(data.size())});
 }
 
 int32_t GrammarBuilder::AddCharacterClass(

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -78,8 +78,11 @@ class GrammarBuilder {
    * \brief Add a GrammarExpr for a regex. The pattern is stored as-is and compiled into an
    * automaton by GrammarFSMBuilder.
    * \param regex_str The regex pattern string.
+   * \param json_string Whether the regex matches the body of a JSON string literal. If true,
+   * the characters that must be escaped in a JSON string (the control characters, '"' and
+   * '\\') are excluded from every character match of the compiled automaton.
    */
-  int32_t AddRegex(const std::string& regex_str);
+  int32_t AddRegex(const std::string& regex_str, bool json_string = false);
 
   /*!
    * \brief Add a GrammarExpr for a character class.

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -75,6 +75,13 @@ class GrammarBuilder {
   int32_t AddByteString(const std::string& str);
 
   /*!
+   * \brief Add a GrammarExpr for a regex. The pattern is stored as-is and compiled into an
+   * automaton by GrammarFSMBuilder.
+   * \param regex_str The regex pattern string.
+   */
+  int32_t AddRegex(const std::string& regex_str);
+
+  /*!
    * \brief Add a GrammarExpr for a character class.
    * \param elements A vector of CharacterClassElement, each containing a lower and a upper bound.
    * \param is_negative Whether the character class is negated.

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -295,6 +295,9 @@ class StructureNormalizerImpl : public GrammarMutator {
       case GrammarExprType::kTagDispatch:
         XGRAMMAR_LOG(FATAL) << "TagDispatch should not be in lookahead assertion";
         XGRAMMAR_UNREACHABLE();
+      case GrammarExprType::kRegex:
+        XGRAMMAR_LOG(FATAL) << "Regex should not be in lookahead assertion";
+        XGRAMMAR_UNREACHABLE();
       case GrammarExprType::kByteString:
       case GrammarExprType::kCharacterClass:
       case GrammarExprType::kCharacterClassStar:
@@ -336,6 +339,9 @@ class StructureNormalizerImpl : public GrammarMutator {
         auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, ttd_expr_id);
         return builder_->AddChoices({builder_->AddSequence({builder_->AddRuleRef(new_rule_id)})});
       }
+      case GrammarExprType::kRegex:
+        // A regex is kept as the direct body of the rule, like a tag dispatch.
+        return builder_->AddGrammarExpr(grammar_expr);
       default:
         XGRAMMAR_LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(grammar_expr.type);
         XGRAMMAR_UNREACHABLE();
@@ -380,6 +386,13 @@ class StructureNormalizerImpl : public GrammarMutator {
         case GrammarExprType::kTokenTagDispatch: {
           auto ttd_expr_id = VisitTokenTagDispatch(choice_expr);
           auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, ttd_expr_id);
+          auto new_sequence_id = builder_->AddSequence({builder_->AddRuleRef(new_rule_id)});
+          new_choice_ids.push_back(new_sequence_id);
+          break;
+        }
+        case GrammarExprType::kRegex: {
+          auto regex_expr_id = builder_->AddGrammarExpr(choice_expr);
+          auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, regex_expr_id);
           auto new_sequence_id = builder_->AddSequence({builder_->AddRuleRef(new_rule_id)});
           new_choice_ids.push_back(new_sequence_id);
           break;
@@ -467,6 +480,12 @@ class StructureNormalizerImpl : public GrammarMutator {
         case GrammarExprType::kTokenTagDispatch: {
           auto ttd_expr_id = VisitTokenTagDispatch(element_expr);
           auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, ttd_expr_id);
+          new_sequence_ids.push_back(builder_->AddRuleRef(new_rule_id));
+          break;
+        }
+        case GrammarExprType::kRegex: {
+          auto regex_expr_id = builder_->AddGrammarExpr(element_expr);
+          auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, regex_expr_id);
           new_sequence_ids.push_back(builder_->AddRuleRef(new_rule_id));
           break;
         }
@@ -748,7 +767,8 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
     auto root_rule = grammar->GetRootRule();
     auto root_grammar_expr = base_grammar_->GetGrammarExpr(root_rule.body_expr_id);
     if (root_grammar_expr.type == GrammarExprType::kTagDispatch ||
-        root_grammar_expr.type == GrammarExprType::kTokenTagDispatch) {
+        root_grammar_expr.type == GrammarExprType::kTokenTagDispatch ||
+        root_grammar_expr.type == GrammarExprType::kRegex) {
       return grammar;
     }
     BuildRuleLookaheadInfo();
@@ -813,6 +833,10 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
         for (const auto& [token_id, rule_id] : token_tag_dispatch.trigger_rule_pairs) {
           rule_lookahead_infos_[rule_id].is_triggered_by_dispatch = true;
         }
+        continue;
+      }
+      if (grammar_expr.type == GrammarExprType::kRegex) {
+        // A regex rule is a leaf: it references no other rules.
         continue;
       }
       XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kChoices);
@@ -931,6 +955,23 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
       if (grammar_expr.type == GrammarExprType::kTagDispatch ||
           grammar_expr.type == GrammarExprType::kTokenTagDispatch) {
         empty_rule_id_set->insert(i);
+        continue;
+      }
+
+      if (grammar_expr.type == GrammarExprType::kRegex) {
+        // A regex rule allows empty iff an end state is in the epsilon closure of the start
+        // state of its automaton. Build errors are reported by GrammarFSMBuilder later.
+        auto regex_fsm_result = RegexFSMBuilder::Build(base_grammar_->GetRegexString(grammar_expr));
+        if (regex_fsm_result.IsOk()) {
+          auto regex_fsm = std::move(regex_fsm_result).Unwrap();
+          std::unordered_set<int> start_closure{regex_fsm.GetStart()};
+          regex_fsm.GetFsm().GetEpsilonClosure(&start_closure);
+          if (std::any_of(start_closure.begin(), start_closure.end(), [&](int state) {
+                return regex_fsm.IsEndState(state);
+              })) {
+            empty_rule_id_set->insert(i);
+          }
+        }
         continue;
       }
 
@@ -1065,6 +1106,17 @@ class GrammarFSMBuilderImpl {
         XGRAMMAR_CHECK(rule_fsm.has_value())
             << "Failed to build token tag dispatch fsm for rule " << i;
         per_rule_fsms[i] = rule_fsm->AddToCompleteFSM(&complete_fsm, &state_mapping);
+      } else if (grammar_expr.type == Grammar::Impl::GrammarExprType::kRegex) {
+        // Every regex rule must have an automaton.
+        auto regex_str = (*grammar)->GetRegexString(grammar_expr);
+        auto rule_fsm_result = Regex(regex_str);
+        if (rule_fsm_result.IsErr()) {
+          XGRAMMAR_LOG(FATAL) << "Failed to build the automaton for rule "
+                              << (*grammar)->GetRule(i).name << " with regex " << regex_str << ": "
+                              << std::move(rule_fsm_result).UnwrapErr().what();
+        }
+        auto rule_fsm = std::move(rule_fsm_result).Unwrap();
+        per_rule_fsms[i] = rule_fsm.AddToCompleteFSM(&complete_fsm, &state_mapping);
       } else {
         XGRAMMAR_DCHECK(grammar_expr.type == Grammar::Impl::GrammarExprType::kChoices);
         auto rule_fsm = Choices(grammar_expr, *grammar);
@@ -1114,6 +1166,7 @@ class GrammarFSMBuilderImpl {
   static std::optional<FSMWithStartEnd> Sequence(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> Choices(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> TagDispatch(const Grammar::Impl::TagDispatch& tag_dispatch);
+  static Result<FSMWithStartEnd> Regex(const std::string& regex);
   static void AddCharacterRange(FSMWithStartEnd& fsm, int from, int to, uint32_t min, uint32_t max);
   /* Building tool functions.*/
   static std::optional<FSMWithStartEnd> BuildTagDispatch(
@@ -1654,6 +1707,12 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::TagDispatch(
   return BuildTagDispatch(
       string_trigger_rules, tag_dispatch.loop_after_dispatch, tag_dispatch.excludes
   );
+}
+
+Result<FSMWithStartEnd> GrammarFSMBuilderImpl::Regex(const std::string& regex) {
+  // Note: do not run SimplifyEpsilon here. Its state-merging rule can merge an accepting
+  // state into its epsilon-successor and change the accepted language.
+  return RegexFSMBuilder::Build(regex);
 }
 
 class RepetitionRangeExpanderImpl : public GrammarMutator {
@@ -2542,6 +2601,13 @@ std::optional<uint64_t> GrammarFSMHasherImpl::HashSequence(
       case (GrammarExprType::kTokenTagDispatch): {
         return std::nullopt;
       }
+      case (GrammarExprType::kRegex): {
+        // Hash the pattern content, like a byte string.
+        for (const auto& element : expr) {
+          hash_result = HashCombine(hash_result, element);
+        }
+        break;
+      }
       case (GrammarExprType::kToken):
       case (GrammarExprType::kExcludeToken): {
         for (const auto& element : expr) {
@@ -2826,6 +2892,10 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilder::Choices(
     const GrammarExpr& expr, const Grammar& grammar
 ) {
   return GrammarFSMBuilderImpl::Choices(expr, grammar);
+}
+
+Result<FSMWithStartEnd> GrammarFSMBuilder::Regex(const std::string& regex) {
+  return GrammarFSMBuilderImpl::Regex(regex);
 }
 
 std::optional<FSMWithStartEnd> GrammarFSMBuilder::TagDispatch(

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1109,7 +1109,7 @@ class GrammarFSMBuilderImpl {
       } else if (grammar_expr.type == Grammar::Impl::GrammarExprType::kRegex) {
         // Every regex rule must have an automaton.
         auto regex_str = (*grammar)->GetRegexString(grammar_expr);
-        auto rule_fsm_result = Regex(regex_str);
+        auto rule_fsm_result = Regex(regex_str, (*grammar)->GetRegexIsJSONString(grammar_expr));
         if (rule_fsm_result.IsErr()) {
           XGRAMMAR_LOG(FATAL) << "Failed to build the automaton for rule "
                               << (*grammar)->GetRule(i).name << " with regex " << regex_str << ": "
@@ -1166,7 +1166,7 @@ class GrammarFSMBuilderImpl {
   static std::optional<FSMWithStartEnd> Sequence(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> Choices(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> TagDispatch(const Grammar::Impl::TagDispatch& tag_dispatch);
-  static Result<FSMWithStartEnd> Regex(const std::string& regex);
+  static Result<FSMWithStartEnd> Regex(const std::string& regex, bool json_string = false);
   static void AddCharacterRange(FSMWithStartEnd& fsm, int from, int to, uint32_t min, uint32_t max);
   /* Building tool functions.*/
   static std::optional<FSMWithStartEnd> BuildTagDispatch(
@@ -1709,10 +1709,18 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::TagDispatch(
   );
 }
 
-Result<FSMWithStartEnd> GrammarFSMBuilderImpl::Regex(const std::string& regex) {
-  // Note: do not run SimplifyEpsilon here. Its state-merging rule can merge an accepting
-  // state into its epsilon-successor and change the accepted language.
-  return RegexFSMBuilder::Build(regex);
+Result<FSMWithStartEnd> GrammarFSMBuilderImpl::Regex(const std::string& regex, bool json_string) {
+  auto build_result = json_string ? RegexFSMBuilder::BuildWithForbiddenChars(
+                                        regex, GrammarFSMBuilder::JSONStringForbiddenChars()
+                                    )
+                                  : RegexFSMBuilder::Build(regex);
+  if (build_result.IsErr()) {
+    return build_result;
+  }
+  auto result = std::move(build_result).Unwrap();
+  result = result.SimplifyEpsilon();
+  result = result.MergeEquivalentStates();
+  return ResultOk(std::move(result));
 }
 
 class RepetitionRangeExpanderImpl : public GrammarMutator {
@@ -2894,8 +2902,21 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilder::Choices(
   return GrammarFSMBuilderImpl::Choices(expr, grammar);
 }
 
-Result<FSMWithStartEnd> GrammarFSMBuilder::Regex(const std::string& regex) {
-  return GrammarFSMBuilderImpl::Regex(regex);
+Result<FSMWithStartEnd> GrammarFSMBuilder::Regex(const std::string& regex, bool json_string) {
+  return GrammarFSMBuilderImpl::Regex(regex, json_string);
+}
+
+const std::bitset<256>& GrammarFSMBuilder::JSONStringForbiddenChars() {
+  static const std::bitset<256> forbidden_chars = [] {
+    std::bitset<256> chars;
+    for (int c = 0x00; c <= 0x1F; ++c) {
+      chars.set(c);
+    }
+    chars.set('"');
+    chars.set('\\');
+    return chars;
+  }();
+  return forbidden_chars;
 }
 
 std::optional<FSMWithStartEnd> GrammarFSMBuilder::TagDispatch(

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -16,6 +16,7 @@
 #include "compiled_grammar_impl.h"
 #include "grammar_builder.h"
 #include "grammar_impl.h"
+#include "support/utils.h"
 #include "xgrammar/grammar.h"
 
 namespace xgrammar {
@@ -143,6 +144,8 @@ class GrammarFunctor {
         return VisitExcludeToken(grammar_expr);
       case GrammarExprType::kTokenTagDispatch:
         return VisitTokenTagDispatch(grammar_expr);
+      case GrammarExprType::kRegex:
+        return VisitRegex(grammar_expr);
       default:
         XGRAMMAR_LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(grammar_expr.type);
         XGRAMMAR_UNREACHABLE();
@@ -236,6 +239,9 @@ class GrammarFunctor {
   virtual T VisitTokenTagDispatch(const GrammarExpr& grammar_expr) {
     return VisitElement(grammar_expr);
   }
+
+  /*! \brief Visit a regex GrammarExpr. It is a leaf: the pattern string is carried as-is. */
+  virtual T VisitRegex(const GrammarExpr& grammar_expr) { return VisitElement(grammar_expr); }
 
   /*! \brief The grammar to visit or mutate. */
   Grammar base_grammar_{NullObj{}};
@@ -373,6 +379,8 @@ class GrammarFSMBuilder {
   static std::optional<FSMWithStartEnd> Sequence(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> Choices(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> TagDispatch(const Grammar::Impl::TagDispatch& tag_dispatch);
+  /*! \brief Build the automaton of a regex pattern. Returns the error message on failure. */
+  static Result<FSMWithStartEnd> Regex(const std::string& regex);
 };
 
 /*!

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -9,6 +9,7 @@
 
 #include <xgrammar/xgrammar.h>
 
+#include <bitset>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -379,8 +380,16 @@ class GrammarFSMBuilder {
   static std::optional<FSMWithStartEnd> Sequence(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> Choices(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> TagDispatch(const Grammar::Impl::TagDispatch& tag_dispatch);
-  /*! \brief Build the automaton of a regex pattern. Returns the error message on failure. */
-  static Result<FSMWithStartEnd> Regex(const std::string& regex);
+  /*!
+   * \brief Build the automaton of a regex pattern. Returns the error message on failure.
+   * \param regex The regex pattern string.
+   * \param json_string Whether the regex matches the body of a JSON string literal. If true,
+   * the characters in JSONStringForbiddenChars() are excluded from every character match.
+   */
+  static Result<FSMWithStartEnd> Regex(const std::string& regex, bool json_string = false);
+  /*! \brief The characters that must be escaped inside a JSON string literal: the control
+   * characters 0x00-0x1F, the quote '"' and the backslash '\\'. */
+  static const std::bitset<256>& JSONStringForbiddenChars();
 };
 
 /*!

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -132,11 +132,13 @@ class Grammar::Impl {
     //               loop_after_dispatch,
     //               exclude_cnt, token_id × M]
     kTokenTagDispatch,
-    // data format: [byte0, byte1, ...]
+    // data format: [json_string, byte0, byte1, ...]
     // The bytes are the regex pattern string. Like kTagDispatch, it can only be the body of a
     // rule. The pattern is carried through the grammar passes as-is; when GrammarFSMBuilder
     // runs, the pattern is compiled into an automaton, so every regex rule always has a
-    // per-rule FSM after optimization.
+    // per-rule FSM after optimization. If json_string is 1, the regex matches the body of a
+    // JSON string literal: the characters that must be escaped in a JSON string (the control
+    // characters, '"' and '\\') are excluded from every character match of the automaton.
     kRegex,
   };
 
@@ -198,9 +200,10 @@ class Grammar::Impl {
   /*! \brief Get the regex pattern string of the regex grammar expr. */
   std::string GetRegexString(const GrammarExpr& grammar_expr) const {
     XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kRegex) << "GrammarExpr is not a regex";
+    XGRAMMAR_DCHECK(grammar_expr.size() >= 1) << "Regex expr must contain the json_string flag";
     std::string str;
-    str.reserve(grammar_expr.size());
-    for (int i = 0; i < grammar_expr.size(); ++i) {
+    str.reserve(grammar_expr.size() - 1);
+    for (int i = 1; i < grammar_expr.size(); ++i) {
       str.push_back(static_cast<char>(static_cast<uint8_t>(grammar_expr[i])));
     }
     return str;
@@ -209,6 +212,13 @@ class Grammar::Impl {
   /*! \brief Get the regex pattern string of the regex grammar expr with the given id. */
   std::string GetRegexString(int32_t grammar_expr_id) const {
     return GetRegexString(GetGrammarExpr(grammar_expr_id));
+  }
+
+  /*! \brief Get whether the regex grammar expr matches the body of a JSON string literal. */
+  bool GetRegexIsJSONString(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kRegex) << "GrammarExpr is not a regex";
+    XGRAMMAR_DCHECK(grammar_expr.size() >= 1) << "Regex expr must contain the json_string flag";
+    return grammar_expr[0] != 0;
   }
 
   /*! \brief The object representing a tag dispatch. */

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -132,6 +132,12 @@ class Grammar::Impl {
     //               loop_after_dispatch,
     //               exclude_cnt, token_id × M]
     kTokenTagDispatch,
+    // data format: [byte0, byte1, ...]
+    // The bytes are the regex pattern string. Like kTagDispatch, it can only be the body of a
+    // rule. The pattern is carried through the grammar passes as-is; when GrammarFSMBuilder
+    // runs, the pattern is compiled into an automaton, so every regex rule always has a
+    // per-rule FSM after optimization.
+    kRegex,
   };
 
   /*! \brief The object representing a grammar expr. */
@@ -187,6 +193,22 @@ class Grammar::Impl {
   /*! \brief Get the string of the byte string grammar expr. */
   std::string GetByteString(int32_t grammar_expr_id) const {
     return GetByteString(GetGrammarExpr(grammar_expr_id));
+  }
+
+  /*! \brief Get the regex pattern string of the regex grammar expr. */
+  std::string GetRegexString(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kRegex) << "GrammarExpr is not a regex";
+    std::string str;
+    str.reserve(grammar_expr.size());
+    for (int i = 0; i < grammar_expr.size(); ++i) {
+      str.push_back(static_cast<char>(static_cast<uint8_t>(grammar_expr[i])));
+    }
+    return str;
+  }
+
+  /*! \brief Get the regex pattern string of the regex grammar expr with the given id. */
+  std::string GetRegexString(int32_t grammar_expr_id) const {
+    return GetRegexString(GetGrammarExpr(grammar_expr_id));
   }
 
   /*! \brief The object representing a tag dispatch. */

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -1018,9 +1018,6 @@ int32_t EBNFParser::ParseRegexMacro() {
   auto args = ParseMacroArguments();
   auto delta_element = start - current_token_;  // Used to report parse errors
 
-  if (!args.named_arguments.empty()) {
-    ReportParseError("Regex does not support named arguments", delta_element);
-  }
   if (args.arguments.size() != 1) {
     ReportParseError("Regex expects exactly one string argument", delta_element);
   }
@@ -1028,7 +1025,21 @@ int32_t EBNFParser::ParseRegexMacro() {
   if (pattern_node == nullptr) {
     ReportParseError("Regex pattern must be a string literal", delta_element);
   }
-  return builder_.AddRegex(pattern_node->value);
+
+  bool json_string = false;
+  for (const auto& [name, _] : args.named_arguments) {
+    if (name != "json_string") {
+      ReportParseError("Regex does not support the named argument " + name, delta_element);
+    }
+  }
+  if (auto it = args.named_arguments.find("json_string"); it != args.named_arguments.end()) {
+    auto bool_node = std::get_if<MacroIR::BooleanNode>(it->second.get());
+    if (bool_node == nullptr) {
+      ReportParseError("json_string must be a boolean", delta_element);
+    }
+    json_string = bool_node->value;
+  }
+  return builder_.AddRegex(pattern_node->value, json_string);
 }
 
 int32_t EBNFParser::ParseTokenSet() {

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -493,6 +493,7 @@ class EBNFParser {
   int32_t ParseTokenSet();
   int32_t ParseExcludeToken();
   int32_t ParseTokenTagDispatch();
+  int32_t ParseRegexMacro();
 
   // Helper functions
 
@@ -544,6 +545,7 @@ const std::unordered_map<std::string, std::function<int32_t(EBNFParser*)>>
         {"Token", [](EBNFParser* parser) { return parser->ParseTokenSet(); }},
         {"ExcludeToken", [](EBNFParser* parser) { return parser->ParseExcludeToken(); }},
         {"TokenTagDispatch", [](EBNFParser* parser) { return parser->ParseTokenTagDispatch(); }},
+        {"Regex", [](EBNFParser* parser) { return parser->ParseRegexMacro(); }},
 };
 
 const EBNFParser::Token& EBNFParser::Peek(int delta) const { return *(current_token_ + delta); }
@@ -1008,6 +1010,25 @@ int32_t EBNFParser::ParseTagDispatch() {
   }
 
   return builder_.AddTagDispatch(tag_dispatch);
+}
+
+int32_t EBNFParser::ParseRegexMacro() {
+  Consume();  // Consume Regex operator
+  auto start = current_token_;
+  auto args = ParseMacroArguments();
+  auto delta_element = start - current_token_;  // Used to report parse errors
+
+  if (!args.named_arguments.empty()) {
+    ReportParseError("Regex does not support named arguments", delta_element);
+  }
+  if (args.arguments.size() != 1) {
+    ReportParseError("Regex expects exactly one string argument", delta_element);
+  }
+  auto pattern_node = std::get_if<MacroIR::StringNode>(args.arguments[0].get());
+  if (pattern_node == nullptr) {
+    ReportParseError("Regex pattern must be a string literal", delta_element);
+  }
+  return builder_.AddRegex(pattern_node->value);
 }
 
 int32_t EBNFParser::ParseTokenSet() {

--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -130,7 +130,11 @@ std::string GrammarPrinter::PrintChoices(const GrammarExpr& grammar_expr) {
 }
 
 std::string GrammarPrinter::PrintRegex(const GrammarExpr& grammar_expr) {
-  return "Regex(" + PrintString(grammar_->GetRegexString(grammar_expr)) + ")";
+  std::string result = "Regex(" + PrintString(grammar_->GetRegexString(grammar_expr));
+  if (grammar_->GetRegexIsJSONString(grammar_expr)) {
+    result += ", json_string=true";
+  }
+  return result + ")";
 }
 
 std::string GrammarPrinter::PrintString(const std::string& str) {

--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -50,6 +50,8 @@ std::string GrammarPrinter::PrintGrammarExpr(const GrammarExpr& grammar_expr) {
       return PrintExcludeToken(grammar_expr);
     case GrammarExprType::kTokenTagDispatch:
       return PrintTokenTagDispatch(grammar_expr);
+    case GrammarExprType::kRegex:
+      return PrintRegex(grammar_expr);
     default:
       XGRAMMAR_LOG(FATAL) << "Unexpected GrammarExpr type: " << static_cast<int>(grammar_expr.type);
       XGRAMMAR_UNREACHABLE();
@@ -125,6 +127,10 @@ std::string GrammarPrinter::PrintChoices(const GrammarExpr& grammar_expr) {
   }
   result += ")";
   return result;
+}
+
+std::string GrammarPrinter::PrintRegex(const GrammarExpr& grammar_expr) {
+  return "Regex(" + PrintString(grammar_->GetRegexString(grammar_expr)) + ")";
 }
 
 std::string GrammarPrinter::PrintString(const std::string& str) {

--- a/cpp/grammar_printer.h
+++ b/cpp/grammar_printer.h
@@ -68,6 +68,8 @@ class GrammarPrinter {
   std::string PrintExcludeToken(const GrammarExpr& grammar_expr);
   /*! \brief Print a GrammarExpr for token tag dispatch. */
   std::string PrintTokenTagDispatch(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for regex. */
+  std::string PrintRegex(const GrammarExpr& grammar_expr);
   /*! \brief Print a string. */
   std::string PrintString(const std::string& str);
   /*! \brief Print a boolean. */

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -22,7 +22,7 @@
 #include <variant>
 #include <vector>
 
-#include "fsm_builder.h"
+#include "grammar_functor.h"
 #include "json_schema_converter_ext.h"
 #include "regex_converter.h"
 #include "support/encoding.h"
@@ -2154,16 +2154,32 @@ std::string JSONSchemaConverter::GenerateNumber(
 }
 
 /*!
- * \brief Emit the EBNF fragment matching a regex. Prefer the Regex(...) macro so the pattern
- * is compiled into a single automaton by GrammarFSMBuilder; fall back to the CFG expansion
- * when the FSM regex engine does not support the pattern.
+ * \brief Emit the EBNF fragment matching a regex that forms the body of a JSON string
+ * literal. Prefer the Regex(..., json_string=true) macro so the pattern is compiled into a
+ * single automaton by GrammarFSMBuilder; json_string=true excludes the characters that must
+ * be escaped in a JSON string ('"', '\\' and the control characters) from every character
+ * match, so classes like \S cannot emit an unescaped quote. Fall back to the CFG expansion
+ * when the FSM regex engine does not support the pattern, or when the exclusion makes the
+ * pattern unmatchable (e.g. a pattern requiring a literal '"').
  */
 static std::string RegexToEBNFElement(const std::string& regex) {
   bool is_printable_ascii = std::all_of(regex.begin(), regex.end(), [](unsigned char c) {
     return c >= 0x20 && c <= 0x7E;
   });
-  if (is_printable_ascii && RegexFSMBuilder::Build(regex).IsOk()) {
-    return "Regex(\"" + EscapeString(regex) + "\")";
+  if (is_printable_ascii) {
+    auto fsm_result = GrammarFSMBuilder::Regex(regex, /*json_string=*/true);
+    if (fsm_result.IsOk()) {
+      auto fsm = std::move(fsm_result).Unwrap();
+      std::unordered_set<int> reachable_states;
+      fsm.GetReachableStates(&reachable_states);
+      bool language_is_empty =
+          std::none_of(reachable_states.begin(), reachable_states.end(), [&](int state) {
+            return fsm.IsEndState(state);
+          });
+      if (!language_is_empty) {
+        return "Regex(\"" + EscapeString(regex) + "\", json_string=true)";
+      }
+    }
   }
   return RegexToEBNF(regex, false);
 }

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -22,8 +22,10 @@
 #include <variant>
 #include <vector>
 
+#include "fsm_builder.h"
 #include "json_schema_converter_ext.h"
 #include "regex_converter.h"
+#include "support/encoding.h"
 #include "support/logging.h"
 #include "support/utils.h"
 
@@ -2151,6 +2153,21 @@ std::string JSONSchemaConverter::GenerateNumber(
   return "\"-\"? (\"0\" | [1-9] [0-9]*) (\".\" [0-9]+)? ([eE] [+-]? [0-9]+)?";
 }
 
+/*!
+ * \brief Emit the EBNF fragment matching a regex. Prefer the Regex(...) macro so the pattern
+ * is compiled into a single automaton by GrammarFSMBuilder; fall back to the CFG expansion
+ * when the FSM regex engine does not support the pattern.
+ */
+static std::string RegexToEBNFElement(const std::string& regex) {
+  bool is_printable_ascii = std::all_of(regex.begin(), regex.end(), [](unsigned char c) {
+    return c >= 0x20 && c <= 0x7E;
+  });
+  if (is_printable_ascii && RegexFSMBuilder::Build(regex).IsOk()) {
+    return "Regex(\"" + EscapeString(regex) + "\")";
+  }
+  return RegexToEBNF(regex, false);
+}
+
 std::string JSONSchemaConverter::GenerateString(
     const StringSpec& spec, const std::string& rule_name
 ) {
@@ -2160,6 +2177,8 @@ std::string JSONSchemaConverter::GenerateString(
     auto regex_pattern = JSONFormatToRegexPattern(format);
 
     if (regex_pattern.has_value()) {
+      // The built-in format regexes use constructs that the FSM regex engine does not fully
+      // support yet (e.g. quoted email local parts), so they keep the CFG expansion.
       std::string converted_regex = RegexToEBNF(regex_pattern.value(), false);
       return "\"\\\"\" " + converted_regex + " \"\\\"\"";
     }
@@ -2167,7 +2186,7 @@ std::string JSONSchemaConverter::GenerateString(
 
   // Check for pattern
   if (spec.pattern.has_value()) {
-    std::string converted_regex = RegexToEBNF(*spec.pattern, false);
+    std::string converted_regex = RegexToEBNFElement(*spec.pattern);
     return "\"\\\"\" " + converted_regex + " \"\\\"\"";
   }
 
@@ -2793,7 +2812,7 @@ std::string JSONSchemaConverter::GenerateObject(
       for (size_t i = 0; i < spec.pattern_properties.size(); ++i) {
         const auto& pp = spec.pattern_properties[i];
         std::string value = CreateRule(pp.schema, rule_name + "_pp_" + std::to_string(i));
-        std::string pp_single = "\"\\\"\"" + RegexToEBNF(pp.pattern, false) + "\"\\\"\" " +
+        std::string pp_single = "\"\\\"\" " + RegexToEBNFElement(pp.pattern) + " \"\\\"\" " +
                                 colon_pattern_ + " " + value;
         if (i != 0) pp_body += " | ";
         pp_body += pp_single;
@@ -2843,8 +2862,8 @@ std::string JSONSchemaConverter::GenerateObject(
         for (size_t i = 0; i < spec.pattern_properties.size(); ++i) {
           const auto& pp = spec.pattern_properties[i];
           std::string value = CreateRule(pp.schema, rule_name + "_prop_" + std::to_string(i));
-          std::string property_pattern = "\"\\\"\"" + RegexToEBNF(pp.pattern, false) + "\"\\\"\" " +
-                                         colon_pattern_ + " " + value;
+          std::string property_pattern = "\"\\\"\" " + RegexToEBNFElement(pp.pattern) +
+                                         " \"\\\"\" " + colon_pattern_ + " " + value;
           if (i != 0) {
             property_rule_body += " | ";
           }

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v14";
+  static constexpr const char kXGrammarSerializeVersion[] = "v15";
 };
 
 /*!

--- a/tests/cpp/test_fsm.cc
+++ b/tests/cpp/test_fsm.cc
@@ -523,6 +523,59 @@ TEST(XGrammarFSMTest, MergeEquivalentStatesNoCrossRuleChaining) {
   EXPECT_FALSE(merged.AcceptString("ybn"));
 }
 
+TEST(XGrammarFSMTest, SimplifyEpsilonPreservesAcceptance) {
+  // (ab)+ : the accepting state's only edge is an epsilon back to the non-accepting start.
+  // Merging the two states would wrongly make the start state accepting.
+  auto fsm_wse = RegexFSMBuilder::Build("(ab)+").Unwrap();
+  fsm_wse = fsm_wse.SimplifyEpsilon();
+  EXPECT_FALSE(fsm_wse.AcceptString(""));
+  EXPECT_FALSE(fsm_wse.AcceptString("a"));
+  EXPECT_TRUE(fsm_wse.AcceptString("ab"));
+  EXPECT_TRUE(fsm_wse.AcceptString("abab"));
+
+  fsm_wse = RegexFSMBuilder::Build("a+").Unwrap();
+  fsm_wse = fsm_wse.SimplifyEpsilon();
+  EXPECT_FALSE(fsm_wse.AcceptString(""));
+  EXPECT_TRUE(fsm_wse.AcceptString("a"));
+  EXPECT_TRUE(fsm_wse.AcceptString("aaa"));
+
+  // Hand-built: accepting state 1 has a single epsilon edge to non-accepting state 2, and
+  // state 2 is also reachable via another path (0 -b-> 2). Merging 1 and 2 would wrongly
+  // accept "b". The language is {"a", "ac", "bc"}.
+  FSMWithStartEnd manual_fsm;
+  for (int i = 0; i < 4; i++) {
+    manual_fsm.AddState();
+  }
+  manual_fsm.SetStartState(0);
+  manual_fsm.AddEndState(1);
+  manual_fsm.AddEndState(3);
+  manual_fsm.GetFsm().AddEdge(0, 1, 'a', 'a');
+  manual_fsm.GetFsm().AddEpsilonEdge(1, 2);
+  manual_fsm.GetFsm().AddEdge(0, 2, 'b', 'b');
+  manual_fsm.GetFsm().AddEdge(2, 3, 'c', 'c');
+  manual_fsm = manual_fsm.SimplifyEpsilon();
+  EXPECT_TRUE(manual_fsm.AcceptString("a"));
+  EXPECT_TRUE(manual_fsm.AcceptString("ac"));
+  EXPECT_TRUE(manual_fsm.AcceptString("bc"));
+  EXPECT_FALSE(manual_fsm.AcceptString("b"));
+  EXPECT_FALSE(manual_fsm.AcceptString(""));
+
+  // The safe direction still merges: non-accepting state with a single epsilon edge into an
+  // accepting state.
+  FSMWithStartEnd mergeable_fsm;
+  for (int i = 0; i < 3; i++) {
+    mergeable_fsm.AddState();
+  }
+  mergeable_fsm.SetStartState(0);
+  mergeable_fsm.AddEndState(2);
+  mergeable_fsm.GetFsm().AddEdge(0, 1, 'a', 'a');
+  mergeable_fsm.GetFsm().AddEpsilonEdge(1, 2);
+  mergeable_fsm = mergeable_fsm.SimplifyEpsilon();
+  EXPECT_EQ(mergeable_fsm.GetFsm().NumStates(), 2);
+  EXPECT_TRUE(mergeable_fsm.AcceptString("a"));
+  EXPECT_FALSE(mergeable_fsm.AcceptString(""));
+}
+
 TEST(XGrammarFSMTest, EpsilonSimplificationTest) {
   FSMWithStartEnd fsm_wse;
   for (int i = 0; i < 10; i++) {

--- a/tests/cpp/test_fsm_builder.cc
+++ b/tests/cpp/test_fsm_builder.cc
@@ -369,3 +369,71 @@ TEST(XGrammarFSMBuilderTest, TestChoicesFSMBuilder) {
   EXPECT_TRUE(fsm_rule2_result.has_value());
   EXPECT_EQ(fsm_rule2_result->ToString(), expected_fsm_rule2);
 }
+
+TEST(XGrammarFSMBuilderTest, TestRegexBuildWithForbiddenChars) {
+  // \S matches any non-whitespace byte. With the JSON forbidden characters removed, the
+  // quote and the backslash must be rejected while other printable characters stay.
+  const auto& forbidden = GrammarFSMBuilder::JSONStringForbiddenChars();
+  auto fsm_wse = RegexFSMBuilder::BuildWithForbiddenChars("\\S+", forbidden).Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString("abc"));
+  EXPECT_TRUE(fsm_wse.AcceptString("a!~z"));
+  EXPECT_FALSE(fsm_wse.AcceptString("a\"b"));
+  EXPECT_FALSE(fsm_wse.AcceptString("a\\b"));
+  EXPECT_FALSE(fsm_wse.AcceptString("a b"));
+
+  // A positive class spanning the quote and the backslash is split around them.
+  fsm_wse = RegexFSMBuilder::BuildWithForbiddenChars("[ -~]+", forbidden).Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString("A z!"));
+  EXPECT_FALSE(fsm_wse.AcceptString("\""));
+  EXPECT_FALSE(fsm_wse.AcceptString("\\"));
+
+  // . matches any byte; the control characters must be rejected as well.
+  fsm_wse = RegexFSMBuilder::BuildWithForbiddenChars(".", forbidden).Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString("a"));
+  EXPECT_FALSE(fsm_wse.AcceptString("\t"));
+  EXPECT_FALSE(fsm_wse.AcceptString("\n"));
+  EXPECT_FALSE(fsm_wse.AcceptString("\""));
+
+  // Epsilon transitions are preserved: the pattern still accepts the empty string.
+  fsm_wse = RegexFSMBuilder::BuildWithForbiddenChars("(ab)*", forbidden).Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString(""));
+  EXPECT_TRUE(fsm_wse.AcceptString("abab"));
+  EXPECT_FALSE(fsm_wse.AcceptString("a"));
+
+  // A pattern that requires a forbidden character becomes the empty language.
+  fsm_wse = RegexFSMBuilder::BuildWithForbiddenChars("a\"b", forbidden).Unwrap();
+  EXPECT_FALSE(fsm_wse.AcceptString("a\"b"));
+  EXPECT_FALSE(fsm_wse.AcceptString("ab"));
+  EXPECT_FALSE(fsm_wse.AcceptString(""));
+
+  // Multi-byte UTF-8 characters (bytes >= 0x80) are not affected by the JSON exclusion.
+  fsm_wse = RegexFSMBuilder::BuildWithForbiddenChars(".+", forbidden).Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString("你好"));
+}
+
+TEST(XGrammarFSMBuilderTest, TestGrammarFSMBuilderRegex) {
+  // The compiled regex automaton must preserve the language after simplification.
+  auto fsm_wse = GrammarFSMBuilder::Regex("(ab)+").Unwrap();
+  EXPECT_FALSE(fsm_wse.AcceptString(""));
+  EXPECT_FALSE(fsm_wse.AcceptString("a"));
+  EXPECT_TRUE(fsm_wse.AcceptString("ab"));
+  EXPECT_TRUE(fsm_wse.AcceptString("abab"));
+
+  fsm_wse = GrammarFSMBuilder::Regex("[0-9]{5}$").Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString("12345"));
+  EXPECT_FALSE(fsm_wse.AcceptString("1234"));
+  EXPECT_FALSE(fsm_wse.AcceptString("123456"));
+
+  // json_string=true excludes the JSON forbidden characters.
+  fsm_wse = GrammarFSMBuilder::Regex("\\S+", /*json_string=*/true).Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString("abc"));
+  EXPECT_FALSE(fsm_wse.AcceptString("a\"b"));
+  EXPECT_FALSE(fsm_wse.AcceptString("a\\b"));
+
+  // Without the flag, the quote is accepted.
+  fsm_wse = GrammarFSMBuilder::Regex("\\S+").Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString("a\"b"));
+
+  // Invalid patterns report an error.
+  EXPECT_TRUE(GrammarFSMBuilder::Regex("+a").IsErr());
+}

--- a/tests/cpp/test_fsm_builder.cc
+++ b/tests/cpp/test_fsm_builder.cc
@@ -437,3 +437,33 @@ TEST(XGrammarFSMBuilderTest, TestGrammarFSMBuilderRegex) {
   // Invalid patterns report an error.
   EXPECT_TRUE(GrammarFSMBuilder::Regex("+a").IsErr());
 }
+
+TEST(XGrammarFSMBuilderTest, TestRegexRepeatZero) {
+  // {0} / {0,0} matches exactly the empty string (ECMA-262 semantics, and consistent
+  // with the EBNF parser and the CFG fallback path).
+  auto fsm_wse = RegexFSMBuilder::Build("a{0}").Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString(""));
+  EXPECT_FALSE(fsm_wse.AcceptString("a"));
+
+  fsm_wse = RegexFSMBuilder::Build("a{0,0}").Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString(""));
+  EXPECT_FALSE(fsm_wse.AcceptString("a"));
+
+  fsm_wse = RegexFSMBuilder::Build("(ab){0}").Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString(""));
+  EXPECT_FALSE(fsm_wse.AcceptString("ab"));
+
+  // In a concatenation the {0} element contributes nothing.
+  fsm_wse = RegexFSMBuilder::Build("ba{0}c").Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString("bc"));
+  EXPECT_FALSE(fsm_wse.AcceptString("bac"));
+
+  // The empty-string FSM survives the simplification passes.
+  fsm_wse = GrammarFSMBuilder::Regex("ba{0}c").Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString("bc"));
+  EXPECT_FALSE(fsm_wse.AcceptString("bac"));
+
+  // A lower bound larger than the upper bound is an error in every regex dialect.
+  EXPECT_TRUE(RegexFSMBuilder::Build("a{3,1}").IsErr());
+  EXPECT_TRUE(RegexFSMBuilder::Build("a{1,0}").IsErr());
+}

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -375,7 +375,7 @@ xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
 root_prop_0 ::= [^]{1,}
-root_prop_1_prop_0 ::= "\"" [0-9]{5} "\""
+root_prop_1_prop_0 ::= "\"" Regex("[0-9]{5}$") "\""
 root_prop_1_prop_1 ::= "\"" ( ( [a-zA-Z0-9_!#$%&'*+/=?^`{|}~-]+ ( "." [a-zA-Z0-9_!#$%&'*+/=?^`{|}~-]+ )* ) | "\\" "\"" ( "\\" [ -~] | [ !#-[\]-~] )* "\\" "\"" ) "@" ( [A-Za-z0-9] ( [\-A-Za-z0-9]* [A-Za-z0-9] )? ) ( ( "." [A-Za-z0-9] [\-A-Za-z0-9]* [A-Za-z0-9] )* ) "\""
 root_prop_1_part_0 ::= [ \n\t]* "," [ \n\t]* "\"email\"" [ \n\t]* ":" [ \n\t]* root_prop_1_prop_1 ""
 root_prop_1 ::= "{" [ \n\t]* (("\"phone\"" [ \n\t]* ":" [ \n\t]* root_prop_1_prop_0 root_prop_1_part_0)) [ \n\t]* "}"
@@ -794,7 +794,7 @@ xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
 root_prop_0 ::= [^]{1,}
-root_prop_1_prop_0 ::= "\"" [0-9]{5} "\""
+root_prop_1_prop_0 ::= "\"" Regex("[0-9]{5}$") "\""
 root_prop_1_prop_1 ::= "\"" ( ( [a-zA-Z0-9_!#$%&'*+/=?^`{|}~-]+ ( "." [a-zA-Z0-9_!#$%&'*+/=?^`{|}~-]+ )* ) | "\\" "\"" ( "\\" [ -~] | [ !#-[\]-~] )* "\\" "\"" ) "@" ( [A-Za-z0-9] ( [\-A-Za-z0-9]* [A-Za-z0-9] )? ) ( ( "." [A-Za-z0-9] [\-A-Za-z0-9]* [A-Za-z0-9] )* ) "\""
 root_prop_1_part_0 ::= [ \n\t]* "," [ \n\t]* "\"email\"" [ \n\t]* ":" [ \n\t]* root_prop_1_prop_1 ""
 root_prop_1 ::= "{" [ \n\t]* (("\"phone\"" [ \n\t]* ":" [ \n\t]* root_prop_1_prop_0 root_prop_1_part_0)) [ \n\t]* "}"

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -375,7 +375,7 @@ xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter=" xml_variable_name ">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
 root_prop_0 ::= [^]{1,}
-root_prop_1_prop_0 ::= "\"" Regex("[0-9]{5}$") "\""
+root_prop_1_prop_0 ::= "\"" Regex("[0-9]{5}$", json_string=true) "\""
 root_prop_1_prop_1 ::= "\"" ( ( [a-zA-Z0-9_!#$%&'*+/=?^`{|}~-]+ ( "." [a-zA-Z0-9_!#$%&'*+/=?^`{|}~-]+ )* ) | "\\" "\"" ( "\\" [ -~] | [ !#-[\]-~] )* "\\" "\"" ) "@" ( [A-Za-z0-9] ( [\-A-Za-z0-9]* [A-Za-z0-9] )? ) ( ( "." [A-Za-z0-9] [\-A-Za-z0-9]* [A-Za-z0-9] )* ) "\""
 root_prop_1_part_0 ::= [ \n\t]* "," [ \n\t]* "\"email\"" [ \n\t]* ":" [ \n\t]* root_prop_1_prop_1 ""
 root_prop_1 ::= "{" [ \n\t]* (("\"phone\"" [ \n\t]* ":" [ \n\t]* root_prop_1_prop_0 root_prop_1_part_0)) [ \n\t]* "}"
@@ -794,7 +794,7 @@ xml_any ::= xml_string | basic_array | basic_object
 xml_object ::= ( [ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>" ([ \n\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\t]* xml_any [ \n\t]* "</parameter>")* [ \n\t]*) | [ \n\t]*
 xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
 root_prop_0 ::= [^]{1,}
-root_prop_1_prop_0 ::= "\"" Regex("[0-9]{5}$") "\""
+root_prop_1_prop_0 ::= "\"" Regex("[0-9]{5}$", json_string=true) "\""
 root_prop_1_prop_1 ::= "\"" ( ( [a-zA-Z0-9_!#$%&'*+/=?^`{|}~-]+ ( "." [a-zA-Z0-9_!#$%&'*+/=?^`{|}~-]+ )* ) | "\\" "\"" ( "\\" [ -~] | [ !#-[\]-~] )* "\\" "\"" ) "@" ( [A-Za-z0-9] ( [\-A-Za-z0-9]* [A-Za-z0-9] )? ) ( ( "." [A-Za-z0-9] [\-A-Za-z0-9]* [A-Za-z0-9] )* ) "\""
 root_prop_1_part_0 ::= [ \n\t]* "," [ \n\t]* "\"email\"" [ \n\t]* ":" [ \n\t]* root_prop_1_prop_1 ""
 root_prop_1 ::= "{" [ \n\t]* (("\"phone\"" [ \n\t]* ":" [ \n\t]* root_prop_1_prop_0 root_prop_1_part_0)) [ \n\t]* "}"

--- a/tests/python/test_grammar_regex_macro.py
+++ b/tests/python/test_grammar_regex_macro.py
@@ -1,0 +1,239 @@
+"""Tests the Regex(...) macro of the grammar parser, printer and matcher."""
+
+import json
+import sys
+from typing import Optional
+
+import pytest
+
+import xgrammar as xgr
+from xgrammar.testing import _ebnf_to_grammar_no_normalization, _is_grammar_accept_string
+
+
+def test_regex_macro_parse_and_print():
+    before = 'root ::= Regex("[0-9]{5}")'
+    expected = 'root ::= ((Regex("[0-9]{5}")))\n'
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+    # The printed form can be parsed again.
+    assert str(xgr.Grammar.from_ebnf(str(grammar))) == 'root ::= Regex("[0-9]{5}")\n'
+
+
+def test_regex_macro_parse_and_print_json_string():
+    before = r'root ::= Regex("\\S+", json_string=true)'
+    expected = 'root ::= ((Regex("\\\\S+", json_string=true)))\n'
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+    assert (
+        str(xgr.Grammar.from_ebnf(str(grammar))) == 'root ::= Regex("\\\\S+", json_string=true)\n'
+    )
+
+    # json_string=false is the default and is not printed.
+    before = r'root ::= Regex("\\S+", json_string=false)'
+    expected = 'root ::= ((Regex("\\\\S+")))\n'
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+def test_regex_macro_normalization():
+    # A regex is kept as the direct body of a rule.
+    grammar = xgr.Grammar.from_ebnf('root ::= Regex("[0-9]{5}")')
+    assert str(grammar) == 'root ::= Regex("[0-9]{5}")\n'
+
+    # A regex inside a sequence is extracted into a new rule.
+    grammar = xgr.Grammar.from_ebnf('root ::= "x" Regex("[0-9]+") "y"')
+    assert str(grammar) == 'root ::= (("x" root_1 "y"))\nroot_1 ::= Regex("[0-9]+")\n'
+
+
+ebnf_str__input_str__accepted__test_regex_macro_accept_string = [
+    # Literals and classes
+    ('root ::= Regex("abc")', "abc", True),
+    ('root ::= Regex("abc")', "ab", False),
+    ('root ::= Regex("abc")', "abcd", False),
+    ('root ::= Regex("[0-9]{5}")', "12345", True),
+    ('root ::= Regex("[0-9]{5}")', "1234", False),
+    ('root ::= Regex("[0-9]{5}")', "123456", False),
+    ('root ::= Regex("[a-f]{2,3}")', "ab", True),
+    ('root ::= Regex("[a-f]{2,3}")', "abc", True),
+    ('root ::= Regex("[a-f]{2,3}")', "a", False),
+    ('root ::= Regex("[a-f]{2,3}")', "abcd", False),
+    ('root ::= Regex("[0-9]{2,}")', "123456", True),
+    ('root ::= Regex("[0-9]{2,}")', "1", False),
+    ('root ::= Regex("[^a-z]")', "A", True),
+    ('root ::= Regex("[^a-z]")', "a", False),
+    # Anchors are allowed and ignored
+    ('root ::= Regex("^[0-9]+$")', "123", True),
+    ('root ::= Regex("^[0-9]+$")', "a", False),
+    # Union and grouping
+    ('root ::= Regex("a|bc|def")', "a", True),
+    ('root ::= Regex("a|bc|def")', "bc", True),
+    ('root ::= Regex("a|bc|def")', "def", True),
+    ('root ::= Regex("a|bc|def")', "b", False),
+    ('root ::= Regex("(a|b)(c|d)")', "ac", True),
+    ('root ::= Regex("(a|b)(c|d)")', "bd", True),
+    ('root ::= Regex("(a|b)(c|d)")', "ab", False),
+    # Repetition operators
+    ('root ::= Regex("a+b*c?")', "a", True),
+    ('root ::= Regex("a+b*c?")', "aabbc", True),
+    ('root ::= Regex("a+b*c?")', "bc", False),
+    ('root ::= Regex("a*")', "", True),
+    ('root ::= Regex("a*")', "aaa", True),
+    ('root ::= Regex("a*")', "b", False),
+    # The accepting state of (ab)+ has a single epsilon edge back to the start state; the
+    # simplification passes must not make the start state accepting.
+    ('root ::= Regex("(ab)+")', "", False),
+    ('root ::= Regex("(ab)+")', "a", False),
+    ('root ::= Regex("(ab)+")', "ab", True),
+    ('root ::= Regex("(ab)+")', "abab", True),
+    # Escapes
+    ('root ::= Regex("\\\\d+\\\\.\\\\d+")', "3.14", True),
+    ('root ::= Regex("\\\\d+\\\\.\\\\d+")', "3.", False),
+    ('root ::= Regex("\\\\w+")', "a_1", True),
+    ('root ::= Regex("\\\\w+")', "a b", False),
+    # . matches any byte, including multi-byte UTF-8 characters
+    ('root ::= Regex("a.c")', "abc", True),
+    ('root ::= Regex("a.c")', "a?c", True),
+    ('root ::= Regex(".+")', "你好", True),
+    # Regex used in a sequence and in choices
+    ('root ::= "x" Regex("[0-9]+") "y"', "x123y", True),
+    ('root ::= "x" Regex("[0-9]+") "y"', "xy", False),
+    ('root ::= Regex("[0-9]+") | "abc"', "123", True),
+    ('root ::= Regex("[0-9]+") | "abc"', "abc", True),
+    ('root ::= Regex("[0-9]+") | "abc"', "abd", False),
+]
+
+
+@pytest.mark.parametrize(
+    "ebnf_str, input_str, accepted", ebnf_str__input_str__accepted__test_regex_macro_accept_string
+)
+def test_regex_macro_accept_string(ebnf_str: str, input_str: str, accepted: bool):
+    grammar = xgr.Grammar.from_ebnf(ebnf_str)
+    assert _is_grammar_accept_string(grammar, input_str) == accepted
+
+
+ebnf_str__input_str__accepted__test_regex_macro_json_string = [
+    # json_string=true excludes '"', '\' and the control characters from every character
+    # match, so the regex cannot produce an unescaped quote inside a JSON string literal.
+    (r'root ::= Regex("\\S+", json_string=true)', "abc", True),
+    (r'root ::= Regex("\\S+", json_string=true)', "a.b!c", True),
+    (r'root ::= Regex("\\S+", json_string=true)', 'a"b', False),
+    (r'root ::= Regex("\\S+", json_string=true)', "a\\b", False),
+    (r'root ::= Regex("\\S+", json_string=true)', "a b", False),
+    (r'root ::= Regex(".+", json_string=true)', "ab", True),
+    (r'root ::= Regex(".+", json_string=true)', "a\tb", False),
+    (r'root ::= Regex(".+", json_string=true)', "a\nb", False),
+    (r'root ::= Regex(".+", json_string=true)', "你好", True),
+    # Without the flag, the quote, backslash and control characters are accepted.
+    (r'root ::= Regex("\\S+")', 'a"b', True),
+    (r'root ::= Regex("\\S+")', "a\\b", True),
+    (r'root ::= Regex(".+")', "a\tb", True),
+]
+
+
+@pytest.mark.parametrize(
+    "ebnf_str, input_str, accepted", ebnf_str__input_str__accepted__test_regex_macro_json_string
+)
+def test_regex_macro_json_string(ebnf_str: str, input_str: str, accepted: bool):
+    grammar = xgr.Grammar.from_ebnf(ebnf_str)
+    assert _is_grammar_accept_string(grammar, input_str) == accepted
+
+
+def test_regex_macro_nullable_rule():
+    # The allow-empty analysis must detect that the regex rule accepts the empty string.
+    grammar = xgr.Grammar.from_ebnf('root ::= r "z"\nr ::= Regex("a*")')
+    assert _is_grammar_accept_string(grammar, "z")
+    assert _is_grammar_accept_string(grammar, "aaz")
+    assert not _is_grammar_accept_string(grammar, "a")
+
+    grammar = xgr.Grammar.from_ebnf('root ::= r "z"\nr ::= Regex("a+")')
+    assert not _is_grammar_accept_string(grammar, "z")
+    assert _is_grammar_accept_string(grammar, "az")
+
+
+def test_regex_macro_serialization_roundtrip():
+    for ebnf_str in ['root ::= Regex("[0-9]{5}")', r'root ::= Regex("\\S+", json_string=true)']:
+        grammar = xgr.Grammar.from_ebnf(ebnf_str)
+        roundtrip = xgr.Grammar.deserialize_json(grammar.serialize_json())
+        assert str(roundtrip) == str(grammar)
+
+    # The json_string flag keeps its effect after the round trip.
+    grammar = xgr.Grammar.from_ebnf(r'root ::= Regex("\\S+", json_string=true)')
+    roundtrip = xgr.Grammar.deserialize_json(grammar.serialize_json())
+    assert _is_grammar_accept_string(roundtrip, "abc")
+    assert not _is_grammar_accept_string(roundtrip, 'a"b')
+
+
+ebnf_str__expected_error_regex__test_regex_macro_parser_errors = [
+    ("root ::= Regex()", "Regex expects exactly one string argument"),
+    ('root ::= Regex("a", "b")', "Regex expects exactly one string argument"),
+    ("root ::= Regex(abc)", "Regex pattern must be a string literal"),
+    ('root ::= Regex("a", foo=true)', "Regex does not support the named argument foo"),
+    ('root ::= Regex("a", json_string="yes")', "json_string must be a boolean"),
+    ('root ::= Regex("a", json_string=1)', "json_string must be a boolean"),
+]
+
+
+@pytest.mark.parametrize(
+    "ebnf_str, expected_error_regex", ebnf_str__expected_error_regex__test_regex_macro_parser_errors
+)
+def test_regex_macro_parser_errors(ebnf_str: str, expected_error_regex: Optional[str]):
+    with pytest.raises(RuntimeError, match=expected_error_regex):
+        _ebnf_to_grammar_no_normalization(ebnf_str)
+
+
+def test_regex_macro_invalid_pattern():
+    # The pattern is only compiled when the grammar automaton is built.
+    grammar = xgr.Grammar.from_ebnf('root ::= Regex("+a")')
+    with pytest.raises(RuntimeError, match="Failed to build the automaton for rule root"):
+        _is_grammar_accept_string(grammar, "a")
+
+
+def test_json_schema_pattern_uses_regex_macro():
+    schema = json.dumps({"type": "string", "pattern": "^\\S+$"})
+    grammar = xgr.Grammar.from_json_schema(schema, any_whitespace=False)
+    assert 'Regex("^\\\\S+$", json_string=true)' in str(grammar)
+    assert _is_grammar_accept_string(grammar, '"abc"')
+    assert _is_grammar_accept_string(grammar, '"a.b!c"')
+    # An unescaped quote or backslash inside the string would be invalid JSON.
+    assert not _is_grammar_accept_string(grammar, '"""')
+    assert not _is_grammar_accept_string(grammar, '"a"b"')
+    assert not _is_grammar_accept_string(grammar, '"a\\b"')
+    assert not _is_grammar_accept_string(grammar, '"a b"')
+    assert not _is_grammar_accept_string(grammar, '""')
+
+
+def test_json_schema_pattern_repetition():
+    # End-to-end check of the simplification passes on the compiled pattern automaton.
+    schema = json.dumps({"type": "string", "pattern": "^(ab)+$"})
+    grammar = xgr.Grammar.from_json_schema(schema, any_whitespace=False)
+    assert 'Regex("^(ab)+$", json_string=true)' in str(grammar)
+    assert _is_grammar_accept_string(grammar, '"abab"')
+    assert not _is_grammar_accept_string(grammar, '""')
+    assert not _is_grammar_accept_string(grammar, '"a"')
+
+
+def test_json_schema_pattern_fallback_to_cfg():
+    # A pattern that requires a literal quote cannot be matched inside a JSON string body,
+    # so the conversion falls back to the CFG expansion of the regex.
+    schema = json.dumps({"type": "string", "pattern": '^a"b$'})
+    grammar = xgr.Grammar.from_json_schema(schema, any_whitespace=False)
+    assert "Regex(" not in str(grammar)
+
+    # A pattern with non-printable-ASCII characters also falls back to the CFG expansion.
+    schema = json.dumps({"type": "string", "pattern": "^[一-龥]+$"})
+    grammar = xgr.Grammar.from_json_schema(schema, any_whitespace=False)
+    assert "Regex(" not in str(grammar)
+    assert _is_grammar_accept_string(grammar, '"你好"')
+    assert not _is_grammar_accept_string(grammar, '"ab"')
+
+
+def test_json_schema_pattern_properties():
+    schema = json.dumps({"type": "object", "patternProperties": {"^[a-z]+$": {"type": "integer"}}})
+    grammar = xgr.Grammar.from_json_schema(schema, any_whitespace=False)
+    assert "json_string=true" in str(grammar)
+    assert _is_grammar_accept_string(grammar, '{"ab": 1}')
+    assert not _is_grammar_accept_string(grammar, '{"AB": 1}')
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -44,7 +44,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v14"
+    assert xgr.get_serialization_version() == "v15"
 
 
 def test_serialize_grammar():
@@ -64,7 +64,7 @@ def test_serialize_grammar():
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v14",
+        "__VERSION__": "v15",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -84,14 +84,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v14",
+        "__VERSION__": "v15",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v14"
+    expected_json["__VERSION__"] = "v15"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -143,7 +143,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v14"}'
+        '"__VERSION__":"v15"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -258,7 +258,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v14",
+        "__VERSION__": "v15",
     }
 
     class AdaptiveTokenMask(BaseModel):


### PR DESCRIPTION
## What was done

| # | Change | Where |
|---|---|---|
| 1 | New AST node `GrammarExprType::kRegex` — holds the raw regex string like `TagDispatch` holds tags; only compiled into an automaton at the `GrammarFSMBuilder` stage; every regex rule is guaranteed a per-rule FSM (hard error otherwise) | `grammar_impl.h`, `grammar_functor.*` |
| 2 | Full plumbing: builder API `AddRegex`, EBNF macro `Regex("...")`, printer round-trip, nested-position hoisting, nullability via ε-closure, FSM hashing, serialization v14→v15 | `grammar_builder.*`, `grammar_parser.cc`, `grammar_printer.*` |
| 3 | JSON Schema wiring: `pattern` and `patternProperties` emit `Regex(...)` when the FSM engine supports the pattern, else fall back to the old CFG expansion; `format` not wired (engine gaps: lookahead silently skipped) | `json_schema_converter.cc` (uncommitted) |
| 4 | Fixed pre-existing `RegexFSMBuilder` repetition bugs: `{0,n}` behaved as `{2,n}`, `X{1,}` as `X{≥2}` | `fsm_builder.cc` |
| 5 | Fixed: `SimplifyEpsilon` merge rule not language-preserving; `\S` classes accept unescaped `"` (invalid JSON) | reported |

Tests: C++ 47/47; Python behavioral 277/277 (incl. mask-consistency goldens); 252 golden **EBNF-text** asserts need updating (output now contains `Regex(...)`); remaining full-suite failures are environmental (CUDA/HF-cache).

## Data

Full benchmark: 1,020 schemas, ~244k token steps, Qwen2.5-7B tokenizer, same machine/config both runs, 821 accepted both.

**Mask-only latency, all accepted cases:**

| | avg | p25 | p50 | p75 | p90 | p95 | p99 | p99.9 | max |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| main | 281.5 µs | 1.77 µs | 2.81 µs | 29.2 µs | 48.7 µs | 140.8 µs | 1.11 ms | 76.36 ms | 102.33 ms |
| kRegex | 46.3 µs | 1.71 µs | 2.65 µs | 28.9 µs | 47.5 µs | 100.1 µs | 772.9 µs | 2.44 ms | 17.92 ms |
| ratio | 0.16 | 0.97 | 0.94 | 0.99 | 0.97 | 0.71 | 0.69 | **0.032** | 0.175 |

Total (mask+accept) p99: 1.13 ms → 786.6 µs; p99.9: 76.38 ms → 2.59 ms. Compile: flat (avg 984→983 ms, p99 23.3→19.9 s). CFG suite unchanged.

**Biggest per-case wins (max mask step):**

| Case family | main | kRegex | Speedup |
|---|---:|---:|---:|
| `(\S+\s+){0,9}\S+` bounded repetition (o62058/59/60) | 92–102 ms | 0.29–0.88 ms | 116–343× |
| patternProperties BCP-47 regex keys (o76654/o36264) | 17.3–17.4 ms | ~0.2 ms | ~87× |
| base64 pattern (o64727) | 15.4 ms | 0.17 ms | 90× |
| wide required objects (custom ×3) | ~2.0 ms | ~0.17 ms | 11× |

Isolated microbenchmark on the worst pattern: 62 ms → 0.01 ms per token (~6000×); plus 2 valid-value rejections fixed (o45313/o89915).

Remaining tail is non-regex (wide `anyOf` 17.9 ms, large enums 9–17 ms, numeric ranges 8.6 ms) — next targets: token-aware literal alternations, per-stateset mask caching.
