### PR TITLE
docs: move Workflow of XGrammar to Get Started section

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,6 @@ redirects = {
     "tutorials/constrained_decoding": "../start/constrained_decoding.html",
     "tutorials/workflow_of_xgrammar": "../start/workflow_of_xgrammar.html",
     "tutorials/advanced_topics": "../start/workflow_of_xgrammar.html",
-    "using_xgrammar/workflow_of_xgrammar": "../start/workflow_of_xgrammar.html",
     "tutorials/engine_integration": "../using_xgrammar/engine_integration.html",
     "tutorials/json_generation": "../defining_structures/json_generation.html",
     "tutorials/ebnf_guided_generation": "../defining_structures/ebnf_grammar.html",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,8 +94,9 @@ templates_path = ["_templates"]
 # values are the new locations relative to the old page.
 redirects = {
     "tutorials/constrained_decoding": "../start/constrained_decoding.html",
-    "tutorials/workflow_of_xgrammar": "../using_xgrammar/workflow_of_xgrammar.html",
-    "tutorials/advanced_topics": "../using_xgrammar/workflow_of_xgrammar.html",
+    "tutorials/workflow_of_xgrammar": "../start/workflow_of_xgrammar.html",
+    "tutorials/advanced_topics": "../start/workflow_of_xgrammar.html",
+    "using_xgrammar/workflow_of_xgrammar": "../start/workflow_of_xgrammar.html",
     "tutorials/engine_integration": "../using_xgrammar/engine_integration.html",
     "tutorials/json_generation": "../defining_structures/json_generation.html",
     "tutorials/ebnf_guided_generation": "../defining_structures/ebnf_grammar.html",

--- a/docs/defining_structures/json_generation.md
+++ b/docs/defining_structures/json_generation.md
@@ -5,7 +5,7 @@ to use XGrammar to ensure that an LLM's output is a valid JSON, or adheres to a 
 schema.
 
 First, construct a [`xgr.GrammarCompiler`](xgrammar.GrammarCompiler) from the tokenizer info of
-the model (see [Workflow of XGrammar](../using_xgrammar/workflow_of_xgrammar.md) for details).
+the model (see [Workflow of XGrammar](../start/workflow_of_xgrammar.md) for details).
 
 ```python
 import xgrammar as xgr

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ The mission of this project is to bring flexible zero-overhead structure generat
    start/installation
    start/quick_start
    start/constrained_decoding
+   start/workflow_of_xgrammar
 
 .. toctree::
    :maxdepth: 1
@@ -24,7 +25,6 @@ The mission of this project is to bring flexible zero-overhead structure generat
    :maxdepth: 1
    :caption: Using XGrammar
 
-   using_xgrammar/workflow_of_xgrammar
    using_xgrammar/engine_integration
    using_xgrammar/serialization
    using_xgrammar/runtime_safeguards

--- a/docs/start/constrained_decoding.md
+++ b/docs/start/constrained_decoding.md
@@ -31,4 +31,4 @@ The [`xgr.GrammarMatcher`](xgrammar.GrammarMatcher) class, constructed from a [`
 
 ## Next Steps
 
-See [Workflow of XGrammar](../using_xgrammar/workflow_of_xgrammar.md) to learn more about the constrained decoding process.
+See [Workflow of XGrammar](workflow_of_xgrammar.md) to learn more about the constrained decoding process.

--- a/docs/start/quick_start.md
+++ b/docs/start/quick_start.md
@@ -82,7 +82,7 @@ When applying constrained decoding, it is recommended to **clearly describe the 
 
 - To understand how constrained decoding works, see [Constrained Decoding](constrained_decoding).
 - To learn the core concepts and APIs of XGrammar, see
-  [Workflow of XGrammar](../using_xgrammar/workflow_of_xgrammar).
+  [Workflow of XGrammar](workflow_of_xgrammar).
 - To integrate XGrammar into an LLM engine, see
   [Integration with LLM Engine](../using_xgrammar/engine_integration).
 - To constrain tool calling and reasoning outputs, see

--- a/docs/start/workflow_of_xgrammar.md
+++ b/docs/start/workflow_of_xgrammar.md
@@ -1,6 +1,6 @@
 # Workflow of XGrammar
 
-This tutorial introduces the workflow of XGrammar, including most of its core components. Please read [constrained decoding](../start/constrained_decoding.md) first to understand how XGrammar achieves structured generation.
+This tutorial introduces the workflow of XGrammar, including most of its core components. Please read [constrained decoding](constrained_decoding.md) first to understand how XGrammar achieves structured generation.
 
 ```python
 import xgrammar as xgr
@@ -204,4 +204,4 @@ Congratulations! You have successfully generated a structured output using XGram
 
 ## Next Steps
 
-Read [integration with LLM engine](engine_integration.md) to learn how to integrate XGrammar into an LLM engine.
+Read [integration with LLM engine](../using_xgrammar/engine_integration.md) to learn how to integrate XGrammar into an LLM engine.

--- a/docs/using_xgrammar/engine_integration.md
+++ b/docs/using_xgrammar/engine_integration.md
@@ -35,7 +35,7 @@ all its vocabulary. There are several ways of instantiating it, and the most con
 is using an `AutoTokenizer`. Note that for some models, `AutoConfig.vocab_size` can be larger
 than `AutoTokenizer.vocab_size` due to paddings, with the former being the shape of the model's
 logits. To be safe, always pass in the former when instantiating `xgr.TokenizerInfo`. See
-[Workflow of XGrammar](workflow_of_xgrammar.md) for details.
+[Workflow of XGrammar](../start/workflow_of_xgrammar.md) for details.
 
 ```python
 # Get tokenizer info


### PR DESCRIPTION
## Summary

- Move `docs/using_xgrammar/workflow_of_xgrammar.md` to `docs/start/workflow_of_xgrammar.md`, so the Workflow of XGrammar tutorial appears in the Get Started section (after Constrained Decoding, which it asks readers to read first).
- Update all cross-references in `index.rst`, `quick_start.md`, `constrained_decoding.md`, `engine_integration.md`, and `json_generation.md`.
- Update the redirects in `conf.py`: retarget the two old `tutorials/*` redirects and add a new redirect from `using_xgrammar/workflow_of_xgrammar` so existing links keep working.

## Test plan

- Built the docs with `make html`: build succeeded with no new warnings; the only warning is the pre-existing pydantic JSON schema warning for `OrFormat`.
- Verified `_build/html/start/workflow_of_xgrammar.html` is generated and `_build/html/using_xgrammar/workflow_of_xgrammar.html` is a redirect page pointing to the new location.