### PR TITLE
feat: support capture in ebnf and lark.

### DIFF
--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -33,9 +33,17 @@ void EarleyParser::PopLastStates(int32_t cnt) {
   rule_id_to_completable_states_.PopBack(cnt);
   is_completed_.erase(is_completed_.end() - cnt, is_completed_.end());
   scanable_state_history_.PopBack(cnt);
+  if (capture_tracking_) {
+    capture_event_history_.PopBack(cnt);
+  }
 }
 
 void EarleyParser::Complete(const ParserState& state, bool debug_print) {
+  // Record the capture event for captured rules. This is only enabled during definitive
+  // advances; speculative completions (mask computation, lookahead) never record events.
+  if (capture_recording_ && RuleHasCapture(state.rule_id)) {
+    RecordCaptureEvent(state);
+  }
   // Check if a rule is completed.
   if (state.rule_start_pos == ParserState::kNoPrevInputPos) {
     // assert: if a root rule can achieve here, then it must be completed.
@@ -281,6 +289,9 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
 
   // execute Predict and Complete for all states in the queue until empty.
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
+  if (capture_tracking_) {
+    capture_event_history_.PushBack(std::vector<CaptureEvent>());
+  }
   while (!tmp_process_state_queue_.empty()) {
     const auto state = std::move(tmp_process_state_queue_.front());
     tmp_process_state_queue_.pop();
@@ -311,6 +322,12 @@ EarleyParser::EarleyParser(const Grammar& grammar, std::optional<ParserState> in
       break;
     }
   }
+  for (int32_t i = 0; i < grammar_->NumRules(); ++i) {
+    if (!grammar_->GetRule(i).capture_name.empty()) {
+      capture_tracking_ = true;
+      break;
+    }
+  }
   PushStateAndExpand(initial_state.has_value() ? *initial_state : RootInitialState());
 }
 
@@ -332,6 +349,9 @@ void EarleyParser::PushStateAndExpand(const ParserState& state) {
   tmp_states_to_be_added_.clear();
   Enqueue(state);
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
+  if (capture_tracking_) {
+    capture_event_history_.PushBack(std::vector<CaptureEvent>());
+  }
   while (!tmp_process_state_queue_.empty()) {
     const auto state = tmp_process_state_queue_.front();
     tmp_process_state_queue_.pop();
@@ -352,6 +372,10 @@ void EarleyParser::Reset() {
   scanable_state_history_.PopBack(scanable_state_history_.size());
   is_completed_.clear();
   stop_token_is_accepted_ = false;
+  if (capture_tracking_) {
+    capture_event_history_.PopBack(capture_event_history_.size());
+  }
+  capture_recording_ = false;
   XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
   PushStateAndExpand(RootInitialState());
 }
@@ -378,9 +402,13 @@ void EarleyParser::ExpandNextRuleRefElement(
   }
 
   bool right_recursion_to_root = false;
+  // The right-recursion optimization elides the completion of the parent rule (and, in the
+  // to-root case, corrupts the start position of the child rule), so it must be disabled when
+  // either rule is captured; otherwise their capture events would be lost.
   if (state.element_id != grammar_expr.size() - 1 ||
       sub_grammar_expr->type == GrammarExprType::kRepeat ||
-      (state.rule_start_pos == rule_id_to_completable_states_.size() - 1)) {
+      (state.rule_start_pos == rule_id_to_completable_states_.size() - 1) ||
+      RuleHasCapture(state.rule_id) || RuleHasCapture(ref_rule_id)) {
     // It's not the right recursion, or it's the root rule.
     rule_id_to_completable_states_.PushBackInLatestRow(std::make_pair(ref_rule_id, state));
   } else {
@@ -487,8 +515,10 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
     }
     if (!is_repeat && (fsm.GetFsm().GetFsm().GetEdges(target).size() == 0) &&
         fsm.GetFsm().IsEndState(target) &&
-        state.rule_start_pos != static_cast<int32_t>(rule_id_to_completable_states_.size() - 1)) {
-      // It's a right recursion. We can optimize it.
+        state.rule_start_pos != static_cast<int32_t>(rule_id_to_completable_states_.size() - 1) &&
+        !RuleHasCapture(state.rule_id) && !RuleHasCapture(ref_rule_id)) {
+      // It's a right recursion. We can optimize it. The optimization elides the completion of
+      // the parent rule, so it is disabled when either rule is captured.
       // If it's the right recursion, we need to add the ancestors of the parent state.
       if (state.rule_start_pos == ParserState::kNoPrevInputPos) {
         // In this case, we can mark the new state as the root state to speed up.
@@ -918,6 +948,9 @@ bool EarleyParser::AdvanceAtomicToken(int32_t token_id, bool debug_print) {
     return false;
   }
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
+  if (capture_tracking_) {
+    capture_event_history_.PushBack(std::vector<CaptureEvent>());
+  }
   while (!tmp_process_state_queue_.empty()) {
     const auto state = std::move(tmp_process_state_queue_.front());
     tmp_process_state_queue_.pop();

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -240,6 +240,19 @@ class RepeatDetector {
   void Clear();
 };
 
+/*!
+ * \brief A completion event of a captured rule, recorded when the rule is completed during
+ * parsing. The matched span is [start_pos, r) in input positions, where r is the position (i.e.
+ * the history row) at which the event is recorded.
+ */
+struct CaptureEvent {
+  /*! \brief The id of the completed rule. */
+  int32_t rule_id;
+  /*! \brief The position where the rule started matching. kNoPrevInputPos means position 0 (the
+   * rule acts as the root). */
+  int32_t start_pos;
+};
+
 class EarleyParser {
   /*!
    * \brief Here is an article about Earley Parser.
@@ -317,6 +330,35 @@ class EarleyParser {
     }
     int32_t deadline = current_token_index_ + own;
     return parent_deadline >= 0 ? std::min(deadline, parent_deadline) : deadline;
+  }
+
+  /*! \brief Whether any rule of the grammar has a capture name. Fixed at construction. When
+   * false, the capture machinery is fully disabled and has no overhead. */
+  bool capture_tracking_ = false;
+
+  /*!
+   * \brief Whether capture events are currently recorded in Complete(). Only enabled during
+   * definitive advances (accepting a token or string), not during speculative exploration
+   * (mask computation, jump-forward search, lookahead checks), so that speculative completions
+   * never produce capture events.
+   */
+  bool capture_recording_ = false;
+
+  /*!
+   * \brief The history of capture events. capture_event_history_[i] stores the events recorded
+   * when input position i was created. Kept aligned with scanable_state_history_ row-by-row
+   * whenever capture_tracking_ is true, so PopLastStates rolls back events automatically.
+   */
+  Compact2DArray<CaptureEvent> capture_event_history_;
+
+  /*! \brief Returns true if the rule exists and has a capture name. */
+  bool RuleHasCapture(int32_t rule_id) const {
+    return capture_tracking_ && rule_id >= 0 && !grammar_->GetRule(rule_id).capture_name.empty();
+  }
+
+  /*! \brief Record a capture event for a completed captured rule in the current row. */
+  void RecordCaptureEvent(const ParserState& state) {
+    capture_event_history_.PushBackInLatestRow({state.rule_id, state.rule_start_pos});
   }
 
   /*!
@@ -527,7 +569,33 @@ class EarleyParser {
     rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
     is_completed_.push_back(is_completed_.back());
     scanable_state_history_.PushBack(&state, 1);
+    if (capture_tracking_) {
+      capture_event_history_.PushBack(std::vector<CaptureEvent>());
+    }
     return;
+  }
+
+  /*! \brief Whether the grammar has any captured rule. */
+  bool IsCaptureTrackingEnabled() const { return capture_tracking_; }
+
+  /*! \brief Copy the capture events of the latest input position. */
+  std::vector<CaptureEvent> CopyLastCaptureRow() const {
+    if (!capture_tracking_) {
+      return {};
+    }
+    auto row = capture_event_history_[capture_event_history_.size() - 1];
+    return std::vector<CaptureEvent>(row.begin(), row.end());
+  }
+
+  /*!
+   * \brief Push a new row of capture events. Used when a new input position is created outside
+   * of Advance / AdvanceAtomicToken (e.g. when merging parallel advance results), to keep the
+   * capture history aligned with the state history.
+   */
+  void PushCaptureRow(const std::vector<CaptureEvent>& events) {
+    if (capture_tracking_) {
+      capture_event_history_.PushBack(events);
+    }
   }
 
   std::string PrintStates() const {

--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -26,7 +26,7 @@ std::size_t MemorySize(const Grammar::Impl& impl) {
   /// TODO: Now, we evaluatve memory size of rule strings as sizeof(std::string),
   /// with an assumption that the string is small.
   /// This should be improved in the future.
-  return impl.rules_.size() * sizeof(std::string) + MemorySize(impl.grammar_expr_data_) +
+  return impl.rules_.size() * sizeof(Grammar::Impl::Rule) + MemorySize(impl.grammar_expr_data_) +
          MemorySize(impl.grammar_expr_indptr_) + MemorySize(impl.complete_fsm) +
          MemorySize(impl.per_rule_fsms) + MemorySize(impl.allow_empty_rule_ids);
 }

--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -23,8 +23,8 @@ namespace xgrammar {
 /******************* Grammar::Impl *******************/
 
 std::size_t MemorySize(const Grammar::Impl& impl) {
-  /// TODO: Now, we evaluatve memory size of rule strings as sizeof(std::string),
-  /// with an assumption that the string is small.
+  /// TODO: Now, we evaluate the memory size of each rule as sizeof(Rule), which counts its
+  /// string members as sizeof(std::string), with an assumption that the strings are small.
   /// This should be improved in the future.
   return impl.rules_.size() * sizeof(Grammar::Impl::Rule) + MemorySize(impl.grammar_expr_data_) +
          MemorySize(impl.grammar_expr_indptr_) + MemorySize(impl.complete_fsm) +

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -281,6 +281,18 @@ void GrammarBuilder::UpdateMaxTokens(std::string rule_name, int32_t max_tokens) 
   UpdateMaxTokens(rule_id, max_tokens);
 }
 
+void GrammarBuilder::UpdateCaptureName(int32_t rule_id, const std::string& capture_name) {
+  XGRAMMAR_CHECK(rule_id >= 0 && rule_id < static_cast<int32_t>(grammar_->rules_.size()))
+      << "Rule id " << rule_id << " is out of range.";
+  grammar_->rules_[rule_id].capture_name = capture_name;
+}
+
+void GrammarBuilder::UpdateCaptureName(std::string rule_name, const std::string& capture_name) {
+  int32_t rule_id = GetRuleId(rule_name);
+  XGRAMMAR_CHECK(rule_id != -1) << "Rule " << rule_name << " is not found.";
+  UpdateCaptureName(rule_id, capture_name);
+}
+
 std::string GrammarBuilder::GetNewRuleName(const std::string& name_hint) {
   if (rule_name_to_id_.count(name_hint) == 0) {
     return name_hint;

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -209,6 +209,18 @@ class GrammarBuilder {
   void UpdateMaxTokens(std::string rule_name, int32_t max_tokens);
 
   /*!
+   * \brief Update the capture group name of the rule referred by the given rule_id. An empty
+   * string means no capture.
+   */
+  void UpdateCaptureName(int32_t rule_id, const std::string& capture_name);
+
+  /*!
+   * \brief Update the capture group name of the rule referred by the given name. An empty string
+   * means no capture.
+   */
+  void UpdateCaptureName(std::string rule_name, const std::string& capture_name);
+
+  /*!
    * \brief Find a name for a new rule starting with the given name hint. Some integer suffix (_1,
    * _2, ...) may be added to avoid name conflict.
    */

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -70,6 +70,7 @@ class SubGrammarAdderImpl : public GrammarMutator {
       auto new_lookahead_assertion_id = VisitLookaheadAssertion(rule.lookahead_assertion_id);
       builder_->UpdateLookaheadAssertion(new_rule_ids_names[i].first, new_lookahead_assertion_id);
       builder_->UpdateMaxTokens(new_rule_ids_names[i].first, rule.max_tokens);
+      builder_->UpdateCaptureName(new_rule_ids_names[i].first, rule.capture_name);
     }
     return new_rule_ids_names[base_grammar_->GetRootRuleId()].first;
   }
@@ -275,6 +276,7 @@ class StructureNormalizerImpl : public GrammarMutator {
       builder_->UpdateRuleBody(i, new_body_expr_id);
       builder_->UpdateLookaheadAssertion(i, VisitLookaheadAssertion(rule.lookahead_assertion_id));
       builder_->UpdateMaxTokens(i, rule.max_tokens);
+      builder_->UpdateCaptureName(i, rule.capture_name);
     }
     return builder_->Get(base_grammar_->GetRootRule().name);
   }
@@ -619,8 +621,10 @@ class RuleInlinerImpl : public GrammarMutator {
    */
   bool CheckIfRuleCanBeInlined(int32_t rule_id) {
     auto rule = base_grammar_->GetRule(rule_id);
-    // Inlining a budgeted rule would erase the rule its token budget applies to.
-    if (rule.max_tokens >= 0) {
+    // Inlining a budgeted rule would erase the rule its token budget applies to. Inlining a
+    // captured rule would eliminate its completion events, so its capture would never be
+    // recorded.
+    if (rule.max_tokens >= 0 || !rule.capture_name.empty()) {
       return false;
     }
     auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
@@ -725,6 +729,7 @@ class DeadCodeEliminatorImpl : public GrammarMutator {
           rule_id_map_[rule_id], VisitLookaheadAssertion(rule.lookahead_assertion_id)
       );
       builder_->UpdateMaxTokens(rule_id_map_[rule_id], rule.max_tokens);
+      builder_->UpdateCaptureName(rule_id_map_[rule_id], rule.capture_name);
     }
     XGRAMMAR_CHECK(rule_id_map_.count(grammar->GetRootRuleId()) > 0);
     return builder_->Get(rule_id_map_[grammar->GetRootRuleId()]);

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -70,6 +70,7 @@ class GrammarFunctor {
         // Handle lookahead assertion
         builder_->UpdateLookaheadAssertion(i, VisitLookaheadAssertion(rule.lookahead_assertion_id));
         builder_->UpdateMaxTokens(i, rule.max_tokens);
+        builder_->UpdateCaptureName(i, rule.capture_name);
       }
       return builder_->Get(base_grammar_->GetRootRule().name);
     } else {

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -84,6 +84,10 @@ class Grammar::Impl {
      * occurrence of this rule to at most max_tokens LLM tokens, forcing it to end at the
      * earliest possible position once the budget is exhausted. -1 means no budget. */
     int32_t max_tokens = -1;
+    /*! \brief The capture group name of the rule. When non-empty, the matcher records the input
+     * span matched by this rule on every completion, retrievable via GrammarMatcher::GetCaptures.
+     * Empty means no capture. */
+    std::string capture_name = {};
   };
 
   /*! \brief Get the number of rules. */
@@ -358,7 +362,8 @@ XGRAMMAR_MEMBER_ARRAY(
     &Grammar::Impl::Rule::body_expr_id,
     &Grammar::Impl::Rule::lookahead_assertion_id,
     &Grammar::Impl::Rule::is_exact_lookahead,
-    &Grammar::Impl::Rule::max_tokens
+    &Grammar::Impl::Rule::max_tokens,
+    &Grammar::Impl::Rule::capture_name
 );
 
 XGRAMMAR_MEMBER_TABLE(

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -590,12 +590,7 @@ class GrammarMatcher::Impl : public EarleyParser {
     auto bitset = DynamicBitset(
         tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr)
     );
-    for (int i = 0; i < tokenizer_info_.GetVocabSize(); ++i) {
-      if (bitset[i]) {
-        return true;
-      }
-    }
-    return false;
+    return bitset.Any();
   }
 
   /*! \brief Record that num_rows new input positions were created, each consuming one byte of
@@ -984,25 +979,29 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
   if (has_budget_rules_) {
     const auto& row = scanable_state_history_[scanable_state_history_.size() - 1];
     bool any_expired = false;
+    bool any_alive = false;
     for (const auto& state : row) {
       if (IsExpiredState(state)) {
         any_expired = true;
-        break;
+      } else {
+        any_alive = true;
       }
     }
-    if (any_expired) {
-      // Try to force the expired derivations to end here: mask from the other states only. If
-      // no token remains, ending is impossible at this position; relax the budget for one step
-      // and report it on the next accept.
+    if (any_expired && (any_alive || IsCompleted())) {
+      // The expired derivations can be forced to end here: some other derivation can make
+      // progress (or the grammar can terminate), so mask from the non-expired states only.
+      // Only when the vocabulary cannot encode any of the live states' next bytes does the
+      // mask come out empty; fall through to relaxing then.
       FillBitmaskForStates(bitmask_data_ptr, index, /*skip_expired=*/true, debug_print);
       if (BitmaskHasAnyToken(bitmask_data_ptr) || IsCompleted()) {
         budget_enforce_pending_ = true;
         return !IsTokenBitmaskAllTrue(bitmask_data_ptr);
       }
-      budget_enforce_pending_ = false;
-    } else {
-      budget_enforce_pending_ = false;
     }
+    // No enforcement at this position: either no budget has expired, or the expired
+    // derivations cannot end here — relax the budget for one step and report it on the next
+    // accept.
+    budget_enforce_pending_ = false;
   }
   FillBitmaskForStates(bitmask_data_ptr, index, /*skip_expired=*/false, debug_print);
   return !IsTokenBitmaskAllTrue(bitmask_data_ptr);

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -480,8 +480,12 @@ class GrammarMatcher::Impl : public EarleyParser {
     current_token_index_ = -1;
     budget_enforce_pending_ = false;
     budget_exceeded_warned_ = false;
+    accepted_bytes_.clear();
+    row_byte_end_.assign(1, 0);
     EarleyParser::Reset();
   }
+
+  std::vector<std::pair<std::string, std::string>> GetCaptures(bool deduplicate) const;
 
   int GetMaxRollbackTokens() const { return -1; }
 
@@ -542,6 +546,26 @@ class GrammarMatcher::Impl : public EarleyParser {
     Impl* impl_;
   };
 
+  /*!
+   * \brief Enables capture-event recording in the Earley parser for the lifetime of the scope.
+   * Used in the definitive accept paths (AcceptToken / AcceptString) only, so that speculative
+   * advances (mask computation, jump-forward search) never record capture events.
+   */
+  class CaptureRecordingScope {
+   public:
+    explicit CaptureRecordingScope(Impl* impl) : impl_(impl) {
+      if (impl_->capture_tracking_) {
+        impl_->capture_recording_ = true;
+      }
+    }
+    ~CaptureRecordingScope() { impl_->capture_recording_ = false; }
+    CaptureRecordingScope(const CaptureRecordingScope&) = delete;
+    CaptureRecordingScope& operator=(const CaptureRecordingScope&) = delete;
+
+   private:
+    Impl* impl_;
+  };
+
   /*! \brief Fill the bitmask from the current states, optionally excluding the states whose
    * budget deadline has passed. */
   void FillBitmaskForStates(
@@ -574,6 +598,22 @@ class GrammarMatcher::Impl : public EarleyParser {
     return false;
   }
 
+  /*! \brief Record that num_rows new input positions were created, each consuming one byte of
+   * bytes in order. Used for the byte-by-byte advance paths. */
+  void AppendPerByteRows(const std::string& bytes) {
+    for (char c : bytes) {
+      accepted_bytes_.push_back(static_cast<uint8_t>(c));
+      row_byte_end_.push_back(static_cast<int64_t>(accepted_bytes_.size()));
+    }
+  }
+
+  /*! \brief Record that one new input position was created, consuming all bytes of the token.
+   * Used for the atomic token advance path. */
+  void AppendAtomicRow(const std::string& bytes) {
+    accepted_bytes_.insert(accepted_bytes_.end(), bytes.begin(), bytes.end());
+    row_byte_end_.push_back(static_cast<int64_t>(accepted_bytes_.size()));
+  }
+
   CompiledGrammar compiled_grammar_;
   TokenizerInfo tokenizer_info_;
   std::vector<int> stop_token_ids_;
@@ -585,6 +625,12 @@ class GrammarMatcher::Impl : public EarleyParser {
   bool budget_enforce_pending_ = false;
   /*! \brief Whether the one-time budget-exceeded warning has been reported. */
   bool budget_exceeded_warned_ = false;
+
+  /*! \brief The bytes accepted so far. Only maintained when the grammar has captured rules. */
+  std::vector<uint8_t> accepted_bytes_;
+  /*! \brief row_byte_end_[i] is the number of accepted bytes after input position i. Aligned
+   * with the parser's state history. Only maintained when the grammar has captured rules. */
+  std::vector<int64_t> row_byte_end_{0};
 
   // Temporary data for FillNextTokenBitmask. They are stored here to avoid repeated allocation.
   DynamicBitset tmp_accepted_bitset_;
@@ -724,15 +770,21 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
 
   const auto& token = tokenizer_info_.GetDecodedVocab()[token_id];
 
+  // Capture events are only recorded on the definitive accept path.
+  CaptureRecordingScope capture_scope(this);
+  const int32_t size_before_token = rule_id_to_completable_states_.size();
+
   // Phase 1: Try atomic token path (from current state, before byte path)
   std::vector<ParserState> atomic_states;
   std::vector<std::pair<int32_t, ParserState>> atomic_completable;
+  std::vector<CaptureEvent> atomic_capture_row;
   bool atomic_completed = false;
   bool atomic_success = AdvanceAtomicToken(token_id, debug_print);
   if (atomic_success) {
     atomic_states = GetLatestScanableStates();
     auto row = rule_id_to_completable_states_.Back();
     atomic_completable.assign(row.data, row.data + row.data_len);
+    atomic_capture_row = CopyLastCaptureRow();
     atomic_completed = is_completed_.back();
     PopLastStates(1);
   }
@@ -762,8 +814,14 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     PopLastStates(pos);
     AdvanceAtomicToken(token_id, debug_print);
     token_length_history.push_back(1);
+    if (IsCaptureTrackingEnabled()) {
+      AppendAtomicRow(token);
+    }
   } else if (byte_path_success && !atomic_success) {
     token_length_history.push_back(token.size());
+    if (IsCaptureTrackingEnabled()) {
+      AppendPerByteRows(token);
+    }
   } else {
     // Both paths succeeded — merge atomic token states into byte path
     if (token.empty()) {
@@ -771,7 +829,11 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
       scanable_state_history_.PushBack(atomic_states);
       rule_id_to_completable_states_.PushBack(atomic_completable);
       is_completed_.push_back(atomic_completed);
+      PushCaptureRow(atomic_capture_row);
       token_length_history.push_back(1);
+      if (IsCaptureTrackingEnabled()) {
+        AppendAtomicRow(token);
+      }
     } else {
       auto byte_states = GetLatestScanableStates();
       std::vector<ParserState> merged = byte_states;
@@ -788,6 +850,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
       std::vector<std::pair<int32_t, ParserState>> merged_completable(
           byte_row.data, byte_row.data + byte_row.data_len
       );
+      std::vector<CaptureEvent> merged_capture_row = CopyLastCaptureRow();
       bool byte_completed = is_completed_.back();
       PopLastStates(1);
 
@@ -799,10 +862,32 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
         }
       }
 
+      for (auto event : atomic_capture_row) {
+        // In the atomic path, the after-token position was size_before_token; in the byte path
+        // it is the row being re-pushed. Remap events that started at the after-token position
+        // (empty spans) so that they stay empty in the byte-path numbering.
+        if (event.start_pos == size_before_token) {
+          event.start_pos = rule_id_to_completable_states_.size();
+        }
+        if (std::find_if(
+                merged_capture_row.begin(),
+                merged_capture_row.end(),
+                [&](const CaptureEvent& e) {
+                  return e.rule_id == event.rule_id && e.start_pos == event.start_pos;
+                }
+            ) == merged_capture_row.end()) {
+          merged_capture_row.push_back(event);
+        }
+      }
+
       scanable_state_history_.PushBack(merged);
       rule_id_to_completable_states_.PushBack(merged_completable);
       is_completed_.push_back(byte_completed || atomic_completed);
+      PushCaptureRow(merged_capture_row);
       token_length_history.push_back(token.size());
+      if (IsCaptureTrackingEnabled()) {
+        AppendPerByteRows(token);
+      }
     }
   }
 
@@ -827,6 +912,9 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
 
   current_token_index_ = static_cast<int32_t>(token_length_history.size());
 
+  // Capture events are only recorded on the definitive accept path.
+  CaptureRecordingScope capture_scope(this);
+
   int accepted_cnt = 0;
   for (auto char_value : input_str) {
     if (!Advance(char_value, debug_print)) {
@@ -844,6 +932,9 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
     ++accepted_cnt;
   }
   token_length_history.push_back(input_str.size());
+  if (IsCaptureTrackingEnabled()) {
+    AppendPerByteRows(input_str);
+  }
 
   if (debug_print) {
     XGRAMMAR_LOG(INFO) << "String \"" << EscapeString(input_str) << "\" is accepted.";
@@ -1144,9 +1235,75 @@ void GrammarMatcher::Impl::Rollback(int num_tokens) {
     int steps = token_length_history.back();
     PopLastStates(steps);
     token_length_history.pop_back();
+    if (IsCaptureTrackingEnabled() && steps > 0) {
+      row_byte_end_.resize(row_byte_end_.size() - steps);
+      accepted_bytes_.resize(row_byte_end_.back());
+    }
     --num_tokens;
   }
   budget_enforce_pending_ = false;
+}
+
+std::vector<std::pair<std::string, std::string>> GrammarMatcher::Impl::GetCaptures(bool deduplicate
+) const {
+  std::vector<std::pair<std::string, std::string>> result;
+  if (!IsCaptureTrackingEnabled()) {
+    return result;
+  }
+  XGRAMMAR_DCHECK(capture_event_history_.size() == static_cast<int32_t>(row_byte_end_.size()))
+      << "The capture history is not aligned with the byte history: "
+      << capture_event_history_.size() << " vs " << row_byte_end_.size();
+
+  // Flatten the event history. Events are ordered by completion position, and by completion
+  // order within a position.
+  struct FlatEvent {
+    int32_t rule_id;
+    int32_t start_row;
+    int32_t end_row;
+  };
+  std::vector<FlatEvent> events;
+  for (int32_t row = 0; row < capture_event_history_.size(); ++row) {
+    for (const auto& event : capture_event_history_[row]) {
+      int32_t start_row = event.start_pos == ParserState::kNoPrevInputPos ? 0 : event.start_pos;
+      XGRAMMAR_DCHECK(start_row <= row);
+      events.push_back({event.rule_id, start_row, row});
+    }
+  }
+
+  // The Earley parser explores all parse hypotheses in parallel, so one occurrence of a rule
+  // (identified by its rule id and start position) may complete at several candidate end
+  // positions before the following input decides the real one. When deduplicate is true, we
+  // keep only the last (longest) completion of each occurrence.
+  std::vector<bool> keep(events.size(), true);
+  if (deduplicate) {
+    std::unordered_map<int64_t, size_t> last_index;
+    for (size_t i = 0; i < events.size(); ++i) {
+      int64_t key = (static_cast<int64_t>(events[i].rule_id) << 32) |
+                    static_cast<uint32_t>(events[i].start_row);
+      auto it = last_index.find(key);
+      if (it != last_index.end()) {
+        keep[it->second] = false;
+        it->second = i;
+      } else {
+        last_index[key] = i;
+      }
+    }
+  }
+
+  for (size_t i = 0; i < events.size(); ++i) {
+    if (!keep[i]) {
+      continue;
+    }
+    const auto& event = events[i];
+    result.emplace_back(
+        grammar_->GetRule(event.rule_id).capture_name,
+        std::string(
+            accepted_bytes_.begin() + row_byte_end_[event.start_row],
+            accepted_bytes_.begin() + row_byte_end_[event.end_row]
+        )
+    );
+  }
+  return result;
 }
 
 void GrammarMatcher::Impl::SetTokenBitmask(
@@ -1399,6 +1556,11 @@ bool GrammarMatcher::TraverseDraftTree(
 std::string GrammarMatcher::FindJumpForwardString() { return pimpl_->FindJumpForwardString(); }
 
 void GrammarMatcher::Rollback(int num_tokens) { pimpl_->Rollback(num_tokens); }
+
+std::vector<std::pair<std::string, std::string>> GrammarMatcher::GetCaptures(bool deduplicate
+) const {
+  return pimpl_->GetCaptures(deduplicate);
+}
 
 bool GrammarMatcher::IsTerminated() const { return pimpl_->IsTerminated(); }
 

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -547,20 +547,20 @@ class GrammarMatcher::Impl : public EarleyParser {
   };
 
   /*!
-   * \brief Enables capture-event recording in the Earley parser for the lifetime of the scope.
-   * Used in the definitive accept paths (AcceptToken / AcceptString) only, so that speculative
-   * advances (mask computation, jump-forward search) never record capture events.
+   * \brief RAII guard that enables capture-event recording in the Earley parser for its
+   * lifetime. Used in the definitive accept paths (AcceptToken / AcceptString) only, so that
+   * speculative advances (mask computation, jump-forward search) never record capture events.
    */
-  class CaptureRecordingScope {
+  class CaptureRecordingGuard {
    public:
-    explicit CaptureRecordingScope(Impl* impl) : impl_(impl) {
+    explicit CaptureRecordingGuard(Impl* impl) : impl_(impl) {
       if (impl_->capture_tracking_) {
         impl_->capture_recording_ = true;
       }
     }
-    ~CaptureRecordingScope() { impl_->capture_recording_ = false; }
-    CaptureRecordingScope(const CaptureRecordingScope&) = delete;
-    CaptureRecordingScope& operator=(const CaptureRecordingScope&) = delete;
+    ~CaptureRecordingGuard() { impl_->capture_recording_ = false; }
+    CaptureRecordingGuard(const CaptureRecordingGuard&) = delete;
+    CaptureRecordingGuard& operator=(const CaptureRecordingGuard&) = delete;
 
    private:
     Impl* impl_;
@@ -771,7 +771,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   const auto& token = tokenizer_info_.GetDecodedVocab()[token_id];
 
   // Capture events are only recorded on the definitive accept path.
-  CaptureRecordingScope capture_scope(this);
+  CaptureRecordingGuard capture_guard(this);
   const int32_t size_before_token = rule_id_to_completable_states_.size();
 
   // Phase 1: Try atomic token path (from current state, before byte path)
@@ -913,7 +913,7 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
   current_token_index_ = static_cast<int32_t>(token_length_history.size());
 
   // Capture events are only recorded on the definitive accept path.
-  CaptureRecordingScope capture_scope(this);
+  CaptureRecordingGuard capture_guard(this);
 
   int accepted_cnt = 0;
   for (auto char_value : input_str) {

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -142,9 +142,11 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
     };
   }
 
-  // A rule definition may carry a token-budget attribute: name[max_tokens=N] ::= ... The
-  // bracket group is treated as an attribute only when followed by "::="; otherwise it is left
-  // to be lexed as a character class.
+  // A rule definition may carry an attribute block before ::=, e.g.
+  // name[max_tokens=10] ::= ..., name[capture] ::= ..., name[capture="x"] ::= ..., or a
+  // comma-separated combination: name[max_tokens=10, capture="x"] ::= ... The bracket group is
+  // treated as an attribute block only when it is followed by "::="; otherwise it is left to be
+  // lexed as a character class.
   if (*cur_ == '[') {
     int delta = 1;
     auto skip_space = [&]() {
@@ -152,59 +154,111 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
         ++delta;
       }
     };
-    skip_space();
-    constexpr const char kKeyword[] = "max_tokens";
-    bool matched = true;
-    for (int i = 0; kKeyword[i] != '\0'; ++i) {
-      if (Peek(delta + i) != kKeyword[i]) {
-        matched = false;
-        break;
-      }
-    }
-    if (matched) {
-      delta += 10;
-      skip_space();
-      int64_t value = -1;
-      if (Peek(delta) == '=') {
-        ++delta;
-        skip_space();
-        value = 0;
-        int digits = 0;
-        while (Peek(delta) >= '0' && Peek(delta) <= '9' && digits < 10) {
-          value = value * 10 + (Peek(delta) - '0');
-          ++delta;
-          ++digits;
+    // Match the keyword at the current position and advance delta past it on success.
+    auto match_keyword = [&](const char* keyword) {
+      int len = 0;
+      while (keyword[len] != '\0') {
+        if (Peek(delta + len) != keyword[len]) {
+          return false;
         }
-        if (digits == 0 || (Peek(delta) >= '0' && Peek(delta) <= '9')) {
+        ++len;
+      }
+      delta += len;
+      return true;
+    };
+    bool matched = true;
+    bool has_max_tokens = false;
+    bool has_capture = false;
+    int64_t max_tokens_value = -1;
+    std::string capture_value;
+    // Parse a comma-separated attribute list. Each attribute may appear at most once.
+    while (matched) {
+      skip_space();
+      if (!has_max_tokens && match_keyword("max_tokens")) {
+        has_max_tokens = true;
+        skip_space();
+        if (Peek(delta) == '=') {
+          ++delta;
+          skip_space();
+          max_tokens_value = 0;
+          int digits = 0;
+          while (Peek(delta) >= '0' && Peek(delta) <= '9' && digits < 10) {
+            max_tokens_value = max_tokens_value * 10 + (Peek(delta) - '0');
+            ++delta;
+            ++digits;
+          }
+          if (digits == 0 || (Peek(delta) >= '0' && Peek(delta) <= '9')) {
+            matched = false;
+          }
+        } else {
           matched = false;
+        }
+      } else if (!has_capture && match_keyword("capture")) {
+        has_capture = true;
+        skip_space();
+        if (Peek(delta) == '=') {
+          ++delta;
+          skip_space();
+          if (Peek(delta) != '"') {
+            matched = false;
+          } else {
+            ++delta;
+            while (matched && Peek(delta) != '"') {
+              char c = Peek(delta);
+              if (c == '\0' || c == '\n' || c == '\r' || c == '\\') {
+                matched = false;
+                break;
+              }
+              capture_value.push_back(c);
+              ++delta;
+            }
+            if (matched) {
+              ++delta;
+            }
+          }
+        } else {
+          capture_value = identifier;
         }
       } else {
         matched = false;
       }
-      if (matched) {
-        skip_space();
-        if (Peek(delta) == ']') {
-          ++delta;
-        } else {
-          matched = false;
-        }
+      if (!matched) {
+        break;
       }
-      if (matched) {
-        int after_bracket = delta;
-        while (Peek(after_bracket) == ' ' || Peek(after_bracket) == '\t') {
-          ++after_bracket;
-        }
-        if (!(Peek(after_bracket) == ':' && Peek(after_bracket + 1) == ':' &&
-              Peek(after_bracket + 2) == '=')) {
-          matched = false;
-        }
+      skip_space();
+      if (Peek(delta) == ',') {
+        ++delta;
+        continue;
       }
-      if (matched) {
-        Consume(delta);
-        Token token{TokenType::Identifier, identifier, identifier, start_line, start_column};
-        token.max_tokens = static_cast<int32_t>(value);
-        return token;
+      break;
+    }
+    if (matched) {
+      skip_space();
+      if (Peek(delta) == ']') {
+        ++delta;
+      } else {
+        matched = false;
       }
+    }
+    if (matched) {
+      int after_bracket = delta;
+      while (Peek(after_bracket) == ' ' || Peek(after_bracket) == '\t') {
+        ++after_bracket;
+      }
+      if (!(Peek(after_bracket) == ':' && Peek(after_bracket + 1) == ':' &&
+            Peek(after_bracket + 2) == '=')) {
+        matched = false;
+      }
+    }
+    if (matched) {
+      if (has_capture && capture_value.empty()) {
+        ReportLexerError("The capture name must not be empty", start_line, start_column);
+      }
+      Consume(delta);
+      Token token{TokenType::Identifier, identifier, identifier, start_line, start_column};
+      token.max_tokens = static_cast<int32_t>(max_tokens_value);
+      token.capture_name = capture_value;
+      return token;
     }
   }
 
@@ -1254,6 +1308,7 @@ EBNFParser::Rule EBNFParser::ParseRule() {
   }
   cur_rule_name_ = std::any_cast<std::string>(Peek().value);
   int32_t max_tokens = Peek().max_tokens;
+  std::string capture_name = Peek().capture_name;
   Consume();
 
   PeekAndConsume(TokenType::Assign, "Expect ::=");
@@ -1267,6 +1322,7 @@ EBNFParser::Rule EBNFParser::ParseRule() {
 
   Rule rule{cur_rule_name_, body_id, lookahead_id};
   rule.max_tokens = max_tokens;
+  rule.capture_name = capture_name;
   return rule;
 }
 
@@ -1307,6 +1363,7 @@ Grammar EBNFParser::Parse(
     builder_.UpdateRuleBody(new_rule.name, new_rule.body_expr_id);
     builder_.UpdateLookaheadAssertion(new_rule.name, new_rule.lookahead_assertion_id);
     builder_.UpdateMaxTokens(new_rule.name, new_rule.max_tokens);
+    builder_.UpdateCaptureName(new_rule.name, new_rule.capture_name);
   }
 
   return builder_.Get(root_rule_name);

--- a/cpp/grammar_parser.h
+++ b/cpp/grammar_parser.h
@@ -60,6 +60,8 @@ class EBNFLexer {
     int column;
     // The token budget attached to a rule-definition identifier via name[max_tokens=N], or -1.
     int32_t max_tokens = -1;
+    // The capture name attached to a rule-definition identifier via name[capture="x"], or empty.
+    std::string capture_name = {};
   };
 
   EBNFLexer();

--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -13,8 +13,19 @@ namespace xgrammar {
 
 std::string GrammarPrinter::PrintRule(const Rule& rule) {
   std::string res = rule.name;
-  if (rule.max_tokens >= 0) {
-    res += "[max_tokens=" + std::to_string(rule.max_tokens) + "]";
+  // Print the attributes as one comma-separated bracket group, re-parseable by the EBNF lexer.
+  if (rule.max_tokens >= 0 || !rule.capture_name.empty()) {
+    std::string attributes;
+    if (rule.max_tokens >= 0) {
+      attributes += "max_tokens=" + std::to_string(rule.max_tokens);
+    }
+    if (!rule.capture_name.empty()) {
+      if (!attributes.empty()) {
+        attributes += ", ";
+      }
+      attributes += "capture=\"" + rule.capture_name + "\"";
+    }
+    res += "[" + attributes + "]";
   }
   res += " ::= " + PrintGrammarExpr(rule.body_expr_id);
   if (rule.lookahead_assertion_id != -1) {

--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -522,6 +522,8 @@ struct Definition {
   Location suffix_location;
   std::optional<int32_t> max_tokens;
   Location max_tokens_location;
+  std::optional<std::string> capture_name;
+  Location capture_location;
   Node body;
   Location location;
 };
@@ -709,6 +711,41 @@ class LarkParser {
         }
         definition->max_tokens = value;
         definition->max_tokens_location = key.location;
+      } else if (key.text == "capture") {
+        std::string capture_name;
+        Location capture_location = key.location;
+        if (Match(TokenType::kEquals)) {
+          Token name_token = Consume(TokenType::kString, "expected string literal after capture=");
+          Node name_node = ParseStringNode(name_token);
+          if (!name_node.flags.empty()) {
+            RaiseLarkError(
+                source_, name_node.location, "case-insensitive flags are not supported on capture"
+            );
+          }
+          capture_name = std::move(name_node.text);
+          capture_location = name_node.location;
+        } else {
+          capture_name = definition->name;
+        }
+        if (capture_name.empty()) {
+          RaiseLarkError(source_, capture_location, "capture name must not be empty");
+        }
+        for (char c : capture_name) {
+          bool valid = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+                       c == '_' || c == '-' || c == '.';
+          if (!valid) {
+            RaiseLarkError(
+                source_,
+                capture_location,
+                "capture name must only contain letters, digits, '_', '-' and '.'"
+            );
+          }
+        }
+        if (definition->capture_name.has_value()) {
+          RaiseLarkError(source_, key.location, "capture attribute is specified more than once");
+        }
+        definition->capture_name = std::move(capture_name);
+        definition->capture_location = capture_location;
       } else if (key.text == "suffix") {
         Consume(TokenType::kEquals, "expected '=' after suffix attribute");
         Token suffix_token = Consume(TokenType::kString, "expected string literal after suffix=");
@@ -1223,6 +1260,13 @@ class LarkCompiler {
               "max_tokens is not supported on rules consumed by dynamic dispatch"
           );
         }
+        if (definition.capture_name.has_value()) {
+          RaiseLarkError(
+              source_,
+              definition.capture_location,
+              "capture is not supported on rules consumed by dynamic dispatch"
+          );
+        }
         builder_.UpdateRuleBody(rule_ids_.at(definition.name), builder_.AddEmptyStr());
         continue;
       }
@@ -1255,6 +1299,9 @@ class LarkCompiler {
         body_expr_id = CompileNode(definition.body, definition.name, false);
       }
       builder_.UpdateRuleBody(rule_ids_.at(definition.name), body_expr_id);
+      if (definition.capture_name.has_value()) {
+        builder_.UpdateCaptureName(rule_ids_.at(definition.name), definition.capture_name.value());
+      }
     }
 
     auto start_it = rule_ids_.find("start");

--- a/cpp/support/dynamic_bitset.h
+++ b/cpp/support/dynamic_bitset.h
@@ -210,6 +210,21 @@ class DynamicBitset {
     return (data_[buffer_size_ - 1] & last_block_mask) == last_block_mask;
   }
 
+  bool Any() const {
+    if (size_ == 0) return false;
+    // Check all complete blocks except the last one
+    for (int i = 0; i < buffer_size_ - 1; ++i) {
+      if (data_[i] != 0) {
+        return true;
+      }
+    }
+    // For the last block, only consider the valid bits
+    int remaining_bits = size_ % BITS_PER_BLOCK;
+    uint32_t last_block_mask = remaining_bits ? (static_cast<uint32_t>(1) << remaining_bits) - 1
+                                              : ~static_cast<uint32_t>(0);
+    return (data_[buffer_size_ - 1] & last_block_mask) != 0;
+  }
+
   static constexpr int BITS_PER_BLOCK = 32;
 
   friend std::size_t MemorySize(const DynamicBitset& bitset) {

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v16";
+  static constexpr const char kXGrammarSerializeVersion[] = "v15";
 };
 
 /*!

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v15";
+  static constexpr const char kXGrammarSerializeVersion[] = "v16";
 };
 
 /*!

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -711,6 +711,20 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           }
       )
       .def(
+          "get_captures",
+          [](const GrammarMatcherObj* o, bool deduplicate) {
+            auto captures = o->value.GetCaptures(deduplicate);
+            ffi::Array<ffi::Any> result;
+            for (const auto& [name, value] : captures) {
+              ffi::Array<ffi::Any> pair;
+              pair.push_back(ffi::String(name));
+              pair.push_back(ffi::Bytes(value));
+              result.push_back(pair);
+            }
+            return result;
+          }
+      )
+      .def(
           "fork",
           [](GrammarMatcherObj* o) {
             return ffi::ObjectRef(ffi::make_object<GrammarMatcherObj>(o->value.Fork()));

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -485,3 +485,46 @@ generation, not validation/prefill).
 
 `max_tokens` must be positive and cannot be combined with `lazy` or `suffix`, used on
 terminals, or on rules consumed by the dynamic dispatch pattern.
+
+## Capture Groups
+
+A rule can be marked with the `capture` attribute so that the matcher records the input span the
+rule matched:
+
+```text
+start: tool* tail
+tail: TEXT
+
+tool_head[lazy]: TEXT "<tool_call>"
+tool: tool_head arg "</tool_call>"
+arg[capture]: /[0-9]+/
+
+TEXT: /(\n|.)*/
+```
+
+`rule[capture]` uses the rule name as the capture name; `rule[capture="name"]` sets an explicit
+name. Capture names may contain letters, digits, `_`, `-` and `.`. The recorded captures are
+retrieved from the matcher:
+
+```python
+matcher = xgr.GrammarMatcher(compiled)
+matcher.accept_string('x<tool_call>42</tool_call>y<tool_call>7</tool_call>')
+matcher.get_captures()  # [("arg", b"42"), ("arg", b"7")]
+```
+
+Each completion of a captured rule records one capture, so a rule matched repeatedly (for
+example inside a loop or a dispatch pattern) yields one entry per match, in completion order.
+Captures are recorded when tokens or strings are accepted; `fill_next_token_bitmask` never
+records anything, and `rollback` also rolls back the recorded captures.
+
+Since the parser explores parse hypotheses in parallel, one occurrence of a captured rule may
+complete at several candidate end positions (a `/[0-9]+/` body completes after every digit). By
+default `get_captures` keeps only the longest completion of each occurrence, which is exact
+whenever the captured rule's end is determined by a following delimiter that its body cannot
+match (closing tags, quotes, brackets). If the following context can also be matched by the
+rule body itself, the reported span may extend past the span of the finally accepted parse;
+`get_captures(deduplicate=False)` returns the raw completion events instead.
+
+Captures are supported on rules only (not terminals), and not on rules consumed by the dynamic
+dispatch pattern (the head, tool and tail rules themselves); rules referenced from a tool's
+body, like `arg` above, work as expected.

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -150,6 +150,24 @@ class GrammarMatcher {
   void Rollback(int num_tokens = 1);
 
   /*!
+   * \brief Get the capture groups recorded so far, ordered by completion position.
+   * \param deduplicate The Earley parser explores parse hypotheses in parallel, so one
+   * occurrence of a captured rule may complete at several candidate end positions (e.g. a
+   * /[0-9]+/ body completes after every digit). If true (default), only the last (longest)
+   * completion of each occurrence is kept. Distinct occurrences — repeated matches of the same
+   * rule at different positions — are always kept. If false, the raw completion events are
+   * returned.
+   * \return A list of (capture_name, matched_bytes) pairs. Rules gain a capture name via the
+   * Lark attribute rule[capture] / rule[capture="name"] or the EBNF form rule[capture="name"]
+   * ::= ... The bytes are the input span that the rule matched.
+   * \note Captures are recorded when a rule is completed during AcceptToken / AcceptString, and
+   * are rolled back together with Rollback. Mask computation never records captures. Completions
+   * on parse paths that are later abandoned may still be recorded; for unambiguous grammars
+   * whose captured rules have unambiguous boundaries, the deduplicated result is exact.
+   */
+  std::vector<std::pair<std::string, std::string>> GetCaptures(bool deduplicate = true) const;
+
+  /*!
    * \brief Check if the matcher has accepted the stop token and terminated.
    * \sa AcceptToken
    */

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -417,6 +417,31 @@ class GrammarMatcher(XGRObject):
         """
         self._handle.rollback(num_tokens)
 
+    def get_captures(self, *, deduplicate: bool = True) -> List[Tuple[str, bytes]]:
+        """Get the capture groups recorded so far, ordered by completion position.
+
+        A rule gains a capture name via the Lark attribute ``rule[capture]`` or
+        ``rule[capture="name"]``. Each time a captured rule is completed while accepting tokens
+        or strings, the matched input span is recorded. Rollback also rolls back the recorded
+        captures. Mask computation (fill_next_token_bitmask) never records captures.
+
+        Parameters
+        ----------
+        deduplicate : bool, default: True
+            The parser explores parse hypotheses in parallel, so one occurrence of a captured
+            rule may complete at several candidate end positions (e.g. a ``/[0-9]+/`` body
+            completes after every digit). If True, only the last (longest) completion of each
+            occurrence is kept. Distinct occurrences — repeated matches of the same rule at
+            different positions — are always kept. If False, the raw completion events are
+            returned.
+
+        Returns
+        -------
+        captures : List[Tuple[str, bytes]]
+            A list of (capture_name, matched_bytes) pairs.
+        """
+        return [(str(pair[0]), bytes(pair[1])) for pair in self._handle.get_captures(deduplicate)]
+
     def is_terminated(self) -> bool:
         """Check if the matcher has terminated. If terminate_without_stop_token is False, the
         matcher will terminate if it has accepted the stop token. Otherwise, the matcher will

--- a/tests/cpp/test_lark_converter.cc
+++ b/tests/cpp/test_lark_converter.cc
@@ -144,9 +144,14 @@ TEST(LarkConverterTest, ErrorsContainSourceLocations) {
       "circular reference in terminal"
   );
   XGRAMMAR_EXPECT_THROW(
-      Grammar::FromLark("start[capture]: \"a\""),
+      Grammar::FromLark("start[budget=10]: \"a\""),
       XGrammarError,
-      "attribute 'capture' is not supported"
+      "attribute 'budget' is not supported"
+  );
+  XGRAMMAR_EXPECT_THROW(
+      Grammar::FromLark("start[capture=\"a b\"]: \"a\""),
+      XGrammarError,
+      "capture name must only contain letters, digits"
   );
   XGRAMMAR_EXPECT_THROW(
       Grammar::FromLark("start: A & B\nA: \"a\"\nB: \"b\""),

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -855,10 +855,25 @@ def test_lark_large_choice_grammar() -> None:
             id="terminal-references-rule",
         ),
         pytest.param(
-            'start[capture]: "a"', "attribute 'capture' is not supported", id="capture-attribute"
+            'start[budget=10]: "a"',
+            "attribute 'budget' is not supported",
+            id="unknown-attribute",
         ),
         pytest.param(
             'start[stop="x"]: "a"', "attribute 'stop' is not supported", id="stop-attribute"
+        ),
+        pytest.param(
+            'start[capture=""]: "a"', "capture name must not be empty", id="empty-capture-name"
+        ),
+        pytest.param(
+            'start[capture="a b"]: "a"',
+            "capture name must only contain letters, digits",
+            id="invalid-capture-name",
+        ),
+        pytest.param(
+            'start[capture, capture]: "a"',
+            "capture attribute is specified more than once",
+            id="duplicate-capture-attribute",
         ),
         pytest.param(
             "TOKEN[lazy]: /a/\nstart: TOKEN",
@@ -1396,3 +1411,164 @@ def test_lark_max_tokens_works_without_tokenizer_info() -> None:
     assert matcher.accept_token(0) and matcher.accept_token(0)
     assert _allowed_token_ids(matcher, tokenizer_info) == [1]
     assert matcher.accept_token(1) and matcher.is_terminated()
+
+
+def _get_captures(
+    grammar: str, value: str, tokenizer_info: Optional[xgr.TokenizerInfo] = None
+) -> list:
+    compiled = _compile_lark(grammar, tokenizer_info)
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_string(value)
+    return matcher.get_captures()
+
+
+def test_lark_capture_simple() -> None:
+    assert _get_captures('start: "a" v "b"\nv[capture]: /[0-9]+/', "a123b") == [("v", b"123")]
+
+
+def test_lark_capture_named_and_nested() -> None:
+    grammar = 'start: outer\nouter[capture="o"]: "x" inner "!"\ninner[capture="i"]: /[a-z]+/'
+    assert _get_captures(grammar, "xabc!") == [("i", b"abc"), ("o", b"xabc!")]
+
+
+def test_lark_capture_repeated_occurrences() -> None:
+    grammar = 'start: (item ",")* item\nitem[capture]: /[0-9]+/'
+    assert _get_captures(grammar, "1,22,333") == [("item", b"1"), ("item", b"22"), ("item", b"333")]
+
+
+def test_lark_capture_right_recursion() -> None:
+    # The right-recursion optimization elides parent completions; it must be disabled for
+    # captured rules so that every recursion level still records its span.
+    grammar = 'start: lst\nlst[capture]: ITEM "," lst | ITEM\nITEM: /[0-9]+/'
+    assert _get_captures(grammar, "1,2,3") == [("lst", b"3"), ("lst", b"2,3"), ("lst", b"1,2,3")]
+
+
+def test_lark_capture_on_root_rule() -> None:
+    assert _get_captures('start[capture="all"]: "a" /[0-9]+/ "b"', "a12b") == [("all", b"a12b")]
+
+
+def test_lark_capture_raw_events_and_coalescing() -> None:
+    compiled = _compile_lark('start: "a" v "b"\nv[capture]: /[0-9]+/')
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_string("a123b")
+    # The /[0-9]+/ body completes after every digit; deduplication keeps the longest
+    # completion of the occurrence, the raw event list keeps all of them.
+    assert matcher.get_captures() == [("v", b"123")]
+    assert matcher.get_captures(deduplicate=False) == [("v", b"1"), ("v", b"12"), ("v", b"123")]
+
+
+def test_lark_capture_dynamic_tool_call() -> None:
+    grammar = r"""
+        start: tool* tail
+        tail: TEXT
+
+        tool_head[lazy]: TEXT "<tool_call>"
+        tool: tool_head arg "</tool_call>"
+        arg[capture]: /[0-9]+/
+
+        TEXT: /(\n|.)*/
+    """
+    value = "before<tool_call>42</tool_call>mid<tool_call>7</tool_call>after"
+    assert _get_captures(grammar, value) == [("arg", b"42"), ("arg", b"7")]
+
+
+def test_lark_capture_special_token_atomic_path() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "<|tool|>", "b", "</s>"], stop_token_ids=[3])
+    compiled = _compile_lark('start: wrap\nwrap[capture]: "a" <|tool|> "b"', tokenizer_info)
+    matcher = xgr.GrammarMatcher(compiled)
+    for token_id in [0, 1, 2]:
+        assert matcher.accept_token(token_id)
+    assert matcher.get_captures() == [("wrap", b"a<|tool|>b")]
+    # Rollback across the atomic special-token row and re-accept.
+    matcher.rollback(2)
+    assert matcher.get_captures() == []
+    for token_id in [1, 2]:
+        assert matcher.accept_token(token_id)
+    assert matcher.get_captures() == [("wrap", b"a<|tool|>b")]
+
+
+def test_lark_capture_rollback_and_reaccept() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "1", "2", "b", "</s>"], stop_token_ids=[4])
+    compiled = _compile_lark('start: "a" v "b"\nv[capture]: /[0-9]+/', tokenizer_info)
+    matcher = xgr.GrammarMatcher(compiled)
+    for token_id in [0, 1, 3]:
+        assert matcher.accept_token(token_id)
+    assert matcher.get_captures() == [("v", b"1")]
+    matcher.rollback(2)
+    for token_id in [2, 3]:
+        assert matcher.accept_token(token_id)
+    assert matcher.get_captures() == [("v", b"2")]
+
+
+def test_lark_capture_mask_computation_records_nothing() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "1", "b", "</s>"], stop_token_ids=[3])
+    compiled = _compile_lark('start: "a" v "b"\nv[capture]: /[0-9]+/', tokenizer_info)
+    matcher = xgr.GrammarMatcher(compiled)
+    bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    assert matcher.accept_token(0)
+    matcher.fill_next_token_bitmask(bitmask)
+    assert matcher.get_captures(deduplicate=False) == []
+    assert matcher.accept_token(1)
+    matcher.fill_next_token_bitmask(bitmask)
+    before = matcher.get_captures(deduplicate=False)
+    matcher.fill_next_token_bitmask(bitmask)
+    assert matcher.get_captures(deduplicate=False) == before
+    assert matcher.accept_token(2)
+    assert matcher.get_captures() == [("v", b"1")]
+
+
+def test_lark_capture_reset_and_fork() -> None:
+    compiled = _compile_lark('start: "a" v "b"\nv[capture]: /[0-9]+/')
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_string("a5b")
+    forked = matcher.fork()
+    assert forked.get_captures() == [("v", b"5")]
+    matcher.reset()
+    assert matcher.get_captures() == []
+    assert matcher.accept_string("a6b")
+    assert matcher.get_captures() == [("v", b"6")]
+    assert forked.get_captures() == [("v", b"5")]
+
+
+def test_lark_capture_survives_ebnf_round_trip_and_cache() -> None:
+    grammar = xgr.Grammar.from_lark('start: "a" v "b"\nv[capture="num"]: /[0-9]+/')
+    ebnf = str(grammar)
+    assert 'v[capture="num"] ::=' in ebnf
+
+    tokenizer_info = xgr.TokenizerInfo([])
+    reparsed = xgr.Grammar.from_ebnf(ebnf)
+    compiled = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False).compile_grammar(reparsed)
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_string("a77b")
+    assert matcher.get_captures() == [("num", b"77")]
+
+    # The cached compile path re-parses the grammar from its ToString() form.
+    cached_compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=True)
+    compiled_cached = cached_compiler.compile_grammar(grammar)
+    matcher = xgr.GrammarMatcher(compiled_cached, terminate_without_stop_token=True)
+    assert matcher.accept_string("a88b")
+    assert matcher.get_captures() == [("num", b"88")]
+
+
+def test_lark_capture_serialization_round_trip() -> None:
+    grammar = xgr.Grammar.from_lark('start: "a" v "b"\nv[capture="num"]: /[0-9]+/')
+    deserialized = xgr.Grammar.deserialize_json(grammar.serialize_json())
+    assert 'v[capture="num"] ::=' in str(deserialized)
+
+
+def test_lark_capture_on_dispatch_consumed_rule_is_rejected() -> None:
+    grammar = r"""
+        start: tool* tail
+        tail: TEXT
+        tool_head[lazy]: TEXT "<t>"
+        tool[capture]: tool_head /[0-9]+/ "</t>"
+        TEXT: /(\n|.)*/
+    """
+    _assert_lark_error(grammar, "capture is not supported on rules consumed by dynamic dispatch")
+
+
+def test_lark_capture_no_capture_grammar_returns_empty() -> None:
+    compiled = _compile_lark('start: "ab"')
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_string("ab")
+    assert matcher.get_captures() == []

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -855,9 +855,7 @@ def test_lark_large_choice_grammar() -> None:
             id="terminal-references-rule",
         ),
         pytest.param(
-            'start[budget=10]: "a"',
-            "attribute 'budget' is not supported",
-            id="unknown-attribute",
+            'start[budget=10]: "a"', "attribute 'budget' is not supported", id="unknown-attribute"
         ),
         pytest.param(
             'start[stop="x"]: "a"', "attribute 'stop' is not supported", id="stop-attribute"
@@ -1572,3 +1570,114 @@ def test_lark_capture_no_capture_grammar_returns_empty() -> None:
     matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
     assert matcher.accept_string("ab")
     assert matcher.get_captures() == []
+
+
+CAPTURE_BUDGET_ANY_TEXT_GRAMMAR = r"""
+    start: r "<t>"
+    r[max_tokens=3, capture]: TEXT
+    TEXT: /(\n|.)*/
+"""
+
+
+def test_lark_capture_with_max_tokens_any_text() -> None:
+    # Both attributes on one rule, arbitrary-text body (exact token-wildcard strategy): the
+    # budget masks to the terminator and the capture spans the whole region.
+    compiled = _compile_lark(CAPTURE_BUDGET_ANY_TEXT_GRAMMAR, MAX_TOKENS_TOKENIZER)
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    for token_id in [0, 1, 2]:
+        assert matcher.accept_token(token_id)
+    assert _allowed_token_ids(matcher, MAX_TOKENS_TOKENIZER) == [5]
+    assert matcher.accept_token(5) and matcher.is_terminated()
+    assert matcher.get_captures() == [("r", b"ab cd ")]
+
+
+def test_lark_capture_with_max_tokens_cfg_body() -> None:
+    # Both attributes on one rule, CFG body (runtime-deadline strategy), plus a captured rule
+    # after the budgeted region.
+    grammar = r"""
+        start: "<t>" r "</t>" ans
+        r[max_tokens=2, capture="think"]: /([a-z]* )+/
+        ans[capture]: "1"
+    """
+    compiled = _compile_lark(grammar, MAX_TOKENS_TOKENIZER)
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    for token_id in [5, 0, 0]:
+        assert matcher.accept_token(token_id)
+    assert _allowed_token_ids(matcher, MAX_TOKENS_TOKENIZER) == [3]
+    assert matcher.accept_token(3) and matcher.accept_token(4) and matcher.is_terminated()
+    assert matcher.get_captures() == [("think", b"ab ab "), ("ans", b"1")]
+
+
+def test_lark_capture_inside_max_tokens_region() -> None:
+    # The captured rule is nested inside the budgeted rule: the budget follows the outer
+    # derivation while the capture records the inner span.
+    grammar = r"""
+        start: outer "1"
+        outer[max_tokens=3]: "x" inner
+        inner[capture]: /([a-z]* )+/
+    """
+    compiled = _compile_lark(grammar, MAX_TOKENS_TOKENIZER)
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    for token_id in [6, 0, 0]:
+        assert matcher.accept_token(token_id)
+    assert _allowed_token_ids(matcher, MAX_TOKENS_TOKENIZER) == [4]
+    assert matcher.accept_token(4) and matcher.is_terminated()
+    assert matcher.get_captures() == [("inner", b"ab ab ")]
+
+
+def test_lark_capture_with_max_tokens_per_occurrence() -> None:
+    # Each loop occurrence gets its own budget and its own capture.
+    grammar = 'start: r+ "1"\nr[capture, max_tokens=2]: /[a-z]+ /'
+    compiled = _compile_lark(grammar, MAX_TOKENS_TOKENIZER)
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    for _ in range(5):
+        assert matcher.accept_token(0)
+    assert matcher.accept_token(4) and matcher.is_terminated()
+    assert matcher.get_captures() == [("r", b"ab ")] * 5
+    # A single occurrence exceeding its budget mid-word: the budget is relaxed until the
+    # region can close, and the capture still reports the full span.
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_token(1) and matcher.accept_token(1)
+    assert 4 not in _allowed_token_ids(matcher, MAX_TOKENS_TOKENIZER)
+    assert matcher.accept_token(2)
+    assert 4 in _allowed_token_ids(matcher, MAX_TOKENS_TOKENIZER)
+    assert matcher.accept_token(4) and matcher.is_terminated()
+    assert matcher.get_captures() == [("r", b"cdcd ")]
+
+
+def test_lark_capture_with_max_tokens_rollback() -> None:
+    grammar = r"""
+        start: "<t>" r "</t>" ans
+        r[max_tokens=2, capture]: /([a-z]* )+/
+        ans: "1"
+    """
+    compiled = _compile_lark(grammar, MAX_TOKENS_TOKENIZER)
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    for token_id in [5, 0, 0]:
+        assert matcher.accept_token(token_id)
+    assert _allowed_token_ids(matcher, MAX_TOKENS_TOKENIZER) == [3]
+    assert matcher.accept_token(3)
+    matcher.rollback(2)
+    assert matcher.accept_token(1) and matcher.accept_token(2)
+    assert _allowed_token_ids(matcher, MAX_TOKENS_TOKENIZER) == [3]
+    assert matcher.accept_token(3) and matcher.accept_token(4) and matcher.is_terminated()
+    assert matcher.get_captures() == [("r", b"ab cd ")]
+
+
+def test_lark_capture_with_max_tokens_round_trip_and_cache() -> None:
+    # Both attributes must survive the printer -> EBNF-lexer round trip together, since the
+    # cached compile path re-parses the grammar from its ToString() form.
+    grammar = xgr.Grammar.from_lark(
+        CAPTURE_BUDGET_ANY_TEXT_GRAMMAR, tokenizer_info=MAX_TOKENS_TOKENIZER
+    )
+    ebnf = str(grammar)
+    assert 'r[max_tokens=3, capture="r"] ::=' in ebnf
+    assert 'r[max_tokens=3, capture="r"] ::=' in str(xgr.Grammar.from_ebnf(ebnf))
+    compiler = xgr.GrammarCompiler(MAX_TOKENS_TOKENIZER, cache_enabled=True)
+    compiled = compiler.compile_grammar(grammar)
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    for token_id in [0, 1, 2]:
+        assert matcher.accept_token(token_id)
+    assert _allowed_token_ids(matcher, MAX_TOKENS_TOKENIZER) == [5]
+    assert matcher.accept_token(5) and matcher.is_terminated()
+    assert matcher.get_captures() == [("r", b"ab cd ")]

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -44,7 +44,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v16"
+    assert xgr.get_serialization_version() == "v15"
 
 
 def test_serialize_grammar():
@@ -64,7 +64,7 @@ def test_serialize_grammar():
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v16",
+        "__VERSION__": "v15",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -84,14 +84,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v16",
+        "__VERSION__": "v15",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v16"
+    expected_json["__VERSION__"] = "v15"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -143,7 +143,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v16"}'
+        '"__VERSION__":"v15"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -258,7 +258,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v16",
+        "__VERSION__": "v15",
     }
 
     class AdaptiveTokenMask(BaseModel):

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -44,7 +44,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v15"
+    assert xgr.get_serialization_version() == "v16"
 
 
 def test_serialize_grammar():
@@ -52,7 +52,7 @@ def test_serialize_grammar():
     grammar = construct_grammar()
     serialized = grammar.serialize_json()
     expected_json = {
-        "rules": [["rule1", 4, -1, False, -1], ["root", 8, -1, False, -1]],
+        "rules": [["rule1", 4, -1, False, -1, ""], ["root", 8, -1, False, -1, ""]],
         "grammar_expr_data": [0, 5, 8, 12, 14, 18, 21, 24, 28],
         "grammar_expr_indptr": [
             # fmt: off
@@ -64,7 +64,7 @@ def test_serialize_grammar():
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v15",
+        "__VERSION__": "v16",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -73,7 +73,7 @@ def test_serialize_grammar():
 def test_serialize_grammar_exception():
     """Test Grammar serialization produces expected JSON string."""
     expected_json = {
-        "rules": [["rule1", 4, 9, True, -1], ["root", 8, -1, False, -1]],
+        "rules": [["rule1", 4, 9, True, -1, ""], ["root", 8, -1, False, -1, ""]],
         "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 28, 31],
         "grammar_expr_indptr": [
             # fmt: off
@@ -84,14 +84,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v15",
+        "__VERSION__": "v16",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v15"
+    expected_json["__VERSION__"] = "v16"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -143,7 +143,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v15"}'
+        '"__VERSION__":"v16"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -197,7 +197,7 @@ def test_serialize_compiled_grammar():
 
     expected_json = {
         "grammar": {
-            "rules": [["rule1", 4, 9, True, -1], ["root", 8, -1, False, -1]],
+            "rules": [["rule1", 4, 9, True, -1, ""], ["root", 8, -1, False, -1, ""]],
             "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 28, 31],
             "grammar_expr_indptr": [
                 # fmt: off
@@ -258,7 +258,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v15",
+        "__VERSION__": "v16",
     }
 
     class AdaptiveTokenMask(BaseModel):


### PR DESCRIPTION
## Summary

This PR adds **capture groups** to the Lark frontend: a rule can be marked `rule[capture]` / `rule[capture="name"]`, and the matcher records the input span matched by that rule each time it completes. Captures are retrieved with `GrammarMatcher::GetCaptures()` (C++) / `matcher.get_captures()` (Python).

```lark
start: tool* tail
tail: TEXT

tool_head[lazy]: TEXT "<tool_call>"
tool: tool_head "name=" name " age=" age "</tool_call>"
name[capture]: /[A-Za-z]+/
age[capture]: /[0-9]+/

TEXT: /(\n|.)*/
```

```python
matcher.accept_string(
    '<tool_call>name=Alice age=30</tool_call>ok<tool_call>name=Bob age=25</tool_call>'
)
matcher.get_captures()
# [("name", b"Alice"), ("age", b"30"), ("name", b"Bob"), ("age", b"25")]
```

## Design

Recording and materialization are separated:

- **Grammar representation**: `Rule.capture_name` (`grammar_impl.h`), set by the Lark frontend, printed as `name[capture="x"] ::=` by the EBNF printer and re-parsed by the EBNF lexer, so it round-trips through `ToString()` / `FromEBNF()`.
- **Recording** (`earley_parser.cc`): `Complete()` records a `CaptureEvent {rule_id, start_pos}` when a captured rule completes. Events live in a `Compact2DArray` history aligned row-by-row with the existing state history, so `PopLastStates` rolls them back automatically — mask-computation trie backtracking, mid-token rejection, and explicit `Rollback()` are all handled by one mechanism.
- **Definitive/speculative isolation**: recording is enabled only inside `AcceptToken` / `AcceptString` via an RAII scope. `FillNextTokenBitmask`, jump-forward search, and draft-token validation never record events.
- **Materialization** (`grammar_matcher.cc`): the matcher keeps the accepted bytes plus a per-row byte offset; `GetCaptures()` slices spans lazily at query time. Nothing is ever emitted eagerly.
- **Zero overhead when unused**: grammars without any `capture_name` skip the entire machinery (one dead branch in `Complete()`).

## Capture semantics

`get_captures(deduplicate=True)` (default) coalesces events by **occurrence identity** `(rule_id, start_pos)`, keeping the longest completion of each occurrence. This distinguishes two situations:

- Multiple candidate end positions of *one* occurrence (a `/[0-9]+/` body completes after every digit) → merged into one entry.
- Genuinely repeated matches at different positions (loops, repeated tool calls) → all kept, in completion order, even when byte-identical.

`get_captures(deduplicate=False)` returns the raw completion events.

Behavior guarantees:

- Captures are visible as soon as the rule completes — no lag when queried mid-stream.
- `rollback()` rolls back recorded captures together with the parser state; `reset()` clears them.
- Read-only operations such as `fill_next_token_bitmask` never affect captures.
- `fork()` gives the new matcher an independent copy of the captures.

## Exactness

The parser explores all parse hypotheses in parallel, so a capture query observes the currently live hypotheses:

- When the captured rule's boundary is a **delimiter its body cannot match** (quotes, closing tags, brackets — the typical tool-call shape), the coalesced result is exact.
- When the byte following the rule can also be matched by the rule body itself (e.g. `/[a-z]+/` followed by a literal `"y"`), the online query may report a span extending past the boundary of the finally-accepted parse. `get_captures(deduplicate=False)` exposes the raw events for callers that want to apply their own policy.

This edge case is documented in `docs/xgrammar_features/lark_grammar.md`. As future work, an exact mode can reconstruct the surviving derivation from the retained Earley chart once `IsTerminated()`.

## Side fix

`GrammarMatcher::Reset()` previously did not clear `token_length_history`, so a `rollback()` after `reset()` could over-pop parser state; now cleared.

## Testing

- 15 new tests in `tests/python/test_lark.py`: simple/named/nested captures, repeated occurrences, right recursion, root-rule capture, raw-vs-coalesced events, dynamic-dispatch tool calls, special-token atomic path, rollback/re-accept, mask-computation no-op, reset/fork, EBNF round-trip + cached-compile path, serialization round-trip, error cases (empty/invalid/duplicate names, dispatch-consumed rules), no-capture fast path.
- Full `test_lark.py` (210), `test_serialization.py` (14), and C++ gtest (57) pass; the rest of the Python suite shows only failures already present on `main` (verified by stash-and-rerun baseline).
