### PR TITLE
refac: simplify the logic in earley parser.

### DIFF
--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -116,7 +116,8 @@ class CompiledGrammar::Impl {
   Impl() = default;
 
   /*! \brief Mapping from the parser state to the adaptive token mask. */
-  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache> adaptive_token_mask_cache;
+  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache>
+      adaptive_token_mask_cache;
 
   Grammar GetGrammar() const { return grammar; }
 

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -6,10 +6,8 @@
 #include "earley_parser.h"
 
 #include <algorithm>
-#include <cassert>
 #include <cctype>
 #include <cstdint>
-#include <ctime>
 #include <utility>
 #include <vector>
 
@@ -28,9 +26,7 @@ using GrammarExpr = Grammar::Impl::GrammarExpr;
 bool EarleyParser::IsCompleted() const { return is_completed_.back(); }
 
 void EarleyParser::PopLastStates(int32_t cnt) {
-  if (stop_token_is_accepted_) {
-    stop_token_is_accepted_ = false;
-  }
+  stop_token_is_accepted_ = false;
   if (cnt >= static_cast<int32_t>(rule_id_to_completable_states_.size())) {
     XGRAMMAR_LOG(FATAL) << "The number of states to be popped is larger than the size of states.";
   }
@@ -292,49 +288,32 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   return true;
 }
 
-EarleyParser::EarleyParser(
-    const Grammar& grammar, const ParserState& init_state, const bool need_expand
-)
+EarleyParser::EarleyParser(const Grammar& grammar, std::optional<ParserState> initial_state)
     : grammar_(grammar) {
   if (!grammar->optimized) {
     XGRAMMAR_LOG(FATAL) << "The grammar is not optimized. Please optimize the grammar before using "
                            "the Earley parser.";
   }
-  // Check if the initial state is valid. If invalid, then we choose the root state as default.
-  ParserState init = init_state;
-  if (init_state.IsInvalid()) {
-    init = ParserState(
-        grammar_->GetRootRuleId(),
-        ParserState::kUnexpandedRuleStartSequenceId,
-        0,
-        ParserState::kNoPrevInputPos,
-        0
-    );
-  } else {
-    init = init_state;
-  }
+  PushStateAndExpand(initial_state.has_value() ? *initial_state : RootInitialState());
+}
 
-  // If there is no need to expand the initial state, we only need to add it to the
-  // scanable states history.
-  if (!need_expand) {
-    rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
-    is_completed_.push_back(false);
-    scanable_state_history_.PushBack({init});
-    return;
-  }
-
-  // Otherwise, we expand the initial state, and process the queue.
-  PushStateAndExpand(init);
+ParserState EarleyParser::RootInitialState() const {
+  const auto root_rule_id = grammar_->GetRootRuleId();
+  XGRAMMAR_DCHECK(grammar_->per_rule_fsms[root_rule_id].has_value());
+  return ParserState(
+      root_rule_id,
+      grammar_->GetRule(root_rule_id).body_expr_id,
+      grammar_->per_rule_fsms[root_rule_id]->GetFsm().GetStart(),
+      ParserState::kNoPrevInputPos,
+      0
+  );
 }
 
 void EarleyParser::PushStateAndExpand(const ParserState& state) {
   tmp_states_visited_in_queue_.Clear();
   tmp_accept_stop_token_ = false;
   tmp_states_to_be_added_.clear();
-  // If the rule can't be expanded, we need to add it to the queue.
-  if (!ExpandAndEnqueueUnexpandedState(state)) {
-    Enqueue(state);
-  }
+  Enqueue(state);
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
   while (!tmp_process_state_queue_.empty()) {
     const auto state = tmp_process_state_queue_.front();
@@ -357,30 +336,7 @@ void EarleyParser::Reset() {
   is_completed_.clear();
   stop_token_is_accepted_ = false;
   XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
-  PushStateAndExpand(ParserState(
-      grammar_->GetRootRuleId(),
-      ParserState::kUnexpandedRuleStartSequenceId,
-      0,
-      ParserState::kNoPrevInputPos,
-      0
-  ));
-}
-
-bool EarleyParser::ExpandAndEnqueueUnexpandedState(const ParserState& state) {
-  if (state.sequence_id != ParserState::kUnexpandedRuleStartSequenceId) {
-    return false;
-  }
-  auto cur_rule_id = state.rule_id;
-  auto cur_rule_body_id = grammar_->GetRule(cur_rule_id).body_expr_id;
-  XGRAMMAR_DCHECK(state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value());
-  Enqueue(ParserState{
-      cur_rule_id,
-      cur_rule_body_id,
-      grammar_->per_rule_fsms[state.rule_id]->GetFsm().GetStart(),
-      ParserState::kNoPrevInputPos,
-      0
-  });
-  return true;
+  PushStateAndExpand(RootInitialState());
 }
 
 void EarleyParser::ExpandNextRuleRefElement(
@@ -453,13 +409,6 @@ void EarleyParser::ExpandNextRuleRefElement(
   const auto& ref_grammar_expr_id = ref_rule.body_expr_id;
 
   XGRAMMAR_DCHECK(grammar_->per_rule_fsms[ref_rule_id].has_value());
-  if (std::find(
-          grammar_->allow_empty_rule_ids.begin(), grammar_->allow_empty_rule_ids.end(), ref_rule_id
-      ) != grammar_->allow_empty_rule_ids.end()) {
-    Enqueue(
-        ParserState{state.rule_id, state.sequence_id, state.element_id + 1, state.rule_start_pos, 0}
-    );
-  }
   const auto& ref_fsm = grammar_->per_rule_fsms[ref_rule_id].value();
   Enqueue(ParserState{
       ref_rule_id,
@@ -579,13 +528,6 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
     const auto& ref_grammar_expr_id = ref_rule.body_expr_id;
 
     XGRAMMAR_DCHECK(grammar_->per_rule_fsms[ref_rule_id].has_value());
-    if (!is_repeat && std::binary_search(
-                          grammar_->allow_empty_rule_ids.begin(),
-                          grammar_->allow_empty_rule_ids.end(),
-                          ref_rule_id
-                      )) {
-      Enqueue(ParserState{state.rule_id, state.sequence_id, target, state.rule_start_pos, 0});
-    }
     const auto& ref_fsm = grammar_->per_rule_fsms[ref_rule_id].value();
     Enqueue(ParserState{
         ref_rule_id,

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -7,6 +7,7 @@
 #ifndef XGRAMMAR_EARLEY_PARSER_H_
 #define XGRAMMAR_EARLEY_PARSER_H_
 #include <cstdint>
+#include <optional>
 #include <ostream>
 #include <queue>
 #include <unordered_set>
@@ -59,18 +60,10 @@ struct ParserState {
         partial_codepoint(partial_codepoint) {}
 
   /*!
-   * \brief A sequence_id value of kUnexpandedRuleStartSequenceId means a rule hasn't been
-   * expanded.
-   */
-  static constexpr int32_t kUnexpandedRuleStartSequenceId = 128000;
-
-  /*!
-   * \brief A parent_id value of kNoParent means this ParserState is the root of the parsing stack.
+   * \brief A rule_start_pos value of kNoPrevInputPos means this ParserState is the root of the
+   * parsing stack.
    */
   static constexpr int32_t kNoPrevInputPos = -1;
-
-  /*! \brief A sequence_id value of kInvalid means the ParserState is invalid. */
-  static constexpr int32_t kInvalidSequenceId = -1;
 
   /*! \brief The rule's id. */
   int32_t rule_id = -1;
@@ -87,7 +80,7 @@ struct ParserState {
   /*! \brief The position of the state, i.e. from which position, the rule starts. */
   int32_t rule_start_pos = -1;
 
-  /*! \brief The id of the sub element in the current selement of the sequence. */
+  /*! \brief The id of the sub element in the current element of the sequence. */
   int32_t sub_element_id = 0;
 
   /*! \brief The number of times the element is repeated. It will be used in kRepeat.*/
@@ -96,23 +89,18 @@ struct ParserState {
   /*! \brief Partial codepoint accumulated during UTF-8 decoding for positive character classes. */
   int32_t partial_codepoint = 0;
 
-  /*! \brief The element is invalid when sequence_id is -1. */
-  bool IsInvalid() const { return sequence_id == -1; }
-
-  static ParserState GetInvalidState() { return {-1, -1, -1, -1, -1}; }
-
-  bool operator==(const ParserState& other) const {
-    return rule_id == other.rule_id && sequence_id == other.sequence_id &&
-           element_id == other.element_id && sub_element_id == other.sub_element_id;
-  }
-
+  /*!
+   * \brief Lexicographic order over all fields. It is only used to sort the states for
+   * deterministic serialization, and is not needed during parsing.
+   */
   bool operator<(const ParserState& other) const {
     if (rule_id != other.rule_id) return rule_id < other.rule_id;
     if (sequence_id != other.sequence_id) return sequence_id < other.sequence_id;
     if (element_id != other.element_id) return element_id < other.element_id;
     if (rule_start_pos != other.rule_start_pos) return rule_start_pos < other.rule_start_pos;
     if (sub_element_id != other.sub_element_id) return sub_element_id < other.sub_element_id;
-    return repeat_count < other.repeat_count;
+    if (repeat_count != other.repeat_count) return repeat_count < other.repeat_count;
+    return partial_codepoint < other.partial_codepoint;
   }
 
   friend std::ostream& operator<<(std::ostream& os, const ParserState& state) {
@@ -149,12 +137,26 @@ XGRAMMAR_MEMBER_ARRAY(
 );
 
 /*!
- * \brief When getting the mask of the state, we don't need to consider the rule_start_pos.
+ * \brief Hash of a state used as the key of the adaptive token mask cache. The token mask of a
+ * state does not depend on rule_start_pos, repeat_count or partial_codepoint, so they are
+ * ignored. Pairs with StateEqualForCache.
  */
 class StateHashForCache {
  public:
   size_t operator()(const ParserState& state) const {
     return HashCombine(state.rule_id, state.sequence_id, state.element_id, state.sub_element_id);
+  }
+};
+
+/*!
+ * \brief Equality of states used as the key of the adaptive token mask cache. Compares the same
+ * fields as StateHashForCache hashes.
+ */
+class StateEqualForCache {
+ public:
+  bool operator()(const ParserState& lhs, const ParserState& rhs) const {
+    return lhs.rule_id == rhs.rule_id && lhs.sequence_id == rhs.sequence_id &&
+           lhs.element_id == rhs.element_id && lhs.sub_element_id == rhs.sub_element_id;
   }
 };
 
@@ -262,7 +264,7 @@ class EarleyParser {
   Compact2DArray<ParserState> scanable_state_history_;
 
   /*!
-   * \brief A temperate vector only used in Advance, used to add states in the
+   * \brief A temporary vector only used in Advance, used to add states in the
    * scanable_state_history.
    */
   std::vector<ParserState> tmp_states_to_be_added_;
@@ -311,12 +313,8 @@ class EarleyParser {
    */
   std::pair<bool, bool> Predict(const ParserState& state, bool debug_print = false);
 
-  /*!
-   * \brief Handle the unexpanded rule, used for pushing initial state.
-   * \param state The state to be handled.
-   * \return True if the rule is unexpanded, false otherwise.
-   */
-  bool ExpandAndEnqueueUnexpandedState(const ParserState& state);
+  /*! \brief The initial state expanded from the root rule of the grammar. */
+  ParserState RootInitialState() const;
 
   /*!
    * \brief Expand the rule, used for RuleRef and kTagDispatch.
@@ -348,7 +346,7 @@ class EarleyParser {
    * \param state The state to be advanced.
    * \param ch The character to be advanced.
    * \param sub_sequence The sub sequence to be checked.
-   * \return The next state, Invalid state if the character is not accepted.
+   * \note The advanced states are enqueued; nothing is enqueued if the character is not accepted.
    */
   void AdvanceCharacterClass(
       const ParserState& state, const uint8_t ch, const GrammarExpr& sub_sequence
@@ -359,7 +357,7 @@ class EarleyParser {
    * \param state The state to be advanced.
    * \param ch The character to be advanced.
    * \param sub_sequence The sub sequence to be checked.
-   * \return The next state, Invalid state if the character is not accepted.
+   * \note The advanced states are enqueued; nothing is enqueued if the character is not accepted.
    */
   void AdvanceByteString(
       const ParserState& state, const uint8_t ch, const GrammarExpr& sub_sequence
@@ -370,7 +368,7 @@ class EarleyParser {
    * \param state The state to be advanced.
    * \param ch The character to be advanced.
    * \param sub_sequence The sub sequence to be checked.
-   * \return The next state, Invalid state if the character is not accepted.
+   * \note The advanced states are enqueued; nothing is enqueued if the character is not accepted.
    */
   void AdvanceCharacterClassStar(
       const ParserState& state, const uint8_t ch, const GrammarExpr& sub_sequence
@@ -380,8 +378,7 @@ class EarleyParser {
    * \brief Advance the parser to the next state, with the sequence is kTagDispatch.
    * \param state The state to be advanced.
    * \param ch The character to be advanced.
-   * \param cur_sequence The sequence of the current state.
-   * \return The next state, Invalid state if the character is not accepted.
+   * \note The advanced states are enqueued; nothing is enqueued if the character is not accepted.
    */
   void AdvanceFsm(const ParserState& state, const uint8_t ch);
 
@@ -425,11 +422,12 @@ class EarleyParser {
  public:
   /*!
    * \brief Constructor of the Earley parser.
-   * \param grammar The grammar to be parsed.
-   * \param initial_state The initial state to be pushed into the parser.
+   * \param grammar The grammar to be parsed. It must be optimized.
+   * \param initial_state The state to start parsing from. If not provided, parsing starts
+   * from the root rule of the grammar.
    */
-  EarleyParser(
-      const Grammar& grammar, const ParserState& initial_state, const bool need_expand = true
+  explicit EarleyParser(
+      const Grammar& grammar, std::optional<ParserState> initial_state = std::nullopt
   );
 
   /*!

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -45,8 +45,7 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
       const std::unordered_map<int32_t, DynamicBitset>&
           tag_dispatch_rule_id_to_second_slicing_bitset,
       const TokenizerInfo& tokenizer_info,
-      std::optional<RuleLevelCache>& rule_level_cache,
-      const bool& need_expand = true
+      std::optional<RuleLevelCache>& rule_level_cache
   )
       : EarleyParser(grammar, init_state),
         init_rule_id_(init_state.rule_id),
@@ -1082,8 +1081,7 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
         state,
         tag_dispatch_rule_id_to_second_slicing_bitset,
         tokenizer_info_,
-        rule_level_cache_,
-        false
+        rule_level_cache_
     );
     auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask(is_root_rule);
     if (max_threads_ > 1) {

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -453,7 +453,7 @@ class GrammarMatcher::Impl : public EarleyParser {
       // max_rollback_tokens_ is deprecated and not used.
       int max_rollback_tokens = -1
   )
-      : EarleyParser(compiled_grammar->grammar, ParserState::GetInvalidState()),
+      : EarleyParser(compiled_grammar->grammar),
         compiled_grammar_(compiled_grammar),
         tokenizer_info_(compiled_grammar->tokenizer_info),
         stop_token_ids_(override_stop_tokens.value_or(tokenizer_info_.GetStopTokenIds())),


### PR DESCRIPTION
This PR simplifies some logic in the earley parser for better readability without breaking the functions.