### PR TITLE
fix: accept stop token when it completes the grammar

### DIFF
--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -524,6 +524,13 @@ class GrammarMatcher::Impl : public EarleyParser {
    */
   bool StopTokenCompletesGrammar(int32_t token_id);
 
+  /*!
+   * \brief Decide, for every stop token, whether it may be emitted at the current position, and
+   * write that decision into the bitmask. Overrides whatever the grammar-level mask decided, since
+   * emitting a stop token ends generation.
+   */
+  void ApplyStopTokenPolicy(DynamicBitset* next_token_bitset, bool can_reach_end);
+
   bool IsStopTokenAccepted() const;
 
   /*! \brief Check if the token bitmask is all-true. */
@@ -1110,13 +1117,7 @@ void GrammarMatcher::Impl::SetTokenBitmask(
       }
     }
 
-    // Add the stop tokens when the grammar is completed, or when the stop token is itself a
-    // grammar terminal that completes the grammar
-    for (int id : stop_token_ids_) {
-      if (can_reach_end || StopTokenCompletesGrammar(id)) {
-        next_token_bitset.Set(id, true);
-      }
-    }
+    ApplyStopTokenPolicy(&next_token_bitset, can_reach_end);
   } else {
     // Otherwise, the final rejected token set is (rejected_indices \ accepted_indices)
     next_token_bitset.Set();
@@ -1132,12 +1133,19 @@ void GrammarMatcher::Impl::SetTokenBitmask(
         next_token_bitset.Set(id, false);
       }
     }
-    // If the grammar is not completed, only keep the stop tokens that complete the grammar
-    if (!can_reach_end) {
-      for (int id : stop_token_ids_) {
-        next_token_bitset.Set(id, StopTokenCompletesGrammar(id));
-      }
-    }
+    ApplyStopTokenPolicy(&next_token_bitset, can_reach_end);
+  }
+}
+
+void GrammarMatcher::Impl::ApplyStopTokenPolicy(
+    DynamicBitset* next_token_bitset, bool can_reach_end
+) {
+  // Stop tokens are part of the matchable vocabulary, so the mask above may already allow one as
+  // ordinary text. That is not enough: emitting a stop token ends generation, so it is only
+  // allowed when the grammar is complete, or when consuming it as a terminal completes the
+  // grammar. Otherwise the output would be truncated, so the decision is overridden here.
+  for (int id : stop_token_ids_) {
+    next_token_bitset->Set(id, can_reach_end || StopTokenCompletesGrammar(id));
   }
 }
 

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -461,6 +461,15 @@ class GrammarMatcher::Impl : public EarleyParser {
         tmp_accepted_bitset_(tokenizer_info_.GetVocabSize()) {
     XGRAMMAR_CHECK(!override_stop_tokens.has_value() || !override_stop_tokens->empty())
         << "The override_stop_tokens should not be empty";
+    all_stop_token_bits_ = stop_token_ids_.size() >= kMaxTrialStopTokens
+                               ? ~uint64_t{0}
+                               : (uint64_t{1} << stop_token_ids_.size()) - 1;
+    if (stop_token_ids_.size() > kMaxTrialStopTokens) {
+      XGRAMMAR_LOG(WARNING) << "More than " << kMaxTrialStopTokens << " stop tokens are used. "
+                            << "Only the first " << kMaxTrialStopTokens << " can be accepted as "
+                            << "grammar terminals; the rest are only allowed when the grammar is "
+                            << "already completed.";
+    }
   }
 
   bool AcceptToken(int32_t token_id, bool debug_print = false);
@@ -475,7 +484,10 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   bool IsTerminated() const;
 
-  void Reset() { EarleyParser::Reset(); }
+  void Reset() {
+    EarleyParser::Reset();
+    stop_token_trial_memo_.clear();
+  }
 
   int GetMaxRollbackTokens() const { return -1; }
 
@@ -516,20 +528,57 @@ class GrammarMatcher::Impl : public EarleyParser {
   bool AcceptStopToken();
 
   /*!
-   * \brief Check if consuming the given token as a grammar terminal completes the grammar, via a
-   * trial advance that is rolled back. This handles tokens that are both a stop token and a
-   * grammar terminal, e.g. harmony's <|return|>. Completion is required since stopping
-   * mid-grammar would emit a truncated output.
-   * \returns Whether the grammar can consume the token and is completed afterwards.
-   */
-  bool StopTokenCompletesGrammar(int32_t token_id);
-
-  /*!
    * \brief Decide, for every stop token, whether it may be emitted at the current position, and
    * write that decision into the bitmask. Overrides whatever the grammar-level mask decided, since
-   * emitting a stop token ends generation.
+   * emitting a stop token ends generation. When terminate_without_stop_token_ is true, stop
+   * tokens are ordinary tokens and the grammar-level decision is kept as is.
    */
   void ApplyStopTokenPolicy(DynamicBitset* next_token_bitset, bool can_reach_end);
+
+  /*!
+   * \brief The memoization key for GetStopTokenCompleteBits.
+   */
+  struct StopTokenTrialKey {
+    ParserState state;
+    std::vector<ParserState> parents;
+
+    bool operator==(const StopTokenTrialKey& other) const {
+      StateEqualForParsing eq;
+      if (!eq(state, other.state) || parents.size() != other.parents.size()) {
+        return false;
+      }
+      for (size_t i = 0; i < parents.size(); ++i) {
+        if (!eq(parents[i], other.parents[i])) {
+          return false;
+        }
+      }
+      return true;
+    }
+  };
+
+  struct StopTokenTrialKeyHash {
+    size_t operator()(const StopTokenTrialKey& key) const {
+      StateHashForParsing state_hash;
+      size_t result = state_hash(key.state);
+      for (const auto& parent : key.parents) {
+        result = HashCombine(result, state_hash(parent));
+      }
+      return result;
+    }
+  };
+
+  /*! \brief Build the memoization key for the given state into tmp_trial_key_. */
+  void BuildStopTokenTrialKey(const ParserState& state);
+
+  /*!
+   * \brief Check, for every stop token, whether consuming it as a grammar terminal from the given
+   * state completes the grammar, via a trial advance that is rolled back. This handles tokens
+   * that are both a stop token and a grammar terminal, e.g. harmony's <|return|>.
+   * \returns A bitset where bit i corresponds to stop_token_ids_[i], covering at most the first
+   * 64 (kMaxTrialStopTokens) stop tokens.
+   * \details Results are memoized per state in stop_token_trial_memo_.
+   */
+  uint64_t GetStopTokenCompleteBits(const ParserState& state);
 
   bool IsStopTokenAccepted() const;
 
@@ -544,10 +593,24 @@ class GrammarMatcher::Impl : public EarleyParser {
   bool terminate_without_stop_token_;
   std::deque<int> token_length_history;
 
+  /*! \brief How many stop tokens can get completion trials, bounded by the width of the bitset
+   * used to store the trial results. Stop tokens beyond this limit are allowed only when the
+   * grammar is already completed. */
+  static constexpr size_t kMaxTrialStopTokens = 64;
+
+  /*! \brief All the bits GetStopTokenCompleteBits can ever set, i.e. one per stop token, where
+   * bit i corresponds to stop_token_ids_[i]. Only the first kMaxTrialStopTokens are covered. */
+  uint64_t all_stop_token_bits_ = 0;
+
+  /*! \brief Memoized results of GetStopTokenCompleteBits. Must be cleared by Rollback() and
+   * Reset(), since they remove parser state history that the results may depend on. */
+  std::unordered_map<StopTokenTrialKey, uint64_t, StopTokenTrialKeyHash> stop_token_trial_memo_;
+
   // Temporary data for FillNextTokenBitmask. They are stored here to avoid repeated allocation.
   DynamicBitset tmp_accepted_bitset_;
   std::vector<int32_t> tmp_rejected_indices_;
   std::vector<int32_t> tmp_rejected_indices_delta_;
+  StopTokenTrialKey tmp_trial_key_;
 };
 
 class BatchGrammarMatcher::Impl {
@@ -613,39 +676,66 @@ bool GrammarMatcher::Impl::AcceptStopToken() {
   return true;
 }
 
-bool GrammarMatcher::Impl::StopTokenCompletesGrammar(int32_t token_id) {
-  // override_stop_tokens may contain a padded id out of the decoded vocab range.
+void GrammarMatcher::Impl::BuildStopTokenTrialKey(const ParserState& state) {
+  tmp_trial_key_.state = state;
+  tmp_trial_key_.parents.clear();
+  if (state.rule_start_pos != ParserState::kNoPrevInputPos) {
+    // Erase rule_start_pos: the position itself does not matter, only the parent chain it
+    // points to, which is collected below.
+    tmp_trial_key_.state.rule_start_pos = 0;
+    const auto& parent_states_map = rule_id_to_completable_states_[state.rule_start_pos];
+    for (const auto& [ref_id, parent_state] : parent_states_map) {
+      if (ref_id == state.rule_id) {
+        tmp_trial_key_.parents.push_back(parent_state);
+      }
+    }
+  }
+}
+
+uint64_t GrammarMatcher::Impl::GetStopTokenCompleteBits(const ParserState& state) {
+  BuildStopTokenTrialKey(state);
+  auto it = stop_token_trial_memo_.find(tmp_trial_key_);
+  if (it != stop_token_trial_memo_.end()) {
+    return it->second;
+  }
+
+  uint64_t complete_bits = 0;
   const auto& decoded_vocab = tokenizer_info_.GetDecodedVocab();
-  if (token_id < 0 || token_id >= static_cast<int32_t>(decoded_vocab.size())) {
-    return false;
-  }
-
-  // Try the atomic (token-level) path first, then the byte path, mirroring AcceptToken.
-  if (AdvanceAtomicToken(token_id)) {
-    const bool completed = IsCompleted();
-    PopLastStates(1);
-    if (completed) {
-      return true;
+  int num_tokens = static_cast<int>(std::min(stop_token_ids_.size(), kMaxTrialStopTokens));
+  for (int i = 0; i < num_tokens; ++i) {
+    int32_t token_id = stop_token_ids_[i];
+    // override_stop_tokens may contain a padded id out of the decoded vocab range.
+    if (token_id < 0 || token_id >= static_cast<int32_t>(decoded_vocab.size())) {
+      continue;
+    }
+    bool complete = false;
+    PushOneStateToCheck(state);
+    // Try the atomic (token-level) path first, then the byte path, mirroring AcceptToken.
+    if (AdvanceAtomicToken(token_id)) {
+      complete = is_completed_.back();
+      PopLastStates(1);
+    }
+    const auto& token = decoded_vocab[token_id];
+    int num_advanced_chars = 0;
+    bool consumed = true;
+    for (auto char_value : token) {
+      if (!Advance(char_value)) {
+        consumed = false;
+        break;
+      }
+      ++num_advanced_chars;
+    }
+    // An empty token consumes nothing, so it cannot newly complete the grammar; that case is
+    // covered by can_reach_end in ApplyStopTokenPolicy.
+    if (consumed && !token.empty()) {
+      complete = complete || is_completed_.back();
+    }
+    PopLastStates(num_advanced_chars + 1);
+    if (complete) {
+      complete_bits |= uint64_t{1} << i;
     }
   }
-
-  const auto& token = decoded_vocab[token_id];
-  if (token.empty()) {
-    return false;
-  }
-
-  int pos = 0;
-  bool consumed = true;
-  for (auto char_value : token) {
-    if (!Advance(char_value)) {
-      consumed = false;
-      break;
-    }
-    ++pos;
-  }
-  const bool completed = consumed && IsCompleted();
-  PopLastStates(pos);
-  return completed;
+  return stop_token_trial_memo_.emplace(tmp_trial_key_, complete_bits).first->second;
 }
 
 bool GrammarMatcher::Impl::IsTerminated() const {
@@ -683,14 +773,28 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   }
   // Handle the stop token. If the grammar cannot terminate here, fall through: the token may
   // also be a grammar terminal (e.g. harmony's <|return|>) matched by the paths below.
-  if (std::find(stop_token_ids_.begin(), stop_token_ids_.end(), token_id) !=
-      stop_token_ids_.end()) {
+  // When terminate_without_stop_token_ is true, stop tokens are not termination signals and are
+  // matched as ordinary text.
+  bool is_stop_token_as_terminal = false;
+  auto stop_token_it = std::find(stop_token_ids_.begin(), stop_token_ids_.end(), token_id);
+  if (stop_token_it != stop_token_ids_.end() && !terminate_without_stop_token_) {
     if (AcceptStopToken()) {
       if (debug_print) {
         XGRAMMAR_LOG(INFO) << "The token is an end token. Is accepted: true";
       }
       return true;
     }
+    if (static_cast<size_t>(stop_token_it - stop_token_ids_.begin()) >= kMaxTrialStopTokens) {
+      // Only the first kMaxTrialStopTokens stop tokens get completion trials in the mask, so
+      // beyond that a stop token is allowed only when the grammar is already completed. Reject
+      // here as well, to stay consistent with the mask.
+      if (debug_print) {
+        XGRAMMAR_LOG(INFO) << "The token is an end token beyond the first " << kMaxTrialStopTokens
+                           << " ones, and the grammar cannot terminate here. Rejecting the token.";
+      }
+      return false;
+    }
+    is_stop_token_as_terminal = true;
     if (debug_print) {
       XGRAMMAR_LOG(INFO) << "The token is an end token, but the grammar cannot terminate here. "
                          << "Trying to match it as a grammar terminal.";
@@ -788,6 +892,23 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
       is_completed_.push_back(byte_completed || atomic_completed);
       token_length_history.push_back(token.size());
     }
+  }
+
+  if (is_stop_token_as_terminal) {
+    // Emitting a stop token ends generation, so consuming it as a grammar terminal is only
+    // valid when the grammar is completed afterwards; otherwise the output would be truncated.
+    // This mirrors ApplyStopTokenPolicy, keeping accept_token consistent with the mask.
+    if (!IsCompleted()) {
+      PopLastStates(token_length_history.back());
+      token_length_history.pop_back();
+      if (debug_print) {
+        XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<" << EscapeString(token)
+                           << "> is an end token and matches the grammar, but does not complete "
+                           << "it. Rejecting the token.";
+      }
+      return false;
+    }
+    stop_token_is_accepted_ = true;
   }
 
   if (debug_print) {
@@ -1087,6 +1208,7 @@ void GrammarMatcher::Impl::Rollback(int num_tokens) {
     token_length_history.pop_back();
     --num_tokens;
   }
+  stop_token_trial_memo_.clear();
 }
 
 void GrammarMatcher::Impl::SetTokenBitmask(
@@ -1140,12 +1262,39 @@ void GrammarMatcher::Impl::SetTokenBitmask(
 void GrammarMatcher::Impl::ApplyStopTokenPolicy(
     DynamicBitset* next_token_bitset, bool can_reach_end
 ) {
+  if (terminate_without_stop_token_) {
+    // The grammar-level mask above already decided their bits
+    return;
+  }
+
   // Stop tokens are part of the matchable vocabulary, so the mask above may already allow one as
   // ordinary text. That is not enough: emitting a stop token ends generation, so it is only
   // allowed when the grammar is complete, or when consuming it as a terminal completes the
   // grammar. Otherwise the output would be truncated, so the decision is overridden here.
-  for (int id : stop_token_ids_) {
-    next_token_bitset->Set(id, can_reach_end || StopTokenCompletesGrammar(id));
+  uint64_t complete_bits = 0;
+  if (!can_reach_end && all_stop_token_bits_ != 0) {
+    int num_latest_states = scanable_state_history_[scanable_state_history_.size() - 1].size();
+    for (int i = 0; i < num_latest_states; ++i) {
+      ParserState state = scanable_state_history_[scanable_state_history_.size() - 1][i];
+      complete_bits |= GetStopTokenCompleteBits(state);
+      // Stop early once every stop token is known to complete the grammar.
+      if ((complete_bits & all_stop_token_bits_) == all_stop_token_bits_) {
+        break;
+      }
+    }
+  }
+
+  for (size_t i = 0; i < stop_token_ids_.size(); ++i) {
+    int id = stop_token_ids_[i];
+    // Due to override_stop_tokens, a stop token id may be out of the vocabulary range;
+    // Ignore them.
+    if (id < 0 || id >= tokenizer_info_.GetVocabSize()) {
+      continue;
+    }
+    // Stop tokens beyond kMaxTrialStopTokens fall back to being allowed only at completion.
+    bool allowed =
+        can_reach_end || (i < kMaxTrialStopTokens && ((complete_bits >> i) & 1) != 0);
+    next_token_bitset->Set(id, allowed);
   }
 }
 

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -515,6 +515,15 @@ class GrammarMatcher::Impl : public EarleyParser {
    */
   bool AcceptStopToken();
 
+  /*!
+   * \brief Check if consuming the given token as a grammar terminal completes the grammar, via a
+   * trial advance that is rolled back. This handles tokens that are both a stop token and a
+   * grammar terminal, e.g. harmony's <|return|>. Completion is required since stopping
+   * mid-grammar would emit a truncated output.
+   * \returns Whether the grammar can consume the token and is completed afterwards.
+   */
+  bool StopTokenCompletesGrammar(int32_t token_id);
+
   bool IsStopTokenAccepted() const;
 
   /*! \brief Check if the token bitmask is all-true. */
@@ -597,6 +606,41 @@ bool GrammarMatcher::Impl::AcceptStopToken() {
   return true;
 }
 
+bool GrammarMatcher::Impl::StopTokenCompletesGrammar(int32_t token_id) {
+  // override_stop_tokens may contain a padded id out of the decoded vocab range.
+  const auto& decoded_vocab = tokenizer_info_.GetDecodedVocab();
+  if (token_id < 0 || token_id >= static_cast<int32_t>(decoded_vocab.size())) {
+    return false;
+  }
+
+  // Try the atomic (token-level) path first, then the byte path, mirroring AcceptToken.
+  if (AdvanceAtomicToken(token_id)) {
+    const bool completed = IsCompleted();
+    PopLastStates(1);
+    if (completed) {
+      return true;
+    }
+  }
+
+  const auto& token = decoded_vocab[token_id];
+  if (token.empty()) {
+    return false;
+  }
+
+  int pos = 0;
+  bool consumed = true;
+  for (auto char_value : token) {
+    if (!Advance(char_value)) {
+      consumed = false;
+      break;
+    }
+    ++pos;
+  }
+  const bool completed = consumed && IsCompleted();
+  PopLastStates(pos);
+  return completed;
+}
+
 bool GrammarMatcher::Impl::IsTerminated() const {
   if (terminate_without_stop_token_) {
     return IsCompleted();
@@ -630,14 +674,20 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
                        << "\", current state:\n"
                        << states_str;
   }
-  // Handle the stop token
+  // Handle the stop token. If the grammar cannot terminate here, fall through: the token may
+  // also be a grammar terminal (e.g. harmony's <|return|>) matched by the paths below.
   if (std::find(stop_token_ids_.begin(), stop_token_ids_.end(), token_id) !=
       stop_token_ids_.end()) {
-    bool accepted = AcceptStopToken();
-    if (debug_print) {
-      XGRAMMAR_LOG(INFO) << "The token is an end token. Is accepted: " << accepted;
+    if (AcceptStopToken()) {
+      if (debug_print) {
+        XGRAMMAR_LOG(INFO) << "The token is an end token. Is accepted: true";
+      }
+      return true;
     }
-    return accepted;
+    if (debug_print) {
+      XGRAMMAR_LOG(INFO) << "The token is an end token, but the grammar cannot terminate here. "
+                         << "Trying to match it as a grammar terminal.";
+    }
   }
 
   const auto& special_token_ids = tokenizer_info_.GetSpecialTokenIds();
@@ -1060,9 +1110,10 @@ void GrammarMatcher::Impl::SetTokenBitmask(
       }
     }
 
-    if (can_reach_end) {
-      // add end tokens
-      for (int id : stop_token_ids_) {
+    // Add the stop tokens when the grammar is completed, or when the stop token is itself a
+    // grammar terminal that completes the grammar
+    for (int id : stop_token_ids_) {
+      if (can_reach_end || StopTokenCompletesGrammar(id)) {
         next_token_bitset.Set(id, true);
       }
     }
@@ -1081,9 +1132,10 @@ void GrammarMatcher::Impl::SetTokenBitmask(
         next_token_bitset.Set(id, false);
       }
     }
+    // If the grammar is not completed, only keep the stop tokens that complete the grammar
     if (!can_reach_end) {
       for (int id : stop_token_ids_) {
-        next_token_bitset.Set(id, false);
+        next_token_bitset.Set(id, StopTokenCompletesGrammar(id));
       }
     }
   }

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -1292,8 +1292,7 @@ void GrammarMatcher::Impl::ApplyStopTokenPolicy(
       continue;
     }
     // Stop tokens beyond kMaxTrialStopTokens fall back to being allowed only at completion.
-    bool allowed =
-        can_reach_end || (i < kMaxTrialStopTokens && ((complete_bits >> i) & 1) != 0);
+    bool allowed = can_reach_end || (i < kMaxTrialStopTokens && ((complete_bits >> i) & 1) != 0);
     next_token_bitset->Set(id, allowed);
   }
 }

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v14";
+  static constexpr const char kXGrammarSerializeVersion[] = "v15";
 };
 
 /*!

--- a/cpp/tokenizer_info.cc
+++ b/cpp/tokenizer_info.cc
@@ -282,7 +282,12 @@ TokenizerInfo::Impl::Impl(
         (stop_token_ids &&
          std::find(stop_token_ids->begin(), stop_token_ids->end(), i) != stop_token_ids->end())) {
       stop_token_ids_.push_back(i);
-    } else if (IsSpecialToken(token)) {
+    }
+    // A stop token is kept in the matchable vocabulary as well: it may be a terminal that the
+    // grammar must consume (e.g. harmony's <|return|>, which closes the final-message tag).
+    // Whether a stop token may actually be emitted at a given position is decided by the matcher,
+    // which is the only layer that knows the effective stop token set (override_stop_tokens).
+    if (IsSpecialToken(token)) {
       special_token_ids_.push_back(i);
     } else {
       sorted_decoded_vocab_.push_back({i, token});

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -611,6 +611,7 @@ def _mask_allows(matcher, token_id):
     return bool((bitmask[0][token_id >> 5] >> (token_id & 31)) & 1)
 
 
+@pytest.mark.hf_token_required
 def test_stop_token_as_grammar_terminal_harmony():
     """<|return|> closes the harmony final-message tag and must be accepted."""
     from xgrammar.builtin_structural_tag import get_harmony_structural_tag
@@ -632,6 +633,7 @@ def test_stop_token_as_grammar_terminal_harmony():
     assert matcher.is_terminated()
 
 
+@pytest.mark.hf_token_required
 def test_stop_token_as_grammar_terminal_mask_matches_accept():
     """The mask and accept_token must agree for an overridden stop token."""
     from xgrammar.structural_tag import (
@@ -672,6 +674,7 @@ def test_stop_token_as_grammar_terminal_mask_matches_accept():
     assert matcher.is_terminated()
 
 
+@pytest.mark.hf_token_required
 def test_stop_token_masked_out_when_it_would_truncate():
     """A stop token is only allowed when emitting it leaves a complete grammar."""
     _, tokenizer_info = _gpt_oss_tokenizer_info()
@@ -701,6 +704,7 @@ def test_stop_token_masked_out_when_it_would_truncate():
     assert matcher.is_terminated()
 
 
+@pytest.mark.hf_token_required
 def test_stop_token_as_grammar_terminal_rollback():
     """Rolling back an accepted dual-role stop token restores the matcher."""
     from xgrammar.builtin_structural_tag import get_harmony_structural_tag

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -591,5 +591,106 @@ def test_tag_dispatch_perf(ebnf, input_str):
     print(f"Accept token: avg={statistics.mean(flat_accept):.2f} us, max={max(flat_accept):.2f} us")
 
 
+# A token can be both a stop token and a grammar terminal, e.g. gpt-oss's <|return|> ends
+# generation and also closes harmony's final-message tag. The tests are token-level because
+# accept_string bypasses the stop token handling.
+_GPT_OSS_MODEL = "openai/gpt-oss-20b"
+_GPT_OSS_VOCAB_SIZE = 200019
+_RETURN_TOKEN = 200002  # <|return|>: gpt-oss stop token, and a harmony tag terminal
+_CALL_TOKEN = 200012  # <|call|>: terminal closing a harmony tool call
+
+
+def _gpt_oss_tokenizer_info():
+    tokenizer = AutoTokenizer.from_pretrained(_GPT_OSS_MODEL)
+    return tokenizer, xgr.TokenizerInfo.from_huggingface(tokenizer, vocab_size=_GPT_OSS_VOCAB_SIZE)
+
+
+def _mask_allows(matcher, token_id):
+    bitmask = xgr.allocate_token_bitmask(1, _GPT_OSS_VOCAB_SIZE)
+    matcher.fill_next_token_bitmask(bitmask)
+    return bool((bitmask[0][token_id >> 5] >> (token_id & 31)) & 1)
+
+
+def test_stop_token_as_grammar_terminal_harmony():
+    """<|return|> closes the harmony final-message tag and must be accepted."""
+    from xgrammar.builtin_structural_tag import get_harmony_structural_tag
+
+    tokenizer, tokenizer_info = _gpt_oss_tokenizer_info()
+    # Check that the tag terminal <|return|> is also a stop token
+    assert _RETURN_TOKEN in tokenizer_info.stop_token_ids
+
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_structural_tag(
+        get_harmony_structural_tag(tools=[], reasoning=False)
+    )
+    matcher = xgr.GrammarMatcher(compiled)
+
+    output = "<|channel|>final<|message|>ok<|return|>"
+    for token in tokenizer.encode(output, add_special_tokens=False):
+        assert _mask_allows(matcher, token), f"token {token} masked out"
+        assert matcher.accept_token(token), f"token {token} rejected"
+
+
+def test_stop_token_as_grammar_terminal_mask_matches_accept():
+    """The mask and accept_token must agree for an overridden stop token."""
+    from xgrammar.structural_tag import (
+        JSONSchemaFormat,
+        StructuralTag,
+        TagFormat,
+        TagsWithSeparatorFormat,
+    )
+
+    tokenizer, tokenizer_info = _gpt_oss_tokenizer_info()
+    schema = {"type": "object", "properties": {"bar": {"type": "string"}}, "required": ["bar"]}
+    tag = StructuralTag(
+        format=TagsWithSeparatorFormat(
+            tags=[
+                TagFormat(
+                    begin="<|channel|>commentary to=functions.foo<|constrain|>json<|message|>",
+                    content=JSONSchemaFormat(json_schema=schema),
+                    end="<|call|>",
+                )
+            ],
+            separator="<|start|>assistant",
+        )
+    )
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_structural_tag(tag)
+    # <|call|> is a stop token only because of the override, so it stays in the matchable
+    # vocabulary; accept_token should agree with the mask
+    matcher = xgr.GrammarMatcher(compiled, override_stop_tokens=[_RETURN_TOKEN, _CALL_TOKEN])
+
+    output = (
+        "<|channel|>commentary to=functions.foo<|constrain|>json<|message|>" '{"bar":"ok"}<|call|>'
+    )
+    for token in tokenizer.encode(output, add_special_tokens=False):
+        allowed = _mask_allows(matcher, token)
+        accepted = matcher.accept_token(token)
+        assert allowed == accepted, f"mask/accept disagree on token {token}"
+        assert accepted, f"token {token} rejected"
+
+
+def test_stop_token_masked_out_when_it_would_truncate():
+    """A stop token is only allowed when emitting it leaves a complete grammar."""
+    _, tokenizer_info = _gpt_oss_tokenizer_info()
+    schema = {"type": "object", "properties": {"bar": {"type": "string"}}, "required": ["bar"]}
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_json_schema(schema)
+
+    # A JSON string can contain the literal text "<|return|>", so the grammar can consume
+    # those bytes, but stopping there would emit truncated JSON
+    probe = xgr.GrammarMatcher(compiled)
+    assert probe.accept_string('{"bar": "')
+    assert probe.accept_string("<|return|>")
+
+    matcher = xgr.GrammarMatcher(compiled)
+    assert matcher.accept_string('{"bar": "')
+    assert not _mask_allows(matcher, _RETURN_TOKEN)
+
+    # Once the JSON is complete, the stop token is allowed and terminates the matcher
+    matcher = xgr.GrammarMatcher(compiled)
+    assert matcher.accept_string('{"bar": "ok"}')
+    assert _mask_allows(matcher, _RETURN_TOKEN)
+    assert matcher.accept_token(_RETURN_TOKEN)
+    assert matcher.is_terminated()
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -628,6 +628,8 @@ def test_stop_token_as_grammar_terminal_harmony():
     for token in tokenizer.encode(output, add_special_tokens=False):
         assert _mask_allows(matcher, token), f"token {token} masked out"
         assert matcher.accept_token(token), f"token {token} rejected"
+    # Emitting the stop token ends generation, so the matcher must be terminated
+    assert matcher.is_terminated()
 
 
 def test_stop_token_as_grammar_terminal_mask_matches_accept():
@@ -666,6 +668,8 @@ def test_stop_token_as_grammar_terminal_mask_matches_accept():
         accepted = matcher.accept_token(token)
         assert allowed == accepted, f"mask/accept disagree on token {token}"
         assert accepted, f"token {token} rejected"
+    # Emitting the stop token ends generation, so the matcher must be terminated
+    assert matcher.is_terminated()
 
 
 def test_stop_token_masked_out_when_it_would_truncate():
@@ -683,10 +687,37 @@ def test_stop_token_masked_out_when_it_would_truncate():
     matcher = xgr.GrammarMatcher(compiled)
     assert matcher.accept_string('{"bar": "')
     assert not _mask_allows(matcher, _RETURN_TOKEN)
+    # accept_token must agree with the mask: the token matches the grammar as text, but
+    # accepting it would truncate the output
+    assert not matcher.accept_token(_RETURN_TOKEN)
+    # The rejection must not corrupt the matcher state
+    assert matcher.accept_string('ok"}')
 
     # Once the JSON is complete, the stop token is allowed and terminates the matcher
     matcher = xgr.GrammarMatcher(compiled)
     assert matcher.accept_string('{"bar": "ok"}')
+    assert _mask_allows(matcher, _RETURN_TOKEN)
+    assert matcher.accept_token(_RETURN_TOKEN)
+    assert matcher.is_terminated()
+
+
+def test_stop_token_as_grammar_terminal_rollback():
+    """Rolling back an accepted dual-role stop token restores the matcher."""
+    from xgrammar.builtin_structural_tag import get_harmony_structural_tag
+
+    tokenizer, tokenizer_info = _gpt_oss_tokenizer_info()
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_structural_tag(
+        get_harmony_structural_tag(tools=[], reasoning=False)
+    )
+    matcher = xgr.GrammarMatcher(compiled)
+    for token in tokenizer.encode("<|channel|>final<|message|>ok", add_special_tokens=False):
+        assert matcher.accept_token(token)
+
+    assert matcher.accept_token(_RETURN_TOKEN)
+    assert matcher.is_terminated()
+
+    matcher.rollback(1)
+    assert not matcher.is_terminated()
     assert _mask_allows(matcher, _RETURN_TOKEN)
     assert matcher.accept_token(_RETURN_TOKEN)
     assert matcher.is_terminated()

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -44,7 +44,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v14"
+    assert xgr.get_serialization_version() == "v15"
 
 
 def test_serialize_grammar():
@@ -64,7 +64,7 @@ def test_serialize_grammar():
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v14",
+        "__VERSION__": "v15",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -84,14 +84,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v14",
+        "__VERSION__": "v15",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v14"
+    expected_json["__VERSION__"] = "v15"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -141,9 +141,10 @@ def test_serialize_tokenizer_info():
         '{"vocab_type":1,"vocab_size":10,"add_prefix_space":true,'
         '"stop_token_ids":[0,1],"special_token_ids":[9],'
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
-        '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
-        '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v14"}'
+        '"sorted_decoded_vocab":[[6,"-"],[0,"1"],[1,"212"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],'
+        '[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
+        '"trie_subtree_nodes_range":[1,3,3,4,7,6,7,8,9],'
+        '"__VERSION__":"v15"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -258,7 +259,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v14",
+        "__VERSION__": "v15",
     }
 
     class AdaptiveTokenMask(BaseModel):


### PR DESCRIPTION
Fixes #701 

Allow a stop token iff the grammar is already complete, or consuming its text as a grammar terminal completes the grammar. 

## Summary of changes

- Keep stop tokens in `sorted_decoded_vocab_` and bump serialization to v15. Whether they are allowed is decided in the matcher.
- Added a new method `ApplyStopTokenPolicy`, which overrides the stop tokens' mask bits with the decision made by the matcher. The same rule applies to `accept_token`.
- The completion check is memoized, by state (without `rule_start_pos`) and its parent states.


## Benchmark

Ran `cibench_grammar_compile_mask_gen.py` with two tweaks (removing the `.cuda()` calls for my environment, and hardcoding the gorilla BFCL URLs). There are still some failing cases, but they fail equally on main and this PR. If there is another recommended way to measure performance, please let me know.

main:
```
===== XGrammar Benchmark Results =====
Model: meta-llama/Llama-3.1-8B-Instruct
Iterations: 5
Warmup Iterations: 1

Dataset: json-mode-eval
Successful data points: 98 / 99
Failed data points: 1 / 99
Grammar compilation time (ms): 19.1632
Per token overhead (us/token): 322.8906

Dataset: gorilla-bfcl
Successful data points: 694 / 750
Failed data points: 54 / 750
Grammar compilation time (ms): 16.4314
Per token overhead (us/token): 414.0011
```

This PR:
```
===== XGrammar Benchmark Results =====
Model: meta-llama/Llama-3.1-8B-Instruct
Iterations: 5
Warmup Iterations: 1

Dataset: json-mode-eval
Successful data points: 98 / 99
Failed data points: 1 / 99
Grammar compilation time (ms): 19.2090
Per token overhead (us/token): 323.8432

Dataset: gorilla-bfcl
Successful data points: 694 / 750
Failed data points: 54 / 750
Grammar compilation time (ms): 16.4690
Per token overhead (us/token): 415.2750
```