### PR TITLE
Fuse byte strings and inline grammar rules in place

### DIFF
--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -20,19 +20,24 @@ namespace xgrammar {
 GrammarBuilder::GrammarBuilder() : grammar_(std::make_shared<Grammar::Impl>()) {}
 
 GrammarBuilder::GrammarBuilder(const Grammar& grammar)
-    : grammar_(std::make_shared<Grammar::Impl>(*grammar.operator->())) {
-  for (int i = 0; i < static_cast<int>(grammar->NumRules()); ++i) {
-    auto rule = grammar->GetRule(i);
-    rule_name_to_id_[rule.name] = i;
-  }
-}
+    : grammar_(std::make_shared<Grammar::Impl>(*grammar.operator->())),
+      rule_name_map_built_(false) {}
 
 GrammarBuilder GrammarBuilder::FromMutableGrammar(Grammar* grammar) {
-  // The rule name to id map is not built: it is only needed by name-based operations, and
-  // building it costs O(num_rules) string hashing, which in-place rewriters do not need.
   GrammarBuilder builder;
   builder.grammar_ = grammar->pimpl_;
+  builder.rule_name_map_built_ = false;
   return builder;
+}
+
+void GrammarBuilder::EnsureRuleNameMap() const {
+  if (rule_name_map_built_) {
+    return;
+  }
+  for (int32_t i = 0; i < static_cast<int32_t>(grammar_->rules_.size()); ++i) {
+    rule_name_to_id_[grammar_->rules_[i].name] = i;
+  }
+  rule_name_map_built_ = true;
 }
 
 Grammar GrammarBuilder::Get(const std::string& root_rule_name) {
@@ -220,6 +225,7 @@ GrammarBuilder::GrammarExpr GrammarBuilder::GetGrammarExpr(int32_t grammar_expr_
 }
 
 int32_t GrammarBuilder::AddRule(const Rule& rule) {
+  EnsureRuleNameMap();
   int32_t id = static_cast<int32_t>(grammar_->rules_.size());
   grammar_->rules_.push_back(rule);
   XGRAMMAR_CHECK(rule_name_to_id_.count(rule.name) == 0);
@@ -373,6 +379,7 @@ void GrammarBuilder::UpdateLazy(std::string rule_name, bool is_lazy) {
 }
 
 std::string GrammarBuilder::GetNewRuleName(const std::string& name_hint) {
+  EnsureRuleNameMap();
   if (rule_name_to_id_.count(name_hint) == 0) {
     return name_hint;
   }
@@ -387,6 +394,7 @@ std::string GrammarBuilder::GetNewRuleName(const std::string& name_hint) {
 }
 
 int32_t GrammarBuilder::GetRuleId(const std::string& name) const {
+  EnsureRuleNameMap();
   auto it = rule_name_to_id_.find(name);
   if (it == rule_name_to_id_.end()) {
     return -1;

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -28,11 +28,10 @@ GrammarBuilder::GrammarBuilder(const Grammar& grammar)
 }
 
 GrammarBuilder GrammarBuilder::FromMutableGrammar(Grammar* grammar) {
+  // The rule name to id map is not built: it is only needed by name-based operations, and
+  // building it costs O(num_rules) string hashing, which in-place rewriters do not need.
   GrammarBuilder builder;
   builder.grammar_ = grammar->pimpl_;
-  for (int i = 0; i < static_cast<int>(builder.grammar_->NumRules()); ++i) {
-    builder.rule_name_to_id_[builder.grammar_->GetRule(i).name] = i;
-  }
   return builder;
 }
 

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -27,6 +27,15 @@ GrammarBuilder::GrammarBuilder(const Grammar& grammar)
   }
 }
 
+GrammarBuilder GrammarBuilder::FromMutableGrammar(Grammar* grammar) {
+  GrammarBuilder builder;
+  builder.grammar_ = grammar->pimpl_;
+  for (int i = 0; i < static_cast<int>(builder.grammar_->NumRules()); ++i) {
+    builder.rule_name_to_id_[builder.grammar_->GetRule(i).name] = i;
+  }
+  return builder;
+}
+
 Grammar GrammarBuilder::Get(const std::string& root_rule_name) {
   int32_t root_rule_id = GetRuleId(root_rule_name);
   XGRAMMAR_CHECK(root_rule_id != -1)

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -45,6 +45,13 @@ class GrammarBuilder {
   GrammarBuilder(const Grammar& grammar);
 
   /*!
+   * \brief Create a builder bound to an existing grammar without copying it. Unlike the copy
+   * constructor above, appended exprs and rule updates are written directly into *grammar. The
+   * grammar must outlive the builder.
+   */
+  static GrammarBuilder FromMutableGrammar(Grammar* grammar);
+
+  /*!
    * \brief Get the result grammar. This function will also set the root rule to the rule with the
    * specified name. The rule should be already added to the grammar.
    * \param root_rule_name The name of the root rule. Default is "root".

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -47,9 +47,7 @@ class GrammarBuilder {
   /*!
    * \brief Create a builder bound to an existing grammar without copying it. Unlike the copy
    * constructor above, appended exprs and rule updates are written directly into *grammar. The
-   * grammar must outlive the builder. The rule name to id map is not built, so name-based
-   * operations (GetRuleId, AddRule, UpdateRuleBody by name, ...) are not supported on such a
-   * builder.
+   * grammar must outlive the builder.
    */
   static GrammarBuilder FromMutableGrammar(Grammar* grammar);
 
@@ -265,10 +263,18 @@ class GrammarBuilder {
   int32_t GetRuleId(const std::string& name) const;
 
  private:
+  /*!
+   * \brief Build rule_name_to_id_ from the existing rules if it has not been built yet.
+   * Builders bound to an existing grammar (copy constructor, FromMutableGrammar) defer building
+   * the map to the first name-based operation, so id-only rewriting pays no name hashing cost.
+   */
+  void EnsureRuleNameMap() const;
+
   // Mutable pointer to the grammar object.
   std::shared_ptr<Grammar::Impl> grammar_;
-  // Map from rule name to rule id.
-  std::unordered_map<std::string, int32_t> rule_name_to_id_;
+  // Map from rule name to rule id. Built lazily; see EnsureRuleNameMap.
+  mutable std::unordered_map<std::string, int32_t> rule_name_to_id_;
+  mutable bool rule_name_map_built_ = true;
   // Cache of next suffix index per name_hint for GetNewRuleName.
   std::unordered_map<std::string, int> next_cnt_per_hint_;
 };

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -47,7 +47,9 @@ class GrammarBuilder {
   /*!
    * \brief Create a builder bound to an existing grammar without copying it. Unlike the copy
    * constructor above, appended exprs and rule updates are written directly into *grammar. The
-   * grammar must outlive the builder.
+   * grammar must outlive the builder. The rule name to id map is not built, so name-based
+   * operations (GetRuleId, AddRule, UpdateRuleBody by name, ...) are not supported on such a
+   * builder.
    */
   static GrammarBuilder FromMutableGrammar(Grammar* grammar);
 

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -617,7 +617,9 @@ class InPlaceGrammarRewriter {
   /*! \brief Hook run after the builder is bound and before the walk. */
   virtual void Prepare() {}
 
-  /*! \brief Visit an expr; return its rewritten id, or the original id when nothing changed. */
+  /*! \brief Visit an expr; return its rewritten id, or the original id when nothing changed.
+   * Contract: a visit appends to the arena only when it returns a new id, so a caller holding a
+   * GrammarExpr view may keep it as long as the returned id equals the input. */
   int32_t VisitExpr(int32_t expr_id) {
     XGRAMMAR_DCHECK(expr_id < static_cast<int32_t>(memo_.size()));
     if (memo_[expr_id] != -1) {
@@ -638,43 +640,64 @@ class InPlaceGrammarRewriter {
     return result;
   }
 
-  /*! \brief Rebuild a sequence, recursing into each element. Overridden to add rewriting. */
-  virtual int32_t VisitSequence(int32_t expr_id) { return RebuildContainer(expr_id, false); }
-
-  /*! \brief Rebuild a choices, recursing into each choice. Overridden to add rewriting. */
-  virtual int32_t VisitChoices(int32_t expr_id) { return RebuildContainer(expr_id, true); }
-
-  /*! \brief Recurse into a sequence or choices; append a rebuilt expr only if a child changed.
-   * No memory is allocated when no child changes. */
-  int32_t RebuildContainer(int32_t expr_id, bool is_choices) {
-    int32_t size = builder_.GetGrammarExpr(expr_id).size();
-    std::vector<int32_t> new_child_ids;
+  /*! \brief Rebuild a sequence, recursing into each element. Overridden to add rewriting.
+   * No memory is allocated when no element changes. */
+  virtual int32_t VisitSequence(int32_t expr_id) {
+    auto expr = builder_.GetGrammarExpr(expr_id);
+    int32_t size = expr.size();
+    std::vector<int32_t> new_element_ids;
     bool changed = false;
     for (int32_t i = 0; i < size; ++i) {
-      // Re-fetch the expr each iteration: visiting a child may append to the arena and
-      // invalidate previously fetched views.
-      int32_t child_id = builder_.GetGrammarExpr(expr_id)[i];
-      int32_t new_child_id = VisitExpr(child_id);
-      if (!changed && new_child_id != child_id) {
-        changed = true;
-        CopyChildrenPrefix(expr_id, i, &new_child_ids);
+      int32_t element_id = expr[i];
+      int32_t new_element_id = VisitExpr(element_id);
+      if (new_element_id != element_id) {
+        // The rewrite appended to the arena and invalidated the view, so re-fetch it. On the
+        // first change, materialize the already scanned, unchanged prefix.
+        expr = builder_.GetGrammarExpr(expr_id);
+        if (!changed) {
+          changed = true;
+          new_element_ids.reserve(size);
+          new_element_ids.insert(new_element_ids.end(), expr.begin(), expr.begin() + i);
+        }
       }
       if (changed) {
-        new_child_ids.push_back(new_child_id);
+        new_element_ids.push_back(new_element_id);
       }
     }
     if (!changed) {
       return expr_id;
     }
-    return is_choices ? builder_.AddChoices(new_child_ids) : builder_.AddSequence(new_child_ids);
+    return builder_.AddSequence(new_element_ids);
   }
 
-  /*! \brief Copy the first count children of expr into *out. Used to materialize the already
-   * scanned, unchanged prefix once the first change is discovered. */
-  void CopyChildrenPrefix(int32_t expr_id, int32_t count, std::vector<int32_t>* out) {
+  /*! \brief Rebuild a choices, recursing into each choice. Overridden to add rewriting.
+   * No memory is allocated when no choice changes. */
+  virtual int32_t VisitChoices(int32_t expr_id) {
     auto expr = builder_.GetGrammarExpr(expr_id);
-    out->reserve(expr.size());
-    out->insert(out->end(), expr.begin(), expr.begin() + count);
+    int32_t size = expr.size();
+    std::vector<int32_t> new_choice_ids;
+    bool changed = false;
+    for (int32_t i = 0; i < size; ++i) {
+      int32_t choice_id = expr[i];
+      int32_t new_choice_id = VisitExpr(choice_id);
+      if (new_choice_id != choice_id) {
+        // The rewrite appended to the arena and invalidated the view, so re-fetch it. On the
+        // first change, materialize the already scanned, unchanged prefix.
+        expr = builder_.GetGrammarExpr(expr_id);
+        if (!changed) {
+          changed = true;
+          new_choice_ids.reserve(size);
+          new_choice_ids.insert(new_choice_ids.end(), expr.begin(), expr.begin() + i);
+        }
+      }
+      if (changed) {
+        new_choice_ids.push_back(new_choice_id);
+      }
+    }
+    if (!changed) {
+      return expr_id;
+    }
+    return builder_.AddChoices(new_choice_ids);
   }
 
   GrammarBuilder builder_;
@@ -707,13 +730,12 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
   }
 
   int32_t VisitChoices(int32_t expr_id) override {
-    int32_t size = builder_.GetGrammarExpr(expr_id).size();
+    auto expr = builder_.GetGrammarExpr(expr_id);
+    int32_t size = expr.size();
     std::vector<int32_t> new_choice_ids;
     bool changed = false;
     for (int32_t i = 0; i < size; ++i) {
-      // Re-fetch views each iteration: rewriting may append to the arena and invalidate
-      // previously fetched views.
-      int32_t choice_id = builder_.GetGrammarExpr(expr_id)[i];
+      int32_t choice_id = expr[i];
       auto choice_expr = builder_.GetGrammarExpr(choice_id);
       int32_t inline_rule_id = -1;
       if (choice_expr.type == GrammarExprType::kSequence && choice_expr.size() > 0) {
@@ -724,9 +746,15 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
       }
       if (inline_rule_id == -1) {
         int32_t new_choice_id = VisitExpr(choice_id);
-        if (!changed && new_choice_id != choice_id) {
-          changed = true;
-          CopyChildrenPrefix(expr_id, i, &new_choice_ids);
+        if (new_choice_id != choice_id) {
+          // The rewrite appended to the arena and invalidated the view, so re-fetch it. On the
+          // first change, materialize the already scanned, unchanged prefix.
+          expr = builder_.GetGrammarExpr(expr_id);
+          if (!changed) {
+            changed = true;
+            new_choice_ids.reserve(size);
+            new_choice_ids.insert(new_choice_ids.end(), expr.begin(), expr.begin() + i);
+          }
         }
         if (changed) {
           new_choice_ids.push_back(new_choice_id);
@@ -735,7 +763,8 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
       }
       if (!changed) {
         changed = true;
-        CopyChildrenPrefix(expr_id, i, &new_choice_ids);
+        new_choice_ids.reserve(size);
+        new_choice_ids.insert(new_choice_ids.end(), expr.begin(), expr.begin() + i);
       }
       // Do inlining: prepend each choice of the referenced rule to the rest of this sequence.
       // Copy the needed element ids before appending anything.
@@ -749,6 +778,8 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
         new_sequence.insert(new_sequence.end(), rest_element_ids.begin(), rest_element_ids.end());
         new_choice_ids.push_back(builder_.AddSequence(new_sequence));
       }
+      // The appended sequences invalidated the view, so re-fetch it for the next iteration.
+      expr = builder_.GetGrammarExpr(expr_id);
     }
     if (!changed) {
       return expr_id;

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -618,8 +618,7 @@ class InPlaceGrammarRewriter {
   virtual void Prepare() {}
 
   /*! \brief Visit an expr; return its rewritten id, or the original id when nothing changed.
-   * Contract: a visit appends to the arena only when it returns a new id, so a caller holding a
-   * GrammarExpr view may keep it as long as the returned id equals the input. */
+   * May append new exprs to the arena, invalidating outstanding GrammarExpr views. */
   int32_t VisitExpr(int32_t expr_id) {
     XGRAMMAR_DCHECK(expr_id < static_cast<int32_t>(memo_.size()));
     if (memo_[expr_id] != -1) {
@@ -650,15 +649,13 @@ class InPlaceGrammarRewriter {
     for (int32_t i = 0; i < size; ++i) {
       int32_t element_id = expr[i];
       int32_t new_element_id = VisitExpr(element_id);
-      if (new_element_id != element_id) {
-        // The rewrite appended to the arena and invalidated the view, so re-fetch it. On the
-        // first change, materialize the already scanned, unchanged prefix.
-        expr = builder_.GetGrammarExpr(expr_id);
-        if (!changed) {
-          changed = true;
-          new_element_ids.reserve(size);
-          new_element_ids.insert(new_element_ids.end(), expr.begin(), expr.begin() + i);
-        }
+      // The visit may have appended exprs to the arena and invalidated the view, so re-fetch.
+      expr = builder_.GetGrammarExpr(expr_id);
+      if (!changed && new_element_id != element_id) {
+        // Materialize the already scanned, unchanged prefix on the first change.
+        changed = true;
+        new_element_ids.reserve(size);
+        new_element_ids.insert(new_element_ids.end(), expr.begin(), expr.begin() + i);
       }
       if (changed) {
         new_element_ids.push_back(new_element_id);
@@ -680,15 +677,13 @@ class InPlaceGrammarRewriter {
     for (int32_t i = 0; i < size; ++i) {
       int32_t choice_id = expr[i];
       int32_t new_choice_id = VisitExpr(choice_id);
-      if (new_choice_id != choice_id) {
-        // The rewrite appended to the arena and invalidated the view, so re-fetch it. On the
-        // first change, materialize the already scanned, unchanged prefix.
-        expr = builder_.GetGrammarExpr(expr_id);
-        if (!changed) {
-          changed = true;
-          new_choice_ids.reserve(size);
-          new_choice_ids.insert(new_choice_ids.end(), expr.begin(), expr.begin() + i);
-        }
+      // The visit may have appended exprs to the arena and invalidated the view, so re-fetch.
+      expr = builder_.GetGrammarExpr(expr_id);
+      if (!changed && new_choice_id != choice_id) {
+        // Materialize the already scanned, unchanged prefix on the first change.
+        changed = true;
+        new_choice_ids.reserve(size);
+        new_choice_ids.insert(new_choice_ids.end(), expr.begin(), expr.begin() + i);
       }
       if (changed) {
         new_choice_ids.push_back(new_choice_id);
@@ -746,15 +741,13 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
       }
       if (inline_rule_id == -1) {
         int32_t new_choice_id = VisitExpr(choice_id);
-        if (new_choice_id != choice_id) {
-          // The rewrite appended to the arena and invalidated the view, so re-fetch it. On the
-          // first change, materialize the already scanned, unchanged prefix.
-          expr = builder_.GetGrammarExpr(expr_id);
-          if (!changed) {
-            changed = true;
-            new_choice_ids.reserve(size);
-            new_choice_ids.insert(new_choice_ids.end(), expr.begin(), expr.begin() + i);
-          }
+        // The visit may have appended exprs to the arena and invalidated the view, so re-fetch.
+        expr = builder_.GetGrammarExpr(expr_id);
+        if (!changed && new_choice_id != choice_id) {
+          // Materialize the already scanned, unchanged prefix on the first change.
+          changed = true;
+          new_choice_ids.reserve(size);
+          new_choice_ids.insert(new_choice_ids.end(), expr.begin(), expr.begin() + i);
         }
         if (changed) {
           new_choice_ids.push_back(new_choice_id);

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -760,14 +760,20 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
         new_choice_ids.insert(new_choice_ids.end(), expr.begin(), expr.begin() + i);
       }
       // Do inlining: prepend each choice of the referenced rule to the rest of this sequence.
-      // Copy the needed element ids before appending anything.
+      // Copy and visit the needed element ids before appending anything.
       std::vector<int32_t> rest_element_ids(choice_expr.begin() + 1, choice_expr.end());
+      for (int32_t& element_id : rest_element_ids) {
+        element_id = VisitExpr(element_id);
+      }
       auto ref_body = builder_.GetGrammarExpr(original_body_expr_ids_[inline_rule_id]);
       std::vector<int32_t> ref_choice_ids(ref_body.begin(), ref_body.end());
       for (int32_t ref_choice_id : ref_choice_ids) {
         auto ref_choice_expr = builder_.GetGrammarExpr(ref_choice_id);
         XGRAMMAR_ICHECK(ref_choice_expr.type == GrammarExprType::kSequence);
         std::vector<int32_t> new_sequence(ref_choice_expr.begin(), ref_choice_expr.end());
+        for (int32_t& element_id : new_sequence) {
+          element_id = VisitExpr(element_id);
+        }
         new_sequence.insert(new_sequence.end(), rest_element_ids.begin(), rest_element_ids.end());
         new_choice_ids.push_back(builder_.AddSequence(new_sequence));
       }
@@ -2818,23 +2824,24 @@ class GrammarOptimizerImpl {
 class ByteStringFuserImpl : public InPlaceGrammarRewriter {
  protected:
   int32_t VisitSequence(int32_t expr_id) override {
-    // Read-only probe: rewrite only if the sequence contains two adjacent byte strings. The
-    // probe appends nothing, so no memory is allocated for the common unchanged case.
+    // Read-only probe: rewrite only if the sequence contains an empty byte string or two adjacent
+    // byte strings. The probe appends nothing, so no memory is allocated for the common unchanged
+    // case.
     bool previous_is_byte_string = false;
-    bool has_adjacent_byte_strings = false;
+    bool needs_rewrite = false;
     {
       auto expr = builder_.GetGrammarExpr(expr_id);
       for (int32_t element_id : expr) {
-        bool is_byte_string =
-            builder_.GetGrammarExpr(element_id).type == GrammarExprType::kByteString;
-        if (is_byte_string && previous_is_byte_string) {
-          has_adjacent_byte_strings = true;
+        auto element = builder_.GetGrammarExpr(element_id);
+        bool is_byte_string = element.type == GrammarExprType::kByteString;
+        if (is_byte_string && (previous_is_byte_string || element.size() == 0)) {
+          needs_rewrite = true;
           break;
         }
         previous_is_byte_string = is_byte_string;
       }
     }
-    if (!has_adjacent_byte_strings) {
+    if (!needs_rewrite) {
       return expr_id;
     }
     // Copy the element ids first: fusing appends to the arena and invalidates expr views.
@@ -2858,10 +2865,13 @@ class ByteStringFuserImpl : public InPlaceGrammarRewriter {
         fused_bytes.insert(fused_bytes.end(), element.begin(), element.end());
         ++run_end;
       }
-      if (run_end - i == 1) {
-        new_element_ids.push_back(element_ids[i]);
-      } else {
-        new_element_ids.push_back(builder_.AddByteString(fused_bytes));
+      // Empty byte strings are epsilon and can be omitted from a sequence.
+      if (!fused_bytes.empty()) {
+        if (run_end - i == 1) {
+          new_element_ids.push_back(element_ids[i]);
+        } else {
+          new_element_ids.push_back(builder_.AddByteString(fused_bytes));
+        }
       }
       i = run_end;
     }

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -581,93 +581,166 @@ class GrammarNormalizerImpl {
  * 1. at the beginning of a sequence
  * 2. The rule should be a sequence of choices, cannot be empty, cannot refer to other rules
  */
-class RuleInlinerImpl : public GrammarMutator {
+/*!
+ * \brief Inline rule references in place.
+ * \details The pass scans every choices expr. When a choice's sequence starts with a reference to
+ * an inlinable rule, the expanded sequences and the new choices record are appended to the
+ * grammar's expr storage, and all references to the old choices id are redirected. Before the
+ * first rewrite, the grammar handle is replaced with a copy so that other holders of the same
+ * grammar are unaffected. Stale records left behind are removed later by DeadCodeEliminator.
+ */
+class RuleInlinerImpl {
  public:
-  using GrammarMutator::Apply;
-  using GrammarMutator::GrammarMutator;
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
 
- private:
-  int32_t VisitChoices(const GrammarExpr& grammar_expr) final {
-    std::vector<int32_t> new_choice_ids;
-    for (int i : grammar_expr) {
-      auto choice_expr = base_grammar_->GetGrammarExpr(i);
-      if (choice_expr.type == GrammarExprType::kEmptyStr) {
-        new_choice_ids.push_back(VisitExpr(i));
-        continue;
-      }
-      XGRAMMAR_ICHECK(choice_expr.type == GrammarExprType::kSequence);
-      auto first_element = base_grammar_->GetGrammarExpr(choice_expr[0]);
-      if (first_element.type != GrammarExprType::kRuleRef) {
-        new_choice_ids.push_back(VisitExpr(choice_expr));
-        continue;
-      }
-      auto rule_ref_id = first_element[0];
-      if (can_rule_be_inlined_.count(rule_ref_id) == 0) {
-        can_rule_be_inlined_[rule_ref_id] = CheckIfRuleCanBeInlined(rule_ref_id);
-      }
-      if (!can_rule_be_inlined_[rule_ref_id]) {
-        new_choice_ids.push_back(VisitExpr(choice_expr));
-        continue;
-      }
-
-      // Do inlining
-      std::vector<int32_t> other_elements;
-      for (int i = 1; i < choice_expr.size(); ++i) {
-        other_elements.push_back(VisitExpr(choice_expr[i]));
-      }
-
-      auto ref_rule = base_grammar_->GetRule(rule_ref_id);
-      auto ref_grammar_expr = base_grammar_->GetGrammarExpr(ref_rule.body_expr_id);
-
-      for (auto ref_choice_id : ref_grammar_expr) {
-        auto ref_choice_expr = base_grammar_->GetGrammarExpr(ref_choice_id);
-        XGRAMMAR_ICHECK(ref_choice_expr.type == GrammarExprType::kSequence);
-        std::vector<int32_t> choice_to_add;
-        for (auto ref_element_id : ref_choice_expr) {
-          choice_to_add.push_back(VisitExpr(ref_element_id));
+  void Apply(Grammar* grammar) {
+    auto& grammar_ref = *grammar;
+    bool owned = false;
+    const int32_t original_num_exprs = grammar_ref->NumGrammarExprs();
+    std::unordered_map<int32_t, int32_t> choices_replacement;
+    std::vector<int32_t> choice_ids;
+    for (int32_t expr_id = 0; expr_id < original_num_exprs; ++expr_id) {
+      {
+        auto expr = grammar_ref->GetGrammarExpr(expr_id);
+        if (expr.type != GrammarExprType::kChoices) {
+          continue;
         }
-        choice_to_add.insert(choice_to_add.end(), other_elements.begin(), other_elements.end());
-        new_choice_ids.push_back(builder_->AddSequence(choice_to_add));
+        bool needs_inlining = false;
+        for (int32_t choice_id : expr) {
+          auto choice_expr = grammar_ref->GetGrammarExpr(choice_id);
+          if (choice_expr.type != GrammarExprType::kSequence || choice_expr.size() == 0) {
+            continue;
+          }
+          auto first_element = grammar_ref->GetGrammarExpr(choice_expr[0]);
+          if (first_element.type == GrammarExprType::kRuleRef &&
+              CanRuleBeInlined(grammar_ref, first_element[0])) {
+            needs_inlining = true;
+            break;
+          }
+        }
+        if (!needs_inlining) {
+          continue;
+        }
+        choice_ids.assign(expr.begin(), expr.end());
+      }
+
+      if (!owned) {
+        // Copy before the first rewrite so that other holders of this grammar are unaffected.
+        grammar_ref = GrammarBuilder(grammar_ref).Get(grammar_ref->GetRootRuleId());
+        owned = true;
+      }
+
+      std::vector<int32_t> new_choice_ids;
+      std::vector<int32_t> new_sequence;
+      for (int32_t choice_id : choice_ids) {
+        auto choice_expr = grammar_ref->GetGrammarExpr(choice_id);
+        if (choice_expr.type == GrammarExprType::kEmptyStr) {
+          new_choice_ids.push_back(choice_id);
+          continue;
+        }
+        XGRAMMAR_ICHECK(choice_expr.type == GrammarExprType::kSequence);
+        auto first_element = grammar_ref->GetGrammarExpr(choice_expr[0]);
+        if (first_element.type != GrammarExprType::kRuleRef ||
+            !CanRuleBeInlined(grammar_ref, first_element[0])) {
+          new_choice_ids.push_back(choice_id);
+          continue;
+        }
+
+        // Do inlining. The element ids are copied out first because appending new records may
+        // reallocate the storage the expr views point into.
+        const std::vector<int32_t> other_elements(choice_expr.begin() + 1, choice_expr.end());
+        auto ref_body =
+            grammar_ref->GetGrammarExpr(grammar_ref->GetRule(first_element[0]).body_expr_id);
+        const std::vector<int32_t> ref_choice_ids(ref_body.begin(), ref_body.end());
+        for (int32_t ref_choice_id : ref_choice_ids) {
+          {
+            auto ref_choice_expr = grammar_ref->GetGrammarExpr(ref_choice_id);
+            XGRAMMAR_ICHECK(ref_choice_expr.type == GrammarExprType::kSequence);
+            new_sequence.assign(ref_choice_expr.begin(), ref_choice_expr.end());
+          }
+          new_sequence.insert(new_sequence.end(), other_elements.begin(), other_elements.end());
+          new_choice_ids.push_back(
+              grammar_ref->AddGrammarExpr(GrammarExprType::kSequence, new_sequence)
+          );
+        }
+      }
+      choices_replacement[expr_id] =
+          grammar_ref->AddGrammarExpr(GrammarExprType::kChoices, new_choice_ids);
+    }
+
+    if (choices_replacement.empty()) {
+      return;
+    }
+
+    // Redirect all references to the replaced choices records.
+    for (int32_t rule_id = 0; rule_id < grammar_ref->NumRules(); ++rule_id) {
+      auto& rule = grammar_ref->GetRule(rule_id);
+      if (auto it = choices_replacement.find(rule.body_expr_id); it != choices_replacement.end()) {
+        rule.body_expr_id = it->second;
+      }
+      if (auto it = choices_replacement.find(rule.lookahead_assertion_id);
+          it != choices_replacement.end()) {
+        rule.lookahead_assertion_id = it->second;
       }
     }
-    return builder_->AddChoices(new_choice_ids);
+    const int32_t total_num_exprs = grammar_ref->NumGrammarExprs();
+    for (int32_t expr_id = 0; expr_id < total_num_exprs; ++expr_id) {
+      auto expr = grammar_ref->GetGrammarExpr(expr_id);
+      if (expr.type != GrammarExprType::kSequence && expr.type != GrammarExprType::kChoices) {
+        continue;
+      }
+      for (int32_t i = 0; i < expr.size(); ++i) {
+        if (auto it = choices_replacement.find(expr[i]); it != choices_replacement.end()) {
+          expr.SetData(i, it->second);
+        }
+      }
+    }
   }
 
+ private:
   /**
    * The rule should be: a sequence of choices, cannot be empty, cannot refer to other rules
    */
-  bool CheckIfRuleCanBeInlined(int32_t rule_id) {
-    auto rule = base_grammar_->GetRule(rule_id);
+  bool CanRuleBeInlined(const Grammar& grammar, int32_t rule_id) {
+    if (auto it = can_rule_be_inlined_.find(rule_id); it != can_rule_be_inlined_.end()) {
+      return it->second;
+    }
+    auto rule = grammar->GetRule(rule_id);
     // Inlining a budgeted rule would erase the rule its length budget applies to. Inlining a
     // capture-relevant rule would eliminate its completion events, so its capture or hidden span
     // would never be recorded. Inlining a lazy rule would erase its committed-shortest semantics.
     // Inlining a temperature rule would erase the rule its sampling temperature applies to.
     if (rule.max_tokens >= 0 || rule.max_chars >= 0 || !rule.capture_name.empty() ||
-        base_grammar_->GetSuffixStopInfo(rule_id) != nullptr || rule.is_lazy ||
+        grammar->GetSuffixStopInfo(rule_id) != nullptr || rule.is_lazy ||
         rule.temperature.has_value()) {
+      can_rule_be_inlined_[rule_id] = false;
       return false;
     }
-    auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
-    if (grammar_expr.type != GrammarExprType::kChoices) {
-      return false;
-    }
-    if (grammar_expr.size() == 0) {
-      return false;
-    }
-    for (auto choice_id : grammar_expr) {
-      auto choice_expr = base_grammar_->GetGrammarExpr(choice_id);
-      if (choice_expr.type == GrammarExprType::kEmptyStr) {
-        return false;
-      }
-      XGRAMMAR_ICHECK(choice_expr.type == GrammarExprType::kSequence);
-      for (auto element_id : choice_expr) {
-        auto element_expr = base_grammar_->GetGrammarExpr(element_id);
-        if (element_expr.type == GrammarExprType::kRuleRef) {
-          return false;
+    bool result = true;
+    auto grammar_expr = grammar->GetGrammarExpr(rule.body_expr_id);
+    if (grammar_expr.type != GrammarExprType::kChoices || grammar_expr.size() == 0) {
+      result = false;
+    } else {
+      for (auto choice_id : grammar_expr) {
+        auto choice_expr = grammar->GetGrammarExpr(choice_id);
+        if (choice_expr.type == GrammarExprType::kEmptyStr) {
+          result = false;
+          break;
+        }
+        XGRAMMAR_ICHECK(choice_expr.type == GrammarExprType::kSequence);
+        for (auto element_id : choice_expr) {
+          if (grammar->GetGrammarExpr(element_id).type == GrammarExprType::kRuleRef) {
+            result = false;
+            break;
+          }
+        }
+        if (!result) {
+          break;
         }
       }
     }
-    return true;
+    can_rule_be_inlined_[rule_id] = result;
+    return result;
   }
 
   std::unordered_map<int32_t, bool> can_rule_be_inlined_;
@@ -2591,8 +2664,9 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
 class GrammarOptimizerImpl {
  public:
   static Grammar Apply(const Grammar& grammar) {
-    auto result = ByteStringFuser::Apply(grammar);
-    result = RuleInliner::Apply(result);
+    Grammar result = grammar;
+    ByteStringFuser::Apply(&result);
+    RuleInliner::Apply(&result);
     result = RepetitionRangeExpander::Apply(result);
     result = LazyBodyFlattenerImpl().Apply(result);
     result = DeadCodeEliminator::Apply(result);
@@ -2644,36 +2718,92 @@ class GrammarOptimizerImpl {
   }
 };
 
-class ByteStringFuserImpl : public GrammarMutator {
+/*!
+ * \brief Fuse adjacent byte string elements in sequences, in place.
+ * \details Fused byte strings are appended to the grammar's expr storage and each rewritten
+ * sequence record is shrunk in place (records are self-describing, so the trailing words simply
+ * become unused). Before the first rewrite, the grammar handle is replaced with a copy so that
+ * other holders of the same grammar are unaffected. Stale records left behind are removed later
+ * by DeadCodeEliminator.
+ */
+class ByteStringFuserImpl {
  public:
-  using GrammarMutator::Apply;
-  using GrammarMutator::GrammarMutator;
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
 
- private:
-  /*!
-   * \brief Visit a GrammarExpr containing a sequence.
-   * \returns A list of new sequence GrammarExpr ids.
-   */
-  int32_t VisitSequence(const GrammarExpr& grammar_expr) final {
-    std::vector<int32_t> new_sequence_ids;
-    std::vector<int32_t> cur_byte_string;
-    for (auto i : grammar_expr) {
-      auto element_expr = base_grammar_->GetGrammarExpr(i);
-      if (element_expr.type == GrammarExprType::kByteString) {
-        cur_byte_string.insert(cur_byte_string.end(), element_expr.begin(), element_expr.end());
-        continue;
-      } else {
-        if (!cur_byte_string.empty()) {
-          new_sequence_ids.push_back(builder_->AddByteString(cur_byte_string));
-          cur_byte_string.clear();
+  static void Apply(Grammar* grammar) {
+    auto& grammar_ref = *grammar;
+    bool owned = false;
+    const int32_t num_exprs = grammar_ref->NumGrammarExprs();
+    std::vector<int32_t> element_ids;
+    std::vector<int32_t> new_element_ids;
+    std::vector<int32_t> fused_bytes;
+    for (int32_t expr_id = 0; expr_id < num_exprs; ++expr_id) {
+      {
+        auto expr = grammar_ref->GetGrammarExpr(expr_id);
+        if (expr.type != GrammarExprType::kSequence) {
+          continue;
         }
-        new_sequence_ids.push_back(builder_->AddGrammarExpr(element_expr));
+        bool needs_fusing = false;
+        bool previous_is_byte_string = false;
+        for (int32_t element_id : expr) {
+          bool current_is_byte_string =
+              grammar_ref->GetGrammarExpr(element_id).type == GrammarExprType::kByteString;
+          if (previous_is_byte_string && current_is_byte_string) {
+            needs_fusing = true;
+            break;
+          }
+          previous_is_byte_string = current_is_byte_string;
+        }
+        if (!needs_fusing) {
+          continue;
+        }
+        // The element ids are copied out first because appending new records may reallocate the
+        // storage the expr view points into.
+        element_ids.assign(expr.begin(), expr.end());
       }
+
+      if (!owned) {
+        // Copy before the first rewrite so that other holders of this grammar are unaffected.
+        grammar_ref = GrammarBuilder(grammar_ref).Get(grammar_ref->GetRootRuleId());
+        owned = true;
+      }
+
+      new_element_ids.clear();
+      const int32_t element_count = static_cast<int32_t>(element_ids.size());
+      int32_t run_begin = -1;
+      for (int32_t i = 0; i <= element_count; ++i) {
+        bool is_byte_string =
+            i < element_count &&
+            grammar_ref->GetGrammarExpr(element_ids[i]).type == GrammarExprType::kByteString;
+        if (is_byte_string) {
+          if (run_begin == -1) {
+            run_begin = i;
+          }
+          continue;
+        }
+        if (run_begin != -1) {
+          if (i - run_begin == 1) {
+            new_element_ids.push_back(element_ids[run_begin]);
+          } else {
+            fused_bytes.clear();
+            for (int32_t j = run_begin; j < i; ++j) {
+              auto byte_string_expr = grammar_ref->GetGrammarExpr(element_ids[j]);
+              fused_bytes.insert(
+                  fused_bytes.end(), byte_string_expr.begin(), byte_string_expr.end()
+              );
+            }
+            new_element_ids.push_back(
+                grammar_ref->AddGrammarExpr(GrammarExprType::kByteString, fused_bytes)
+            );
+          }
+          run_begin = -1;
+        }
+        if (i < element_count) {
+          new_element_ids.push_back(element_ids[i]);
+        }
+      }
+      grammar_ref->ShrinkGrammarExprData(expr_id, new_element_ids);
     }
-    if (!cur_byte_string.empty()) {
-      new_sequence_ids.push_back(builder_->AddByteString(cur_byte_string));
-    }
-    return builder_->AddSequence(new_sequence_ids);
   }
 };
 
@@ -3556,7 +3686,7 @@ std::vector<int32_t> AllowEmptyRuleAnalyzer::Apply(const Grammar& grammar) {
   return AllowEmptyRuleAnalyzerImpl().Apply(grammar);
 }
 
-Grammar RuleInliner::Apply(const Grammar& grammar) { return RuleInlinerImpl().Apply(grammar); }
+void RuleInliner::Apply(Grammar* grammar) { RuleInlinerImpl().Apply(grammar); }
 
 Grammar DeadCodeEliminator::Apply(const Grammar& grammar) {
   return DeadCodeEliminatorImpl().Apply(grammar);
@@ -3574,9 +3704,7 @@ Grammar GrammarOptimizer::Apply(const Grammar& grammar) {
   return GrammarOptimizerImpl::Apply(grammar);
 }
 
-Grammar ByteStringFuser::Apply(const Grammar& grammar) {
-  return ByteStringFuserImpl().Apply(grammar);
-}
+void ByteStringFuser::Apply(Grammar* grammar) { ByteStringFuserImpl::Apply(grammar); }
 
 Grammar RootRuleRenamer::Apply(const Grammar& grammar) {
   return RootRuleRenamerImpl().Apply(grammar);

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -575,34 +575,94 @@ class GrammarNormalizerImpl {
 /*************************** Impl of grammar optimizers ***************************/
 
 /*!
- * \brief Redirect all references to replaced exprs according to the replacement map: rule bodies,
- * lookahead assertions, and the children of sequence and choices exprs.
+ * \brief Base for optimizer passes that rewrite a grammar in place. It binds a GrammarBuilder
+ * directly to the target grammar (no copy) and walks every rule body and lookahead assertion.
+ * \details An expr whose subtree is unchanged keeps its original id; a new expr is appended only
+ * where a rewrite actually happens, so a pass with nothing to do writes nothing. Changed ids
+ * propagate upward: a container is rebuilt when any child changed, and a rule body or lookahead is
+ * updated when its expr changed. Stale exprs left behind are removed later by DeadCodeEliminator.
  */
-static void RedirectExprReferences(
-    GrammarBuilder* builder, const std::unordered_map<int32_t, int32_t>& replacement
-) {
+class InPlaceGrammarRewriter {
+ public:
+  using GrammarExpr = Grammar::Impl::GrammarExpr;
   using GrammarExprType = Grammar::Impl::GrammarExprType;
-  for (int32_t rule_id = 0; rule_id < builder->NumRules(); ++rule_id) {
-    const auto& rule = builder->GetRule(rule_id);
-    if (auto it = replacement.find(rule.body_expr_id); it != replacement.end()) {
-      builder->UpdateRuleBody(rule_id, it->second);
-    }
-    if (auto it = replacement.find(rule.lookahead_assertion_id); it != replacement.end()) {
-      builder->UpdateLookaheadAssertion(rule_id, it->second);
-    }
-  }
-  for (int32_t expr_id = 0; expr_id < builder->NumGrammarExprs(); ++expr_id) {
-    auto expr = builder->GetGrammarExpr(expr_id);
-    if (expr.type != GrammarExprType::kSequence && expr.type != GrammarExprType::kChoices) {
-      continue;
-    }
-    for (int32_t i = 0; i < expr.size(); ++i) {
-      if (auto it = replacement.find(expr[i]); it != replacement.end()) {
-        expr.SetData(i, it->second);
+
+  void Apply(Grammar* grammar) {
+    grammar_ = grammar;
+    builder_ = GrammarBuilder::FromMutableGrammar(grammar);
+    Prepare();
+    int32_t num_rules = builder_.NumRules();
+    for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
+      int32_t body_expr_id = builder_.GetRule(rule_id).body_expr_id;
+      int32_t new_body_expr_id = VisitExpr(body_expr_id);
+      if (new_body_expr_id != body_expr_id) {
+        builder_.UpdateRuleBody(rule_id, new_body_expr_id);
+      }
+      int32_t lookahead_id = builder_.GetRule(rule_id).lookahead_assertion_id;
+      if (lookahead_id != -1) {
+        int32_t new_lookahead_id = VisitExpr(lookahead_id);
+        if (new_lookahead_id != lookahead_id) {
+          builder_.UpdateLookaheadAssertion(rule_id, new_lookahead_id);
+        }
       }
     }
   }
-}
+
+  virtual ~InPlaceGrammarRewriter() = default;
+
+ protected:
+  /*! \brief Hook run after the builder is bound and before the walk. */
+  virtual void Prepare() {}
+
+  /*! \brief Visit an expr; return its rewritten id, or the original id when nothing changed. */
+  int32_t VisitExpr(int32_t expr_id) {
+    if (auto it = memo_.find(expr_id); it != memo_.end()) {
+      return it->second;
+    }
+    int32_t result;
+    switch (builder_.GetGrammarExpr(expr_id).type) {
+      case GrammarExprType::kSequence:
+        result = VisitSequence(expr_id);
+        break;
+      case GrammarExprType::kChoices:
+        result = VisitChoices(expr_id);
+        break;
+      default:
+        result = expr_id;
+    }
+    memo_[expr_id] = result;
+    return result;
+  }
+
+  /*! \brief Rebuild a sequence, recursing into each element. Overridden to add rewriting. */
+  virtual int32_t VisitSequence(int32_t expr_id) { return RebuildContainer(expr_id, false); }
+
+  /*! \brief Rebuild a choices, recursing into each choice. Overridden to add rewriting. */
+  virtual int32_t VisitChoices(int32_t expr_id) { return RebuildContainer(expr_id, true); }
+
+  /*! \brief Recurse into a sequence or choices; append a rebuilt expr only if a child changed. */
+  int32_t RebuildContainer(int32_t expr_id, bool is_choices) {
+    auto expr = builder_.GetGrammarExpr(expr_id);
+    std::vector<int32_t> child_ids(expr.begin(), expr.end());
+    std::vector<int32_t> new_child_ids;
+    new_child_ids.reserve(child_ids.size());
+    bool changed = false;
+    for (int32_t child_id : child_ids) {
+      int32_t new_child_id = VisitExpr(child_id);
+      changed |= new_child_id != child_id;
+      new_child_ids.push_back(new_child_id);
+    }
+    if (!changed) {
+      return expr_id;
+    }
+    return is_choices ? builder_.AddChoices(new_child_ids) : builder_.AddSequence(new_child_ids);
+  }
+
+  GrammarBuilder builder_;
+  Grammar* grammar_;
+  // Maps an original expr id to its rewritten id (or itself when unchanged).
+  std::unordered_map<int32_t, int32_t> memo_;
+};
 
 /*!
  * \brief Inline rules that can be inlined.
@@ -611,120 +671,99 @@ static void RedirectExprReferences(
  * 1. at the beginning of a sequence
  * 2. The rule should be a sequence of choices, cannot be empty, cannot refer to other rules
  *
- * \details The pass first scans the grammar; if nothing can be inlined, the grammar is left
- * unchanged. Otherwise the grammar is copied into a GrammarBuilder, the expanded sequences and
- * choices are added as new exprs (expr ids are preserved by the copy), and all references to the
- * replaced choices are redirected. Stale exprs are removed later by DeadCodeEliminator.
+ * \details Rewrites the grammar in place: only choices that actually have an inlinable leading
+ * rule reference are rebuilt, the rest keep their original ids. Inlinability is judged on the
+ * original grammar so the result does not depend on the order rules are rewritten. Stale exprs are
+ * removed later by DeadCodeEliminator.
  */
-class RuleInlinerImpl {
- public:
-  using GrammarExprType = Grammar::Impl::GrammarExprType;
-
-  void Apply(Grammar* grammar) {
-    const Grammar& original = *grammar;
-    const int32_t num_exprs = original->NumGrammarExprs();
-
-    bool needs_inlining = false;
-    for (int32_t expr_id = 0; expr_id < num_exprs && !needs_inlining; ++expr_id) {
-      auto expr = original->GetGrammarExpr(expr_id);
-      needs_inlining =
-          expr.type == GrammarExprType::kChoices && ChoicesNeedInlining(original, expr);
+class RuleInlinerImpl : public InPlaceGrammarRewriter {
+ protected:
+  void Prepare() override {
+    int32_t num_rules = builder_.NumRules();
+    original_body_expr_ids_.reserve(num_rules);
+    for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
+      original_body_expr_ids_.push_back(builder_.GetRule(rule_id).body_expr_id);
     }
-    if (!needs_inlining) {
-      return;
-    }
+  }
 
-    GrammarBuilder builder(original);
-    std::unordered_map<int32_t, int32_t> choices_replacement;
-    for (int32_t expr_id = 0; expr_id < num_exprs; ++expr_id) {
-      auto expr = original->GetGrammarExpr(expr_id);
-      if (expr.type != GrammarExprType::kChoices || !ChoicesNeedInlining(original, expr)) {
+  int32_t VisitChoices(int32_t expr_id) override {
+    auto expr = builder_.GetGrammarExpr(expr_id);
+    std::vector<int32_t> choice_ids(expr.begin(), expr.end());
+    std::vector<int32_t> new_choice_ids;
+    bool changed = false;
+    for (int32_t choice_id : choice_ids) {
+      auto choice_expr = builder_.GetGrammarExpr(choice_id);
+      int32_t inline_rule_id = -1;
+      if (choice_expr.type == GrammarExprType::kSequence && choice_expr.size() > 0) {
+        auto first_element = builder_.GetGrammarExpr(choice_expr[0]);
+        if (first_element.type == GrammarExprType::kRuleRef && CanRuleBeInlined(first_element[0])) {
+          inline_rule_id = first_element[0];
+        }
+      }
+      if (inline_rule_id == -1) {
+        int32_t new_choice_id = VisitExpr(choice_id);
+        changed |= new_choice_id != choice_id;
+        new_choice_ids.push_back(new_choice_id);
         continue;
       }
-      std::vector<int32_t> new_choice_ids;
-      for (int32_t choice_id : expr) {
-        auto choice_expr = original->GetGrammarExpr(choice_id);
-        if (choice_expr.type == GrammarExprType::kEmptyStr) {
-          new_choice_ids.push_back(choice_id);
-          continue;
-        }
-        XGRAMMAR_ICHECK(choice_expr.type == GrammarExprType::kSequence);
-        auto first_element = original->GetGrammarExpr(choice_expr[0]);
-        if (first_element.type != GrammarExprType::kRuleRef ||
-            !CanRuleBeInlined(original, first_element[0])) {
-          new_choice_ids.push_back(choice_id);
-          continue;
-        }
-        // Do inlining: prepend each choice of the referenced rule to the rest of this sequence.
-        auto ref_body = original->GetGrammarExpr(original->GetRule(first_element[0]).body_expr_id);
-        for (int32_t ref_choice_id : ref_body) {
-          auto ref_choice_expr = original->GetGrammarExpr(ref_choice_id);
-          XGRAMMAR_ICHECK(ref_choice_expr.type == GrammarExprType::kSequence);
-          std::vector<int32_t> new_sequence(ref_choice_expr.begin(), ref_choice_expr.end());
-          new_sequence.insert(new_sequence.end(), choice_expr.begin() + 1, choice_expr.end());
-          new_choice_ids.push_back(builder.AddSequence(new_sequence));
-        }
+      // Do inlining: prepend each choice of the referenced rule to the rest of this sequence.
+      std::vector<int32_t> rest_element_ids(choice_expr.begin() + 1, choice_expr.end());
+      auto ref_body = builder_.GetGrammarExpr(original_body_expr_ids_[inline_rule_id]);
+      std::vector<int32_t> ref_choice_ids(ref_body.begin(), ref_body.end());
+      for (int32_t ref_choice_id : ref_choice_ids) {
+        auto ref_choice_expr = builder_.GetGrammarExpr(ref_choice_id);
+        XGRAMMAR_ICHECK(ref_choice_expr.type == GrammarExprType::kSequence);
+        std::vector<int32_t> new_sequence(ref_choice_expr.begin(), ref_choice_expr.end());
+        new_sequence.insert(new_sequence.end(), rest_element_ids.begin(), rest_element_ids.end());
+        new_choice_ids.push_back(builder_.AddSequence(new_sequence));
       }
-      choices_replacement[expr_id] = builder.AddChoices(new_choice_ids);
+      changed = true;
     }
-
-    RedirectExprReferences(&builder, choices_replacement);
-    *grammar = builder.Get(original->GetRootRuleId());
+    if (!changed) {
+      return expr_id;
+    }
+    return builder_.AddChoices(new_choice_ids);
   }
 
  private:
-  bool ChoicesNeedInlining(const Grammar& grammar, const Grammar::Impl::GrammarExpr& expr) {
-    for (int32_t choice_id : expr) {
-      auto choice_expr = grammar->GetGrammarExpr(choice_id);
-      if (choice_expr.type != GrammarExprType::kSequence || choice_expr.size() == 0) {
-        continue;
-      }
-      auto first_element = grammar->GetGrammarExpr(choice_expr[0]);
-      if (first_element.type == GrammarExprType::kRuleRef &&
-          CanRuleBeInlined(grammar, first_element[0])) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * The rule should be: a sequence of choices, cannot be empty, cannot refer to other rules
-   */
-  bool CanRuleBeInlined(const Grammar& grammar, int32_t rule_id) {
+  /*! \brief A rule can be inlined iff its body is a non-empty choices of sequences that contain no
+   * rule references. Judged on the original grammar via original_body_expr_ids_. */
+  bool CanRuleBeInlined(int32_t rule_id) {
     if (auto it = can_rule_be_inlined_.find(rule_id); it != can_rule_be_inlined_.end()) {
       return it->second;
     }
-    auto rule = grammar->GetRule(rule_id);
+    const auto& rule = (*grammar_)->GetRule(rule_id);
     // Inlining a budgeted rule would erase the rule its length budget applies to. Inlining a
     // capture-relevant rule would eliminate its completion events, so its capture or hidden span
     // would never be recorded. Inlining a lazy rule would erase its committed-shortest semantics.
     // Inlining a temperature rule would erase the rule its sampling temperature applies to.
     if (rule.max_tokens >= 0 || rule.max_chars >= 0 || !rule.capture_name.empty() ||
-        grammar->GetSuffixStopInfo(rule_id) != nullptr || rule.is_lazy ||
+        (*grammar_)->GetSuffixStopInfo(rule_id) != nullptr || rule.is_lazy ||
         rule.temperature.has_value()) {
       can_rule_be_inlined_[rule_id] = false;
       return false;
     }
     bool result = true;
-    auto grammar_expr = grammar->GetGrammarExpr(rule.body_expr_id);
-    if (grammar_expr.type != GrammarExprType::kChoices || grammar_expr.size() == 0) {
+    auto body = builder_.GetGrammarExpr(original_body_expr_ids_[rule_id]);
+    if (body.type != GrammarExprType::kChoices || body.size() == 0) {
       result = false;
     } else {
-      for (auto choice_id : grammar_expr) {
-        auto choice_expr = grammar->GetGrammarExpr(choice_id);
+      for (int32_t choice_id : body) {
+        auto choice_expr = builder_.GetGrammarExpr(choice_id);
         if (choice_expr.type == GrammarExprType::kEmptyStr) {
           result = false;
           break;
         }
         XGRAMMAR_ICHECK(choice_expr.type == GrammarExprType::kSequence);
-        for (auto element_id : choice_expr) {
-          if (grammar->GetGrammarExpr(element_id).type == GrammarExprType::kRuleRef) {
-            result = false;
+        bool has_rule_ref = false;
+        for (int32_t element_id : choice_expr) {
+          if (builder_.GetGrammarExpr(element_id).type == GrammarExprType::kRuleRef) {
+            has_rule_ref = true;
             break;
           }
         }
-        if (!result) {
+        if (has_rule_ref) {
+          result = false;
           break;
         }
       }
@@ -733,6 +772,8 @@ class RuleInlinerImpl {
     return result;
   }
 
+  // Rule body expr ids captured before any rewriting, for order-independent inlinability checks.
+  std::vector<int32_t> original_body_expr_ids_;
   std::unordered_map<int32_t, bool> can_rule_be_inlined_;
 };
 
@@ -2654,7 +2695,9 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
 class GrammarOptimizerImpl {
  public:
   static Grammar Apply(const Grammar& grammar) {
-    Grammar result = grammar;
+    // ByteStringFuser and RuleInliner rewrite the grammar in place, so work on a private copy: the
+    // input grammar may be shared (e.g. a cached grammar) and must not be mutated.
+    Grammar result = GrammarBuilder(grammar).Get(grammar->GetRootRuleId());
     ByteStringFuser::Apply(&result);
     RuleInliner::Apply(&result);
     result = RepetitionRangeExpander::Apply(result);
@@ -2710,80 +2753,46 @@ class GrammarOptimizerImpl {
 
 /*!
  * \brief Fuse adjacent byte string elements in sequences.
- * \details The pass first scans the grammar; if no sequence contains adjacent byte strings, the
- * grammar is left unchanged. Otherwise the grammar is copied into a GrammarBuilder, the fused
- * byte strings and the rewritten sequences are added as new exprs (expr ids are preserved by the
- * copy), and all references to the replaced sequences are redirected. Stale exprs are removed
- * later by DeadCodeEliminator.
+ * \details Rewrites the grammar in place: only sequences that actually contain a run of adjacent
+ * byte strings are rebuilt, the rest keep their original ids. Stale exprs are removed later by
+ * DeadCodeEliminator.
  */
-class ByteStringFuserImpl {
- public:
-  using GrammarExprType = Grammar::Impl::GrammarExprType;
-
-  static void Apply(Grammar* grammar) {
-    const Grammar& original = *grammar;
-    const int32_t num_exprs = original->NumGrammarExprs();
-
-    bool needs_fusing = false;
-    for (int32_t expr_id = 0; expr_id < num_exprs && !needs_fusing; ++expr_id) {
-      auto expr = original->GetGrammarExpr(expr_id);
-      needs_fusing = expr.type == GrammarExprType::kSequence && SequenceNeedsFusing(original, expr);
-    }
-    if (!needs_fusing) {
-      return;
-    }
-
-    GrammarBuilder builder(original);
-    std::unordered_map<int32_t, int32_t> sequence_replacement;
-    for (int32_t expr_id = 0; expr_id < num_exprs; ++expr_id) {
-      auto expr = original->GetGrammarExpr(expr_id);
-      if (expr.type != GrammarExprType::kSequence || !SequenceNeedsFusing(original, expr)) {
+class ByteStringFuserImpl : public InPlaceGrammarRewriter {
+ protected:
+  int32_t VisitSequence(int32_t expr_id) override {
+    auto expr = builder_.GetGrammarExpr(expr_id);
+    std::vector<int32_t> element_ids(expr.begin(), expr.end());
+    std::vector<int32_t> new_element_ids;
+    bool changed = false;
+    for (size_t i = 0; i < element_ids.size();) {
+      if (builder_.GetGrammarExpr(element_ids[i]).type != GrammarExprType::kByteString) {
+        new_element_ids.push_back(element_ids[i]);
+        ++i;
         continue;
       }
-      std::vector<int32_t> new_element_ids;
+      // Gather the run of adjacent byte strings starting at i.
       std::vector<int32_t> fused_bytes;
-      for (int32_t i = 0; i < expr.size(); ++i) {
-        if (original->GetGrammarExpr(expr[i]).type != GrammarExprType::kByteString) {
-          new_element_ids.push_back(expr[i]);
-          continue;
+      size_t run_end = i;
+      while (run_end < element_ids.size()) {
+        auto element = builder_.GetGrammarExpr(element_ids[run_end]);
+        if (element.type != GrammarExprType::kByteString) {
+          break;
         }
-        // Find the run of adjacent byte strings starting at i.
-        int32_t run_end = i + 1;
-        while (run_end < expr.size() &&
-               original->GetGrammarExpr(expr[run_end]).type == GrammarExprType::kByteString) {
-          ++run_end;
-        }
-        if (run_end - i == 1) {
-          new_element_ids.push_back(expr[i]);
-        } else {
-          fused_bytes.clear();
-          for (int32_t j = i; j < run_end; ++j) {
-            auto byte_string_expr = original->GetGrammarExpr(expr[j]);
-            fused_bytes.insert(fused_bytes.end(), byte_string_expr.begin(), byte_string_expr.end());
-          }
-          new_element_ids.push_back(builder.AddByteString(fused_bytes));
-        }
-        i = run_end - 1;
+        fused_bytes.insert(fused_bytes.end(), element.begin(), element.end());
+        ++run_end;
       }
-      sequence_replacement[expr_id] = builder.AddSequence(new_element_ids);
-    }
-
-    RedirectExprReferences(&builder, sequence_replacement);
-    *grammar = builder.Get(original->GetRootRuleId());
-  }
-
- private:
-  static bool SequenceNeedsFusing(const Grammar& grammar, const Grammar::Impl::GrammarExpr& expr) {
-    bool previous_is_byte_string = false;
-    for (int32_t element_id : expr) {
-      bool current_is_byte_string =
-          grammar->GetGrammarExpr(element_id).type == GrammarExprType::kByteString;
-      if (previous_is_byte_string && current_is_byte_string) {
-        return true;
+      if (run_end - i == 1) {
+        new_element_ids.push_back(element_ids[i]);
+      } else {
+        new_element_ids.push_back(builder_.AddByteString(fused_bytes));
+        changed = true;
       }
-      previous_is_byte_string = current_is_byte_string;
+      i = run_end;
     }
-    return false;
+    if (!changed) {
+      return expr_id;
+    }
+    return builder_.AddSequence(new_element_ids);
   }
 };
 
@@ -3684,7 +3693,7 @@ Grammar GrammarOptimizer::Apply(const Grammar& grammar) {
   return GrammarOptimizerImpl::Apply(grammar);
 }
 
-void ByteStringFuser::Apply(Grammar* grammar) { ByteStringFuserImpl::Apply(grammar); }
+void ByteStringFuser::Apply(Grammar* grammar) { ByteStringFuserImpl().Apply(grammar); }
 
 Grammar RootRuleRenamer::Apply(const Grammar& grammar) {
   return RootRuleRenamerImpl().Apply(grammar);

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -575,129 +575,119 @@ class GrammarNormalizerImpl {
 /*************************** Impl of grammar optimizers ***************************/
 
 /*!
+ * \brief Redirect all references to replaced exprs according to the replacement map: rule bodies,
+ * lookahead assertions, and the children of sequence and choices exprs.
+ */
+static void RedirectExprReferences(
+    GrammarBuilder* builder, const std::unordered_map<int32_t, int32_t>& replacement
+) {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  for (int32_t rule_id = 0; rule_id < builder->NumRules(); ++rule_id) {
+    const auto& rule = builder->GetRule(rule_id);
+    if (auto it = replacement.find(rule.body_expr_id); it != replacement.end()) {
+      builder->UpdateRuleBody(rule_id, it->second);
+    }
+    if (auto it = replacement.find(rule.lookahead_assertion_id); it != replacement.end()) {
+      builder->UpdateLookaheadAssertion(rule_id, it->second);
+    }
+  }
+  for (int32_t expr_id = 0; expr_id < builder->NumGrammarExprs(); ++expr_id) {
+    auto expr = builder->GetGrammarExpr(expr_id);
+    if (expr.type != GrammarExprType::kSequence && expr.type != GrammarExprType::kChoices) {
+      continue;
+    }
+    for (int32_t i = 0; i < expr.size(); ++i) {
+      if (auto it = replacement.find(expr[i]); it != replacement.end()) {
+        expr.SetData(i, it->second);
+      }
+    }
+  }
+}
+
+/*!
  * \brief Inline rules that can be inlined.
  *
  * Now we only inline rule references that:
  * 1. at the beginning of a sequence
  * 2. The rule should be a sequence of choices, cannot be empty, cannot refer to other rules
- */
-/*!
- * \brief Inline rule references in place.
- * \details The pass scans every choices expr. When a choice's sequence starts with a reference to
- * an inlinable rule, the expanded sequences and the new choices record are appended to the
- * grammar's expr storage, and all references to the old choices id are redirected. Before the
- * first rewrite, the grammar handle is replaced with a copy so that other holders of the same
- * grammar are unaffected. Stale records left behind are removed later by DeadCodeEliminator.
+ *
+ * \details The pass first scans the grammar; if nothing can be inlined, the grammar is left
+ * unchanged. Otherwise the grammar is copied into a GrammarBuilder, the expanded sequences and
+ * choices are added as new exprs (expr ids are preserved by the copy), and all references to the
+ * replaced choices are redirected. Stale exprs are removed later by DeadCodeEliminator.
  */
 class RuleInlinerImpl {
  public:
   using GrammarExprType = Grammar::Impl::GrammarExprType;
 
   void Apply(Grammar* grammar) {
-    auto& grammar_ref = *grammar;
-    bool owned = false;
-    const int32_t original_num_exprs = grammar_ref->NumGrammarExprs();
+    const Grammar& original = *grammar;
+    const int32_t num_exprs = original->NumGrammarExprs();
+
+    bool needs_inlining = false;
+    for (int32_t expr_id = 0; expr_id < num_exprs && !needs_inlining; ++expr_id) {
+      auto expr = original->GetGrammarExpr(expr_id);
+      needs_inlining =
+          expr.type == GrammarExprType::kChoices && ChoicesNeedInlining(original, expr);
+    }
+    if (!needs_inlining) {
+      return;
+    }
+
+    GrammarBuilder builder(original);
     std::unordered_map<int32_t, int32_t> choices_replacement;
-    std::vector<int32_t> choice_ids;
-    for (int32_t expr_id = 0; expr_id < original_num_exprs; ++expr_id) {
-      {
-        auto expr = grammar_ref->GetGrammarExpr(expr_id);
-        if (expr.type != GrammarExprType::kChoices) {
-          continue;
-        }
-        bool needs_inlining = false;
-        for (int32_t choice_id : expr) {
-          auto choice_expr = grammar_ref->GetGrammarExpr(choice_id);
-          if (choice_expr.type != GrammarExprType::kSequence || choice_expr.size() == 0) {
-            continue;
-          }
-          auto first_element = grammar_ref->GetGrammarExpr(choice_expr[0]);
-          if (first_element.type == GrammarExprType::kRuleRef &&
-              CanRuleBeInlined(grammar_ref, first_element[0])) {
-            needs_inlining = true;
-            break;
-          }
-        }
-        if (!needs_inlining) {
-          continue;
-        }
-        choice_ids.assign(expr.begin(), expr.end());
+    for (int32_t expr_id = 0; expr_id < num_exprs; ++expr_id) {
+      auto expr = original->GetGrammarExpr(expr_id);
+      if (expr.type != GrammarExprType::kChoices || !ChoicesNeedInlining(original, expr)) {
+        continue;
       }
-
-      if (!owned) {
-        // Copy before the first rewrite so that other holders of this grammar are unaffected.
-        grammar_ref = GrammarBuilder(grammar_ref).Get(grammar_ref->GetRootRuleId());
-        owned = true;
-      }
-
       std::vector<int32_t> new_choice_ids;
-      std::vector<int32_t> new_sequence;
-      for (int32_t choice_id : choice_ids) {
-        auto choice_expr = grammar_ref->GetGrammarExpr(choice_id);
+      for (int32_t choice_id : expr) {
+        auto choice_expr = original->GetGrammarExpr(choice_id);
         if (choice_expr.type == GrammarExprType::kEmptyStr) {
           new_choice_ids.push_back(choice_id);
           continue;
         }
         XGRAMMAR_ICHECK(choice_expr.type == GrammarExprType::kSequence);
-        auto first_element = grammar_ref->GetGrammarExpr(choice_expr[0]);
+        auto first_element = original->GetGrammarExpr(choice_expr[0]);
         if (first_element.type != GrammarExprType::kRuleRef ||
-            !CanRuleBeInlined(grammar_ref, first_element[0])) {
+            !CanRuleBeInlined(original, first_element[0])) {
           new_choice_ids.push_back(choice_id);
           continue;
         }
-
-        // Do inlining. The element ids are copied out first because appending new records may
-        // reallocate the storage the expr views point into.
-        const std::vector<int32_t> other_elements(choice_expr.begin() + 1, choice_expr.end());
-        auto ref_body =
-            grammar_ref->GetGrammarExpr(grammar_ref->GetRule(first_element[0]).body_expr_id);
-        const std::vector<int32_t> ref_choice_ids(ref_body.begin(), ref_body.end());
-        for (int32_t ref_choice_id : ref_choice_ids) {
-          {
-            auto ref_choice_expr = grammar_ref->GetGrammarExpr(ref_choice_id);
-            XGRAMMAR_ICHECK(ref_choice_expr.type == GrammarExprType::kSequence);
-            new_sequence.assign(ref_choice_expr.begin(), ref_choice_expr.end());
-          }
-          new_sequence.insert(new_sequence.end(), other_elements.begin(), other_elements.end());
-          new_choice_ids.push_back(
-              grammar_ref->AddGrammarExpr(GrammarExprType::kSequence, new_sequence)
-          );
+        // Do inlining: prepend each choice of the referenced rule to the rest of this sequence.
+        auto ref_body = original->GetGrammarExpr(original->GetRule(first_element[0]).body_expr_id);
+        for (int32_t ref_choice_id : ref_body) {
+          auto ref_choice_expr = original->GetGrammarExpr(ref_choice_id);
+          XGRAMMAR_ICHECK(ref_choice_expr.type == GrammarExprType::kSequence);
+          std::vector<int32_t> new_sequence(ref_choice_expr.begin(), ref_choice_expr.end());
+          new_sequence.insert(new_sequence.end(), choice_expr.begin() + 1, choice_expr.end());
+          new_choice_ids.push_back(builder.AddSequence(new_sequence));
         }
       }
-      choices_replacement[expr_id] =
-          grammar_ref->AddGrammarExpr(GrammarExprType::kChoices, new_choice_ids);
+      choices_replacement[expr_id] = builder.AddChoices(new_choice_ids);
     }
 
-    if (choices_replacement.empty()) {
-      return;
-    }
-
-    // Redirect all references to the replaced choices records.
-    for (int32_t rule_id = 0; rule_id < grammar_ref->NumRules(); ++rule_id) {
-      auto& rule = grammar_ref->GetRule(rule_id);
-      if (auto it = choices_replacement.find(rule.body_expr_id); it != choices_replacement.end()) {
-        rule.body_expr_id = it->second;
-      }
-      if (auto it = choices_replacement.find(rule.lookahead_assertion_id);
-          it != choices_replacement.end()) {
-        rule.lookahead_assertion_id = it->second;
-      }
-    }
-    const int32_t total_num_exprs = grammar_ref->NumGrammarExprs();
-    for (int32_t expr_id = 0; expr_id < total_num_exprs; ++expr_id) {
-      auto expr = grammar_ref->GetGrammarExpr(expr_id);
-      if (expr.type != GrammarExprType::kSequence && expr.type != GrammarExprType::kChoices) {
-        continue;
-      }
-      for (int32_t i = 0; i < expr.size(); ++i) {
-        if (auto it = choices_replacement.find(expr[i]); it != choices_replacement.end()) {
-          expr.SetData(i, it->second);
-        }
-      }
-    }
+    RedirectExprReferences(&builder, choices_replacement);
+    *grammar = builder.Get(original->GetRootRuleId());
   }
 
  private:
+  bool ChoicesNeedInlining(const Grammar& grammar, const Grammar::Impl::GrammarExpr& expr) {
+    for (int32_t choice_id : expr) {
+      auto choice_expr = grammar->GetGrammarExpr(choice_id);
+      if (choice_expr.type != GrammarExprType::kSequence || choice_expr.size() == 0) {
+        continue;
+      }
+      auto first_element = grammar->GetGrammarExpr(choice_expr[0]);
+      if (first_element.type == GrammarExprType::kRuleRef &&
+          CanRuleBeInlined(grammar, first_element[0])) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * The rule should be: a sequence of choices, cannot be empty, cannot refer to other rules
    */
@@ -2719,91 +2709,81 @@ class GrammarOptimizerImpl {
 };
 
 /*!
- * \brief Fuse adjacent byte string elements in sequences, in place.
- * \details Fused byte strings are appended to the grammar's expr storage and each rewritten
- * sequence record is shrunk in place (records are self-describing, so the trailing words simply
- * become unused). Before the first rewrite, the grammar handle is replaced with a copy so that
- * other holders of the same grammar are unaffected. Stale records left behind are removed later
- * by DeadCodeEliminator.
+ * \brief Fuse adjacent byte string elements in sequences.
+ * \details The pass first scans the grammar; if no sequence contains adjacent byte strings, the
+ * grammar is left unchanged. Otherwise the grammar is copied into a GrammarBuilder, the fused
+ * byte strings and the rewritten sequences are added as new exprs (expr ids are preserved by the
+ * copy), and all references to the replaced sequences are redirected. Stale exprs are removed
+ * later by DeadCodeEliminator.
  */
 class ByteStringFuserImpl {
  public:
   using GrammarExprType = Grammar::Impl::GrammarExprType;
 
   static void Apply(Grammar* grammar) {
-    auto& grammar_ref = *grammar;
-    bool owned = false;
-    const int32_t num_exprs = grammar_ref->NumGrammarExprs();
-    std::vector<int32_t> element_ids;
-    std::vector<int32_t> new_element_ids;
-    std::vector<int32_t> fused_bytes;
-    for (int32_t expr_id = 0; expr_id < num_exprs; ++expr_id) {
-      {
-        auto expr = grammar_ref->GetGrammarExpr(expr_id);
-        if (expr.type != GrammarExprType::kSequence) {
-          continue;
-        }
-        bool needs_fusing = false;
-        bool previous_is_byte_string = false;
-        for (int32_t element_id : expr) {
-          bool current_is_byte_string =
-              grammar_ref->GetGrammarExpr(element_id).type == GrammarExprType::kByteString;
-          if (previous_is_byte_string && current_is_byte_string) {
-            needs_fusing = true;
-            break;
-          }
-          previous_is_byte_string = current_is_byte_string;
-        }
-        if (!needs_fusing) {
-          continue;
-        }
-        // The element ids are copied out first because appending new records may reallocate the
-        // storage the expr view points into.
-        element_ids.assign(expr.begin(), expr.end());
-      }
+    const Grammar& original = *grammar;
+    const int32_t num_exprs = original->NumGrammarExprs();
 
-      if (!owned) {
-        // Copy before the first rewrite so that other holders of this grammar are unaffected.
-        grammar_ref = GrammarBuilder(grammar_ref).Get(grammar_ref->GetRootRuleId());
-        owned = true;
-      }
-
-      new_element_ids.clear();
-      const int32_t element_count = static_cast<int32_t>(element_ids.size());
-      int32_t run_begin = -1;
-      for (int32_t i = 0; i <= element_count; ++i) {
-        bool is_byte_string =
-            i < element_count &&
-            grammar_ref->GetGrammarExpr(element_ids[i]).type == GrammarExprType::kByteString;
-        if (is_byte_string) {
-          if (run_begin == -1) {
-            run_begin = i;
-          }
-          continue;
-        }
-        if (run_begin != -1) {
-          if (i - run_begin == 1) {
-            new_element_ids.push_back(element_ids[run_begin]);
-          } else {
-            fused_bytes.clear();
-            for (int32_t j = run_begin; j < i; ++j) {
-              auto byte_string_expr = grammar_ref->GetGrammarExpr(element_ids[j]);
-              fused_bytes.insert(
-                  fused_bytes.end(), byte_string_expr.begin(), byte_string_expr.end()
-              );
-            }
-            new_element_ids.push_back(
-                grammar_ref->AddGrammarExpr(GrammarExprType::kByteString, fused_bytes)
-            );
-          }
-          run_begin = -1;
-        }
-        if (i < element_count) {
-          new_element_ids.push_back(element_ids[i]);
-        }
-      }
-      grammar_ref->ShrinkGrammarExprData(expr_id, new_element_ids);
+    bool needs_fusing = false;
+    for (int32_t expr_id = 0; expr_id < num_exprs && !needs_fusing; ++expr_id) {
+      auto expr = original->GetGrammarExpr(expr_id);
+      needs_fusing = expr.type == GrammarExprType::kSequence && SequenceNeedsFusing(original, expr);
     }
+    if (!needs_fusing) {
+      return;
+    }
+
+    GrammarBuilder builder(original);
+    std::unordered_map<int32_t, int32_t> sequence_replacement;
+    for (int32_t expr_id = 0; expr_id < num_exprs; ++expr_id) {
+      auto expr = original->GetGrammarExpr(expr_id);
+      if (expr.type != GrammarExprType::kSequence || !SequenceNeedsFusing(original, expr)) {
+        continue;
+      }
+      std::vector<int32_t> new_element_ids;
+      std::vector<int32_t> fused_bytes;
+      for (int32_t i = 0; i < expr.size(); ++i) {
+        if (original->GetGrammarExpr(expr[i]).type != GrammarExprType::kByteString) {
+          new_element_ids.push_back(expr[i]);
+          continue;
+        }
+        // Find the run of adjacent byte strings starting at i.
+        int32_t run_end = i + 1;
+        while (run_end < expr.size() &&
+               original->GetGrammarExpr(expr[run_end]).type == GrammarExprType::kByteString) {
+          ++run_end;
+        }
+        if (run_end - i == 1) {
+          new_element_ids.push_back(expr[i]);
+        } else {
+          fused_bytes.clear();
+          for (int32_t j = i; j < run_end; ++j) {
+            auto byte_string_expr = original->GetGrammarExpr(expr[j]);
+            fused_bytes.insert(fused_bytes.end(), byte_string_expr.begin(), byte_string_expr.end());
+          }
+          new_element_ids.push_back(builder.AddByteString(fused_bytes));
+        }
+        i = run_end - 1;
+      }
+      sequence_replacement[expr_id] = builder.AddSequence(new_element_ids);
+    }
+
+    RedirectExprReferences(&builder, sequence_replacement);
+    *grammar = builder.Get(original->GetRootRuleId());
+  }
+
+ private:
+  static bool SequenceNeedsFusing(const Grammar& grammar, const Grammar::Impl::GrammarExpr& expr) {
+    bool previous_is_byte_string = false;
+    for (int32_t element_id : expr) {
+      bool current_is_byte_string =
+          grammar->GetGrammarExpr(element_id).type == GrammarExprType::kByteString;
+      if (previous_is_byte_string && current_is_byte_string) {
+        return true;
+      }
+      previous_is_byte_string = current_is_byte_string;
+    }
+    return false;
   }
 };
 

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -590,6 +590,9 @@ class InPlaceGrammarRewriter {
   void Apply(Grammar* grammar) {
     grammar_ = grammar;
     builder_ = GrammarBuilder::FromMutableGrammar(grammar);
+    // Expr ids are dense, so the memo is a plain array over the original exprs. Appended exprs
+    // are never visited again, so they need no memo slots.
+    memo_.assign(builder_.NumGrammarExprs(), -1);
     Prepare();
     int32_t num_rules = builder_.NumRules();
     for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
@@ -616,8 +619,9 @@ class InPlaceGrammarRewriter {
 
   /*! \brief Visit an expr; return its rewritten id, or the original id when nothing changed. */
   int32_t VisitExpr(int32_t expr_id) {
-    if (auto it = memo_.find(expr_id); it != memo_.end()) {
-      return it->second;
+    XGRAMMAR_DCHECK(expr_id < static_cast<int32_t>(memo_.size()));
+    if (memo_[expr_id] != -1) {
+      return memo_[expr_id];
     }
     int32_t result;
     switch (builder_.GetGrammarExpr(expr_id).type) {
@@ -640,17 +644,24 @@ class InPlaceGrammarRewriter {
   /*! \brief Rebuild a choices, recursing into each choice. Overridden to add rewriting. */
   virtual int32_t VisitChoices(int32_t expr_id) { return RebuildContainer(expr_id, true); }
 
-  /*! \brief Recurse into a sequence or choices; append a rebuilt expr only if a child changed. */
+  /*! \brief Recurse into a sequence or choices; append a rebuilt expr only if a child changed.
+   * No memory is allocated when no child changes. */
   int32_t RebuildContainer(int32_t expr_id, bool is_choices) {
-    auto expr = builder_.GetGrammarExpr(expr_id);
-    std::vector<int32_t> child_ids(expr.begin(), expr.end());
+    int32_t size = builder_.GetGrammarExpr(expr_id).size();
     std::vector<int32_t> new_child_ids;
-    new_child_ids.reserve(child_ids.size());
     bool changed = false;
-    for (int32_t child_id : child_ids) {
+    for (int32_t i = 0; i < size; ++i) {
+      // Re-fetch the expr each iteration: visiting a child may append to the arena and
+      // invalidate previously fetched views.
+      int32_t child_id = builder_.GetGrammarExpr(expr_id)[i];
       int32_t new_child_id = VisitExpr(child_id);
-      changed |= new_child_id != child_id;
-      new_child_ids.push_back(new_child_id);
+      if (!changed && new_child_id != child_id) {
+        changed = true;
+        CopyChildrenPrefix(expr_id, i, &new_child_ids);
+      }
+      if (changed) {
+        new_child_ids.push_back(new_child_id);
+      }
     }
     if (!changed) {
       return expr_id;
@@ -658,10 +669,18 @@ class InPlaceGrammarRewriter {
     return is_choices ? builder_.AddChoices(new_child_ids) : builder_.AddSequence(new_child_ids);
   }
 
+  /*! \brief Copy the first count children of expr into *out. Used to materialize the already
+   * scanned, unchanged prefix once the first change is discovered. */
+  void CopyChildrenPrefix(int32_t expr_id, int32_t count, std::vector<int32_t>* out) {
+    auto expr = builder_.GetGrammarExpr(expr_id);
+    out->reserve(expr.size());
+    out->insert(out->end(), expr.begin(), expr.begin() + count);
+  }
+
   GrammarBuilder builder_;
   Grammar* grammar_;
-  // Maps an original expr id to its rewritten id (or itself when unchanged).
-  std::unordered_map<int32_t, int32_t> memo_;
+  // Maps an original expr id to its rewritten id (or itself when unchanged); -1 means unvisited.
+  std::vector<int32_t> memo_;
 };
 
 /*!
@@ -684,14 +703,17 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
     for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
       original_body_expr_ids_.push_back(builder_.GetRule(rule_id).body_expr_id);
     }
+    can_rule_be_inlined_.assign(num_rules, -1);
   }
 
   int32_t VisitChoices(int32_t expr_id) override {
-    auto expr = builder_.GetGrammarExpr(expr_id);
-    std::vector<int32_t> choice_ids(expr.begin(), expr.end());
+    int32_t size = builder_.GetGrammarExpr(expr_id).size();
     std::vector<int32_t> new_choice_ids;
     bool changed = false;
-    for (int32_t choice_id : choice_ids) {
+    for (int32_t i = 0; i < size; ++i) {
+      // Re-fetch views each iteration: rewriting may append to the arena and invalidate
+      // previously fetched views.
+      int32_t choice_id = builder_.GetGrammarExpr(expr_id)[i];
       auto choice_expr = builder_.GetGrammarExpr(choice_id);
       int32_t inline_rule_id = -1;
       if (choice_expr.type == GrammarExprType::kSequence && choice_expr.size() > 0) {
@@ -702,11 +724,21 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
       }
       if (inline_rule_id == -1) {
         int32_t new_choice_id = VisitExpr(choice_id);
-        changed |= new_choice_id != choice_id;
-        new_choice_ids.push_back(new_choice_id);
+        if (!changed && new_choice_id != choice_id) {
+          changed = true;
+          CopyChildrenPrefix(expr_id, i, &new_choice_ids);
+        }
+        if (changed) {
+          new_choice_ids.push_back(new_choice_id);
+        }
         continue;
       }
+      if (!changed) {
+        changed = true;
+        CopyChildrenPrefix(expr_id, i, &new_choice_ids);
+      }
       // Do inlining: prepend each choice of the referenced rule to the rest of this sequence.
+      // Copy the needed element ids before appending anything.
       std::vector<int32_t> rest_element_ids(choice_expr.begin() + 1, choice_expr.end());
       auto ref_body = builder_.GetGrammarExpr(original_body_expr_ids_[inline_rule_id]);
       std::vector<int32_t> ref_choice_ids(ref_body.begin(), ref_body.end());
@@ -717,7 +749,6 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
         new_sequence.insert(new_sequence.end(), rest_element_ids.begin(), rest_element_ids.end());
         new_choice_ids.push_back(builder_.AddSequence(new_sequence));
       }
-      changed = true;
     }
     if (!changed) {
       return expr_id;
@@ -729,8 +760,8 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
   /*! \brief A rule can be inlined iff its body is a non-empty choices of sequences that contain no
    * rule references. Judged on the original grammar via original_body_expr_ids_. */
   bool CanRuleBeInlined(int32_t rule_id) {
-    if (auto it = can_rule_be_inlined_.find(rule_id); it != can_rule_be_inlined_.end()) {
-      return it->second;
+    if (can_rule_be_inlined_[rule_id] != -1) {
+      return can_rule_be_inlined_[rule_id] != 0;
     }
     const auto& rule = (*grammar_)->GetRule(rule_id);
     // Inlining a budgeted rule would erase the rule its length budget applies to. Inlining a
@@ -768,13 +799,14 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
         }
       }
     }
-    can_rule_be_inlined_[rule_id] = result;
+    can_rule_be_inlined_[rule_id] = result ? 1 : 0;
     return result;
   }
 
   // Rule body expr ids captured before any rewriting, for order-independent inlinability checks.
   std::vector<int32_t> original_body_expr_ids_;
-  std::unordered_map<int32_t, bool> can_rule_be_inlined_;
+  // Per-rule cache of CanRuleBeInlined: -1 unknown, 0 false, 1 true.
+  std::vector<int8_t> can_rule_be_inlined_;
 };
 
 /*!
@@ -2696,8 +2728,10 @@ class GrammarOptimizerImpl {
  public:
   static Grammar Apply(const Grammar& grammar) {
     // ByteStringFuser and RuleInliner rewrite the grammar in place, so work on a private copy: the
-    // input grammar may be shared (e.g. a cached grammar) and must not be mutated.
-    Grammar result = GrammarBuilder(grammar).Get(grammar->GetRootRuleId());
+    // input grammar may be shared (e.g. a cached grammar) and must not be mutated. Copy the impl
+    // directly (contiguous vector copies) instead of going through GrammarBuilder, which would
+    // also build the unneeded rule name map.
+    Grammar result(std::make_shared<Grammar::Impl>(*grammar.operator->()));
     ByteStringFuser::Apply(&result);
     RuleInliner::Apply(&result);
     result = RepetitionRangeExpander::Apply(result);
@@ -2760,10 +2794,29 @@ class GrammarOptimizerImpl {
 class ByteStringFuserImpl : public InPlaceGrammarRewriter {
  protected:
   int32_t VisitSequence(int32_t expr_id) override {
+    // Read-only probe: rewrite only if the sequence contains two adjacent byte strings. The
+    // probe appends nothing, so no memory is allocated for the common unchanged case.
+    bool previous_is_byte_string = false;
+    bool has_adjacent_byte_strings = false;
+    {
+      auto expr = builder_.GetGrammarExpr(expr_id);
+      for (int32_t element_id : expr) {
+        bool is_byte_string =
+            builder_.GetGrammarExpr(element_id).type == GrammarExprType::kByteString;
+        if (is_byte_string && previous_is_byte_string) {
+          has_adjacent_byte_strings = true;
+          break;
+        }
+        previous_is_byte_string = is_byte_string;
+      }
+    }
+    if (!has_adjacent_byte_strings) {
+      return expr_id;
+    }
+    // Copy the element ids first: fusing appends to the arena and invalidates expr views.
     auto expr = builder_.GetGrammarExpr(expr_id);
     std::vector<int32_t> element_ids(expr.begin(), expr.end());
     std::vector<int32_t> new_element_ids;
-    bool changed = false;
     for (size_t i = 0; i < element_ids.size();) {
       if (builder_.GetGrammarExpr(element_ids[i]).type != GrammarExprType::kByteString) {
         new_element_ids.push_back(element_ids[i]);
@@ -2785,12 +2838,8 @@ class ByteStringFuserImpl : public InPlaceGrammarRewriter {
         new_element_ids.push_back(element_ids[i]);
       } else {
         new_element_ids.push_back(builder_.AddByteString(fused_bytes));
-        changed = true;
       }
       i = run_end;
-    }
-    if (!changed) {
-      return expr_id;
     }
     return builder_.AddSequence(new_element_ids);
   }

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -330,10 +330,10 @@ class StructureNormalizer {
 /*************************** Grammar Optimizer ***************************/
 
 /*!
- * \brief Fuse adjacent byte string elements in sequences, in place.
- * \details If any rewrite is needed, the grammar handle is first replaced with a copy so that
- * other holders of the same grammar are unaffected. If nothing needs rewriting, the pass is a
- * read-only scan.
+ * \brief Fuse adjacent byte string elements in sequences.
+ * \details If nothing needs rewriting, the pass is a read-only scan and the grammar is left
+ * unchanged. Otherwise the grammar handle is replaced with a rewritten copy, so other holders of
+ * the same grammar are unaffected.
  */
 class ByteStringFuser {
  public:
@@ -349,10 +349,10 @@ class AllowEmptyRuleAnalyzer {
 };
 
 /*!
- * \brief Inline the rule references in the grammar, in place.
- * \details If any rewrite is needed, the grammar handle is first replaced with a copy so that
- * other holders of the same grammar are unaffected. If nothing needs rewriting, the pass is a
- * read-only scan.
+ * \brief Inline the rule references in the grammar.
+ * \details If nothing needs rewriting, the pass is a read-only scan and the grammar is left
+ * unchanged. Otherwise the grammar handle is replaced with a rewritten copy, so other holders of
+ * the same grammar are unaffected.
  */
 class RuleInliner {
  public:

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -330,11 +330,14 @@ class StructureNormalizer {
 /*************************** Grammar Optimizer ***************************/
 
 /*!
- * \brief Fuse the byte string elements in the grammar.
+ * \brief Fuse adjacent byte string elements in sequences, in place.
+ * \details If any rewrite is needed, the grammar handle is first replaced with a copy so that
+ * other holders of the same grammar are unaffected. If nothing needs rewriting, the pass is a
+ * read-only scan.
  */
 class ByteStringFuser {
  public:
-  static Grammar Apply(const Grammar& grammar);
+  static void Apply(Grammar* grammar);
 };
 
 /*!
@@ -346,11 +349,14 @@ class AllowEmptyRuleAnalyzer {
 };
 
 /*!
- * \brief Inline the rule references in the grammar.
+ * \brief Inline the rule references in the grammar, in place.
+ * \details If any rewrite is needed, the grammar handle is first replaced with a copy so that
+ * other holders of the same grammar are unaffected. If nothing needs rewriting, the pass is a
+ * read-only scan.
  */
 class RuleInliner {
  public:
-  static Grammar Apply(const Grammar& grammar);
+  static void Apply(Grammar* grammar);
 };
 
 /*!

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -331,9 +331,9 @@ class StructureNormalizer {
 
 /*!
  * \brief Fuse adjacent byte string elements in sequences.
- * \details If nothing needs rewriting, the pass is a read-only scan and the grammar is left
- * unchanged. Otherwise the grammar handle is replaced with a rewritten copy, so other holders of
- * the same grammar are unaffected.
+ * \details Rewrites *grammar in place. Only sequences that actually contain adjacent byte strings
+ * are rewritten; if nothing needs fusing, the grammar is left untouched. The caller must own the
+ * grammar, as the input is mutated directly.
  */
 class ByteStringFuser {
  public:
@@ -350,9 +350,9 @@ class AllowEmptyRuleAnalyzer {
 
 /*!
  * \brief Inline the rule references in the grammar.
- * \details If nothing needs rewriting, the pass is a read-only scan and the grammar is left
- * unchanged. Otherwise the grammar handle is replaced with a rewritten copy, so other holders of
- * the same grammar are unaffected.
+ * \details Rewrites *grammar in place. Only choices with an inlinable leading rule reference are
+ * rewritten; if nothing can be inlined, the grammar is left untouched. The caller must own the
+ * grammar, as the input is mutated directly.
  */
 class RuleInliner {
  public:

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -231,6 +231,30 @@ class Grammar::Impl {
     return {type, data_ptr, data_len};
   }
 
+  /*!
+   * \brief Append a new grammar expr record and return its id. The data must not alias this
+   * grammar's own storage, because appending may reallocate it.
+   */
+  int32_t AddGrammarExpr(GrammarExprType type, const std::vector<int32_t>& data) {
+    grammar_expr_indptr_.push_back(static_cast<int32_t>(grammar_expr_data_.size()));
+    grammar_expr_data_.push_back(static_cast<int32_t>(type));
+    grammar_expr_data_.push_back(static_cast<int32_t>(data.size()));
+    grammar_expr_data_.insert(grammar_expr_data_.end(), data.begin(), data.end());
+    return static_cast<int32_t>(grammar_expr_indptr_.size()) - 1;
+  }
+
+  /*!
+   * \brief Overwrite the data of an existing grammar expr record in place. Records are stored
+   * back to back and are self-describing, so the new data must not be longer than the existing
+   * data; shrinking simply leaves the trailing words unused.
+   */
+  void ShrinkGrammarExprData(int32_t grammar_expr_id, const std::vector<int32_t>& data) {
+    int start_index = grammar_expr_indptr_[grammar_expr_id];
+    XGRAMMAR_DCHECK(static_cast<int32_t>(data.size()) <= grammar_expr_data_[start_index + 1]);
+    grammar_expr_data_[start_index + 1] = static_cast<int32_t>(data.size());
+    std::copy(data.begin(), data.end(), grammar_expr_data_.begin() + start_index + 2);
+  }
+
   /******************* GrammarExpr Getters *******************/
 
   /*! \brief Get the string of the byte string grammar expr. */

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -9,7 +9,6 @@
 
 #include <xgrammar/xgrammar.h>
 
-#include <algorithm>
 #include <cstddef>
 #include <optional>
 #include <string>
@@ -229,30 +228,6 @@ class Grammar::Impl {
     auto data_ptr = start_ptr + 2;
     auto data_len = start_ptr[1];
     return {type, data_ptr, data_len};
-  }
-
-  /*!
-   * \brief Append a new grammar expr record and return its id. The data must not alias this
-   * grammar's own storage, because appending may reallocate it.
-   */
-  int32_t AddGrammarExpr(GrammarExprType type, const std::vector<int32_t>& data) {
-    grammar_expr_indptr_.push_back(static_cast<int32_t>(grammar_expr_data_.size()));
-    grammar_expr_data_.push_back(static_cast<int32_t>(type));
-    grammar_expr_data_.push_back(static_cast<int32_t>(data.size()));
-    grammar_expr_data_.insert(grammar_expr_data_.end(), data.begin(), data.end());
-    return static_cast<int32_t>(grammar_expr_indptr_.size()) - 1;
-  }
-
-  /*!
-   * \brief Overwrite the data of an existing grammar expr record in place. Records are stored
-   * back to back and are self-describing, so the new data must not be longer than the existing
-   * data; shrinking simply leaves the trailing words unused.
-   */
-  void ShrinkGrammarExprData(int32_t grammar_expr_id, const std::vector<int32_t>& data) {
-    int start_index = grammar_expr_indptr_[grammar_expr_id];
-    XGRAMMAR_DCHECK(static_cast<int32_t>(data.size()) <= grammar_expr_data_[start_index + 1]);
-    grammar_expr_data_[start_index + 1] = static_cast<int32_t>(data.size());
-    std::copy(data.begin(), data.end(), grammar_expr_data_.begin() + start_index + 2);
   }
 
   /******************* GrammarExpr Getters *******************/

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -912,7 +912,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           [](O grammar_ref) {
             // The pass rewrites in place, so copy first to leave the input grammar unaffected.
             const Grammar& input = grammar_ref.as<GrammarObj>()->value;
-            Grammar grammar = GrammarBuilder(input).Get(input->GetRootRuleId());
+            Grammar grammar(std::make_shared<Grammar::Impl>(*input.operator->()));
             ByteStringFuser::Apply(&grammar);
             return ffi::ObjectRef(ffi::make_object<GrammarObj>(grammar));
           }
@@ -922,7 +922,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           [](O grammar_ref) {
             // The pass rewrites in place, so copy first to leave the input grammar unaffected.
             const Grammar& input = grammar_ref.as<GrammarObj>()->value;
-            Grammar grammar = GrammarBuilder(input).Get(input->GetRootRuleId());
+            Grammar grammar(std::make_shared<Grammar::Impl>(*input.operator->()));
             RuleInliner::Apply(&grammar);
             return ffi::ObjectRef(ffi::make_object<GrammarObj>(grammar));
           }

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -910,17 +910,19 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def(
           "xgrammar.tvm_ffi_binding.testing.grammar_functor.byte_string_fuser",
           [](O grammar_ref) {
-            return ffi::ObjectRef(ffi::make_object<GrammarObj>(
-                ByteStringFuser::Apply(grammar_ref.as<GrammarObj>()->value)
-            ));
+            // The pass copies the grammar before its first rewrite, so the input is unaffected.
+            Grammar grammar = grammar_ref.as<GrammarObj>()->value;
+            ByteStringFuser::Apply(&grammar);
+            return ffi::ObjectRef(ffi::make_object<GrammarObj>(grammar));
           }
       )
       .def(
           "xgrammar.tvm_ffi_binding.testing.grammar_functor.rule_inliner",
           [](O grammar_ref) {
-            return ffi::ObjectRef(ffi::make_object<GrammarObj>(
-                RuleInliner::Apply(grammar_ref.as<GrammarObj>()->value)
-            ));
+            // The pass copies the grammar before its first rewrite, so the input is unaffected.
+            Grammar grammar = grammar_ref.as<GrammarObj>()->value;
+            RuleInliner::Apply(&grammar);
+            return ffi::ObjectRef(ffi::make_object<GrammarObj>(grammar));
           }
       )
       .def(

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -910,7 +910,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def(
           "xgrammar.tvm_ffi_binding.testing.grammar_functor.byte_string_fuser",
           [](O grammar_ref) {
-            // The pass copies the grammar before its first rewrite, so the input is unaffected.
+            // The pass rewrites a copy if needed, so the input grammar is unaffected.
             Grammar grammar = grammar_ref.as<GrammarObj>()->value;
             ByteStringFuser::Apply(&grammar);
             return ffi::ObjectRef(ffi::make_object<GrammarObj>(grammar));
@@ -919,7 +919,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def(
           "xgrammar.tvm_ffi_binding.testing.grammar_functor.rule_inliner",
           [](O grammar_ref) {
-            // The pass copies the grammar before its first rewrite, so the input is unaffected.
+            // The pass rewrites a copy if needed, so the input grammar is unaffected.
             Grammar grammar = grammar_ref.as<GrammarObj>()->value;
             RuleInliner::Apply(&grammar);
             return ffi::ObjectRef(ffi::make_object<GrammarObj>(grammar));

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -910,8 +910,9 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def(
           "xgrammar.tvm_ffi_binding.testing.grammar_functor.byte_string_fuser",
           [](O grammar_ref) {
-            // The pass rewrites a copy if needed, so the input grammar is unaffected.
-            Grammar grammar = grammar_ref.as<GrammarObj>()->value;
+            // The pass rewrites in place, so copy first to leave the input grammar unaffected.
+            const Grammar& input = grammar_ref.as<GrammarObj>()->value;
+            Grammar grammar = GrammarBuilder(input).Get(input->GetRootRuleId());
             ByteStringFuser::Apply(&grammar);
             return ffi::ObjectRef(ffi::make_object<GrammarObj>(grammar));
           }
@@ -919,8 +920,9 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def(
           "xgrammar.tvm_ffi_binding.testing.grammar_functor.rule_inliner",
           [](O grammar_ref) {
-            // The pass rewrites a copy if needed, so the input grammar is unaffected.
-            Grammar grammar = grammar_ref.as<GrammarObj>()->value;
+            // The pass rewrites in place, so copy first to leave the input grammar unaffected.
+            const Grammar& input = grammar_ref.as<GrammarObj>()->value;
+            Grammar grammar = GrammarBuilder(input).Get(input->GetRootRuleId());
             RuleInliner::Apply(&grammar);
             return ffi::ObjectRef(ffi::make_object<GrammarObj>(grammar));
           }

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -199,6 +199,9 @@ class Grammar {
    */
   static std::variant<Grammar, SerializationError> DeserializeJSON(const std::string& json_string);
 
+  // Allow the builder to bind to this grammar's impl for in-place editing (FromMutableGrammar).
+  friend class GrammarBuilder;
+
   XGRAMMAR_DEFINE_PIMPL_METHODS(Grammar);
 };
 

--- a/tests/python/test_grammar_parser.py
+++ b/tests/python/test_grammar_parser.py
@@ -4,7 +4,11 @@ from typing import Optional
 import pytest
 
 import xgrammar as xgr
-from xgrammar.testing import GrammarFunctor, _ebnf_to_grammar_no_normalization
+from xgrammar.testing import (
+    GrammarFunctor,
+    _ebnf_to_grammar_no_normalization,
+    _get_allow_empty_rule_ids,
+)
 
 
 def test_basic_string_literal():
@@ -544,6 +548,16 @@ rule1 ::= (("a" [a-z]*) | ("b"))
 rule2 ::= (("b") | ("c" [b-c]))
 """,
     ),
+    (
+        r"""root ::= rule1 (rule2 "y")
+rule1 ::= "a" | "b"
+rule2 ::= "c" | "d"
+""",
+        r"""root ::= (("a" (("c" "y") | ("d" "y"))) | ("b" (("c" "y") | ("d" "y"))))
+rule1 ::= (("a") | ("b"))
+rule2 ::= (("c") | ("d"))
+""",
+    ),
 ]
 
 
@@ -659,6 +673,30 @@ rule1 ::= (("ab")) (=(("cd")))
     grammar = _ebnf_to_grammar_no_normalization(before)
     grammar = GrammarFunctor.byte_string_fuser(grammar)
     assert str(grammar) == expected
+
+
+def test_byte_string_fuser_removes_empty_byte_strings():
+    structural_tag = {
+        "type": "structural_tag",
+        "format": {
+            "type": "triggered_tags",
+            "triggers": ["<t>"],
+            "tags": [
+                {
+                    "type": "tag",
+                    "begin": "<t>",
+                    "content": {"type": "const_string", "value": ""},
+                    "end": "",
+                }
+            ],
+        },
+    }
+    grammar = xgr.Grammar.from_structural_tag(structural_tag)
+    fused = GrammarFunctor.byte_string_fuser(grammar)
+    assert "triggered_tags_group ::= ((const_string))\n" in str(fused)
+
+    compiled = xgr.GrammarCompiler(xgr.TokenizerInfo([])).compile_grammar(grammar)
+    assert _get_allow_empty_rule_ids(compiled) == [0, 1, 2, 3]
 
 
 def test_optimizer_passes_do_not_mutate_input():

--- a/tests/python/test_grammar_parser.py
+++ b/tests/python/test_grammar_parser.py
@@ -555,6 +555,147 @@ def test_rule_inliner(before: str, expected: str):
     assert after == expected
 
 
+before__expected__test_rule_inliner_no_rewrite = [
+    # A rule with an empty-string choice is not inlined.
+    (
+        r"""root ::= rule1 "x"
+rule1 ::= "a" | ""
+""",
+        r"""root ::= ((rule1 "x"))
+rule1 ::= ("" | ("a"))
+""",
+    ),
+    # A rule whose body contains a rule reference is not inlined.
+    (
+        r"""root ::= rule1 "x"
+rule1 ::= "a" rule2 | "b"
+rule2 ::= "c"
+""",
+        r"""root ::= ((rule1 "x"))
+rule1 ::= (("a" rule2) | ("b"))
+rule2 ::= (("c"))
+""",
+    ),
+    # Only a rule reference at the start of a sequence triggers inlining.
+    (
+        r"""root ::= "x" rule1
+rule1 ::= "a" | "b"
+""",
+        r"""root ::= (("x" rule1))
+rule1 ::= (("a") | ("b"))
+""",
+    ),
+]
+
+
+@pytest.mark.parametrize("before, expected", before__expected__test_rule_inliner_no_rewrite)
+def test_rule_inliner_no_rewrite(before: str, expected: str):
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    grammar = GrammarFunctor.structure_normalizer(grammar)
+    grammar = GrammarFunctor.rule_inliner(grammar)
+    after = str(grammar)
+    assert after == expected
+
+
+def test_rule_inliner_preserves_lookahead_assertion():
+    """When the inliner rewrites a rule body, the rule's lookahead assertion must be kept."""
+    before = r"""root ::= rule2
+rule2 ::= rule1 "x" (= "q" "r")
+rule1 ::= "a" | "b"
+"""
+    expected = r"""root ::= ((rule2))
+rule2 ::= (("a" "x") | ("b" "x")) (=(("q" "r")))
+rule1 ::= (("a") | ("b"))
+"""
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    grammar = GrammarFunctor.rule_inliner(grammar)
+    assert str(grammar) == expected
+
+
+before__expected__test_byte_string_fuser = [
+    # A whole run of adjacent byte strings is fused into one.
+    (
+        r"""root ::= "a" "b" "c"
+""",
+        r"""root ::= (("abc"))
+""",
+    ),
+    # Runs are split by non-byte-string elements; fusing also applies inside choices.
+    (
+        r"""root ::= "a" "b" [0-9] "c" "d" rule1
+rule1 ::= "x" "y" | [a-z]
+""",
+        r"""root ::= (("ab" [0-9] "cd" rule1))
+rule1 ::= (("xy") | ([a-z]))
+""",
+    ),
+    # Nothing to fuse: the grammar stays unchanged.
+    (
+        r"""root ::= "a" [0-9] "b" | rule1
+rule1 ::= [x]
+""",
+        r"""root ::= (("a" [0-9] "b") | (rule1))
+rule1 ::= (([x]))
+""",
+    ),
+]
+
+
+@pytest.mark.parametrize("before, expected", before__expected__test_byte_string_fuser)
+def test_byte_string_fuser(before: str, expected: str):
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    grammar = GrammarFunctor.byte_string_fuser(grammar)
+    assert str(grammar) == expected
+
+
+def test_byte_string_fuser_lookahead_assertion():
+    """Byte strings inside lookahead assertions are fused as well."""
+    before = r"""root ::= "x" rule1
+rule1 ::= "a" "b" (= "c" "d")
+"""
+    expected = r"""root ::= (("x" rule1))
+rule1 ::= (("ab")) (=(("cd")))
+"""
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    grammar = GrammarFunctor.byte_string_fuser(grammar)
+    assert str(grammar) == expected
+
+
+def test_optimizer_passes_do_not_mutate_input():
+    """The passes rewrite a copy: the caller's grammar object must stay unchanged."""
+    fuser_before = r"""root ::= "a" "b" rule1
+rule1 ::= "c" | "d"
+"""
+    grammar = _ebnf_to_grammar_no_normalization(fuser_before)
+    before_str = str(grammar)
+    fused = GrammarFunctor.byte_string_fuser(grammar)
+    assert str(grammar) == before_str
+    assert str(fused) != before_str
+
+    inliner_before = r"""root ::= rule1 "x"
+rule1 ::= "a" | "b"
+"""
+    grammar = _ebnf_to_grammar_no_normalization(inliner_before)
+    before_str = str(grammar)
+    inlined = GrammarFunctor.rule_inliner(grammar)
+    assert str(grammar) == before_str
+    assert str(inlined) != before_str
+
+    optimizer_before = r"""root ::= rule1 "x" | "y"
+rule1 ::= "a" | "b"
+"""
+    grammar = xgr.Grammar.from_ebnf(optimizer_before)
+    before_str = str(grammar)
+    optimized = GrammarFunctor.grammar_optimizer(grammar)
+    assert str(grammar) == before_str
+    assert str(optimized) == 'root ::= (("a" "x") | ("b" "x") | ("y"))\n'
+
+    # Compiling must not mutate the caller's grammar either.
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]))
+    compiler.compile_grammar(grammar)
+    assert str(grammar) == before_str
+
+
 before__expected__test_dead_code_eliminator = [
     # Test basic dead code elimination
     (


### PR DESCRIPTION
## 改动

语法优化器中的字节串合并会把相邻字面字符串合成一段，规则内联会用规则内容替换引用。旧实现每次执行都重建整份语法树，包括未改变的子树。本请求把两个阶段改为单次遍历的原地重写：

- 未变子树保留原编号，只为发生变化的容器追加新记录。
- 字节串合并先检查序列是否真的需要改写，规则内联只重建受影响的选择。
- 规则名称查找表改为首次按名称操作时再构造，只使用数字编号的重写不再支付字符串摘要成本。
- 不使用的旧表达式记录由紧随其后的无用代码删除阶段统一清理。

同时修正两个正确性问题：从序列中删除空字节串，保持空规则分析正确；规则内联时递归访问新复制的嵌套表达式与序列剩余元素。

## 性能

使用发布构建，每个版本交替运行两组，每组 15 个样本，下列结果为 30 个样本的中位数。

单独优化阶段：

- 字节串合并，无需改写：216.45 -> 35.24 微秒，快 6.14 倍。
- 字节串合并，需要改写：273.26 -> 186.05 微秒，快 1.47 倍。
- 规则内联，无需改写：219.50 -> 48.20 微秒，快 4.55 倍。
- 规则内联，需要改写：456.73 -> 193.93 微秒，快 2.36 倍。

完整流程：

- 在同时触发两个阶段的 501 条规则语法上，完整语法优化从 15.581 毫秒降到 15.414 毫秒，减少 1.1%；从扩展巴科斯范式（Extended Backus-Naur Form，EBNF）文本开始的全流程从 17.882 毫秒降到 17.819 毫秒，减少 0.4%。
- 包含 200 个必需字符串属性的 JSON Schema（用于描述 JSON 数据结构的规格）首次编译从 7.221 毫秒降到 6.732 毫秒，降低 6.8%，快 1.07 倍。

## 验证

- 新增字节串合并、规则内联、无需改写、前瞻断言和输入语法不可变的专项测试。
- 新增空字节串影响空规则分析，以及外层内联后遗漏嵌套表达式的回归测试。
- 语法解析 67 项、Lark 语法转换 338 项、生成温度 34 项、空规则编译 4 项和结构化标签 1,024 项 Python 语言测试全部通过。Lark 在这里指项目支持的一种语法文本格式。
- 发布构建、格式检查和提交前检查通过。
