### PR TITLE
feat: support lazy in ebnf and lark.

### DIFF
--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -44,6 +44,9 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print) {
   if (capture_recording_ && RuleHasCapture(state.rule_id)) {
     RecordCaptureEvent(state);
   }
+  if (state.rule_id != -1 && grammar_->GetRule(state.rule_id).is_lazy) {
+    tmp_completed_lazy_occurrences_.emplace_back(state.rule_id, state.rule_start_pos);
+  }
   // Check if a rule is completed.
   if (state.rule_start_pos == ParserState::kNoPrevInputPos) {
     // assert: if a root rule can achieve here, then it must be completed.
@@ -273,6 +276,7 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   tmp_states_visited_in_queue_.Clear();
   tmp_states_to_be_added_.clear();
   tmp_accept_stop_token_ = false;
+  tmp_completed_lazy_occurrences_.clear();
   const auto& latest_states = scanable_state_history_[scanable_state_history_.size() - 1];
   // Scan all the scanable states.
   for (const auto& state : latest_states) {
@@ -305,9 +309,27 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   }
 
   // Check if the grammar is completed, and add the scannable states to the history.
+  if (!tmp_completed_lazy_occurrences_.empty()) {
+    RemoveCommittedLazyStates();
+  }
   is_completed_.push_back(tmp_accept_stop_token_);
   scanable_state_history_.PushBack(tmp_states_to_be_added_);
   return true;
+}
+
+void EarleyParser::RemoveCommittedLazyStates() {
+  auto is_committed = [&](const ParserState& state) {
+    for (const auto& [rule_id, rule_start_pos] : tmp_completed_lazy_occurrences_) {
+      if (state.rule_id == rule_id && state.rule_start_pos == rule_start_pos) {
+        return true;
+      }
+    }
+    return false;
+  };
+  tmp_states_to_be_added_.erase(
+      std::remove_if(tmp_states_to_be_added_.begin(), tmp_states_to_be_added_.end(), is_committed),
+      tmp_states_to_be_added_.end()
+  );
 }
 
 EarleyParser::EarleyParser(const Grammar& grammar, std::optional<ParserState> initial_state)
@@ -347,6 +369,7 @@ void EarleyParser::PushStateAndExpand(const ParserState& state) {
   tmp_states_visited_in_queue_.Clear();
   tmp_accept_stop_token_ = false;
   tmp_states_to_be_added_.clear();
+  tmp_completed_lazy_occurrences_.clear();
   Enqueue(state);
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
   if (capture_tracking_) {
@@ -362,6 +385,9 @@ void EarleyParser::PushStateAndExpand(const ParserState& state) {
     if (scanable) {
       tmp_states_to_be_added_.push_back(state);
     }
+  }
+  if (!tmp_completed_lazy_occurrences_.empty()) {
+    RemoveCommittedLazyStates();
   }
   is_completed_.push_back(tmp_accept_stop_token_);
   scanable_state_history_.PushBack(tmp_states_to_be_added_);
@@ -937,6 +963,7 @@ bool EarleyParser::AdvanceAtomicToken(int32_t token_id, bool debug_print) {
   tmp_states_visited_in_queue_.Clear();
   tmp_states_to_be_added_.clear();
   tmp_accept_stop_token_ = false;
+  tmp_completed_lazy_occurrences_.clear();
   const auto& latest_states = scanable_state_history_[scanable_state_history_.size() - 1];
   for (const auto& state : latest_states) {
     if (skip_expired_states_ && IsExpiredState(state)) {
@@ -961,6 +988,9 @@ bool EarleyParser::AdvanceAtomicToken(int32_t token_id, bool debug_print) {
     if (scanable) {
       tmp_states_to_be_added_.push_back(state);
     }
+  }
+  if (!tmp_completed_lazy_occurrences_.empty()) {
+    RemoveCommittedLazyStates();
   }
   is_completed_.push_back(tmp_accept_stop_token_);
   scanable_state_history_.PushBack(tmp_states_to_be_added_);

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -362,6 +362,16 @@ class EarleyParser {
   }
 
   /*!
+   * \brief The lazy rule occurrences (rule_id, rule_start_pos) completed while building the
+   * current row. Committed-shortest matching: their remaining states are removed when the row is
+   * finalized, so the occurrence cannot be extended further.
+   */
+  std::vector<std::pair<int32_t, int32_t>> tmp_completed_lazy_occurrences_;
+
+  /*! \brief Remove the states of the lazy occurrences completed in the current row. */
+  void RemoveCommittedLazyStates();
+
+  /*!
    * \brief Check if the state has been added into the queue.
    * \param state The state to check.
    * \return True if in the vector, false otherwise.

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -293,6 +293,18 @@ void GrammarBuilder::UpdateCaptureName(std::string rule_name, const std::string&
   UpdateCaptureName(rule_id, capture_name);
 }
 
+void GrammarBuilder::UpdateLazy(int32_t rule_id, bool is_lazy) {
+  XGRAMMAR_CHECK(rule_id < static_cast<int32_t>(grammar_->rules_.size()))
+      << "Rule id " << rule_id << " is out of range.";
+  grammar_->rules_[rule_id].is_lazy = is_lazy;
+}
+
+void GrammarBuilder::UpdateLazy(std::string rule_name, bool is_lazy) {
+  int32_t rule_id = GetRuleId(rule_name);
+  XGRAMMAR_CHECK(rule_id != -1) << "Rule " << rule_name << " is not found.";
+  UpdateLazy(rule_id, is_lazy);
+}
+
 std::string GrammarBuilder::GetNewRuleName(const std::string& name_hint) {
   if (rule_name_to_id_.count(name_hint) == 0) {
     return name_hint;

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -220,6 +220,12 @@ class GrammarBuilder {
    */
   void UpdateCaptureName(std::string rule_name, const std::string& capture_name);
 
+  /*! \brief Set whether the rule referred by the given rule_id is lazy (committed-shortest). */
+  void UpdateLazy(int32_t rule_id, bool is_lazy);
+
+  /*! \brief Set whether the rule referred by the given name is lazy (committed-shortest). */
+  void UpdateLazy(std::string rule_name, bool is_lazy);
+
   /*!
    * \brief Find a name for a new rule starting with the given name hint. Some integer suffix (_1,
    * _2, ...) may be added to avoid name conflict.

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -431,6 +431,11 @@ std::pair<bool, std::bitset<256>> GrammarMatcherForTokenMaskCache::GetSpeculativ
   using GrammarExprType = Grammar::Impl::GrammarExprType;
   // If the initial rule is a tag dispatch, we will check if it can achieve its initial state.
   const auto& rule = grammar_->GetRule(init_rule_id_);
+  if (rule.is_lazy) {
+    // The fast path assumes greedy self-loop extension is always legal, which does not hold for
+    // committed-shortest rules; they must go through the full per-token simulation.
+    return {false, std::bitset<256>()};
+  }
   const auto& rule_body = grammar_->GetGrammarExpr(rule.body_expr_id);
   if (rule_body.type == GrammarExprType::kTagDispatch) {
     std::bitset<256> speculative_mask;

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -2050,6 +2050,8 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
           rule.is_lazy ? BuildFlattenedLazyBody(rule.body_expr_id) : VisitExpr(rule.body_expr_id);
       builder_->UpdateRuleBody(i, new_body_expr_id);
       builder_->UpdateLookaheadAssertion(i, VisitLookaheadAssertion(rule.lookahead_assertion_id));
+      builder_->UpdateMaxTokens(i, rule.max_tokens);
+      builder_->UpdateCaptureName(i, rule.capture_name);
       builder_->UpdateLazy(i, rule.is_lazy);
     }
     return builder_->Get(base_grammar_->GetRootRule().name);

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -2022,7 +2022,9 @@ class RepetitionNormalizerImpl {
 /*!
  * \brief Rewrite lazy rule bodies into their terminal-like form where possible: unwrap the
  * single-reference chains produced by regex conversion, and flatten the right-recursive plus
- * pattern (x ::= cc x | cc) into (cc cc*). Grammars without lazy rules are returned unchanged.
+ * pattern (x ::= cc x | cc) and star pattern (x ::= cc x | "") produced by regex conversion and
+ * repetition expansion into (cc cc*) and (cc*). Grammars without lazy rules are returned
+ * unchanged.
  */
 class LazyBodyFlattenerImpl : public GrammarMutator {
  public:
@@ -2078,11 +2080,13 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
 
     const auto& body = base_grammar_->GetGrammarExpr(cur_body_id);
     if (body.type != GrammarExprType::kChoices) {
+      XGRAMMAR_LOG(WARNING) << "The body of the lazy rule '" << cur_rule_name_
+                            << "' cannot be flattened into a terminal-like form";
       return VisitExpr(cur_body_id);
     }
-    std::vector<int32_t> plus_elements;
-    if (cur_rule_id != -1 && TryEmitPlusPattern(body, cur_rule_id, &plus_elements)) {
-      return builder_->AddChoices({builder_->AddSequence(plus_elements)});
+    std::vector<int32_t> repeat_elements;
+    if (cur_rule_id != -1 && TryEmitRepeatPattern(body, cur_rule_id, &repeat_elements)) {
+      return builder_->AddChoices({builder_->AddSequence(repeat_elements)});
     }
     std::vector<int32_t> new_choice_ids;
     for (auto choice_id : body) {
@@ -2094,6 +2098,8 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
       std::vector<int32_t> elements;
       if (!FlattenSequenceInto(choice, &elements, 0)) {
         // Not flattenable; copy as is and let the terminal-like validation report the error.
+        XGRAMMAR_LOG(WARNING) << "The body of the lazy rule '" << cur_rule_name_
+                              << "' cannot be flattened into a terminal-like form";
         return VisitExpr(cur_body_id);
       }
       new_choice_ids.push_back(builder_->AddSequence(elements));
@@ -2102,8 +2108,9 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
   }
 
   /*! \brief Append the flattened elements of the sequence, splicing rule references whose body
-   * is a single terminal-like sequence or the plus-desugar pattern. Returns false if some
-   * element cannot be flattened. */
+   * is a single terminal-like sequence or the plus-desugar pattern, and coalescing references
+   * to single-character alternations into character classes. Returns false if some element
+   * cannot be flattened. */
   bool FlattenSequenceInto(const GrammarExpr& seq, std::vector<int32_t>* elements, int depth) {
     if (depth > 64) {
       return false;
@@ -2124,7 +2131,7 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
         return false;
       }
       const auto& ref_body = base_grammar_->GetGrammarExpr(ref_rule.body_expr_id);
-      if (TryEmitPlusPattern(ref_body, element[0], elements)) {
+      if (TryEmitRepeatPattern(ref_body, element[0], elements)) {
         continue;
       }
       if (ref_body.type == GrammarExprType::kChoices && ref_body.size() == 1) {
@@ -2137,14 +2144,113 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
           continue;
         }
       }
+      std::vector<GrammarBuilder::CharacterClassElement> ranges;
+      if (CollectSingleCharRanges(element_id, &ranges, 0)) {
+        elements->push_back(builder_->AddCharacterClass(UnionRanges(std::move(ranges)), false));
+        continue;
+      }
       return false;
     }
     return true;
   }
 
-  /*! \brief If the body matches the plus-desugar pattern (self ::= e self | e) with a
-   * star-expressible e (a character class, or a single-byte string), append (e e*) to the
-   * elements and return true. */
+  /*! \brief Resolve an expr matching exactly one character into the set of codepoint ranges it
+   * accepts, appending them to ranges. Accepts character classes, single-byte strings, and
+   * references to non-lazy rules that are alternations of such elements. Returns false
+   * otherwise. */
+  bool CollectSingleCharRanges(
+      int32_t expr_id, std::vector<GrammarBuilder::CharacterClassElement>* ranges, int depth
+  ) {
+    if (depth > 64) {
+      return false;
+    }
+    const auto& expr = base_grammar_->GetGrammarExpr(expr_id);
+    if (expr.type == GrammarExprType::kCharacterClass) {
+      AppendPositiveRanges(expr, ranges);
+      return true;
+    }
+    if (expr.type == GrammarExprType::kByteString && expr.size() == 1) {
+      ranges->push_back({expr[0], expr[0]});
+      return true;
+    }
+    if (expr.type != GrammarExprType::kRuleRef) {
+      return false;
+    }
+    const auto& rule = base_grammar_->GetRule(expr[0]);
+    if (rule.is_lazy) {
+      return false;
+    }
+    const auto& body = base_grammar_->GetGrammarExpr(rule.body_expr_id);
+    if (body.type != GrammarExprType::kChoices) {
+      return false;
+    }
+    for (auto choice_id : body) {
+      const auto& choice = base_grammar_->GetGrammarExpr(choice_id);
+      if (choice.type != GrammarExprType::kSequence || choice.size() != 1 ||
+          !CollectSingleCharRanges(choice[0], ranges, depth + 1)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /*! \brief If the body matches the plus-desugar pattern (self ::= e self | e) or the
+   * (generalized) star-desugar pattern (self ::= "" | e1 self | e2 self | ...), append the
+   * equivalent (e e*) or ((e1|e2|...)*) to the elements and return true. */
+  bool TryEmitRepeatPattern(
+      const GrammarExpr& body, int32_t self_rule_id, std::vector<int32_t>* elements
+  ) {
+    return TryEmitPlusPattern(body, self_rule_id, elements) ||
+           TryEmitGeneralizedPlusPattern(body, self_rule_id, elements) ||
+           TryEmitStarPattern(body, self_rule_id, elements);
+  }
+
+  /*! \brief If the body matches the generalized plus-desugar pattern (self ::= e1 self | ... |
+   * e1 | ...) with single-character elements whose recursive and base unions are equal, append
+   * the equivalent (cc cc*) over the union to the elements and return true. */
+  bool TryEmitGeneralizedPlusPattern(
+      const GrammarExpr& body, int32_t self_rule_id, std::vector<int32_t>* elements
+  ) {
+    if (body.type != GrammarExprType::kChoices) {
+      return false;
+    }
+    std::vector<GrammarBuilder::CharacterClassElement> recursive_ranges;
+    std::vector<GrammarBuilder::CharacterClassElement> base_ranges;
+    for (auto choice_id : body) {
+      const auto& choice = base_grammar_->GetGrammarExpr(choice_id);
+      if (choice.type != GrammarExprType::kSequence) {
+        return false;
+      }
+      if (choice.size() == 1) {
+        if (!CollectSingleCharRanges(choice[0], &base_ranges, 0)) {
+          return false;
+        }
+        continue;
+      }
+      if (choice.size() == 2) {
+        const auto& tail = base_grammar_->GetGrammarExpr(choice[1]);
+        if (tail.type == GrammarExprType::kRuleRef && tail[0] == self_rule_id &&
+            CollectSingleCharRanges(choice[0], &recursive_ranges, 0)) {
+          continue;
+        }
+      }
+      return false;
+    }
+    recursive_ranges = UnionRanges(std::move(recursive_ranges));
+    base_ranges = UnionRanges(std::move(base_ranges));
+    // The unions must coincide: with differing sets (e.g. self ::= a self | b, which is a*b),
+    // the language is not (a|b)+.
+    if (recursive_ranges.empty() || !RangesEqual(recursive_ranges, base_ranges)) {
+      return false;
+    }
+    elements->push_back(builder_->AddCharacterClass(recursive_ranges, false));
+    elements->push_back(builder_->AddCharacterClassStar(recursive_ranges, false));
+    return true;
+  }
+
+  /*! \brief If the body matches the plus-desugar pattern (self ::= e self | e) with e resolving
+   * to a star-expressible expr, append the equivalent (e e*) (or (e*) when e itself resolves to
+   * a star) to the elements and return true. */
   bool TryEmitPlusPattern(
       const GrammarExpr& body, int32_t self_rule_id, std::vector<int32_t>* elements
   ) {
@@ -2166,23 +2272,274 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
           !std::equal(element.begin(), element.end(), base_element.begin())) {
         continue;
       }
+      int32_t resolved_id = ResolveStarExpressible(recursive[0]);
+      if (resolved_id == -1) {
+        // Not a single terminal; e may still be a single-character alternation, giving
+        // (e1|e2|...)+ = cc cc* over the union of the ranges.
+        std::vector<GrammarBuilder::CharacterClassElement> ranges;
+        if (!CollectSingleCharRanges(recursive[0], &ranges, 0)) {
+          continue;
+        }
+        ranges = UnionRanges(std::move(ranges));
+        elements->push_back(builder_->AddCharacterClass(ranges, false));
+        elements->push_back(builder_->AddCharacterClassStar(ranges, false));
+        return true;
+      }
+      const auto& resolved = base_grammar_->GetGrammarExpr(resolved_id);
+      if (resolved.type == GrammarExprType::kCharacterClassStar) {
+        // (e*)+ is e*.
+        elements->push_back(builder_->AddGrammarExpr(resolved));
+        return true;
+      }
       std::vector<GrammarBuilder::CharacterClassElement> character_ranges;
       bool is_negative = false;
-      if (element.type == GrammarExprType::kCharacterClass) {
-        is_negative = static_cast<bool>(element[0]);
-        for (int i = 1; i < static_cast<int>(element.size()); i += 2) {
-          character_ranges.push_back({element[i], element[i + 1]});
+      if (resolved.type == GrammarExprType::kCharacterClass) {
+        is_negative = static_cast<bool>(resolved[0]);
+        for (int i = 1; i < static_cast<int>(resolved.size()); i += 2) {
+          character_ranges.push_back({resolved[i], resolved[i + 1]});
         }
-      } else if (element.type == GrammarExprType::kByteString && element.size() == 1) {
-        character_ranges.push_back({element[0], element[0]});
-      } else {
-        continue;
+      } else {  // single-byte kByteString
+        character_ranges.push_back({resolved[0], resolved[0]});
       }
-      elements->push_back(builder_->AddGrammarExpr(element));
+      elements->push_back(builder_->AddGrammarExpr(resolved));
       elements->push_back(builder_->AddCharacterClassStar(character_ranges, is_negative));
       return true;
     }
     return false;
+  }
+
+  /*! \brief If the body matches the generalized star-desugar pattern (self ::= "" | e1 self |
+   * e2 self | ...) with each e resolving to character ranges, append the equivalent single
+   * character class star ((e1|e2|...)*) to the elements and return true. */
+  bool TryEmitStarPattern(
+      const GrammarExpr& body, int32_t self_rule_id, std::vector<int32_t>* elements
+  ) {
+    if (body.type != GrammarExprType::kChoices) {
+      return false;
+    }
+    bool has_empty = false;
+    std::vector<GrammarBuilder::CharacterClassElement> ranges;
+    for (auto choice_id : body) {
+      const auto& choice = base_grammar_->GetGrammarExpr(choice_id);
+      if (choice.type == GrammarExprType::kEmptyStr) {
+        has_empty = true;
+        continue;
+      }
+      if (choice.type != GrammarExprType::kSequence || choice.size() != 2) {
+        return false;
+      }
+      const auto& tail = base_grammar_->GetGrammarExpr(choice[1]);
+      if (tail.type != GrammarExprType::kRuleRef || tail[0] != self_rule_id) {
+        return false;
+      }
+      if (!CollectStarRanges(choice[0], &ranges, 0)) {
+        return false;
+      }
+    }
+    if (!has_empty || ranges.empty()) {
+      return false;
+    }
+    elements->push_back(builder_->AddCharacterClassStar(UnionRanges(std::move(ranges)), false));
+    return true;
+  }
+
+  /*! \brief Resolve an expr repeated under an enclosing star into the set of codepoint ranges it
+   * repeats over, appending them to ranges. Accepts character classes, character class stars,
+   * single-byte strings, and references to non-lazy rules that are alternations of such
+   * elements, or star/plus recursions over them — under an enclosing star, all of these are
+   * equivalent to the union of their character ranges. Returns false otherwise. */
+  bool CollectStarRanges(
+      int32_t expr_id, std::vector<GrammarBuilder::CharacterClassElement>* ranges, int depth
+  ) {
+    if (depth > 64) {
+      return false;
+    }
+    const auto& expr = base_grammar_->GetGrammarExpr(expr_id);
+    if (expr.type == GrammarExprType::kCharacterClass ||
+        expr.type == GrammarExprType::kCharacterClassStar) {
+      AppendPositiveRanges(expr, ranges);
+      return true;
+    }
+    if (expr.type == GrammarExprType::kByteString && expr.size() == 1) {
+      ranges->push_back({expr[0], expr[0]});
+      return true;
+    }
+    if (expr.type != GrammarExprType::kRuleRef) {
+      return false;
+    }
+    int32_t rule_id = expr[0];
+    const auto& rule = base_grammar_->GetRule(rule_id);
+    if (rule.is_lazy) {
+      return false;
+    }
+    const auto& body = base_grammar_->GetGrammarExpr(rule.body_expr_id);
+    if (body.type != GrammarExprType::kChoices) {
+      return false;
+    }
+    bool has_empty = false;
+    std::vector<int32_t> base_elements;
+    std::vector<int32_t> recursive_elements;
+    for (auto choice_id : body) {
+      const auto& choice = base_grammar_->GetGrammarExpr(choice_id);
+      if (choice.type == GrammarExprType::kEmptyStr) {
+        has_empty = true;
+        continue;
+      }
+      if (choice.type != GrammarExprType::kSequence) {
+        return false;
+      }
+      if (choice.size() == 1) {
+        base_elements.push_back(choice[0]);
+        continue;
+      }
+      if (choice.size() == 2) {
+        const auto& tail = base_grammar_->GetGrammarExpr(choice[1]);
+        if (tail.type == GrammarExprType::kRuleRef && tail[0] == rule_id) {
+          recursive_elements.push_back(choice[0]);
+          continue;
+        }
+      }
+      return false;
+    }
+    // The safe shapes: an alternation (a | b | ...), a star ("" | e1 self | ...), and a plus
+    // (e self | e, or single-character alternated forms with equal recursive/base unions).
+    // Mixed shapes like (a self | b) are a*b, whose star is not the union, so they are rejected.
+    std::vector<int32_t>* collect = nullptr;
+    if (recursive_elements.empty()) {
+      collect = &base_elements;
+    } else if (base_elements.empty() && has_empty) {
+      collect = &recursive_elements;
+    } else if (recursive_elements.size() == 1 && base_elements.size() == 1 && !has_empty &&
+               ExprsEqual(recursive_elements[0], base_elements[0])) {
+      collect = &recursive_elements;
+    } else if (!has_empty) {
+      std::vector<GrammarBuilder::CharacterClassElement> recursive_ranges;
+      std::vector<GrammarBuilder::CharacterClassElement> base_ranges;
+      for (auto element_id : recursive_elements) {
+        if (!CollectSingleCharRanges(element_id, &recursive_ranges, depth + 1)) {
+          return false;
+        }
+      }
+      for (auto element_id : base_elements) {
+        if (!CollectSingleCharRanges(element_id, &base_ranges, depth + 1)) {
+          return false;
+        }
+      }
+      recursive_ranges = UnionRanges(std::move(recursive_ranges));
+      if (!RangesEqual(recursive_ranges, UnionRanges(std::move(base_ranges)))) {
+        return false;
+      }
+      ranges->insert(ranges->end(), recursive_ranges.begin(), recursive_ranges.end());
+      return true;
+    } else {
+      return false;
+    }
+    for (auto element_id : *collect) {
+      if (!CollectStarRanges(element_id, ranges, depth + 1)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /*! \brief Whether two exprs have identical type and content. */
+  bool ExprsEqual(int32_t lhs_id, int32_t rhs_id) {
+    const auto& lhs = base_grammar_->GetGrammarExpr(lhs_id);
+    const auto& rhs = base_grammar_->GetGrammarExpr(rhs_id);
+    return lhs.type == rhs.type && lhs.size() == rhs.size() &&
+           std::equal(lhs.begin(), lhs.end(), rhs.begin());
+  }
+
+  /*! \brief Whether two normalized range vectors are identical. */
+  static bool RangesEqual(
+      const std::vector<GrammarBuilder::CharacterClassElement>& lhs,
+      const std::vector<GrammarBuilder::CharacterClassElement>& rhs
+  ) {
+    if (lhs.size() != rhs.size()) {
+      return false;
+    }
+    for (size_t i = 0; i < lhs.size(); ++i) {
+      if (lhs[i].lower != rhs[i].lower || lhs[i].upper != rhs[i].upper) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /*! \brief Append the positive codepoint ranges of a character class or character class star,
+   * complementing negated classes over [0, 0x10FFFF]. */
+  void AppendPositiveRanges(
+      const GrammarExpr& expr, std::vector<GrammarBuilder::CharacterClassElement>* ranges
+  ) {
+    std::vector<GrammarBuilder::CharacterClassElement> class_ranges;
+    for (int i = 1; i < static_cast<int>(expr.size()); i += 2) {
+      class_ranges.push_back({expr[i], expr[i + 1]});
+    }
+    if (!static_cast<bool>(expr[0])) {
+      ranges->insert(ranges->end(), class_ranges.begin(), class_ranges.end());
+      return;
+    }
+    class_ranges = UnionRanges(std::move(class_ranges));
+    int32_t next = 0;
+    for (const auto& range : class_ranges) {
+      if (range.lower > next) {
+        ranges->push_back({next, range.lower - 1});
+      }
+      next = std::max(next, range.upper + 1);
+    }
+    if (next <= 0x10FFFF) {
+      ranges->push_back({next, 0x10FFFF});
+    }
+  }
+
+  /*! \brief Sort the ranges and merge overlapping or adjacent ones. */
+  static std::vector<GrammarBuilder::CharacterClassElement> UnionRanges(
+      std::vector<GrammarBuilder::CharacterClassElement> ranges
+  ) {
+    std::sort(ranges.begin(), ranges.end(), [](const auto& a, const auto& b) {
+      return a.lower < b.lower;
+    });
+    std::vector<GrammarBuilder::CharacterClassElement> result;
+    for (const auto& range : ranges) {
+      if (!result.empty() && range.lower <= result.back().upper + 1) {
+        result.back().upper = std::max(result.back().upper, range.upper);
+      } else {
+        result.push_back(range);
+      }
+    }
+    return result;
+  }
+
+  /*! \brief Resolve an expr through chains of non-lazy single-reference rules to a
+   * star-expressible expr: a character class, a single-byte string, or a character class star.
+   * Returns the resolved expr id, or -1 if it does not resolve to one. */
+  int32_t ResolveStarExpressible(int32_t expr_id) {
+    int32_t cur_id = expr_id;
+    for (int depth = 0; depth < 64; ++depth) {
+      const auto& cur = base_grammar_->GetGrammarExpr(cur_id);
+      if (cur.type == GrammarExprType::kCharacterClass ||
+          cur.type == GrammarExprType::kCharacterClassStar ||
+          (cur.type == GrammarExprType::kByteString && cur.size() == 1)) {
+        return cur_id;
+      }
+      if (cur.type != GrammarExprType::kRuleRef) {
+        return -1;
+      }
+      const auto& ref_rule = base_grammar_->GetRule(cur[0]);
+      if (ref_rule.is_lazy) {
+        return -1;
+      }
+      const auto& ref_body = base_grammar_->GetGrammarExpr(ref_rule.body_expr_id);
+      if (ref_body.type != GrammarExprType::kChoices || ref_body.size() != 1) {
+        return -1;
+      }
+      const auto& only_choice = base_grammar_->GetGrammarExpr(ref_body[0]);
+      if (only_choice.type != GrammarExprType::kSequence || only_choice.size() != 1) {
+        return -1;
+      }
+      cur_id = only_choice[0];
+    }
+    return -1;
   }
 };
 

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -71,6 +71,7 @@ class SubGrammarAdderImpl : public GrammarMutator {
       builder_->UpdateLookaheadAssertion(new_rule_ids_names[i].first, new_lookahead_assertion_id);
       builder_->UpdateMaxTokens(new_rule_ids_names[i].first, rule.max_tokens);
       builder_->UpdateCaptureName(new_rule_ids_names[i].first, rule.capture_name);
+      builder_->UpdateLazy(new_rule_ids_names[i].first, rule.is_lazy);
     }
     return new_rule_ids_names[base_grammar_->GetRootRuleId()].first;
   }
@@ -277,6 +278,7 @@ class StructureNormalizerImpl : public GrammarMutator {
       builder_->UpdateLookaheadAssertion(i, VisitLookaheadAssertion(rule.lookahead_assertion_id));
       builder_->UpdateMaxTokens(i, rule.max_tokens);
       builder_->UpdateCaptureName(i, rule.capture_name);
+      builder_->UpdateLazy(i, rule.is_lazy);
     }
     return builder_->Get(base_grammar_->GetRootRule().name);
   }
@@ -623,8 +625,8 @@ class RuleInlinerImpl : public GrammarMutator {
     auto rule = base_grammar_->GetRule(rule_id);
     // Inlining a budgeted rule would erase the rule its token budget applies to. Inlining a
     // captured rule would eliminate its completion events, so its capture would never be
-    // recorded.
-    if (rule.max_tokens >= 0 || !rule.capture_name.empty()) {
+    // recorded. Inlining a lazy rule would erase its committed-shortest semantics.
+    if (rule.max_tokens >= 0 || !rule.capture_name.empty() || rule.is_lazy) {
       return false;
     }
     auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
@@ -730,6 +732,7 @@ class DeadCodeEliminatorImpl : public GrammarMutator {
       );
       builder_->UpdateMaxTokens(rule_id_map_[rule_id], rule.max_tokens);
       builder_->UpdateCaptureName(rule_id_map_[rule_id], rule.capture_name);
+      builder_->UpdateLazy(rule_id_map_[rule_id], rule.is_lazy);
     }
     XGRAMMAR_CHECK(rule_id_map_.count(grammar->GetRootRuleId()) > 0);
     return builder_->Get(rule_id_map_[grammar->GetRootRuleId()]);
@@ -1877,9 +1880,10 @@ int32_t RepetitionRangeExpanderImpl::HandleRepetitionRange(
   int32_t grammar_expr_id = builder_->AddRuleRef(rule_id);
   const auto& ref_rule = base_grammar_->GetRule(rule_id);
   const auto& ref_rule_body = base_grammar_->GetGrammarExpr(ref_rule.body_expr_id);
-  // Keep the reference to budgeted rules: replacing it with the rule's content would erase the
-  // rule the token budget applies to.
-  if (ref_rule.max_tokens < 0 && ref_rule_body.type == GrammarBuilder::GrammarExprType::kChoices &&
+  // Keep the reference to budgeted and lazy rules: replacing it with the rule's content would
+  // erase the rule the token budget or lazy semantics applies to.
+  if (ref_rule.max_tokens < 0 && !ref_rule.is_lazy &&
+      ref_rule_body.type == GrammarBuilder::GrammarExprType::kChoices &&
       ref_rule_body.size() == 1) {
     const auto& ref_choice = base_grammar_->GetGrammarExpr(ref_rule_body[0]);
     if (ref_choice.size() == 1) {
@@ -2015,19 +2019,231 @@ class RepetitionNormalizerImpl {
   }
 };
 
+/*!
+ * \brief Rewrite lazy rule bodies into their terminal-like form where possible: unwrap the
+ * single-reference chains produced by regex conversion, and flatten the right-recursive plus
+ * pattern (x ::= cc x | cc) into (cc cc*). Grammars without lazy rules are returned unchanged.
+ */
+class LazyBodyFlattenerImpl : public GrammarMutator {
+ public:
+  using GrammarMutator::GrammarMutator;
+
+  Grammar Apply(const Grammar& grammar) final {
+    bool has_lazy_rule = false;
+    for (int i = 0; i < grammar->NumRules(); ++i) {
+      has_lazy_rule = has_lazy_rule || grammar->GetRule(i).is_lazy;
+    }
+    if (!has_lazy_rule) {
+      return grammar;
+    }
+    InitGrammar(grammar);
+    InitBuilder();
+    for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
+      builder_->AddEmptyRule(base_grammar_->GetRule(i).name);
+    }
+    for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
+      auto rule = base_grammar_->GetRule(i);
+      cur_rule_name_ = rule.name;
+      int32_t new_body_expr_id =
+          rule.is_lazy ? BuildFlattenedLazyBody(rule.body_expr_id) : VisitExpr(rule.body_expr_id);
+      builder_->UpdateRuleBody(i, new_body_expr_id);
+      builder_->UpdateLookaheadAssertion(i, VisitLookaheadAssertion(rule.lookahead_assertion_id));
+      builder_->UpdateLazy(i, rule.is_lazy);
+    }
+    return builder_->Get(base_grammar_->GetRootRule().name);
+  }
+
+ private:
+  int32_t BuildFlattenedLazyBody(int32_t body_expr_id) {
+    // Unwrap chains of single rule references (r ::= (x), x ::= (y), ...) produced by regex
+    // conversion, and detect the plus-desugar pattern at the top level.
+    int32_t cur_body_id = body_expr_id;
+    int32_t cur_rule_id = -1;
+    for (int depth = 0; depth < 64; ++depth) {
+      const auto& body = base_grammar_->GetGrammarExpr(cur_body_id);
+      if (body.type != GrammarExprType::kChoices || body.size() != 1) {
+        break;
+      }
+      const auto& choice = base_grammar_->GetGrammarExpr(body[0]);
+      if (choice.type != GrammarExprType::kSequence || choice.size() != 1) {
+        break;
+      }
+      const auto& element = base_grammar_->GetGrammarExpr(choice[0]);
+      if (element.type != GrammarExprType::kRuleRef || base_grammar_->GetRule(element[0]).is_lazy) {
+        break;
+      }
+      cur_rule_id = element[0];
+      cur_body_id = base_grammar_->GetRule(cur_rule_id).body_expr_id;
+    }
+
+    const auto& body = base_grammar_->GetGrammarExpr(cur_body_id);
+    if (body.type != GrammarExprType::kChoices) {
+      return VisitExpr(cur_body_id);
+    }
+    std::vector<int32_t> plus_elements;
+    if (cur_rule_id != -1 && TryEmitPlusPattern(body, cur_rule_id, &plus_elements)) {
+      return builder_->AddChoices({builder_->AddSequence(plus_elements)});
+    }
+    std::vector<int32_t> new_choice_ids;
+    for (auto choice_id : body) {
+      const auto& choice = base_grammar_->GetGrammarExpr(choice_id);
+      if (choice.type != GrammarExprType::kSequence) {
+        new_choice_ids.push_back(VisitExpr(choice_id));
+        continue;
+      }
+      std::vector<int32_t> elements;
+      if (!FlattenSequenceInto(choice, &elements, 0)) {
+        // Not flattenable; copy as is and let the terminal-like validation report the error.
+        return VisitExpr(cur_body_id);
+      }
+      new_choice_ids.push_back(builder_->AddSequence(elements));
+    }
+    return builder_->AddChoices(new_choice_ids);
+  }
+
+  /*! \brief Append the flattened elements of the sequence, splicing rule references whose body
+   * is a single terminal-like sequence or the plus-desugar pattern. Returns false if some
+   * element cannot be flattened. */
+  bool FlattenSequenceInto(const GrammarExpr& seq, std::vector<int32_t>* elements, int depth) {
+    if (depth > 64) {
+      return false;
+    }
+    for (auto element_id : seq) {
+      const auto& element = base_grammar_->GetGrammarExpr(element_id);
+      if (element.type == GrammarExprType::kByteString ||
+          element.type == GrammarExprType::kCharacterClass ||
+          element.type == GrammarExprType::kCharacterClassStar) {
+        elements->push_back(builder_->AddGrammarExpr(element));
+        continue;
+      }
+      if (element.type != GrammarExprType::kRuleRef) {
+        return false;
+      }
+      const auto& ref_rule = base_grammar_->GetRule(element[0]);
+      if (ref_rule.is_lazy) {
+        return false;
+      }
+      const auto& ref_body = base_grammar_->GetGrammarExpr(ref_rule.body_expr_id);
+      if (TryEmitPlusPattern(ref_body, element[0], elements)) {
+        continue;
+      }
+      if (ref_body.type == GrammarExprType::kChoices && ref_body.size() == 1) {
+        const auto& only_choice = base_grammar_->GetGrammarExpr(ref_body[0]);
+        if (only_choice.type == GrammarExprType::kEmptyStr) {
+          continue;
+        }
+        if (only_choice.type == GrammarExprType::kSequence &&
+            FlattenSequenceInto(only_choice, elements, depth + 1)) {
+          continue;
+        }
+      }
+      return false;
+    }
+    return true;
+  }
+
+  /*! \brief If the body matches the plus-desugar pattern (self ::= e self | e) with a
+   * star-expressible e (a character class, or a single-byte string), append (e e*) to the
+   * elements and return true. */
+  bool TryEmitPlusPattern(
+      const GrammarExpr& body, int32_t self_rule_id, std::vector<int32_t>* elements
+  ) {
+    if (body.type != GrammarExprType::kChoices || body.size() != 2) {
+      return false;
+    }
+    for (int recursive_pos = 0; recursive_pos < 2; ++recursive_pos) {
+      const auto& recursive = base_grammar_->GetGrammarExpr(body[recursive_pos]);
+      const auto& base = base_grammar_->GetGrammarExpr(body[1 - recursive_pos]);
+      if (recursive.type != GrammarExprType::kSequence || recursive.size() != 2 ||
+          base.type != GrammarExprType::kSequence || base.size() != 1) {
+        continue;
+      }
+      const auto& element = base_grammar_->GetGrammarExpr(recursive[0]);
+      const auto& tail = base_grammar_->GetGrammarExpr(recursive[1]);
+      const auto& base_element = base_grammar_->GetGrammarExpr(base[0]);
+      if (tail.type != GrammarExprType::kRuleRef || tail[0] != self_rule_id ||
+          element.type != base_element.type || element.size() != base_element.size() ||
+          !std::equal(element.begin(), element.end(), base_element.begin())) {
+        continue;
+      }
+      std::vector<GrammarBuilder::CharacterClassElement> character_ranges;
+      bool is_negative = false;
+      if (element.type == GrammarExprType::kCharacterClass) {
+        is_negative = static_cast<bool>(element[0]);
+        for (int i = 1; i < static_cast<int>(element.size()); i += 2) {
+          character_ranges.push_back({element[i], element[i + 1]});
+        }
+      } else if (element.type == GrammarExprType::kByteString && element.size() == 1) {
+        character_ranges.push_back({element[0], element[0]});
+      } else {
+        continue;
+      }
+      elements->push_back(builder_->AddGrammarExpr(element));
+      elements->push_back(builder_->AddCharacterClassStar(character_ranges, is_negative));
+      return true;
+    }
+    return false;
+  }
+};
+
 class GrammarOptimizerImpl {
  public:
   static Grammar Apply(const Grammar& grammar) {
     auto result = ByteStringFuser::Apply(grammar);
     result = RuleInliner::Apply(result);
     result = RepetitionRangeExpander::Apply(result);
+    result = LazyBodyFlattenerImpl().Apply(result);
     result = DeadCodeEliminator::Apply(result);
     result = LookaheadAssertionAnalyzer::Apply(result);
     result->allow_empty_rule_ids = AllowEmptyRuleAnalyzer::Apply(result);
+    ValidateLazyRules(result);
     RepetitionNormalizer::Apply(&result);
     GrammarFSMBuilder::Apply(&result);
     result->optimized = true;
     return result;
+  }
+
+ private:
+  /*!
+   * \brief Committed-shortest (lazy) matching requires the whole rule body to compile into a
+   * single per-rule FSM without rule references, so that the states of one occurrence are exactly
+   * the states with the rule's id. Also warn on lazy rules that can match empty: they commit at
+   * entry and always match the empty string.
+   */
+  static void ValidateLazyRules(const Grammar& grammar) {
+    for (int32_t i = 0; i < grammar->NumRules(); ++i) {
+      const auto& rule = grammar->GetRule(i);
+      if (!rule.is_lazy) {
+        continue;
+      }
+      const auto& body = grammar->GetGrammarExpr(rule.body_expr_id);
+      XGRAMMAR_CHECK(body.type == Grammar::Impl::GrammarExprType::kChoices)
+          << "lazy rule '" << rule.name << "' must have a terminal-like body";
+      for (auto choice_id : body) {
+        const auto& choice = grammar->GetGrammarExpr(choice_id);
+        if (choice.type == Grammar::Impl::GrammarExprType::kEmptyStr) {
+          continue;
+        }
+        for (auto element_id : choice) {
+          const auto& element = grammar->GetGrammarExpr(element_id);
+          XGRAMMAR_CHECK(
+              element.type == Grammar::Impl::GrammarExprType::kByteString ||
+              element.type == Grammar::Impl::GrammarExprType::kCharacterClass ||
+              element.type == Grammar::Impl::GrammarExprType::kCharacterClassStar
+          ) << "lazy rule '"
+            << rule.name
+            << "' must have a terminal-like body (strings, character classes, and regexes that "
+               "compile to a single FSM); rule references and repetition ranges are not supported";
+        }
+      }
+      if (std::binary_search(
+              grammar->allow_empty_rule_ids.begin(), grammar->allow_empty_rule_ids.end(), i
+          )) {
+        XGRAMMAR_LOG(WARNING) << "The lazy rule '" << rule.name
+                              << "' can match the empty string, so it always matches the empty "
+                                 "string (committed-shortest matching).";
+      }
+    }
   }
 };
 

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -71,6 +71,7 @@ class GrammarFunctor {
         builder_->UpdateLookaheadAssertion(i, VisitLookaheadAssertion(rule.lookahead_assertion_id));
         builder_->UpdateMaxTokens(i, rule.max_tokens);
         builder_->UpdateCaptureName(i, rule.capture_name);
+        builder_->UpdateLazy(i, rule.is_lazy);
       }
       return builder_->Get(base_grammar_->GetRootRule().name);
     } else {

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -88,6 +88,9 @@ class Grammar::Impl {
      * span matched by this rule on every completion, retrievable via GrammarMatcher::GetCaptures.
      * Empty means no capture. */
     std::string capture_name = {};
+    /*! \brief Whether the rule matches with committed-shortest (lazy) semantics: at the first
+     * position where the body can complete, it must complete. */
+    bool is_lazy = false;
   };
 
   /*! \brief Get the number of rules. */
@@ -363,7 +366,8 @@ XGRAMMAR_MEMBER_ARRAY(
     &Grammar::Impl::Rule::lookahead_assertion_id,
     &Grammar::Impl::Rule::is_exact_lookahead,
     &Grammar::Impl::Rule::max_tokens,
-    &Grammar::Impl::Rule::capture_name
+    &Grammar::Impl::Rule::capture_name,
+    &Grammar::Impl::Rule::is_lazy
 );
 
 XGRAMMAR_MEMBER_TABLE(

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <variant>
 #include <vector>
@@ -143,10 +144,11 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
   }
 
   // A rule definition may carry an attribute block before ::=, e.g.
-  // name[max_tokens=10] ::= ..., name[capture] ::= ..., name[capture="x"] ::= ..., or a
-  // comma-separated combination: name[max_tokens=10, capture="x"] ::= ... The bracket group is
-  // treated as an attribute block only when it is followed by "::="; otherwise it is left to be
-  // lexed as a character class.
+  // name[max_tokens=10] ::= ..., name[capture] ::= ..., name[capture="x"] ::= ...,
+  // name[lazy] ::= ..., or a comma-separated combination:
+  // name[max_tokens=10, capture="x", lazy] ::= ... The bracket group is treated as an attribute
+  // block only when it is followed by "::="; otherwise it is left to be lexed as a character
+  // class.
   if (*cur_ == '[') {
     int delta = 1;
     auto skip_space = [&]() {
@@ -169,6 +171,7 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
     bool matched = true;
     bool has_max_tokens = false;
     bool has_capture = false;
+    bool has_lazy = false;
     int64_t max_tokens_value = -1;
     std::string capture_value;
     // Parse a comma-separated attribute list. Each attribute may appear at most once.
@@ -219,6 +222,8 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
         } else {
           capture_value = identifier;
         }
+      } else if (!has_lazy && match_keyword("lazy")) {
+        has_lazy = true;
       } else {
         matched = false;
       }
@@ -258,6 +263,7 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
       Token token{TokenType::Identifier, identifier, identifier, start_line, start_column};
       token.max_tokens = static_cast<int32_t>(max_tokens_value);
       token.capture_name = capture_value;
+      token.is_lazy = has_lazy;
       return token;
     }
   }
@@ -1309,6 +1315,7 @@ EBNFParser::Rule EBNFParser::ParseRule() {
   cur_rule_name_ = std::any_cast<std::string>(Peek().value);
   int32_t max_tokens = Peek().max_tokens;
   std::string capture_name = Peek().capture_name;
+  bool is_lazy = Peek().is_lazy;
   Consume();
 
   PeekAndConsume(TokenType::Assign, "Expect ::=");
@@ -1323,6 +1330,7 @@ EBNFParser::Rule EBNFParser::ParseRule() {
   Rule rule{cur_rule_name_, body_id, lookahead_id};
   rule.max_tokens = max_tokens;
   rule.capture_name = capture_name;
+  rule.is_lazy = is_lazy;
   return rule;
 }
 
@@ -1364,6 +1372,7 @@ Grammar EBNFParser::Parse(
     builder_.UpdateLookaheadAssertion(new_rule.name, new_rule.lookahead_assertion_id);
     builder_.UpdateMaxTokens(new_rule.name, new_rule.max_tokens);
     builder_.UpdateCaptureName(new_rule.name, new_rule.capture_name);
+    builder_.UpdateLazy(new_rule.name, new_rule.is_lazy);
   }
 
   return builder_.Get(root_rule_name);

--- a/cpp/grammar_parser.h
+++ b/cpp/grammar_parser.h
@@ -62,6 +62,8 @@ class EBNFLexer {
     int32_t max_tokens = -1;
     // The capture name attached to a rule-definition identifier via name[capture="x"], or empty.
     std::string capture_name = {};
+    // Whether the identifier is a rule name carrying the [lazy] attribute, e.g. r[lazy] ::= ...
+    bool is_lazy = false;
   };
 
   EBNFLexer();

--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -14,7 +14,7 @@ namespace xgrammar {
 std::string GrammarPrinter::PrintRule(const Rule& rule) {
   std::string res = rule.name;
   // Print the attributes as one comma-separated bracket group, re-parseable by the EBNF lexer.
-  if (rule.max_tokens >= 0 || !rule.capture_name.empty()) {
+  if (rule.max_tokens >= 0 || !rule.capture_name.empty() || rule.is_lazy) {
     std::string attributes;
     if (rule.max_tokens >= 0) {
       attributes += "max_tokens=" + std::to_string(rule.max_tokens);
@@ -24,6 +24,12 @@ std::string GrammarPrinter::PrintRule(const Rule& rule) {
         attributes += ", ";
       }
       attributes += "capture=\"" + rule.capture_name + "\"";
+    }
+    if (rule.is_lazy) {
+      if (!attributes.empty()) {
+        attributes += ", ";
+      }
+      attributes += "lazy";
     }
     res += "[" + attributes + "]";
   }

--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -1599,7 +1599,10 @@ class LarkCompiler {
           );
         }
         int32_t result = builder_.AddRuleRef(rule_ids_.at(node.text));
-        return !terminal_mode && definition_it->second->is_terminal ? AppendSkip(result) : result;
+        // Lazy rules are compiled like terminals (lexemes), so they also take a trailing skip.
+        bool skip_after =
+            definition_it->second->is_terminal || HasLazySemantics(*definition_it->second);
+        return !terminal_mode && skip_after ? AppendSkip(result) : result;
       }
       case Node::Kind::kString: {
         int32_t result = CompileStringLiteral(node);
@@ -1952,12 +1955,10 @@ class LarkCompiler {
     }
     auto trigger = ExtractLazyTrigger(definition);
     if (!trigger.has_value()) {
-      RaiseLarkError(
-          source_,
-          definition.location,
-          "general lazy rules are not supported; expected ANY_TEXT with a fixed string, token, "
-          "regex suffix, or suffix attribute"
-      );
+      // General committed-shortest lazy rule: compiled like a terminal (no skip insertion);
+      // the terminal-like requirement is validated after grammar optimization.
+      builder_.UpdateLazy(rule_ids_.at(definition.name), true);
+      return CompileNode(definition.body, definition.name, true);
     }
     int32_t empty_rule = builder_.AddRuleWithHint("lark_lazy_end", builder_.AddEmptyStr());
     int32_t result;

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v16";
+  static constexpr const char kXGrammarSerializeVersion[] = "v15";
 };
 
 /*!

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v15";
+  static constexpr const char kXGrammarSerializeVersion[] = "v16";
 };
 
 /*!

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -461,10 +461,12 @@ rest: /[a-z]+/
 
 Notes:
 
-- The body must compile to a single terminal-like automaton: strings, character classes,
-  the `+`/`*`/`?` quantifiers over them, and alternations of these. Bodies that need rule
-  references (recursion, general repetition ranges like `{2,5}` over groups) are rejected at
-  compile time.
+- The body must compile to a single terminal-like automaton: sequences and alternations of
+  strings and character classes, and the `+`/`*` quantifiers over single-character elements
+  (character classes, single-character strings, and alternations of these — directly or through
+  terminal references like `TEXT*`). Bodies that need rule references (recursion, `?` in the
+  middle of a sequence, quantifiers over multi-character strings, and repetition ranges like
+  `{2,5}`) are rejected at compile time.
 - A lazy rule that can match the empty string always matches the empty string (for example
   `foo[lazy]: /.*/`); the compiler emits a warning for this.
 - Lazy rules are compiled as lexemes: `%ignore` is not woven inside their bodies, and like

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -445,8 +445,35 @@ TEXT: /(\n|.)*/
 
 This matches arbitrary text and completes as soon as the trigger appears; nothing may follow the
 trigger. Text that never produces the trigger is also accepted. The regex-suffix and
-`suffix="..."` head forms are only accepted inside the full dispatch pattern, and general lazy
-rules over other bodies (for example `value[lazy]: /[a-z]+/`) are rejected.
+`suffix="..."` head forms are only accepted inside the full dispatch pattern.
+
+### General Lazy Rules (Committed-Shortest Matching)
+
+Any other rule may also carry `[lazy]`, which gives it **committed-shortest** matching: at the
+first position where the rule's body can end, it must end — the derivations in which this
+occurrence keeps consuming input are discarded.
+
+```text
+start: "<" name ">" rest
+name[lazy]: /[a-z]+/     // stops at the first position where it can end
+rest: /[a-z]+/
+```
+
+Notes:
+
+- The body must compile to a single terminal-like automaton: strings, character classes,
+  the `+`/`*`/`?` quantifiers over them, and alternations of these. Bodies that need rule
+  references (recursion, general repetition ranges like `{2,5}` over groups) are rejected at
+  compile time.
+- A lazy rule that can match the empty string always matches the empty string (for example
+  `foo[lazy]: /.*/`); the compiler emits a warning for this.
+- Lazy rules are compiled as lexemes: `%ignore` is not woven inside their bodies, and like
+  terminals they take the ignored-token skip after them.
+- Each occurrence of the rule commits independently, and the commit is exact for validation
+  (`accept_string`) as well as mask generation. `rollback`/`fork`/`reset` restore the state
+  across a commit exactly.
+- The same attribute is available in the EBNF frontend: `name[lazy] ::= ...`, and it round-trips
+  through `Grammar.__str__()` / `Grammar.from_ebnf()`.
 
 ## Token Budgets
 

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -1947,3 +1947,132 @@ def test_ebnf_lazy_mask_matches_lark_form() -> None:
     assert _mask_allowed_token_ids(matcher) == [2, 3, 5, 7]
     assert matcher.accept_token(2)
     assert _mask_allowed_token_ids(matcher) == [1]
+
+
+# Combined attributes: lazy + max_tokens + capture interacting in one grammar.
+
+COMBINED_TOKENIZER = xgr.TokenizerInfo(["x", "<t>", ">", "a", "b", "ab"])
+
+
+def _combined_allowed_token_ids(matcher: xgr.GrammarMatcher) -> list:
+    bitmask = xgr.allocate_token_bitmask(1, COMBINED_TOKENIZER.vocab_size)
+    matcher.fill_next_token_bitmask(bitmask)
+    return [
+        i
+        for i in range(COMBINED_TOKENIZER.vocab_size)
+        if (int(bitmask[0, i // 32]) >> (i % 32)) & 1
+    ]
+
+
+ALL_THREE_GRAMMAR = r"""
+    start: reasoning "<t>" val ">"
+    reasoning[max_tokens=2, capture]: TEXT
+    val[lazy, capture="value"]: /[ab]+/
+    TEXT: /(\n|.)*/
+"""
+
+
+def test_lark_lazy_with_capture_records_committed_span() -> None:
+    # The lazy commit makes the capture exact: the occurrence cannot complete again past the
+    # committed end, so only the shortest span is recorded.
+    grammar = "start: r rest\nr[lazy, capture]: /[a-z]+/\nrest: /[a-z]*/"
+    compiled = _compile_lark(grammar)
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_string("abc")
+    assert matcher.get_captures() == [("r", b"a")]
+    # Greedy control: without lazy, coalescing keeps the longest completion of the occurrence.
+    compiled = _compile_lark("start: r rest\nr[capture]: /[a-z]+/\nrest: /[a-z]*/")
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_string("abc")
+    assert matcher.get_captures() == [("r", b"abc")]
+
+
+def test_lark_lazy_with_capture_round_trip_and_cache() -> None:
+    grammar_obj = xgr.Grammar.from_lark(
+        'start: "<" r ">"\nr[lazy, capture="x"]: /[a-z]+/', tokenizer_info=COMBINED_TOKENIZER
+    )
+    printed = str(grammar_obj)
+    assert 'r[capture="x", lazy] ::=' in printed
+    assert 'r[capture="x", lazy] ::=' in str(xgr.Grammar.from_ebnf(printed))
+    deserialized = xgr.Grammar.deserialize_json(grammar_obj.serialize_json())
+    assert str(deserialized) == printed
+    # The compiler cache path re-parses ToString(); both attributes must survive it.
+    compiler = xgr.GrammarCompiler(COMBINED_TOKENIZER, cache_enabled=True)
+    compiled = compiler.compile_grammar(grammar_obj)
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert not matcher.accept_string("<ab>")
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_string("<a>") and matcher.is_terminated()
+    assert matcher.get_captures() == [("x", b"a")]
+
+
+def test_ebnf_all_three_attributes_round_trip() -> None:
+    # The EBNF frontend round-trips all three attributes in one bracket group, in any order.
+    ebnf = 'root ::= "<" r ">"\nr[max_tokens=3, capture="x", lazy] ::= [a-z] [a-z]*'
+    grammar_obj = xgr.Grammar.from_ebnf(ebnf)
+    assert 'r[max_tokens=3, capture="x", lazy] ::=' in str(grammar_obj)
+    reordered = xgr.Grammar.from_ebnf(
+        'root ::= "<" r ">"\nr[lazy, capture="x", max_tokens=3] ::= [a-z] [a-z]*'
+    )
+    assert str(reordered) == str(grammar_obj)
+    deserialized = xgr.Grammar.deserialize_json(grammar_obj.serialize_json())
+    assert str(deserialized) == str(grammar_obj)
+
+
+def test_lark_all_three_features_in_one_grammar_masks() -> None:
+    # Tokens: 0 "x", 1 "<t>", 2 ">", 3 "a", 4 "b", 5 "ab"
+    compiled = xgr.GrammarCompiler(COMBINED_TOKENIZER, cache_enabled=False).compile_grammar(
+        xgr.Grammar.from_lark(ALL_THREE_GRAMMAR, tokenizer_info=COMBINED_TOKENIZER)
+    )
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_token(0) and matcher.accept_token(0)
+    # Budget of the reasoning region exhausted: the mask only allows leaving it.
+    assert _combined_allowed_token_ids(matcher) == [1]
+    assert matcher.accept_token(1)
+    # Inside the lazy value: single region chars are allowed, "ab" would extend the occurrence
+    # past its commit point.
+    assert _combined_allowed_token_ids(matcher) == [3, 4]
+    assert matcher.accept_token(3)
+    # The lazy commit: only the closing literal remains.
+    assert _combined_allowed_token_ids(matcher) == [2]
+    assert matcher.accept_token(2) and matcher.is_terminated()
+    assert matcher.get_captures() == [("reasoning", b"xx"), ("value", b"a")]
+
+
+def test_lark_all_three_features_rollback_and_fork() -> None:
+    compiled = xgr.GrammarCompiler(COMBINED_TOKENIZER, cache_enabled=False).compile_grammar(
+        xgr.Grammar.from_lark(ALL_THREE_GRAMMAR, tokenizer_info=COMBINED_TOKENIZER)
+    )
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    # Generation-style loop: the fill before each accept enforces the budget close.
+    for token_id in [0, 0, 1, 3]:
+        assert token_id in _combined_allowed_token_ids(matcher)
+        assert matcher.accept_token(token_id)
+    forked = matcher.fork()
+    assert _combined_allowed_token_ids(forked) == [2]
+    # Rollback across the lazy commit and the budget close, then replay.
+    matcher.rollback(2)
+    assert _combined_allowed_token_ids(matcher) == [1]
+    assert matcher.accept_token(1) and matcher.accept_token(4)
+    assert matcher.accept_token(2) and matcher.is_terminated()
+    assert matcher.get_captures() == [("reasoning", b"xx"), ("value", b"b")]
+    assert forked.accept_token(2) and forked.is_terminated()
+    assert forked.get_captures() == [("reasoning", b"xx"), ("value", b"a")]
+
+
+def test_lark_all_three_features_serialization_round_trip() -> None:
+    grammar_obj = xgr.Grammar.from_lark(ALL_THREE_GRAMMAR, tokenizer_info=COMBINED_TOKENIZER)
+    printed = str(grammar_obj)
+    assert 'reasoning[max_tokens=2, capture="reasoning"] ::=' in printed
+    assert 'val[capture="value", lazy] ::=' in printed
+    deserialized = xgr.Grammar.deserialize_json(grammar_obj.serialize_json())
+    compiled = xgr.GrammarCompiler(COMBINED_TOKENIZER, cache_enabled=False).compile_grammar(
+        deserialized
+    )
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_token(0) and matcher.accept_token(0)
+    assert _combined_allowed_token_ids(matcher) == [1]
+    for token_id in [1, 3, 2]:
+        assert matcher.accept_token(token_id)
+    assert matcher.is_terminated()
+    assert matcher.get_captures() == [("reasoning", b"xx"), ("value", b"a")]

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -1817,3 +1817,89 @@ def test_lark_lazy_non_terminal_like_bodies_are_rejected() -> None:
     ):
         with pytest.raises(RuntimeError, match="terminal-like"):
             xgr.GrammarCompiler(LAZY_TOKENIZER, cache_enabled=False).compile_grammar(grammar_obj)
+
+
+# Tokens: 0 "<", 1 ">", 2 "a", 3 "b", 4 "ab", 5 "a>", 6 "ab>", 7 "b>", 8 "bb", 9 " "
+LAZY_MASK_TOKENIZER = xgr.TokenizerInfo(["<", ">", "a", "b", "ab", "a>", "ab>", "b>", "bb", " "])
+
+
+def _lazy_mask_matcher(grammar_obj: xgr.Grammar) -> xgr.GrammarMatcher:
+    compiled = xgr.GrammarCompiler(LAZY_MASK_TOKENIZER, cache_enabled=False).compile_grammar(
+        grammar_obj
+    )
+    return xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+
+
+def _mask_allowed_token_ids(matcher: xgr.GrammarMatcher) -> list:
+    bitmask = xgr.allocate_token_bitmask(1, LAZY_MASK_TOKENIZER.vocab_size)
+    matcher.fill_next_token_bitmask(bitmask)
+    return [
+        i
+        for i in range(LAZY_MASK_TOKENIZER.vocab_size)
+        if (int(bitmask[0, i // 32]) >> (i % 32)) & 1
+    ]
+
+
+def test_lark_lazy_mask_commit_inside_token() -> None:
+    # A token may cross the commit point: the region char commits the rule mid-token and the
+    # rest of the token must match what follows the rule.
+    grammar_obj = xgr.Grammar.from_lark('start: "<" r ">"\nr[lazy]: /[a-z]+/')
+    matcher = _lazy_mask_matcher(grammar_obj)
+    assert matcher.accept_token(0)
+    # "a", "b" open the region; "a>"/"b>" commit mid-token and exit. "ab" and "ab>" would
+    # extend the region past the commit; ">" needs a non-empty region first.
+    assert _mask_allowed_token_ids(matcher) == [2, 3, 5, 7]
+    # Refilling must give the identical mask.
+    assert _mask_allowed_token_ids(matcher) == [2, 3, 5, 7]
+    assert matcher.accept_token(5) and matcher.is_terminated()
+
+
+def test_lark_lazy_mask_exit_only_after_commit() -> None:
+    grammar_obj = xgr.Grammar.from_lark('start: "<" r ">"\nr[lazy]: /[a-z]+/')
+    matcher = _lazy_mask_matcher(grammar_obj)
+    assert matcher.accept_token(0) and matcher.accept_token(2)
+    assert _mask_allowed_token_ids(matcher) == [1]
+    assert matcher.accept_token(1) and matcher.is_terminated()
+
+
+def test_lark_lazy_mask_greedy_control() -> None:
+    # The same grammar without lazy: region tokens may extend freely.
+    grammar_obj = xgr.Grammar.from_lark('start: "<" r ">"\nr: /[a-z]+/')
+    matcher = _lazy_mask_matcher(grammar_obj)
+    assert matcher.accept_token(0)
+    assert _mask_allowed_token_ids(matcher) == [2, 3, 4, 5, 6, 7, 8]
+    assert matcher.accept_token(2)
+    assert _mask_allowed_token_ids(matcher) == [1, 2, 3, 4, 5, 6, 7, 8]
+
+
+def test_lark_lazy_mask_choices_commit_kills_longer_alternative() -> None:
+    # After "<a", "b" completes the "ab" alternative and the commit removes the "abb" branch
+    # of the same occurrence: "bb" must be masked out, "b"/"b>" stay legal.
+    grammar_obj = xgr.Grammar.from_lark('start: "<" r ">"\nr[lazy]: "ab" | "abb"')
+    matcher = _lazy_mask_matcher(grammar_obj)
+    assert matcher.accept_token(0) and matcher.accept_token(2)
+    assert _mask_allowed_token_ids(matcher) == [3, 7]
+    assert not matcher.accept_token(8)
+    assert matcher.accept_token(7) and matcher.is_terminated()
+
+
+def test_lark_lazy_mask_fresh_budget_per_occurrence() -> None:
+    grammar_obj = xgr.Grammar.from_lark('start: r " " r\nr[lazy]: /[a-z]+/')
+    matcher = _lazy_mask_matcher(grammar_obj)
+    # First occurrence commits after one char: only the separator remains.
+    assert matcher.accept_token(2)
+    assert _mask_allowed_token_ids(matcher) == [9]
+    # The second occurrence is fresh: region chars are allowed again, but still commit at one
+    # char ("ab" spans two region chars and stays masked out).
+    assert matcher.accept_token(9)
+    assert _mask_allowed_token_ids(matcher) == [2, 3]
+    assert matcher.accept_token(3) and matcher.is_terminated()
+
+
+def test_ebnf_lazy_mask_matches_lark_form() -> None:
+    grammar_obj = xgr.Grammar.from_ebnf('root ::= "<" r ">"\nr[lazy] ::= [a-z] [a-z]*')
+    matcher = _lazy_mask_matcher(grammar_obj)
+    assert matcher.accept_token(0)
+    assert _mask_allowed_token_ids(matcher) == [2, 3, 5, 7]
+    assert matcher.accept_token(2)
+    assert _mask_allowed_token_ids(matcher) == [1]

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -706,6 +706,49 @@ def test_lark_standalone_lazy_rule() -> None:
     _assert_language(grammar, ["", "plain", "<end>", "plain<end>"], ["<end>x", "a<end>b"])
 
 
+def test_lark_lazy_rule_starred_terminal() -> None:
+    grammar = r"""
+        start: head "!"
+        head[lazy]: TEXT* "<end>"
+        TEXT: /[a-z]/
+    """
+    _assert_language(grammar, ["<end>!", "abc<end>!"], ["ABC<end>!", "a<end>b<end>!", "abc<end>"])
+
+
+def test_lark_lazy_rule_starred_any_text() -> None:
+    grammar = r"""
+        start: head "!"
+        head[lazy]: TEXT* "<end>"
+        TEXT: /(\n|.)*/
+    """
+    _assert_language(
+        grammar, ["<end>!", "abc<end>!", "a\nb<end>!", "你好<end>!"], ["a<end>b<end>!"]
+    )
+
+
+def test_lark_lazy_rule_plus_terminal() -> None:
+    grammar = r"""
+        start: head "!"
+        head[lazy]: TEXT+ "<end>"
+        TEXT: /[a-z]/
+    """
+    _assert_language(grammar, ["a<end>!", "abc<end>!"], ["<end>!", "a<end>b<end>!"])
+
+
+def test_lark_lazy_rule_quantified_alternation() -> None:
+    grammar = r"""
+        start: head "!"
+        head[lazy]: AB+ "<end>"
+        AB: "a" | "b"
+    """
+    _assert_language(grammar, ["ab<end>!", "b<end>!"], ["<end>!", "c<end>!", "a<end>b<end>!"])
+    _assert_language(
+        'start: head "!"\nhead[lazy]: ("a"|"b")* "<end>"',
+        ["<end>!", "ba<end>!"],
+        ["c<end>!", "a<end>b<end>!"],
+    )
+
+
 def test_lark_dynamic_special_token_trigger() -> None:
     tokenizer_info = xgr.TokenizerInfo(
         ["plain", "<|tool|>", "{", '"x"', ":", "1", "}", "</tool>", "bad", "</s>"],
@@ -1813,6 +1856,7 @@ def test_lark_lazy_non_terminal_like_bodies_are_rejected() -> None:
     _assert_lark_error("start: r\nR[lazy]: /[a-z]+/\nr: R", "attributes are only supported")
     for grammar_obj in (
         xgr.Grammar.from_lark('start: "<" r ">"\nr[lazy]: /([a-z]+ )+/'),
+        xgr.Grammar.from_lark('start: "<" r ">"\nr[lazy]: T* "x"\nT: /ab/'),
         xgr.Grammar.from_ebnf('root ::= "<" r ">"\nr[lazy] ::= sub\nsub ::= sub [a-z] | [a-z]'),
     ):
         with pytest.raises(RuntimeError, match="terminal-like"):

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -1057,9 +1057,9 @@ def test_lark_large_choice_grammar() -> None:
             id="grammar-options-not-object",
         ),
         pytest.param(
-            "start: thing\nthing[lazy]: /[a-z]+/",
-            "general lazy rules are not supported",
-            id="unsupported-general-lazy",
+            'start: thing\nthing[lazy]: "a" thing | "b"',
+            "terminal cannot reference rule",
+            id="lazy-rule-reference",
         ),
         pytest.param(
             'start: head\nhead[suffix=""]: TEXT\nTEXT: /(\\n|.)*/',
@@ -1681,3 +1681,139 @@ def test_lark_capture_with_max_tokens_round_trip_and_cache() -> None:
     assert _allowed_token_ids(matcher, MAX_TOKENS_TOKENIZER) == [5]
     assert matcher.accept_token(5) and matcher.is_terminated()
     assert matcher.get_captures() == [("r", b"ab cd ")]
+
+
+LAZY_TOKENIZER = xgr.TokenizerInfo(["<", ">", "a", "b", "ab", "abb", " "])
+
+
+def _lazy_matcher(grammar_obj: xgr.Grammar) -> xgr.GrammarMatcher:
+    compiled = xgr.GrammarCompiler(LAZY_TOKENIZER, cache_enabled=False).compile_grammar(grammar_obj)
+    return xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+
+
+def _lazy_allowed_token_ids(matcher: xgr.GrammarMatcher) -> list:
+    bitmask = xgr.allocate_token_bitmask(1, LAZY_TOKENIZER.vocab_size)
+    matcher.fill_next_token_bitmask(bitmask)
+    return [
+        i for i in range(LAZY_TOKENIZER.vocab_size) if (int(bitmask[0, i // 32]) >> (i % 32)) & 1
+    ]
+
+
+def test_lark_lazy_committed_shortest_regex() -> None:
+    _assert_language(
+        'start: "<" r ">"\nr[lazy]: /[a-z]+/', ["<a>", "<b>"], ["<ab>", "<>", "<a", "a>"]
+    )
+    # Greedy control: the same grammar without lazy accepts longer matches.
+    _assert_language('start: "<" r ">"\nr: /[a-z]+/', ["<a>", "<ab>"], ["<>"])
+
+
+def test_lark_lazy_matches_exactly_one_unit() -> None:
+    _assert_language('start: r "a"\nr[lazy]: /[b]+/', ["ba"], ["bba", "a"])
+
+
+def test_lark_lazy_nullable_always_matches_empty() -> None:
+    _assert_language('start: "<" r ">"\nr[lazy]: /[a-z]*/', ["<>"], ["<a>", "<ab>"])
+    _assert_language('start: "<" r ">"\nr[lazy]: /[a-z]?/', ["<>"], ["<a>"])
+
+
+def test_lark_lazy_choices_commit_at_shortest() -> None:
+    _assert_language('start: "<" r ">"\nr[lazy]: "ab" | "abc"', ["<ab>"], ["<abc>"])
+    # Prefix-free alternatives are unaffected by the commit.
+    _assert_language('start: "<" r ">"\nr[lazy]: "aa" | "bb"', ["<aa>", "<bb>"], ["<a>", "<ab>"])
+
+
+def test_lark_lazy_composed_of_terminals() -> None:
+    _assert_language('start: "<" r ">"\nr[lazy]: SUB SUB\nSUB: /[a-z]/', ["<ab>"], ["<a>", "<abc>"])
+
+
+def test_ebnf_lazy_committed_shortest_and_plus_desugar() -> None:
+    for body in ("[a-z] [a-z]*", "[a-z]+"):
+        grammar_obj = xgr.Grammar.from_ebnf(f'root ::= "<" r ">"\nr[lazy] ::= {body}')
+        _assert_grammar_language(grammar_obj, ["<a>"], ["<ab>", "<>"])
+
+
+def test_ebnf_lazy_attribute_round_trips() -> None:
+    grammar_obj = xgr.Grammar.from_lark('start: "<" r ">"\nr[lazy]: /[a-z]+/')
+    printed = str(grammar_obj)
+    assert "r[lazy] ::=" in printed
+    _assert_grammar_language(xgr.Grammar.from_ebnf(printed), ["<a>"], ["<ab>"])
+    deserialized = xgr.Grammar.deserialize_json(grammar_obj.serialize_json())
+    _assert_grammar_language(deserialized, ["<a>"], ["<ab>"])
+    # The compiler cache path re-parses ToString(); the attribute must survive it.
+    compiled = xgr.GrammarCompiler(LAZY_TOKENIZER, cache_enabled=True).compile_grammar(grammar_obj)
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert not matcher.accept_string("<ab>")
+
+
+def test_lark_lazy_mask_is_exit_only_after_commit() -> None:
+    # Tokens: 0 "<", 1 ">", 2 "a", 3 "b", 4 "ab", 5 "abb", 6 " "
+    grammar_obj = xgr.Grammar.from_lark('start: "<" r "b"\nr[lazy]: /[ab]+/')
+    matcher = _lazy_matcher(grammar_obj)
+    assert matcher.accept_token(0)
+    allowed = _lazy_allowed_token_ids(matcher)
+    # "ab" = one region char, then the closing literal: allowed. "abb" would extend the
+    # region past the commit point: rejected.
+    assert 4 in allowed and 5 not in allowed
+    assert matcher.accept_token(4) and matcher.is_terminated()
+    # After committing via a single region char, only the closing literal remains.
+    matcher = _lazy_matcher(grammar_obj)
+    assert matcher.accept_token(0) and matcher.accept_token(2)
+    assert _lazy_allowed_token_ids(matcher) == [3]
+
+
+def test_lark_lazy_per_occurrence_commit() -> None:
+    _assert_language('start: r " " r\nr[lazy]: /[a-z]+/', ["a b"], ["ab b", "a bb", "a b c"])
+
+
+def test_lark_lazy_root_anchored_occurrence() -> None:
+    grammar_obj = xgr.Grammar.from_lark('start: "<" r\nr[lazy]: /[a-z]+/')
+    matcher = _lazy_matcher(grammar_obj)
+    assert matcher.accept_token(0) and matcher.accept_token(2)
+    assert _lazy_allowed_token_ids(matcher) == []
+    _assert_grammar_language(grammar_obj, ["<a"], ["<ab", "<"])
+
+
+def test_lark_lazy_rollback_reset_fork() -> None:
+    grammar_obj = xgr.Grammar.from_lark('start: "<" r ">"\nr[lazy]: /[a-z]+/')
+    matcher = _lazy_matcher(grammar_obj)
+    assert matcher.accept_token(0) and matcher.accept_token(2)
+    assert _lazy_allowed_token_ids(matcher) == [1]
+    forked = matcher.fork()
+    matcher.rollback(1)
+    assert 2 in _lazy_allowed_token_ids(matcher)
+    assert _lazy_allowed_token_ids(forked) == [1]
+    matcher.reset()
+    assert matcher.accept_string("<a>")
+
+
+def test_lark_lazy_accept_string_and_tokens_agree() -> None:
+    grammar_obj = xgr.Grammar.from_lark('start: "<" r ">"\nr[lazy]: /[a-z]+/')
+    matcher = _lazy_matcher(grammar_obj)
+    assert not matcher.accept_string("<ab>")
+    matcher.reset()
+    assert matcher.accept_token(0) and matcher.accept_token(2)
+    assert not matcher.accept_token(3)
+    assert matcher.accept_token(1) and matcher.is_terminated()
+
+
+def test_lark_lazy_ignore_is_not_woven_into_lazy_rules() -> None:
+    grammar = 'start: "<" r ">"\nr[lazy]: /[a-z]+/\n%ignore " "'
+    _assert_language(grammar, ["<a>", "< a >"], ["<ab>"])
+
+
+def test_lark_lazy_dispatch_subset_keeps_tag_dispatch() -> None:
+    grammar_obj = xgr.Grammar.from_lark('start: head\nhead[lazy]: TEXT "<end>"\nTEXT: /(\\n|.)*/')
+    printed = str(grammar_obj)
+    assert "TagDispatch" in printed
+    assert "[lazy]" not in printed
+
+
+def test_lark_lazy_non_terminal_like_bodies_are_rejected() -> None:
+    _assert_lark_error('start: "<" r ">"\nr[lazy]: "a" r | "b"', "terminal cannot reference rule")
+    _assert_lark_error("start: r\nR[lazy]: /[a-z]+/\nr: R", "attributes are only supported")
+    for grammar_obj in (
+        xgr.Grammar.from_lark('start: "<" r ">"\nr[lazy]: /([a-z]+ )+/'),
+        xgr.Grammar.from_ebnf('root ::= "<" r ">"\nr[lazy] ::= sub\nsub ::= sub [a-z] | [a-z]'),
+    ):
+        with pytest.raises(RuntimeError, match="terminal-like"):
+            xgr.GrammarCompiler(LAZY_TOKENIZER, cache_enabled=False).compile_grammar(grammar_obj)

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -44,7 +44,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v15"
+    assert xgr.get_serialization_version() == "v16"
 
 
 def test_serialize_grammar():
@@ -52,7 +52,7 @@ def test_serialize_grammar():
     grammar = construct_grammar()
     serialized = grammar.serialize_json()
     expected_json = {
-        "rules": [["rule1", 4, -1, False, -1, ""], ["root", 8, -1, False, -1, ""]],
+        "rules": [["rule1", 4, -1, False, -1, "", False], ["root", 8, -1, False, -1, "", False]],
         "grammar_expr_data": [0, 5, 8, 12, 14, 18, 21, 24, 28],
         "grammar_expr_indptr": [
             # fmt: off
@@ -64,7 +64,7 @@ def test_serialize_grammar():
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v15",
+        "__VERSION__": "v16",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -73,7 +73,7 @@ def test_serialize_grammar():
 def test_serialize_grammar_exception():
     """Test Grammar serialization produces expected JSON string."""
     expected_json = {
-        "rules": [["rule1", 4, 9, True, -1, ""], ["root", 8, -1, False, -1, ""]],
+        "rules": [["rule1", 4, 9, True, -1, "", False], ["root", 8, -1, False, -1, "", False]],
         "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 28, 31],
         "grammar_expr_indptr": [
             # fmt: off
@@ -84,14 +84,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v15",
+        "__VERSION__": "v16",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v15"
+    expected_json["__VERSION__"] = "v16"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -143,7 +143,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v15"}'
+        '"__VERSION__":"v16"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -197,7 +197,7 @@ def test_serialize_compiled_grammar():
 
     expected_json = {
         "grammar": {
-            "rules": [["rule1", 4, 9, True, -1, ""], ["root", 8, -1, False, -1, ""]],
+            "rules": [["rule1", 4, 9, True, -1, "", False], ["root", 8, -1, False, -1, "", False]],
             "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 28, 31],
             "grammar_expr_indptr": [
                 # fmt: off
@@ -258,7 +258,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v15",
+        "__VERSION__": "v16",
     }
 
     class AdaptiveTokenMask(BaseModel):

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -44,7 +44,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v16"
+    assert xgr.get_serialization_version() == "v15"
 
 
 def test_serialize_grammar():
@@ -64,7 +64,7 @@ def test_serialize_grammar():
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v16",
+        "__VERSION__": "v15",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -84,14 +84,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v16",
+        "__VERSION__": "v15",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v16"
+    expected_json["__VERSION__"] = "v15"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -143,7 +143,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v16"}'
+        '"__VERSION__":"v15"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -258,7 +258,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v16",
+        "__VERSION__": "v15",
     }
 
     class AdaptiveTokenMask(BaseModel):


### PR DESCRIPTION
## Summary

This PR adds the **`[lazy]` attribute** for rules in both the Lark and the EBNF frontends: `r[lazy]` gives the rule **committed-shortest** matching — at the first position where its body *can* end, it *must* end, and every derivation in which this occurrence keeps consuming input is discarded. Typical use: lexeme-like segments that should stop at the earliest boundary instead of matching greedily.

```lark
start: "<" name ">" rest
name[lazy]: /[a-z]+/     // stops at the first position where it can end
rest: /[a-z]+/
```

- The existing lazy subset (ANY_TEXT + fixed-trigger heads, dispatch heads) keeps its TagDispatch compilation unchanged; `[lazy]` on any other rule now takes the new path instead of being rejected.
- The body must compile to a single terminal-like automaton: strings, character classes, `+`/`*`/`?` over them, and alternations of these. Bodies that need rule references (recursion, repetition ranges over groups) are rejected at compile time.
- Lazy changes the **language** of the grammar: validation (`accept_string`) and mask generation agree by construction.
- EBNF syntax: `name[lazy] ::= ...`, round-tripping through `ToString()` / `FromEBNF()` (the compiled-grammar cache path relies on this).

## Design

**Grammar representation.** `Rule.is_lazy`, set by both frontends, printed as `name[lazy] ::=` and re-parsed by the EBNF lexer; propagated through the grammar functor rebuild loops; `RuleInliner` and the repetition expander's single-element shortcut are exempted for lazy rules (both would erase the rule carrying the attribute). A small flattening pass rewrites lazy rule bodies into their terminal-like form where possible — unwrapping the single-reference chains produced by regex conversion, splicing simple terminal references, and flattening the plus-desugar pattern (`x ::= e x | e` → `e e*`) — so the common regex bodies (`/[a-z]+/` etc.) just work; grammars without lazy rules skip the pass entirely.

**Runtime: commit = prune at row construction.** Under the terminal-like restriction, every state inside an occurrence of lazy rule R carries R's rule id and start position — the occurrence identity is already part of the parser state, so `ParserState` is unchanged (no new fields, no hash/equality changes). When an occurrence completes (detected in `Complete`, including the root-completion path, which covers rules in tail position of the root), the parser drops the occurrence's remaining states while finalizing that row of scanable states. Properties:

- **Irreversible with zero bookkeeping**: after the prune the occurrence has no live states, so it can never complete again — no persistent "committed" set is needed. The prune lives in the history rows, so `rollback()`/`fork()`/`reset()` restore it exactly, for free, and speculative decoding keeps working with no extra bookkeeping.
- **Byte granularity, all flows agree**: pruning happens inside `Advance`'s row construction; token accepts, `accept_string`, and every mask computation go through the same `Advance`.
- **Per-occurrence**: each occurrence of the rule commits independently; occurrences are distinguished by start position, and multiple parents sharing one occurrence commit together.

**Token masks need no changes.** The per-state mask cache is computed by simulating the same `Advance`, so a token that would extend an occurrence past its earliest completion point automatically flips from *accepted* to *uncertain*, and the fill-time uncertain re-verification (full context, same pruning) resolves it exactly. The one accompanying switch: the speculative self-loop fast path is disabled for lazy rules, since it assumes greedy extension is always legal.

## Behavior

- `foo[lazy]: /[0-9]+/` matches exactly one digit; `"ab" | "abc"` under lazy can only produce `"ab"`; prefix-free alternatives are unaffected.
- A nullable lazy rule always matches the empty string (it can complete at entry); the compiler emits a warning.
- In Lark, lazy rules are compiled as lexemes: `%ignore` is not woven inside their bodies, and like terminals they take the ignored-token skip after them.
- Grammars without lazy rules pay one boolean check per completion; nothing else changes.

## Restrictions

The body must be terminal-like (see above); `suffix=` stays dispatch-only; attributes on terminals stay rejected; nested lazy is impossible by construction (a terminal-like body cannot reference rules).

## Testing

15 new tests in `tests/python/test_lark.py`:

- committed-shortest for regex bodies (with a greedy control), exactly-one-unit matching, nullable ≡ ε,
- shortest-alternative commit for choices, composition from simple terminals, `+`-desugar flattening in both frontends,
- mask correctness at the commit point (a token crossing the commit boundary into the follow-up literal is allowed; a token extending the region past it is rejected), exit-only mask after commit,
- per-occurrence commits, root-anchored occurrences (rule in tail position of the root),
- `rollback`/`fork`/`reset` across a commit, `accept_string`/`accept_token` agreement,
- `%ignore` lexeme behavior, dispatch subset regression (still TagDispatch), attribute/EBNF/serialization round-trips (incl. the cached-compile path),
- error cases: rule references in lazy bodies, non-flattenable regex bodies, attributes on terminals.

Results, with the package built and installed from this branch (based on current `main`) via `uv pip install .`: `tests/python/test_lark.py` (207) and `test_serialization.py` (14, expectations updated for v15) pass; the C++ gtest suite passes (57/57); the full Python suite passes with **zero failures** (2726 tests, `hf_token_required` deselected).
