### PR TITLE
Reduce first-time grammar compilation cost

### DIFF
--- a/cpp/ebnf_script_creator.h
+++ b/cpp/ebnf_script_creator.h
@@ -162,6 +162,9 @@ class EBNFScriptCreator {
     return script;
   }
 
+  /*! \brief Get generated rules without materializing a combined EBNF script. */
+  const std::vector<std::pair<std::string, std::string>>& GetRules() const { return rules_; }
+
   /*!
    * \brief Retrieves the content/definition of a specific rule
    * \param rule_name The name of the rule to look up

--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -51,6 +51,12 @@ Grammar Grammar::FromJSONSchema(
     bool print_converted_ebnf,
     bool any_order
 ) {
+  if (!print_converted_ebnf) {
+    auto grammar = JSONSchemaToGrammar(
+        schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+    );
+    return GrammarNormalizer().Apply(grammar);
+  }
   auto ebnf_string = JSONSchemaToEBNF(
       schema,
       any_whitespace,

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -22,6 +22,7 @@
 #include "fsm.h"
 #include "grammar_functor.h"
 #include "grammar_impl.h"
+#include "support/aho_corasick.h"
 #include "support/dynamic_bitset.h"
 #include "support/int_set.h"
 #include "support/logging.h"
@@ -1194,9 +1195,16 @@ void GrammarCompilerSub::TagDispatchOptimization(
     Grammar::Impl::TagDispatch tag_dispatch =
         compiled_grammar_impl->GetGrammar()->GetTagDispatch(rule.body_expr_id);
     const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
+    std::vector<std::string> patterns;
+    patterns.reserve(tag_dispatch.tag_rule_pairs.size() + tag_dispatch.excludes.size());
+    for (const auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
+      patterns.push_back(trigger);
+    }
+    patterns.insert(patterns.end(), tag_dispatch.excludes.begin(), tag_dispatch.excludes.end());
+    AhoCorasick matcher(patterns);
+
     DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
     for (int j = 0; j < static_cast<int32_t>(sorted_decoded_vocab.size()); j++) {
-      bool definite_accept_since_second_char = true;
       const auto& token = sorted_decoded_vocab[j].second;
       if (token.empty()) {
         definite_accepted_tokens_since_second_char.Set(j);
@@ -1204,22 +1212,7 @@ void GrammarCompilerSub::TagDispatchOptimization(
       }
 
       // Check if the token contains any string trigger or exclude string after first char.
-      for (const auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
-        if (token.find(trigger, 1) != std::string::npos) {
-          definite_accept_since_second_char = false;
-          break;
-        }
-      }
-      if (definite_accept_since_second_char) {
-        for (const auto& excl : tag_dispatch.excludes) {
-          if (token.find(excl, 1) != std::string::npos) {
-            definite_accept_since_second_char = false;
-            break;
-          }
-        }
-      }
-
-      if (definite_accept_since_second_char) {
+      if (!matcher.ContainsMatch(token, 1)) {
         definite_accepted_tokens_since_second_char.Set(j);
       }
     }

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -140,10 +140,24 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   std::vector<int32_t> tmp_accepted_by_lookahead_indices_;
   std::vector<bool> tmp_can_reach_end_stack_;
   std::vector<bool> tmp_can_reach_end_prefix_or_stack_;
+  // Whether every token not explicitly classified as rejected or uncertain is known to be
+  // accepted. This lets TagDispatch masks use their natural "accept all + sparse delta"
+  // representation without first materializing every accepted vocabulary index.
+  bool tmp_store_rejected_only_ = false;
   // Temporary data for GetTokenEdgeAcceptedIndices.
   std::vector<int32_t> tmp_token_edge_accepted_;
   std::vector<int32_t> tmp_token_edge_excluded_;
 };
+
+AdaptiveTokenMask MakeRejectedAdaptiveTokenMask(
+    const std::vector<int32_t>& rejected_indices, const std::vector<int32_t>& uncertain_indices
+) {
+  AdaptiveTokenMask result;
+  result.store_type = AdaptiveTokenMask::StoreType::kRejected;
+  result.rejected_indices = rejected_indices;
+  result.uncertain_indices = uncertain_indices;
+  return result;
+}
 
 void GrammarMatcherForTokenMaskCache::AdaptCacheWithLookahead(
     AdaptiveTokenMask* cache_ptr, bool is_root_rule
@@ -530,6 +544,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
     XGRAMMAR_DCHECK(tag_dispatch_rule_id_to_second_slicing_bitset_.count(init_rule_id_) > 0);
     definite_accepted_bitset = &tag_dispatch_rule_id_to_second_slicing_bitset_.at(init_rule_id_);
   }
+  tmp_store_rejected_only_ = is_tag_dispatch_rule && speculative_calculation && fill_reject_indices;
 
   const std::string* prev_token = nullptr;
   int32_t skip_ptr = 0;
@@ -546,10 +561,12 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       if (i < last_rejected_range) {
         if (fill_reject_indices) {
           tmp_rejected_indices_.push_back(i);
-          fill_reject_indices =
-              tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
-                  ? false
-                  : fill_reject_indices;
+          if (!tmp_store_rejected_only_) {
+            fill_reject_indices =
+                tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
+                    ? false
+                    : fill_reject_indices;
+          }
         } else {
           i = last_rejected_range - 1;
         }
@@ -562,7 +579,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
         if (definite_accepted_bitset.has_value()) {
           // If the token is empty, it must be accepted.
           if (token.empty()) {
-            tmp_accepted_indices_.push_back(i);
+            if (!tmp_store_rejected_only_) {
+              tmp_accepted_indices_.push_back(i);
+            }
             continue;
           }
           // If the token doesn't contain tags or stop strings since the second character, and it
@@ -570,7 +589,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
           // accepted.
           if (speculative_mask[static_cast<uint8_t>(token[0])] &&
               (*definite_accepted_bitset.value())[i]) {
-            tmp_accepted_indices_.push_back(i);
+            if (!tmp_store_rejected_only_) {
+              tmp_accepted_indices_.push_back(i);
+            }
             continue;
           }
         } else {
@@ -584,7 +605,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
             }
           }
           if (all_accepted) {
-            tmp_accepted_indices_.push_back(i);
+            if (!tmp_store_rejected_only_) {
+              tmp_accepted_indices_.push_back(i);
+            }
             continue;
           }
         }
@@ -637,7 +660,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       bool can_reach_end = tmp_can_reach_end_prefix_or_stack_.back();
 
       if (accepted) {
-        tmp_accepted_indices_.push_back(i);
+        if (!tmp_store_rejected_only_) {
+          tmp_accepted_indices_.push_back(i);
+        }
       } else if (can_reach_end && prev_matched_size > 0) {
         auto [lookahead_accepted, lookahead_completed] =
             IsTokenPassLookaheadAssertion(token, tmp_can_reach_end_stack_);
@@ -658,10 +683,12 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       } else {
         tmp_rejected_indices_.push_back(i);
         last_rejected_range = subtree_nodes_range[i];
-        fill_reject_indices =
-            tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
-                ? false
-                : fill_reject_indices;
+        if (!tmp_store_rejected_only_) {
+          fill_reject_indices =
+              tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
+                  ? false
+                  : fill_reject_indices;
+        }
       }
     }
     if (interval_idx != possible_intervals.size() - 1 && fill_reject_indices) {
@@ -669,9 +696,12 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       for (int i = interval.second; i < next_interval.first; ++i) {
         tmp_rejected_indices_.push_back(i);
       }
-      fill_reject_indices = tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
-                                ? false
-                                : fill_reject_indices;
+      if (!tmp_store_rejected_only_) {
+        fill_reject_indices =
+            tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
+                ? false
+                : fill_reject_indices;
+      }
     }
   }
 
@@ -785,6 +815,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   tmp_accepted_by_lookahead_indices_.clear();
   tmp_can_reach_end_prefix_or_stack_.clear();
   tmp_can_reach_end_stack_.clear();
+  tmp_store_rejected_only_ = false;
   // For every character in the current token, stores whether it is possible to reach the end of
   // the rule when matching until this character. Store it in a stack for later rollback.
   tmp_can_reach_end_stack_.push_back(false);
@@ -854,18 +885,23 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   // rejected  = rejected - token_edge_accepted
   // uncertain = uncertain - token_edge_accepted
   if (!token_edge_accepted.empty()) {
-    IntsetUnion(&tmp_accepted_indices_, token_edge_accepted);
+    if (!tmp_store_rejected_only_) {
+      IntsetUnion(&tmp_accepted_indices_, token_edge_accepted);
+    }
     IntsetDifference(&tmp_rejected_indices_, token_edge_accepted);
     IntsetDifference(&tmp_uncertain_indices_, token_edge_accepted);
   }
   if (rejected_filled) {
-    auto return_value = AdaptiveTokenMask(
-        tokenizer_info_.GetVocabSize(),
-        tokenizer_info_.GetSortedDecodedVocab(),
-        tmp_accepted_indices_,
-        tmp_rejected_indices_,
-        tmp_uncertain_indices_
-    );
+    auto return_value =
+        tmp_store_rejected_only_
+            ? MakeRejectedAdaptiveTokenMask(tmp_rejected_indices_, tmp_uncertain_indices_)
+            : AdaptiveTokenMask(
+                  tokenizer_info_.GetVocabSize(),
+                  tokenizer_info_.GetSortedDecodedVocab(),
+                  tmp_accepted_indices_,
+                  tmp_rejected_indices_,
+                  tmp_uncertain_indices_
+              );
     if (rule_level_cache_is_available) {
       if (lookahead_id == -1 && !is_root_rule) {
         // If the rule doesn't have a lookahead, then it is exactly the same fsm.
@@ -908,13 +944,16 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
           new_state_id,
           fsm.GetNodeNum(),
           fsm.GetEdgeNum(),
-          AdaptiveTokenMask(
-              tokenizer_info_.GetVocabSize(),
-              tokenizer_info_.GetSortedDecodedVocab(),
-              accepted_indices_without_lookahead,
-              rejected_indices_without_lookahead,
-              tmp_uncertain_indices_
-          )
+          tmp_store_rejected_only_ ? MakeRejectedAdaptiveTokenMask(
+                                         rejected_indices_without_lookahead, tmp_uncertain_indices_
+                                     )
+                                   : AdaptiveTokenMask(
+                                         tokenizer_info_.GetVocabSize(),
+                                         tokenizer_info_.GetSortedDecodedVocab(),
+                                         accepted_indices_without_lookahead,
+                                         rejected_indices_without_lookahead,
+                                         tmp_uncertain_indices_
+                                     )
       );
       if (lookahead_hash.has_value()) {
         auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -37,22 +37,29 @@ namespace xgrammar {
 
 /************** AdaptiveTokenMaskCache Generator **************/
 
+struct TagDispatchTokenOptimization {
+  // Tokens that contain no trigger or exclude string after their first byte.
+  DynamicBitset definitely_accepted_since_second_byte;
+  // The sorted-vocabulary indices of all other tokens. Keeping the sparse complement avoids
+  // scanning the full vocabulary again for every state of a large TagDispatch automaton.
+  std::vector<int32_t> requires_full_match_since_second_byte;
+};
+
 /*! \brief The concrete implementation of GrammarMatcherNode. */
 class GrammarMatcherForTokenMaskCache : public EarleyParser {
  public:
   GrammarMatcherForTokenMaskCache(
       const Grammar& grammar,
       const ParserState& init_state,
-      const std::unordered_map<int32_t, DynamicBitset>&
-          tag_dispatch_rule_id_to_second_slicing_bitset,
+      const std::unordered_map<int32_t, TagDispatchTokenOptimization>&
+          tag_dispatch_token_optimizations,
       const TokenizerInfo& tokenizer_info,
       std::optional<RuleLevelCache>& rule_level_cache
   )
       : EarleyParser(grammar, init_state),
         init_rule_id_(init_state.rule_id),
         initial_state_(init_state),
-        tag_dispatch_rule_id_to_second_slicing_bitset_(tag_dispatch_rule_id_to_second_slicing_bitset
-        ),
+        tag_dispatch_token_optimizations_(tag_dispatch_token_optimizations),
         tokenizer_info_(tokenizer_info),
         rule_level_cache_(rule_level_cache) {}
   /*!
@@ -126,7 +133,8 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
    *  When we check a token, we first check if its first character can transit to the start state.
    *  If yes, then we check if it is in the bitset. If yes, then we accept it directly.
    */
-  const std::unordered_map<int32_t, DynamicBitset>& tag_dispatch_rule_id_to_second_slicing_bitset_;
+  const std::unordered_map<int32_t, TagDispatchTokenOptimization>&
+      tag_dispatch_token_optimizations_;
 
   const TokenizerInfo& tokenizer_info_;
 
@@ -537,24 +545,84 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
   int last_rejected_range = 0;
   const bool& is_exact_lookahead = grammar_->GetRule(init_rule_id_).is_exact_lookahead;
   std::optional<const DynamicBitset*> definite_accepted_bitset = std::nullopt;
+  const TagDispatchTokenOptimization* tag_dispatch_token_optimization = nullptr;
   const bool is_tag_dispatch_rule =
       grammar_->GetGrammarExpr(grammar_->GetRule(init_rule_id_).body_expr_id).type ==
       Grammar::Impl::GrammarExprType::kTagDispatch;
   if (is_tag_dispatch_rule) {
-    XGRAMMAR_DCHECK(tag_dispatch_rule_id_to_second_slicing_bitset_.count(init_rule_id_) > 0);
-    definite_accepted_bitset = &tag_dispatch_rule_id_to_second_slicing_bitset_.at(init_rule_id_);
+    XGRAMMAR_DCHECK(tag_dispatch_token_optimizations_.count(init_rule_id_) > 0);
+    tag_dispatch_token_optimization = &tag_dispatch_token_optimizations_.at(init_rule_id_);
+    definite_accepted_bitset =
+        &tag_dispatch_token_optimization->definitely_accepted_since_second_byte;
   }
   tmp_store_rejected_only_ = is_tag_dispatch_rule && speculative_calculation && fill_reject_indices;
+
+  std::vector<int32_t> sparse_candidate_indices;
+  if (tmp_store_rejected_only_) {
+    XGRAMMAR_DCHECK(tag_dispatch_token_optimization != nullptr);
+    const auto& requires_full_match =
+        tag_dispatch_token_optimization->requires_full_match_since_second_byte;
+    sparse_candidate_indices.reserve(requires_full_match.size());
+    for (int32_t i : requires_full_match) {
+      const auto& token = sorted_decoded_vocab[i].second;
+      XGRAMMAR_DCHECK(!token.empty());
+      const auto first_byte = static_cast<uint8_t>(token[0]);
+      if (first_char_mask[first_byte] && speculative_mask[first_byte]) {
+        sparse_candidate_indices.push_back(i);
+      }
+    }
+
+    // Any first byte that is accepted by the grammar but does not return the TagDispatch
+    // automaton to its start state also requires full matching. These byte ranges are disjoint
+    // from the indices collected above.
+    std::bitset<256> non_speculative_first_bytes = first_char_mask & ~speculative_mask;
+    if (non_speculative_first_bytes.any()) {
+      std::vector<std::pair<int32_t, int32_t>> non_speculative_intervals;
+      GetPossibleTokenIntervals(
+          sorted_decoded_vocab, non_speculative_first_bytes, non_speculative_intervals
+      );
+      for (const auto& [begin, end] : non_speculative_intervals) {
+        for (int32_t i = begin; i < end; ++i) {
+          sparse_candidate_indices.push_back(i);
+        }
+      }
+      std::sort(sparse_candidate_indices.begin(), sparse_candidate_indices.end());
+    }
+  }
 
   const std::string* prev_token = nullptr;
   int32_t skip_ptr = 0;
   const int32_t skip_size = static_cast<int32_t>(token_edge_accepted.size());
+  size_t sparse_candidate_ptr = 0;
+  auto next_token_index = [&](int32_t cursor, int32_t interval_end) {
+    if (!tmp_store_rejected_only_) {
+      return cursor;
+    }
+    while (sparse_candidate_ptr < sparse_candidate_indices.size() &&
+           sparse_candidate_indices[sparse_candidate_ptr] < cursor) {
+      ++sparse_candidate_ptr;
+    }
+    if (sparse_candidate_ptr == sparse_candidate_indices.size() ||
+        sparse_candidate_indices[sparse_candidate_ptr] >= interval_end) {
+      return interval_end;
+    }
+    return sparse_candidate_indices[sparse_candidate_ptr++];
+  };
   for (size_t interval_idx = 0; interval_idx < possible_intervals.size(); ++interval_idx) {
     const auto& interval = possible_intervals[interval_idx];
-    for (int i = interval.first; i < interval.second; ++i) {
+    int32_t cursor = interval.first;
+    while (cursor < interval.second) {
+      int32_t i = next_token_index(cursor, interval.second);
+      if (i == interval.second) {
+        break;
+      }
+      int32_t next_cursor = i + 1;
       // Skip tokens already accepted by token edges (avoid expensive Earley simulation).
       while (skip_ptr < skip_size && token_edge_accepted[skip_ptr] < i) ++skip_ptr;
-      if (skip_ptr < skip_size && token_edge_accepted[skip_ptr] == i) continue;
+      if (skip_ptr < skip_size && token_edge_accepted[skip_ptr] == i) {
+        cursor = next_cursor;
+        continue;
+      }
 
       // Check if the current token is in the rejected range. i.e. check if the current token
       // is on the subtree of the rejected token.
@@ -568,8 +636,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
                     : fill_reject_indices;
           }
         } else {
-          i = last_rejected_range - 1;
+          next_cursor = last_rejected_range;
         }
+        cursor = next_cursor;
         continue;
       }
       const auto& token = sorted_decoded_vocab[i].second;
@@ -582,6 +651,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
             if (!tmp_store_rejected_only_) {
               tmp_accepted_indices_.push_back(i);
             }
+            cursor = next_cursor;
             continue;
           }
           // If the token doesn't contain tags or stop strings since the second character, and it
@@ -592,6 +662,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
             if (!tmp_store_rejected_only_) {
               tmp_accepted_indices_.push_back(i);
             }
+            cursor = next_cursor;
             continue;
           }
         } else {
@@ -608,6 +679,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
             if (!tmp_store_rejected_only_) {
               tmp_accepted_indices_.push_back(i);
             }
+            cursor = next_cursor;
             continue;
           }
         }
@@ -678,7 +750,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
             tmp_rejected_indices_.push_back(j);
             tmp_rejected_by_lookahead_indices_.push_back(j);
           }
-          i = subtree_nodes_range[i] - 1;  // Skip the subtree nodes.
+          next_cursor = subtree_nodes_range[i];
         }
       } else {
         tmp_rejected_indices_.push_back(i);
@@ -690,6 +762,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
                   : fill_reject_indices;
         }
       }
+      cursor = next_cursor;
     }
     if (interval_idx != possible_intervals.size() - 1 && fill_reject_indices) {
       const auto& next_interval = possible_intervals[interval_idx + 1];
@@ -1068,12 +1141,12 @@ class GrammarCompilerSub {
   CompiledGrammar MultiThreadCompileGrammar(Grammar grammar);
   /*! \brief Optimization for TagDispatch.
    *  \param compiled_grammar_impl the compiled_grammar to be optimized.
-   *  \param tag_dispatch_rule_id_to_second_slicing_bitset Return value. Mapping from the rule_id to
-   * the definite accepted token mask.
+   *  \param tag_dispatch_token_optimizations Return value. Mapping from the rule_id to the
+   * TagDispatch vocabulary optimization.
    */
   void TagDispatchOptimization(
       std::shared_ptr<CompiledGrammar::Impl> compiled_grammar_impl,
-      std::unordered_map<int32_t, DynamicBitset>* tag_dispatch_rule_id_to_second_slicing_bitset
+      std::unordered_map<int32_t, TagDispatchTokenOptimization>* tag_dispatch_token_optimizations
   );
 
   /*! \brief The vocabulary associated with this storage class. */
@@ -1092,8 +1165,8 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
   }
-  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
-  TagDispatchOptimization(compiled_grammar_impl, &tag_dispatch_rule_id_to_second_slicing_bitset);
+  std::unordered_map<int32_t, TagDispatchTokenOptimization> tag_dispatch_token_optimizations;
+  TagDispatchOptimization(compiled_grammar_impl, &tag_dispatch_token_optimizations);
 
   // If the compiler is cache-enabled, then we hash the grammars for crossing-grammar caching.
   if (rule_level_cache_.has_value()) {
@@ -1119,7 +1192,7 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
     auto grammar_matcher = GrammarMatcherForTokenMaskCache(
         compiled_grammar_impl->grammar,
         state,
-        tag_dispatch_rule_id_to_second_slicing_bitset,
+        tag_dispatch_token_optimizations,
         tokenizer_info_,
         rule_level_cache_
     );
@@ -1218,10 +1291,10 @@ CompiledGrammar GrammarCompilerSub::CompileGrammar(
 
 void GrammarCompilerSub::TagDispatchOptimization(
     std::shared_ptr<CompiledGrammar::Impl> compiled_grammar_impl,
-    std::unordered_map<int32_t, DynamicBitset>* tag_dispatch_rule_id_to_second_slicing_bitset
+    std::unordered_map<int32_t, TagDispatchTokenOptimization>* tag_dispatch_token_optimizations
 ) {
   using GrammarExprType = Grammar::Impl::GrammarExprType;
-  tag_dispatch_rule_id_to_second_slicing_bitset->clear();
+  tag_dispatch_token_optimizations->clear();
 
   // Optimization for TagDispatch: Precompute the definitely accepted tokens.
   for (int i = 0; i < compiled_grammar_impl->grammar->NumRules(); i++) {
@@ -1242,21 +1315,23 @@ void GrammarCompilerSub::TagDispatchOptimization(
     patterns.insert(patterns.end(), tag_dispatch.excludes.begin(), tag_dispatch.excludes.end());
     AhoCorasick matcher(patterns);
 
-    DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
+    TagDispatchTokenOptimization optimization;
+    optimization.definitely_accepted_since_second_byte = DynamicBitset(sorted_decoded_vocab.size());
     for (int j = 0; j < static_cast<int32_t>(sorted_decoded_vocab.size()); j++) {
       const auto& token = sorted_decoded_vocab[j].second;
       if (token.empty()) {
-        definite_accepted_tokens_since_second_char.Set(j);
+        optimization.definitely_accepted_since_second_byte.Set(j);
         continue;
       }
 
       // Check if the token contains any string trigger or exclude string after first char.
       if (!matcher.ContainsMatch(token, 1)) {
-        definite_accepted_tokens_since_second_char.Set(j);
+        optimization.definitely_accepted_since_second_byte.Set(j);
+      } else {
+        optimization.requires_full_match_since_second_byte.push_back(j);
       }
     }
-    (*tag_dispatch_rule_id_to_second_slicing_bitset)[i] =
-        definite_accepted_tokens_since_second_char;
+    (*tag_dispatch_token_optimizations)[i] = std::move(optimization);
   }
 }
 

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1533,30 +1533,74 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Sequence(
   // immediately instead of retaining one allocation-heavy FSM object per sequence element.
   FSM result_fsm;
   int start = -1;
-  std::vector<int32_t> previous_ends;
+  int previous_end = -1;
   std::vector<int> state_mapping;
   for (int32_t sequence_id : expr) {
-    auto element_fsm = build_element(grammar->GetGrammarExpr(sequence_id));
-    if (!element_fsm.has_value()) {
-      return std::nullopt;
+    const auto& element_expr = grammar->GetGrammarExpr(sequence_id);
+    int element_start = result_fsm.NumStates();
+    int element_end = -1;
+    switch (element_expr.type) {
+      case ExprType::kByteString: {
+        int current_state = result_fsm.AddState();
+        for (int32_t byte : element_expr) {
+          int next_state = result_fsm.AddState();
+          result_fsm.AddEdge(
+              current_state, next_state, static_cast<uint8_t>(byte), static_cast<uint8_t>(byte)
+          );
+          current_state = next_state;
+        }
+        element_end = current_state;
+        break;
+      }
+      case ExprType::kRuleRef: {
+        result_fsm.AddState();
+        element_end = result_fsm.AddState();
+        result_fsm.AddRuleEdge(element_start, element_end, element_expr[0]);
+        break;
+      }
+      case ExprType::kRepeat: {
+        result_fsm.AddState();
+        element_end = result_fsm.AddState();
+        result_fsm.AddRepeatEdge(
+            element_start, element_end, element_expr[0], element_expr[1], element_expr[2]
+        );
+        break;
+      }
+      case ExprType::kToken:
+      case ExprType::kExcludeToken: {
+        result_fsm.AddState();
+        element_end = result_fsm.AddState();
+        std::vector<int32_t> token_ids(element_expr.begin(), element_expr.end());
+        if (element_expr.type == ExprType::kToken) {
+          result_fsm.AddTokenEdge(element_start, element_end, token_ids);
+        } else {
+          result_fsm.AddExcludeTokenEdge(element_start, element_end, token_ids);
+        }
+        break;
+      }
+      case ExprType::kCharacterClass:
+      case ExprType::kCharacterClassStar: {
+        auto element_fsm = CharacterClass(element_expr);
+        result_fsm.AddFSM(element_fsm.GetFsm(), &state_mapping);
+        element_start = state_mapping[element_fsm.GetStart()];
+        XGRAMMAR_DCHECK(element_fsm.GetEnds().size() == 1);
+        element_end = state_mapping[element_fsm.GetEnds()[0]];
+        break;
+      }
+      default: {
+        return std::nullopt;
+      }
     }
-    result_fsm.AddFSM(element_fsm->GetFsm(), &state_mapping);
-    int element_start = state_mapping[element_fsm->GetStart()];
+
     if (start == -1) {
       start = element_start;
     } else {
-      for (int32_t previous_end : previous_ends) {
-        result_fsm.AddEpsilonEdge(previous_end, element_start);
-      }
+      result_fsm.AddEpsilonEdge(previous_end, element_start);
     }
-    previous_ends.clear();
-    previous_ends.reserve(element_fsm->GetEnds().size());
-    for (int32_t end : element_fsm->GetEnds()) {
-      previous_ends.push_back(state_mapping[end]);
-    }
+    previous_end = element_end;
   }
 
-  return FSMWithStartEnd(result_fsm, start, std::move(previous_ends));
+  return FSMWithStartEnd(result_fsm, start, {previous_end});
 }
 
 FSMWithStartEnd GrammarFSMBuilderImpl::RuleRef(const GrammarExpr& expr) {

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -635,7 +635,9 @@ class UsedRulesAnalyzer : public GrammarVisitor<std::vector<int32_t>> {
   std::vector<int32_t> Apply(const Grammar& grammar) final {
     InitGrammar(grammar);
 
-    std::set<int32_t> visited;
+    std::vector<uint8_t> visited(base_grammar_->NumRules(), 0);
+    std::vector<int32_t> used_rules;
+    used_rules.reserve(base_grammar_->NumRules());
 
     std::queue<int32_t>().swap(visit_queue_);
 
@@ -643,10 +645,11 @@ class UsedRulesAnalyzer : public GrammarVisitor<std::vector<int32_t>> {
     while (!visit_queue_.empty()) {
       auto rule_id = visit_queue_.front();
       visit_queue_.pop();
-      if (visited.count(rule_id)) {
+      if (visited[rule_id]) {
         continue;
       }
-      visited.insert(rule_id);
+      visited[rule_id] = 1;
+      used_rules.push_back(rule_id);
       auto rule = base_grammar_->GetRule(rule_id);
       VisitExpr(rule.body_expr_id);
       if (rule.lookahead_assertion_id != -1) {
@@ -654,7 +657,8 @@ class UsedRulesAnalyzer : public GrammarVisitor<std::vector<int32_t>> {
       }
     }
 
-    return std::vector<int32_t>(visited.begin(), visited.end());
+    std::sort(used_rules.begin(), used_rules.end());
+    return used_rules;
   }
 
   void VisitTagDispatch(const GrammarExpr& grammar_expr) {
@@ -1936,9 +1940,71 @@ class RepetitionNormalizerImpl {
 
 class GrammarOptimizerImpl {
  public:
+  static bool NeedsByteStringFusing(const Grammar& grammar) {
+    for (int32_t expr_id = 0; expr_id < grammar->NumGrammarExprs(); ++expr_id) {
+      const auto& expr = grammar->GetGrammarExpr(expr_id);
+      if (expr.type != Grammar::Impl::GrammarExprType::kSequence) {
+        continue;
+      }
+      bool previous_is_byte_string = false;
+      for (int32_t element_id : expr) {
+        bool current_is_byte_string =
+            grammar->GetGrammarExpr(element_id).type == Grammar::Impl::GrammarExprType::kByteString;
+        if (previous_is_byte_string && current_is_byte_string) {
+          return true;
+        }
+        previous_is_byte_string = current_is_byte_string;
+      }
+    }
+    return false;
+  }
+
+  static bool RuleCanBeInlined(const Grammar& grammar, int32_t rule_id) {
+    const auto& body = grammar->GetGrammarExpr(grammar->GetRule(rule_id).body_expr_id);
+    if (body.type != Grammar::Impl::GrammarExprType::kChoices || body.size() == 0) {
+      return false;
+    }
+    for (int32_t choice_id : body) {
+      const auto& choice = grammar->GetGrammarExpr(choice_id);
+      if (choice.type == Grammar::Impl::GrammarExprType::kEmptyStr) {
+        return false;
+      }
+      XGRAMMAR_DCHECK(choice.type == Grammar::Impl::GrammarExprType::kSequence);
+      for (int32_t element_id : choice) {
+        if (grammar->GetGrammarExpr(element_id).type == Grammar::Impl::GrammarExprType::kRuleRef) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  static bool HasPotentialInline(const Grammar& grammar) {
+    for (int32_t rule_id : UsedRulesAnalyzer().Apply(grammar)) {
+      const auto& body = grammar->GetGrammarExpr(grammar->GetRule(rule_id).body_expr_id);
+      if (body.type != Grammar::Impl::GrammarExprType::kChoices) {
+        continue;
+      }
+      for (int32_t choice_id : body) {
+        const auto& choice = grammar->GetGrammarExpr(choice_id);
+        if (choice.type != Grammar::Impl::GrammarExprType::kSequence || choice.size() == 0) {
+          continue;
+        }
+        const auto& first = grammar->GetGrammarExpr(choice[0]);
+        if (first.type == Grammar::Impl::GrammarExprType::kRuleRef &&
+            RuleCanBeInlined(grammar, first[0])) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   static Grammar Apply(const Grammar& grammar) {
-    auto result = ByteStringFuser::Apply(grammar);
-    result = RuleInliner::Apply(result);
+    auto result = NeedsByteStringFusing(grammar) ? ByteStringFuser::Apply(grammar) : grammar;
+    if (HasPotentialInline(result)) {
+      result = RuleInliner::Apply(result);
+    }
     result = RepetitionRangeExpander::Apply(result);
     result = DeadCodeEliminator::Apply(result);
     result = LookaheadAssertionAnalyzer::Apply(result);

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1490,45 +1490,34 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::TokenTagDispatch(
 std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Sequence(
     const GrammarExpr& expr, const Grammar& grammar
 ) {
-  std::vector<FSMWithStartEnd> fsm_lists;
-
-  // Build the fsm of sub-expressions.
-  for (const auto& sequence_id : expr) {
-    const auto& sequence_expr = grammar->GetGrammarExpr(sequence_id);
-    switch (sequence_expr.type) {
+  auto build_element = [](const GrammarExpr& element_expr) -> std::optional<FSMWithStartEnd> {
+    switch (element_expr.type) {
       case (ExprType::kByteString): {
-        fsm_lists.push_back(ByteString(sequence_expr));
-        break;
+        return ByteString(element_expr);
       }
       case (ExprType::kRuleRef): {
-        fsm_lists.push_back(RuleRef(sequence_expr));
-        break;
+        return RuleRef(element_expr);
       }
       case (ExprType::kCharacterClass):
       case (ExprType::kCharacterClassStar): {
-        fsm_lists.push_back(CharacterClass(sequence_expr));
-        break;
+        return CharacterClass(element_expr);
       }
       case (ExprType::kRepeat): {
-        fsm_lists.push_back(Repeat(sequence_expr));
-        break;
+        return Repeat(element_expr);
       }
       case (ExprType::kToken): {
-        fsm_lists.push_back(Token(sequence_expr));
-        break;
+        return Token(element_expr);
       }
       case (ExprType::kExcludeToken): {
-        fsm_lists.push_back(ExcludeToken(sequence_expr));
-        break;
+        return ExcludeToken(element_expr);
       }
       default: {
         return std::nullopt;
       }
     }
-  }
+  };
 
-  // Check if the sequence is empty.
-  if (fsm_lists.empty()) {
+  if (expr.size() == 0) {
     FSMWithStartEnd empty_fsm;
     empty_fsm.AddState();
     empty_fsm.SetStartState(0);
@@ -1536,7 +1525,38 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Sequence(
     return empty_fsm;
   }
 
-  return FSMWithStartEnd::Concat(fsm_lists);
+  if (expr.size() == 1) {
+    return build_element(grammar->GetGrammarExpr(expr[0]));
+  }
+
+  // Concatenate the element FSMs as they are built so temporary FSMs can be released
+  // immediately instead of retaining one allocation-heavy FSM object per sequence element.
+  FSM result_fsm;
+  int start = -1;
+  std::vector<int32_t> previous_ends;
+  std::vector<int> state_mapping;
+  for (int32_t sequence_id : expr) {
+    auto element_fsm = build_element(grammar->GetGrammarExpr(sequence_id));
+    if (!element_fsm.has_value()) {
+      return std::nullopt;
+    }
+    result_fsm.AddFSM(element_fsm->GetFsm(), &state_mapping);
+    int element_start = state_mapping[element_fsm->GetStart()];
+    if (start == -1) {
+      start = element_start;
+    } else {
+      for (int32_t previous_end : previous_ends) {
+        result_fsm.AddEpsilonEdge(previous_end, element_start);
+      }
+    }
+    previous_ends.clear();
+    previous_ends.reserve(element_fsm->GetEnds().size());
+    for (int32_t end : element_fsm->GetEnds()) {
+      previous_ends.push_back(state_mapping[end]);
+    }
+  }
+
+  return FSMWithStartEnd(result_fsm, start, std::move(previous_ends));
 }
 
 FSMWithStartEnd GrammarFSMBuilderImpl::RuleRef(const GrammarExpr& expr) {

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -433,6 +433,12 @@ class EBNFParser {
       const int& max_nest_layer = 1000
   );
 
+  Grammar ParseRules(
+      const std::vector<std::pair<std::string, std::string>>& rules,
+      const std::string& root_rule_name,
+      const int& max_nest_layer = 1000
+  );
+
  private:
   using Rule = Grammar::Impl::Rule;
   using GrammarExprType = Grammar::Impl::GrammarExprType;
@@ -1210,11 +1216,54 @@ Grammar EBNFParser::Parse(
   return builder_.Get(root_rule_name);
 }
 
+Grammar EBNFParser::ParseRules(
+    const std::vector<std::pair<std::string, std::string>>& rules,
+    const std::string& root_rule_name,
+    const int& max_nest_layer
+) {
+  max_nest_layer_ = max_nest_layer;
+  root_rule_name_ = root_rule_name;
+
+  // Register every generated rule before parsing bodies to preserve forward-reference behavior.
+  for (const auto& [rule_name, _] : rules) {
+    XGRAMMAR_CHECK(builder_.GetRuleId(rule_name) == -1)
+        << "Rule \"" << rule_name << "\" is defined multiple times";
+    builder_.AddEmptyRule(rule_name);
+  }
+  XGRAMMAR_CHECK(builder_.GetRuleId(root_rule_name_) != -1)
+      << "The root rule with name \"" << root_rule_name_ << "\" is not found";
+
+  EBNFLexer lexer;
+  for (const auto& [rule_name, rule_body] : rules) {
+    nest_layer_guard_ = 0;
+    std::string definition;
+    definition.reserve(rule_name.size() + rule_body.size() + 6);
+    definition.append(rule_name).append(" ::= ").append(rule_body);
+    tokens_ = lexer.Tokenize(definition);
+    current_token_ = tokens_.data();
+
+    auto new_rule = ParseRule();
+    XGRAMMAR_DCHECK(new_rule.name == rule_name);
+    XGRAMMAR_CHECK(Peek().type == TokenType::EndOfFile)
+        << "Unexpected trailing tokens in generated rule \"" << rule_name << "\"";
+    builder_.UpdateRuleBody(new_rule.name, new_rule.body_expr_id);
+    builder_.UpdateLookaheadAssertion(new_rule.name, new_rule.lookahead_assertion_id);
+  }
+
+  return builder_.Get(root_rule_name_);
+}
+
 Grammar ParseEBNF(const std::string& ebnf_string, const std::string& root_rule_name) {
   EBNFLexer lexer;
   auto tokens = lexer.Tokenize(ebnf_string);
   EBNFParser parser;
   return parser.Parse(std::move(tokens), root_rule_name);
+}
+
+Grammar ParseEBNFRules(
+    const std::vector<std::pair<std::string, std::string>>& rules, const std::string& root_rule_name
+) {
+  return EBNFParser().ParseRules(rules, root_rule_name);
 }
 
 }  // namespace xgrammar

--- a/cpp/grammar_parser.h
+++ b/cpp/grammar_parser.h
@@ -10,6 +10,9 @@
 #include <xgrammar/xgrammar.h>
 
 #include <any>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace xgrammar {
 
@@ -81,6 +84,18 @@ class EBNFLexer {
  * \return The parsed grammar.
  */
 Grammar ParseEBNF(const std::string& ebnf_string, const std::string& root_rule_name = "root");
+
+/*!
+ * \brief Parse generated EBNF rules directly into one GrammarBuilder.
+ *
+ * All rule names are registered before parsing any body, so forward references have the same
+ * semantics as ParseEBNF. Parsing one rule at a time avoids materializing a combined script and
+ * retaining its complete token stream.
+ */
+Grammar ParseEBNFRules(
+    const std::vector<std::pair<std::string, std::string>>& rules,
+    const std::string& root_rule_name = "root"
+);
 
 }  // namespace xgrammar
 

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -22,6 +22,7 @@
 #include <variant>
 #include <vector>
 
+#include "grammar_parser.h"
 #include "json_schema_converter_ext.h"
 #include "regex_converter.h"
 #include "support/logging.h"
@@ -1761,7 +1762,7 @@ JSONSchemaConverter::JSONSchemaConverter(
   }
 }
 
-std::string JSONSchemaConverter::Convert(const SchemaSpecPtr& spec) {
+void JSONSchemaConverter::GenerateRules(const SchemaSpecPtr& spec) {
   AddBasicRules();
 
   // Register the root rule for circular reference handling
@@ -1782,8 +1783,16 @@ std::string JSONSchemaConverter::Convert(const SchemaSpecPtr& spec) {
     std::string root_body = GenerateFromSpec(spec, root_rule_name);
     ebnf_script_creator_.AddRuleWithAllocatedName(root_rule_name, root_body);
   }
+}
 
+std::string JSONSchemaConverter::Convert(const SchemaSpecPtr& spec) {
+  GenerateRules(spec);
   return ebnf_script_creator_.GetScript();
+}
+
+Grammar JSONSchemaConverter::ConvertToGrammar(const SchemaSpecPtr& spec) {
+  GenerateRules(spec);
+  return ParseEBNFRules(ebnf_script_creator_.GetRules());
 }
 
 void JSONSchemaConverter::AddBasicRules() {
@@ -4032,6 +4041,39 @@ std::string JSONSchemaToEBNF(
       json_format,
       any_order
   );
+}
+
+Grammar JSONSchemaToGrammar(
+    const std::string& schema,
+    bool any_whitespace,
+    std::optional<int> indent,
+    std::optional<std::pair<std::string, std::string>> separators,
+    bool strict_mode,
+    std::optional<int> max_whitespace_cnt,
+    bool any_order
+) {
+  picojson::value schema_value;
+  std::string err = picojson::parse(schema_value, schema);
+  XGRAMMAR_CHECK(err.empty()) << "Failed to parse JSON: " << err
+                              << ". The JSON string is:" << schema;
+
+  SchemaParser parser(schema_value, {strict_mode, JSONFormat::kJSON});
+  auto spec_result = parser.Parse(schema_value, "root");
+  if (spec_result.IsErr()) {
+    XGRAMMAR_LOG(FATAL) << std::move(spec_result).UnwrapErr().what();
+  }
+  auto spec = std::move(spec_result).Unwrap();
+  auto ref_resolver = [&parser](const std::string& uri, const std::string& rule_name_hint) {
+    auto result = parser.ResolveRef(uri, rule_name_hint);
+    if (result.IsErr()) {
+      XGRAMMAR_LOG(FATAL) << std::move(result).UnwrapErr().what();
+    }
+    return std::move(result).Unwrap();
+  };
+  JSONSchemaConverter converter(
+      indent, separators, any_whitespace, max_whitespace_cnt, ref_resolver, any_order
+  );
+  return converter.ConvertToGrammar(spec);
 }
 
 std::string JSONSchemaToEBNF(

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "ebnf_script_creator.h"
+#include "xgrammar/grammar.h"
 
 namespace xgrammar {
 
@@ -289,6 +290,9 @@ class JSONSchemaConverter {
    */
   std::string Convert(const SchemaSpecPtr& spec);
 
+  /*! \brief Convert SchemaSpec directly to Grammar without materializing a combined EBNF script. */
+  Grammar ConvertToGrammar(const SchemaSpecPtr& spec);
+
  protected:
   // ==================== Virtual methods for generation ====================
   // Subclasses can override these to customize output format
@@ -434,6 +438,9 @@ class JSONSchemaConverter {
   GenerateCacheManager rule_cache_manager_;
 
  private:
+  void GenerateRules(const SchemaSpecPtr& spec);
+
+ private:
   void AddHelperRules();
 
   std::unordered_map<std::string, std::string>
@@ -516,6 +523,18 @@ std::string JSONSchemaToEBNF(
     bool strict_mode = true,
     std::optional<int> max_whitespace_cnt = std::nullopt,
     JSONFormat json_format = JSONFormat::kJSON,
+    bool any_order = false
+);
+
+/*! \brief Convert a JSON schema directly to Grammar through the generated per-rule representation.
+ */
+Grammar JSONSchemaToGrammar(
+    const std::string& schema,
+    bool any_whitespace = true,
+    std::optional<int> indent = std::nullopt,
+    std::optional<std::pair<std::string, std::string>> separators = std::nullopt,
+    bool strict_mode = true,
+    std::optional<int> max_whitespace_cnt = std::nullopt,
     bool any_order = false
 );
 

--- a/cpp/support/aho_corasick.cc
+++ b/cpp/support/aho_corasick.cc
@@ -1,0 +1,86 @@
+/*!
+ * Copyright (c) 2026 by Contributors
+ * \file xgrammar/support/aho_corasick.cc
+ */
+
+#include "aho_corasick.h"
+
+#include <algorithm>
+#include <queue>
+
+namespace xgrammar {
+
+AhoCorasick::AhoCorasick(const std::vector<std::string>& patterns) {
+  size_t max_num_nodes = 1;
+  for (const auto& pattern : patterns) {
+    max_num_nodes += pattern.size();
+  }
+  nodes_.reserve(max_num_nodes);
+  nodes_.emplace_back();
+
+  // Build the trie.
+  for (const auto& pattern : patterns) {
+    int32_t state = 0;
+    for (unsigned char byte : pattern) {
+      int32_t& next_state = nodes_[state].next[byte];
+      if (next_state == -1) {
+        next_state = static_cast<int32_t>(nodes_.size());
+        nodes_.emplace_back();
+      }
+      state = next_state;
+    }
+    nodes_[state].is_terminal = true;
+  }
+
+  // Resolve root transitions and seed the breadth-first traversal.
+  std::queue<int32_t> queue;
+  for (int32_t byte = 0; byte < 256; ++byte) {
+    int32_t child = nodes_[0].next[byte];
+    if (child == -1) {
+      nodes_[0].next[byte] = 0;
+    } else {
+      nodes_[child].failure = 0;
+      queue.push(child);
+    }
+  }
+
+  // Compute full failure links, propagate terminal outputs through those links, and resolve
+  // missing transitions. Propagating terminal outputs is required for cases such as patterns
+  // {"bc", "abcd"} and input "abc": the trie state for "abc" is not directly terminal, but its
+  // failure state for the suffix "bc" is.
+  while (!queue.empty()) {
+    int32_t state = queue.front();
+    queue.pop();
+
+    const int32_t failure = nodes_[state].failure;
+    nodes_[state].is_terminal = nodes_[state].is_terminal || nodes_[failure].is_terminal;
+    for (int32_t byte = 0; byte < 256; ++byte) {
+      int32_t child = nodes_[state].next[byte];
+      if (child == -1) {
+        nodes_[state].next[byte] = nodes_[failure].next[byte];
+      } else {
+        nodes_[child].failure = nodes_[failure].next[byte];
+        queue.push(child);
+      }
+    }
+  }
+}
+
+bool AhoCorasick::ContainsMatch(std::string_view text, size_t start_offset) const {
+  if (start_offset > text.size()) {
+    return false;
+  }
+  int32_t state = 0;
+  if (nodes_[state].is_terminal) {
+    return true;
+  }
+  for (size_t index = start_offset; index < text.size(); ++index) {
+    state = nodes_[state].next[static_cast<uint8_t>(text[index])];
+    if (nodes_[state].is_terminal) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace xgrammar

--- a/cpp/support/aho_corasick.h
+++ b/cpp/support/aho_corasick.h
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) 2026 by Contributors
+ * \file xgrammar/support/aho_corasick.h
+ * \brief A byte-oriented Aho-Corasick matcher.
+ */
+#ifndef XGRAMMAR_SUPPORT_AHO_CORASICK_H_
+#define XGRAMMAR_SUPPORT_AHO_CORASICK_H_
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace xgrammar {
+
+/*!
+ * \brief A byte-oriented Aho-Corasick matcher for finding any of a set of patterns.
+ *
+ * The transition table is fully resolved when the matcher is constructed. Matching is therefore
+ * one table lookup per input byte, with no failure-link loop on the hot path.
+ */
+class AhoCorasick {
+ public:
+  explicit AhoCorasick(const std::vector<std::string>& patterns);
+
+  /*!
+   * \brief Return whether text contains any pattern at or after start_offset.
+   */
+  bool ContainsMatch(std::string_view text, size_t start_offset = 0) const;
+
+  int32_t NumStates() const { return static_cast<int32_t>(nodes_.size()); }
+
+ private:
+  struct Node {
+    Node() { next.fill(-1); }
+
+    std::array<int32_t, 256> next;
+    int32_t failure = 0;
+    bool is_terminal = false;
+  };
+
+  std::vector<Node> nodes_;
+};
+
+}  // namespace xgrammar
+
+#endif  // XGRAMMAR_SUPPORT_AHO_CORASICK_H_

--- a/tests/cpp/test_aho_corasick.cc
+++ b/tests/cpp/test_aho_corasick.cc
@@ -1,0 +1,75 @@
+/*!
+ * \file tests/cpp/test_aho_corasick.cc
+ * \brief Tests for the byte-oriented Aho-Corasick matcher.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "support/aho_corasick.h"
+
+using namespace xgrammar;
+
+TEST(AhoCorasickTest, FailureTransitionsFindOverlappingSuffix) {
+  AhoCorasick matcher({"bcd", "abce"});
+
+  EXPECT_TRUE(matcher.ContainsMatch("abcd"));
+  EXPECT_TRUE(matcher.ContainsMatch("zabcdz"));
+  EXPECT_FALSE(matcher.ContainsMatch("abc"));
+}
+
+TEST(AhoCorasickTest, TerminalOutputsPropagateThroughFailureLinks) {
+  AhoCorasick matcher({"bc", "abcd"});
+
+  EXPECT_TRUE(matcher.ContainsMatch("abc"));
+  EXPECT_TRUE(matcher.ContainsMatch("zabc"));
+  EXPECT_TRUE(matcher.ContainsMatch("abcd"));
+  EXPECT_FALSE(matcher.ContainsMatch("ab"));
+}
+
+TEST(AhoCorasickTest, HonorsStartOffsetAndBytePatterns) {
+  AhoCorasick matcher({"abc", "哈哈"});
+
+  EXPECT_TRUE(matcher.ContainsMatch("abc"));
+  EXPECT_FALSE(matcher.ContainsMatch("abc", 1));
+  EXPECT_TRUE(matcher.ContainsMatch("xabc", 1));
+  EXPECT_TRUE(matcher.ContainsMatch("x哈哈y", 1));
+}
+
+TEST(AhoCorasickTest, EmptyPatternMatchesAtAnyValidOffset) {
+  AhoCorasick matcher({""});
+
+  EXPECT_TRUE(matcher.ContainsMatch(""));
+  EXPECT_TRUE(matcher.ContainsMatch("abc", 1));
+  EXPECT_FALSE(matcher.ContainsMatch("abc", 4));
+}
+
+TEST(AhoCorasickTest, MatchesNaiveSearchExhaustively) {
+  const std::vector<std::string> patterns = {"a", "ab", "bab", "bc", "bca", "c", "caa"};
+  AhoCorasick matcher(patterns);
+
+  int32_t num_texts = 1;
+  for (int32_t length = 0; length <= 6; ++length) {
+    if (length != 0) {
+      num_texts *= 3;
+    }
+    for (int32_t encoded = 0; encoded < num_texts; ++encoded) {
+      int32_t value = encoded;
+      std::string text(length, 'a');
+      for (int32_t index = 0; index < length; ++index) {
+        text[index] = static_cast<char>('a' + value % 3);
+        value /= 3;
+      }
+      for (size_t start = 0; start <= text.size() + 1; ++start) {
+        bool expected = false;
+        for (const auto& pattern : patterns) {
+          expected = expected || text.find(pattern, start) != std::string::npos;
+        }
+        EXPECT_EQ(matcher.ContainsMatch(text, start), expected)
+            << "text=" << text << ", start=" << start;
+      }
+    }
+  }
+}

--- a/tests/cpp/test_parser.cc
+++ b/tests/cpp/test_parser.cc
@@ -7,6 +7,20 @@
 
 using namespace xgrammar;
 
+TEST(XGrammarParserTest, GeneratedRulesMatchCombinedScript) {
+  std::vector<std::pair<std::string, std::string>> rules = {
+      {"helper", "\"x\"+"},
+      {"root", "(\"a\" helper tail) (= [a-z] tail)"},
+      {"tail", "\"z\"?"},
+  };
+  std::string combined;
+  for (const auto& [name, body] : rules) {
+    combined += name + " ::= " + body + "\n";
+  }
+
+  EXPECT_EQ(ParseEBNFRules(rules).ToString(), ParseEBNF(combined).ToString());
+}
+
 // Note: the inputs to the lexer tests may not be valid EBNF
 TEST(XGrammarLexerTest, BasicTokenization) {
   // Test basic token types

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -379,6 +379,67 @@ def test_excludes_overlapping_prefixes():
     )
 
 
+def test_tag_dispatch_sparse_candidates_match_direct_parser():
+    """Cached masks must agree with byte-by-byte parsing at every AC state."""
+    vocab = [
+        "a",
+        "ab",
+        "abc",
+        "abcd",
+        "abcd!",
+        "aba",
+        "abax",
+        "b",
+        "bc",
+        "bc!",
+        "bcd",
+        "c",
+        "d",
+        "!",
+        "x",
+        "xx",
+        "xbc",
+        "xbc!",
+        "cabcd",
+        "zaba",
+        "STOP",
+        "xSTOP",
+        "STO",
+        "TOP",
+        "ordinary",
+        "好",
+        "a好",
+    ]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf(
+        """root ::= TagDispatch(
+  ("abcd", body), ("bc", body),
+  loop_after_dispatch=true,
+  excludes=("aba", "STOP")
+)
+body ::= "!"
+"""
+    )
+    compiled = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, cache_enabled=False
+    ).compile_grammar(grammar)
+
+    for prefix in ["", "a", "ab", "abc", "bc", "x", "xb", "xab"]:
+        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        assert matcher.accept_string(prefix)
+        token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        matcher.fill_next_token_bitmask(token_bitmask)
+        rejected = set(_get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size))
+
+        for token_id, token in enumerate(vocab):
+            direct_matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+            assert direct_matcher.accept_string(prefix)
+            direct_accepted = direct_matcher.accept_token(token_id)
+            assert (
+                token_id not in rejected
+            ) == direct_accepted, f"cached mask disagrees at prefix={prefix!r}, token={token!r}"
+
+
 @pytest.mark.hf_token_required
 def test_utf8_structural_tag_begin_end():
     model = "deepseek-ai/DeepSeek-V3-0324"

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -89,6 +89,54 @@ def check_schema_with_instance(
     assert accepted == is_accepted
 
 
+@pytest.mark.parametrize(
+    "schema,kwargs",
+    [
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "pattern": "^[a-z]+$"},
+                    "items": {
+                        "type": "array",
+                        "prefixItems": [{"type": "integer"}, {"enum": ["x", "y"]}],
+                    },
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+            {},
+        ),
+        (
+            {
+                "$defs": {
+                    "node": {
+                        "type": "object",
+                        "properties": {"value": {"type": "number"}},
+                        "required": ["value"],
+                    }
+                },
+                "anyOf": [{"$ref": "#/$defs/node"}, {"type": "null"}],
+            },
+            {"any_whitespace": False, "indent": 2},
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"a": {"type": "boolean"}, "b": {"type": "integer"}},
+                "required": ["a"],
+            },
+            {"any_order": True, "max_whitespace_cnt": 3},
+        ),
+    ],
+)
+def test_direct_grammar_frontend_matches_text_ebnf(schema, kwargs):
+    schema_json = json.dumps(schema)
+    direct = xgr.Grammar.from_json_schema(schema_json, **kwargs)
+    text_ebnf = xgr.Grammar.from_json_schema(schema_json, print_converted_ebnf=True, **kwargs)
+    assert str(direct) == str(text_ebnf)
+
+
 def test_basic():
     class MainModel(BaseModel):
         integer_field: int


### PR DESCRIPTION
## 改动

本请求降低首次语法编译在结构化标签分派、JSON Schema（用于描述 JSON 数据结构的规格）转换、语法优化和有限状态机构造中的开销。有限状态机是用状态和转换表示允许路径的数据结构。

- 用完整的 Aho-Corasick 多模式字符串匹配自动机替代重复的标签子串扫描，包括失败跳转和终结结果传播。
- 把每个分派状态拒绝的词元集合存为稀疏差异，并遍历稀疏候选，避免重建或扫描密集表。
- 把生成的 JSON 语法按规则解析到共享语法树，避免构造一份巨大的扩展巴科斯范式（Extended Backus-Naur Form，EBNF）文本和中间词元流。
- 跳过不会改变结果的字节串合并和规则内联，以线性时间收集已使用规则，流式连接状态机序列，并直接追加简单序列元素。
- 新增字符串匹配、解析器、JSON Schema 和结构化标签的回归测试。

## 原因

大型规格和大型结构化标签集会同时触发多种首次启动开销：重复子串匹配、状态与词元之间的密集计算、大型语法文本生成、无效优化重写和状态机复制。本改动分别去除这些开销，不改变原有语法与匹配行为。

## 性能

- 4,000 个密集标签的字符串匹配输入：实际耗时从 5,243 毫秒降到 1,115 毫秒，快 4.70 倍；处理器时间从 29,433 毫秒降到 6,058 毫秒，快 4.86 倍。
- 包含 50,000 个并列属性的 JSON Schema：在 JSON 转换、状态机构造和优化组合后，实际耗时从 4,856 毫秒降到 3,948 毫秒，降低 18.7%；处理器时间从 11,456 毫秒降到 10,142 毫秒，降低 11.5%。
- 6 个专项压力输入全部通过，包括密集、唯一和共享前缀标签，以及并列属性和循环引用规格。

## 验证

- 已重放到当时最新的主分支提交 `d6fc0420`。
- 干净重建后，C++ 语言测试 54 项全部通过。
- 专项压力测试 6 项全部通过。
- JSON Schema 与结构化标签的 Python 语言专项测试分别通过 202 项和 149 项。
- Python 语言完整测试通过 3,092 项，跳过 1 项。另外 51 项需要当时不可用的远程词表或缓存文件；一项编译器集成测试单独重跑时通过。
