### PR TITLE
Add EBNF and Lark sampling temperature support

### DIFF
--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -99,6 +99,11 @@ void EarleyParser::RecordCaptureEvent(const ParserState& state, bool marker_pres
   );
 }
 
+int32_t EarleyParser::ResolveActiveTemperatureRule(int32_t rule_id, int32_t inherited_rule_id)
+    const {
+  return grammar_->GetRule(rule_id).temperature.has_value() ? rule_id : inherited_rule_id;
+}
+
 void EarleyParser::PopLastStates(int32_t cnt) {
   stop_token_is_accepted_ = false;
   if (cnt >= static_cast<int32_t>(rule_id_to_completable_states_.size())) {
@@ -159,7 +164,11 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
             parent_state.sequence_id,
             parent_state.element_id + 1,
             parent_state.rule_start_pos,
-            parent_state.budget_deadline
+            parent_state.budget_deadline,
+            0,
+            0,
+            0,
+            parent_state.active_temperature_rule_id
         });
         continue;
       }
@@ -177,7 +186,11 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
             parent_state.sequence_id,
             parent_state.element_id + 1,
             parent_state.rule_start_pos,
-            parent_state.budget_deadline
+            parent_state.budget_deadline,
+            0,
+            0,
+            0,
+            parent_state.active_temperature_rule_id
         });
       }
       // If the repeat count is less than the max repeat count, we can continue to
@@ -206,7 +219,11 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
             parent_state.sequence_id,
             edge.target,
             parent_state.rule_start_pos,
-            parent_state.budget_deadline
+            parent_state.budget_deadline,
+            0,
+            0,
+            0,
+            parent_state.active_temperature_rule_id
         });
       }
       if (new_count < info.Upper()) {
@@ -217,7 +234,9 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
             parent_state.rule_start_pos,
             parent_state.budget_deadline,
             0,
-            new_count
+            new_count,
+            0,
+            parent_state.active_temperature_rule_id
         });
       }
       break;
@@ -263,7 +282,11 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
             state.sequence_id,
             state.element_id + 1,
             state.rule_start_pos,
-            state.budget_deadline
+            state.budget_deadline,
+            0,
+            0,
+            0,
+            state.active_temperature_rule_id
         });
       }
       return std::make_pair(true, false);
@@ -281,7 +304,11 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
             state.sequence_id,
             state.element_id + 1,
             state.rule_start_pos,
-            state.budget_deadline
+            state.budget_deadline,
+            0,
+            0,
+            0,
+            state.active_temperature_rule_id
         });
       }
       return std::make_pair(false, false);
@@ -443,7 +470,11 @@ ParserState EarleyParser::RootInitialState() const {
       grammar_->GetRule(root_rule_id).body_expr_id,
       grammar_->per_rule_fsms[root_rule_id]->GetFsm().GetStart(),
       ParserState::kNoPrevInputPos,
-      DeadlineForRule(root_rule_id, -1)
+      DeadlineForRule(root_rule_id, -1),
+      0,
+      0,
+      0,
+      ResolveActiveTemperatureRule(root_rule_id, -1)
   );
 }
 
@@ -557,7 +588,11 @@ void EarleyParser::ExpandNextRuleRefElement(
         state.sequence_id,
         state.element_id + 1,
         state.rule_start_pos,
-        state.budget_deadline
+        state.budget_deadline,
+        0,
+        0,
+        0,
+        state.active_temperature_rule_id
     });
   }
 
@@ -573,7 +608,11 @@ void EarleyParser::ExpandNextRuleRefElement(
       ref_fsm.GetFsm().GetStart(),
       right_recursion_to_root ? ParserState::kNoPrevInputPos
                               : int32_t(rule_id_to_completable_states_.size() - 1),
-      DeadlineForRule(ref_rule_id, state.budget_deadline)
+      DeadlineForRule(ref_rule_id, state.budget_deadline),
+      0,
+      0,
+      0,
+      ResolveActiveTemperatureRule(ref_rule_id, state.active_temperature_rule_id)
   });
 }
 
@@ -585,7 +624,15 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
   for (const auto& edge : fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
     if (edge.IsEpsilon()) {
       Enqueue(ParserState{
-          state.rule_id, state.sequence_id, edge.target, state.rule_start_pos, state.budget_deadline
+          state.rule_id,
+          state.sequence_id,
+          edge.target,
+          state.rule_start_pos,
+          state.budget_deadline,
+          0,
+          0,
+          0,
+          state.active_temperature_rule_id
       });
       continue;
     }
@@ -606,7 +653,15 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
 
       if (state.repeat_count >= repeat_info.Lower()) {
         Enqueue(ParserState{
-            state.rule_id, state.sequence_id, target, state.rule_start_pos, state.budget_deadline
+            state.rule_id,
+            state.sequence_id,
+            target,
+            state.rule_start_pos,
+            state.budget_deadline,
+            0,
+            0,
+            0,
+            state.active_temperature_rule_id
         });
       }
       if (state.repeat_count >= repeat_info.Upper()) {
@@ -666,7 +721,9 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
                  state.rule_start_pos,
                  state.budget_deadline,
                  0,
-                 state.repeat_count
+                 state.repeat_count,
+                 0,
+                 state.active_temperature_rule_id
              }}
         );
       } else {
@@ -678,7 +735,11 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
                  state.sequence_id,
                  target,
                  state.rule_start_pos,
-                 state.budget_deadline
+                 state.budget_deadline,
+                 0,
+                 0,
+                 0,
+                 state.active_temperature_rule_id
              }}
         );
       }
@@ -691,7 +752,15 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
                           ref_rule_id
                       )) {
       Enqueue(ParserState{
-          state.rule_id, state.sequence_id, target, state.rule_start_pos, state.budget_deadline
+          state.rule_id,
+          state.sequence_id,
+          target,
+          state.rule_start_pos,
+          state.budget_deadline,
+          0,
+          0,
+          0,
+          state.active_temperature_rule_id
       });
     }
 
@@ -707,7 +776,11 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
         ref_fsm.GetFsm().GetStart(),
         right_recursion_to_root ? ParserState::kNoPrevInputPos
                                 : int32_t(rule_id_to_completable_states_.size() - 1),
-        DeadlineForRule(ref_rule_id, state.budget_deadline)
+        DeadlineForRule(ref_rule_id, state.budget_deadline),
+        0,
+        0,
+        0,
+        ResolveActiveTemperatureRule(ref_rule_id, state.active_temperature_rule_id)
     });
   }
 }

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -51,7 +51,8 @@ struct ParserState {
       const int32_t& budget_deadline = -1,
       const int32_t& sub_element_id = 0,
       const int32_t& repeat_count = 0,
-      const int32_t& partial_codepoint = 0
+      const int32_t& partial_codepoint = 0,
+      const int32_t& active_temperature_rule_id = -1
   )
       : rule_id(rule_id),
         sequence_id(sequence_id),
@@ -60,7 +61,8 @@ struct ParserState {
         budget_deadline(budget_deadline),
         sub_element_id(sub_element_id),
         repeat_count(repeat_count),
-        partial_codepoint(partial_codepoint) {}
+        partial_codepoint(partial_codepoint),
+        active_temperature_rule_id(active_temperature_rule_id) {}
 
   /*!
    * \brief A rule_start_pos value of kNoPrevInputPos means this ParserState is the root of the
@@ -97,6 +99,9 @@ struct ParserState {
   /*! \brief Partial codepoint accumulated during UTF-8 decoding for positive character classes. */
   int32_t partial_codepoint = 0;
 
+  /*! \brief The innermost active rule that specifies a sampling temperature. */
+  int32_t active_temperature_rule_id = -1;
+
   /*!
    * \brief Lexicographic order over all fields. It is only used to sort the states for
    * deterministic serialization, and is not needed during parsing.
@@ -108,7 +113,10 @@ struct ParserState {
     if (rule_start_pos != other.rule_start_pos) return rule_start_pos < other.rule_start_pos;
     if (sub_element_id != other.sub_element_id) return sub_element_id < other.sub_element_id;
     if (repeat_count != other.repeat_count) return repeat_count < other.repeat_count;
-    return partial_codepoint < other.partial_codepoint;
+    if (partial_codepoint != other.partial_codepoint) {
+      return partial_codepoint < other.partial_codepoint;
+    }
+    return active_temperature_rule_id < other.active_temperature_rule_id;
   }
 
   friend std::ostream& operator<<(std::ostream& os, const ParserState& state) {
@@ -131,6 +139,9 @@ struct ParserState {
     if (budget_deadline != -1) {
       result += ", budget_deadline=" + std::to_string(budget_deadline);
     }
+    if (active_temperature_rule_id != -1) {
+      result += ", active_temperature_rule_id=" + std::to_string(active_temperature_rule_id);
+    }
     result += ")";
     return result;
   }
@@ -145,7 +156,8 @@ XGRAMMAR_MEMBER_ARRAY(
     &ParserState::budget_deadline,
     &ParserState::sub_element_id,
     &ParserState::repeat_count,
-    &ParserState::partial_codepoint
+    &ParserState::partial_codepoint,
+    &ParserState::active_temperature_rule_id
 );
 
 /*!
@@ -183,7 +195,8 @@ class StateEqualForParsing {
            lhs.element_id == rhs.element_id && lhs.rule_start_pos == rhs.rule_start_pos &&
            lhs.sub_element_id == rhs.sub_element_id && lhs.repeat_count == rhs.repeat_count &&
            lhs.partial_codepoint == rhs.partial_codepoint &&
-           lhs.budget_deadline == rhs.budget_deadline;
+           lhs.budget_deadline == rhs.budget_deadline &&
+           lhs.active_temperature_rule_id == rhs.active_temperature_rule_id;
   }
 };
 
@@ -202,7 +215,8 @@ class StateHashForParsing {
         state.sub_element_id,
         state.repeat_count,
         state.partial_codepoint,
-        state.budget_deadline
+        state.budget_deadline,
+        state.active_temperature_rule_id
     );
   }
 };
@@ -459,6 +473,9 @@ class EarleyParser {
 
   /*! \brief The initial state expanded from the root rule of the grammar. */
   ParserState RootInitialState() const;
+
+  /*! \brief Resolve the active temperature rule when entering a rule. */
+  int32_t ResolveActiveTemperatureRule(int32_t rule_id, int32_t inherited_rule_id) const;
 
   /*!
    * \brief Expand the rule, used for RuleRef and kTagDispatch.

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -263,6 +263,12 @@ void GrammarBuilder::UpdateLookaheadExact(int32_t rule_id, bool is_exact) {
   grammar_->rules_[rule_id].is_exact_lookahead = is_exact;
 }
 
+void GrammarBuilder::UpdateRuleTemperature(int32_t rule_id, std::optional<float> temperature) {
+  XGRAMMAR_CHECK(rule_id >= 0 && rule_id < static_cast<int32_t>(grammar_->rules_.size()))
+      << "Rule id " << rule_id << " is out of range.";
+  grammar_->rules_[rule_id].temperature = temperature;
+}
+
 void GrammarBuilder::UpdateLookaheadAssertion(
     std::string rule_name, int32_t lookahead_assertion_id
 ) {

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -10,6 +10,7 @@
 #include <xgrammar/xgrammar.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -196,6 +197,9 @@ class GrammarBuilder {
   void UpdateLookaheadAssertion(int32_t rule_id, int32_t lookahead_assertion_id);
 
   void UpdateLookaheadExact(int32_t rule_id, bool is_exact = true);
+
+  /*! \brief Set the sampling temperature associated with a rule. */
+  void UpdateRuleTemperature(int32_t rule_id, std::optional<float> temperature);
 
   /*!
    * \brief Add a lookahead assertion to a rule referred by the given name. The lookahead

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -80,6 +80,7 @@ class SubGrammarAdderImpl : public GrammarMutator {
         builder_->UpdateSuffixStopInfo(new_rule_ids_names[i].first, remapped_info);
       }
       builder_->UpdateLazy(new_rule_ids_names[i].first, rule.is_lazy);
+      builder_->UpdateRuleTemperature(new_rule_ids_names[i].first, rule.temperature);
     }
     return new_rule_ids_names[base_grammar_->GetRootRuleId()].first;
   }
@@ -290,6 +291,7 @@ class StructureNormalizerImpl : public GrammarMutator {
         builder_->UpdateSuffixStopInfo(i, *suffix_stop_info);
       }
       builder_->UpdateLazy(i, rule.is_lazy);
+      builder_->UpdateRuleTemperature(i, rule.temperature);
     }
     return builder_->Get(base_grammar_->GetRootRule().name);
   }
@@ -637,8 +639,10 @@ class RuleInlinerImpl : public GrammarMutator {
     // Inlining a budgeted rule would erase the rule its token budget applies to. Inlining a
     // capture-relevant rule would eliminate its completion events, so its capture or hidden span
     // would never be recorded. Inlining a lazy rule would erase its committed-shortest semantics.
+    // Inlining a temperature rule would erase the rule its sampling temperature applies to.
     if (rule.max_tokens >= 0 || !rule.capture_name.empty() ||
-        base_grammar_->GetSuffixStopInfo(rule_id) != nullptr || rule.is_lazy) {
+        base_grammar_->GetSuffixStopInfo(rule_id) != nullptr || rule.is_lazy ||
+        rule.temperature.has_value()) {
       return false;
     }
     auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
@@ -758,6 +762,7 @@ class DeadCodeEliminatorImpl : public GrammarMutator {
         builder_->UpdateSuffixStopInfo(rule_id_map_[rule_id], remapped_info);
       }
       builder_->UpdateLazy(rule_id_map_[rule_id], rule.is_lazy);
+      builder_->UpdateRuleTemperature(rule_id_map_[rule_id], rule.temperature);
     }
     XGRAMMAR_CHECK(rule_id_map_.count(grammar->GetRootRuleId()) > 0);
     return builder_->Get(rule_id_map_[grammar->GetRootRuleId()]);
@@ -1905,10 +1910,11 @@ int32_t RepetitionRangeExpanderImpl::HandleRepetitionRange(
   int32_t grammar_expr_id = builder_->AddRuleRef(rule_id);
   const auto& ref_rule = base_grammar_->GetRule(rule_id);
   const auto& ref_rule_body = base_grammar_->GetGrammarExpr(ref_rule.body_expr_id);
-  // Keep the reference to budgeted, suffix/stop, and lazy rules: replacing it with the rule's
-  // content would erase the rule that the runtime semantics apply to.
+  // Keep the reference to budgeted, suffix/stop, lazy, and temperature rules: replacing it with
+  // the rule's content would erase the rule that the runtime semantics apply to.
   if (ref_rule.max_tokens < 0 && base_grammar_->GetSuffixStopInfo(rule_id) == nullptr &&
-      !ref_rule.is_lazy && ref_rule_body.type == GrammarBuilder::GrammarExprType::kChoices &&
+      !ref_rule.is_lazy && !ref_rule.temperature.has_value() &&
+      ref_rule_body.type == GrammarBuilder::GrammarExprType::kChoices &&
       ref_rule_body.size() == 1) {
     const auto& ref_choice = base_grammar_->GetGrammarExpr(ref_rule_body[0]);
     if (ref_choice.size() == 1) {

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -75,6 +75,7 @@ class GrammarFunctor {
           builder_->UpdateSuffixStopInfo(i, *suffix_stop_info);
         }
         builder_->UpdateLazy(i, rule.is_lazy);
+        builder_->UpdateRuleTemperature(i, rule.temperature);
       }
       return builder_->Get(base_grammar_->GetRootRule().name);
     } else {

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -92,6 +93,8 @@ class Grammar::Impl {
     /*! \brief Whether the rule matches with committed-shortest (lazy) semantics: at the first
      * position where the body can complete, it must complete. */
     bool is_lazy = false;
+    /*! \brief The sampling temperature to use while matching this rule. */
+    std::optional<float> temperature = std::nullopt;
   };
 
   /*! \brief Sparse per-rule metadata used to materialize suffix and stop captures. */
@@ -402,7 +405,8 @@ XGRAMMAR_MEMBER_ARRAY(
     &Grammar::Impl::Rule::is_exact_lookahead,
     &Grammar::Impl::Rule::max_tokens,
     &Grammar::Impl::Rule::capture_name,
-    &Grammar::Impl::Rule::is_lazy
+    &Grammar::Impl::Rule::is_lazy,
+    &Grammar::Impl::Rule::temperature
 );
 
 XGRAMMAR_MEMBER_ARRAY(

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -720,7 +720,7 @@ class BatchGrammarMatcher::Impl {
     }
   }
 
-  std::vector<std::optional<float>> BatchFillNextTokenBitmask(
+  void BatchFillNextTokenBitmask(
       std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
       const std::optional<std::vector<int32_t>>& indices,
@@ -1905,7 +1905,7 @@ int GrammarMatcher::Impl::GetNextUncertainToken(
   }
 }
 
-std::vector<std::optional<float>> BatchGrammarMatcher::Impl::BatchFillNextTokenBitmask(
+void BatchGrammarMatcher::Impl::BatchFillNextTokenBitmask(
     std::vector<GrammarMatcher>* matchers,
     DLTensor* next_token_bitmask,
     const std::optional<std::vector<int32_t>>& indices,
@@ -1914,7 +1914,6 @@ std::vector<std::optional<float>> BatchGrammarMatcher::Impl::BatchFillNextTokenB
   XGRAMMAR_CHECK(!indices.has_value() || indices->size() == matchers->size())
       << "The size of indices (" << (indices.has_value() ? indices->size() : 0)
       << ") should be the same as the size of matchers (" << matchers->size() << ").";
-  std::vector<std::optional<float>> temperatures(matchers->size());
   // Initialize the thread pool if needed. It should be initialized each time,
   // because ThreadPool cannot be reused after Join().
   if (max_threads_ > 1) {
@@ -1928,7 +1927,6 @@ std::vector<std::optional<float>> BatchGrammarMatcher::Impl::BatchFillNextTokenB
           << "The index " << index << " is out of range [0, " << next_token_bitmask->shape[0]
           << ") for batch_id " << i << ".";
       matcher->FillNextTokenBitmask(next_token_bitmask, index, debug_print);
-      temperatures[i] = matcher->GetTemperature();
     }
   } else {
     auto fill_next_token_mask = [&](int32_t batch_id) {
@@ -1938,14 +1936,12 @@ std::vector<std::optional<float>> BatchGrammarMatcher::Impl::BatchFillNextTokenB
           << "The index " << index << " is out of range [0, " << next_token_bitmask->shape[0]
           << ") for batch_id " << batch_id << ".";
       matcher->FillNextTokenBitmask(next_token_bitmask, index, debug_print);
-      temperatures[batch_id] = matcher->GetTemperature();
     };
     for (int i = 0; i < static_cast<int32_t>(matchers->size()); i++) {
       thread_pool_->Execute([fill_next_token_mask, i]() { fill_next_token_mask(i); });
     }
     thread_pool_->Join();
   }
-  return temperatures;
 }
 
 std::vector<uint8_t> BatchGrammarMatcher::Impl::BatchAcceptString(
@@ -2130,13 +2126,24 @@ std::string GrammarMatcher::_DebugPrintInternalState() const {
   return pimpl_->_DebugPrintInternalState();
 }
 
-std::vector<std::optional<float>> BatchGrammarMatcher::BatchFillNextTokenBitmask(
+void BatchGrammarMatcher::BatchFillNextTokenBitmask(
     std::vector<GrammarMatcher>* matchers,
     DLTensor* next_token_bitmask,
     const std::optional<std::vector<int32_t>>& indices,
     bool debug_print
 ) {
-  return pimpl_->BatchFillNextTokenBitmask(matchers, next_token_bitmask, indices, debug_print);
+  pimpl_->BatchFillNextTokenBitmask(matchers, next_token_bitmask, indices, debug_print);
+}
+
+std::vector<std::optional<float>> BatchGrammarMatcher::BatchGetTemperature(
+    const std::vector<GrammarMatcher>& matchers
+) {
+  std::vector<std::optional<float>> temperatures;
+  temperatures.reserve(matchers.size());
+  for (const auto& matcher : matchers) {
+    temperatures.push_back(matcher.GetTemperature());
+  }
+  return temperatures;
 }
 
 std::vector<uint8_t> BatchGrammarMatcher::BatchAcceptString(

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -11,7 +11,9 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <string>
 #include <thread>
@@ -57,6 +59,7 @@ bool TraverseDraftTreeRecursive(
     const int64_t* draft_tokens,
     GrammarMatcher& matcher,
     DLTensor* token_bitmask,
+    float* temperatures,
     double time_threshold,
     const TimePoint& start_time
 ) {
@@ -98,6 +101,10 @@ bool TraverseDraftTreeRecursive(
     if (token_accepted) {
       if (!matcher.IsTerminated()) {
         matcher.FillNextTokenBitmask(token_bitmask, current_position);
+        if (temperatures != nullptr) {
+          temperatures[current_position] =
+              matcher.GetTemperature().value_or(std::numeric_limits<float>::quiet_NaN());
+        }
 
         if (retrieve_next_token[current_position] != -1) {
           bool success = TraverseDraftTreeRecursive(
@@ -108,6 +115,7 @@ bool TraverseDraftTreeRecursive(
               draft_tokens,
               matcher,
               token_bitmask,
+              temperatures,
               time_threshold,
               start_time
           );
@@ -141,6 +149,7 @@ bool TraverseDraftTreeRecursive(
         draft_tokens,
         matcher,
         token_bitmask,
+        temperatures,
         time_threshold,
         start_time
     );
@@ -454,13 +463,15 @@ class GrammarMatcher::Impl : public EarleyParser {
       std::optional<std::vector<int>> override_stop_tokens = std::nullopt,
       bool terminate_without_stop_token = false,
       // max_rollback_tokens_ is deprecated and not used.
-      int max_rollback_tokens = -1
+      int max_rollback_tokens = -1,
+      std::optional<float> default_temperature = std::nullopt
   )
       : EarleyParser(compiled_grammar->grammar),
         compiled_grammar_(compiled_grammar),
         tokenizer_info_(compiled_grammar->tokenizer_info),
         stop_token_ids_(override_stop_tokens.value_or(tokenizer_info_.GetStopTokenIds())),
         terminate_without_stop_token_(terminate_without_stop_token),
+        default_temperature_(default_temperature),
         tmp_accepted_bitset_(tokenizer_info_.GetVocabSize()) {
     XGRAMMAR_CHECK(!override_stop_tokens.has_value() || !override_stop_tokens->empty())
         << "The override_stop_tokens should not be empty";
@@ -477,6 +488,10 @@ class GrammarMatcher::Impl : public EarleyParser {
         }
       }
     }
+    XGRAMMAR_CHECK(
+        !default_temperature_.has_value() ||
+        (std::isfinite(default_temperature_.value()) && default_temperature_.value() >= 0)
+    ) << "The default_temperature must be a finite non-negative number";
   }
 
   bool AcceptToken(int32_t token_id, bool debug_print = false);
@@ -484,6 +499,8 @@ class GrammarMatcher::Impl : public EarleyParser {
   bool AcceptString(const std::string& input_str, bool debug_print = false);
 
   bool FillNextTokenBitmask(DLTensor* next_token_bitmask, int index, bool debug_print = false);
+
+  std::optional<float> GetTemperature() const;
 
   std::string FindJumpForwardString();
 
@@ -645,6 +662,7 @@ class GrammarMatcher::Impl : public EarleyParser {
   TokenizerInfo tokenizer_info_;
   std::vector<int> stop_token_ids_;
   bool terminate_without_stop_token_;
+  std::optional<float> default_temperature_;
   std::deque<int> token_length_history;
 
   /*! \brief Set by the last mask computation when an exhausted budget could be enforced: the
@@ -701,7 +719,7 @@ class BatchGrammarMatcher::Impl {
     }
   }
 
-  void BatchFillNextTokenBitmask(
+  std::vector<std::optional<float>> BatchFillNextTokenBitmask(
       std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
       const std::optional<std::vector<int32_t>>& indices,
@@ -877,6 +895,21 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
   scanable_state_history_.PushBack(tmp_states_to_be_added_);
   is_completed_.back() = tmp_accept_stop_token_;
   return true;
+}
+
+std::optional<float> GrammarMatcher::Impl::GetTemperature() const {
+  std::optional<float> syntax_temperature = std::nullopt;
+  for (const auto& state : GetLatestScanableStates()) {
+    if (state.active_temperature_rule_id == -1) {
+      continue;
+    }
+    const auto& temperature = grammar_->GetRule(state.active_temperature_rule_id).temperature;
+    XGRAMMAR_DCHECK(temperature.has_value());
+    if (!syntax_temperature.has_value() || temperature.value() > syntax_temperature.value()) {
+      syntax_temperature = temperature;
+    }
+  }
+  return syntax_temperature.has_value() ? syntax_temperature : default_temperature_;
 }
 
 // TODO(yixin): Polish verbose logging
@@ -1861,7 +1894,7 @@ int GrammarMatcher::Impl::GetNextUncertainToken(
   }
 }
 
-void BatchGrammarMatcher::Impl::BatchFillNextTokenBitmask(
+std::vector<std::optional<float>> BatchGrammarMatcher::Impl::BatchFillNextTokenBitmask(
     std::vector<GrammarMatcher>* matchers,
     DLTensor* next_token_bitmask,
     const std::optional<std::vector<int32_t>>& indices,
@@ -1870,6 +1903,7 @@ void BatchGrammarMatcher::Impl::BatchFillNextTokenBitmask(
   XGRAMMAR_CHECK(!indices.has_value() || indices->size() == matchers->size())
       << "The size of indices (" << (indices.has_value() ? indices->size() : 0)
       << ") should be the same as the size of matchers (" << matchers->size() << ").";
+  std::vector<std::optional<float>> temperatures(matchers->size());
   // Initialize the thread pool if needed. It should be initialized each time,
   // because ThreadPool cannot be reused after Join().
   if (max_threads_ > 1) {
@@ -1883,6 +1917,7 @@ void BatchGrammarMatcher::Impl::BatchFillNextTokenBitmask(
           << "The index " << index << " is out of range [0, " << next_token_bitmask->shape[0]
           << ") for batch_id " << i << ".";
       matcher->FillNextTokenBitmask(next_token_bitmask, index, debug_print);
+      temperatures[i] = matcher->GetTemperature();
     }
   } else {
     auto fill_next_token_mask = [&](int32_t batch_id) {
@@ -1892,12 +1927,14 @@ void BatchGrammarMatcher::Impl::BatchFillNextTokenBitmask(
           << "The index " << index << " is out of range [0, " << next_token_bitmask->shape[0]
           << ") for batch_id " << batch_id << ".";
       matcher->FillNextTokenBitmask(next_token_bitmask, index, debug_print);
+      temperatures[batch_id] = matcher->GetTemperature();
     };
     for (int i = 0; i < static_cast<int32_t>(matchers->size()); i++) {
       thread_pool_->Execute([fill_next_token_mask, i]() { fill_next_token_mask(i); });
     }
     thread_pool_->Join();
   }
+  return temperatures;
 }
 
 std::vector<uint8_t> BatchGrammarMatcher::Impl::BatchAcceptString(
@@ -1945,10 +1982,15 @@ GrammarMatcher::GrammarMatcher(
     const CompiledGrammar& compiled_grammar,
     std::optional<std::vector<int>> override_stop_tokens,
     bool terminate_without_stop_token,
-    int max_rollback_tokens
+    int max_rollback_tokens,
+    std::optional<float> default_temperature
 )
     : pimpl_(std::make_shared<GrammarMatcher::Impl>(
-          compiled_grammar, override_stop_tokens, terminate_without_stop_token, max_rollback_tokens
+          compiled_grammar,
+          override_stop_tokens,
+          terminate_without_stop_token,
+          max_rollback_tokens,
+          default_temperature
       )) {}
 
 bool GrammarMatcher::AcceptToken(int32_t token_id, bool debug_print) {
@@ -1970,7 +2012,8 @@ bool GrammarMatcher::TraverseDraftTree(
     const DLTensor* retrieve_next_sibling,
     const DLTensor* draft_tokens,
     DLTensor* token_bitmask,
-    double time_threshold
+    double time_threshold,
+    DLTensor* temperatures
 ) {
   auto check_cpu = [](const DLTensor* tensor, const char* name) {
     XGRAMMAR_CHECK(
@@ -1996,11 +2039,20 @@ bool GrammarMatcher::TraverseDraftTree(
       token_bitmask->ndim == 2 && token_bitmask->dtype.code == kDLInt &&
       token_bitmask->dtype.bits == 32
   ) << "The token_bitmask tensor must be a 2D int32 tensor";
+  if (temperatures != nullptr) {
+    XGRAMMAR_CHECK(
+        temperatures->ndim == 1 && temperatures->dtype.code == kDLFloat &&
+        temperatures->dtype.bits == 32
+    ) << "The temperatures tensor must be a 1D float32 tensor";
+  }
 
   check_cpu(retrieve_next_token, "retrieve_next_token");
   check_cpu(retrieve_next_sibling, "retrieve_next_sibling");
   check_cpu(draft_tokens, "draft_tokens");
   check_cpu(token_bitmask, "token_bitmask");
+  if (temperatures != nullptr) {
+    check_cpu(temperatures, "temperatures");
+  }
 
   XGRAMMAR_CHECK(retrieve_next_token->shape[0] == retrieve_next_sibling->shape[0])
       << "The retrieve_next_token and retrieve_next_sibling tensors must have the same length";
@@ -2008,6 +2060,15 @@ bool GrammarMatcher::TraverseDraftTree(
       << "The retrieve_next_token and draft_tokens tensors must have the same length";
   XGRAMMAR_CHECK(retrieve_next_token->shape[0] == token_bitmask->shape[0])
       << "The token_bitmask batch size must match the number of nodes in the tree";
+  if (temperatures != nullptr) {
+    XGRAMMAR_CHECK(retrieve_next_token->shape[0] == temperatures->shape[0])
+        << "The temperatures size must match the number of nodes in the tree";
+    std::fill_n(
+        reinterpret_cast<float*>(temperatures->data),
+        temperatures->shape[0],
+        std::numeric_limits<float>::quiet_NaN()
+    );
+  }
   XGRAMMAR_CHECK(retrieve_next_sibling->shape[0] > 0 && retrieve_next_sibling->data != nullptr)
       << "The draft tree must not be empty";
   XGRAMMAR_CHECK(reinterpret_cast<const int64_t*>(retrieve_next_sibling->data)[0] == -1)
@@ -2021,6 +2082,7 @@ bool GrammarMatcher::TraverseDraftTree(
       reinterpret_cast<const int64_t*>(draft_tokens->data),
       *this,
       token_bitmask,
+      temperatures == nullptr ? nullptr : reinterpret_cast<float*>(temperatures->data),
       time_threshold,
       details::Clock::now()
   );
@@ -2047,6 +2109,8 @@ GrammarMatcher GrammarMatcher::Fork() const {
 
 int GrammarMatcher::GetMaxRollbackTokens() const { return pimpl_->GetMaxRollbackTokens(); }
 
+std::optional<float> GrammarMatcher::GetTemperature() const { return pimpl_->GetTemperature(); }
+
 const std::vector<int>& GrammarMatcher::GetStopTokenIds() const {
   return pimpl_->GetStopTokenIds();
 }
@@ -2055,7 +2119,7 @@ std::string GrammarMatcher::_DebugPrintInternalState() const {
   return pimpl_->_DebugPrintInternalState();
 }
 
-void BatchGrammarMatcher::BatchFillNextTokenBitmask(
+std::vector<std::optional<float>> BatchGrammarMatcher::BatchFillNextTokenBitmask(
     std::vector<GrammarMatcher>* matchers,
     DLTensor* next_token_bitmask,
     const std::optional<std::vector<int32_t>>& indices,

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -663,6 +663,7 @@ class GrammarMatcher::Impl : public EarleyParser {
   std::vector<int> stop_token_ids_;
   bool terminate_without_stop_token_;
   std::optional<float> default_temperature_;
+  mutable bool has_warned_temperature_conflict_ = false;
   std::deque<int> token_length_history;
 
   /*! \brief Set by the last mask computation when an exhausted budget could be enforced: the
@@ -899,15 +900,25 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
 
 std::optional<float> GrammarMatcher::Impl::GetTemperature() const {
   std::optional<float> syntax_temperature = std::nullopt;
+  bool has_temperature_conflict = false;
   for (const auto& state : GetLatestScanableStates()) {
     if (state.active_temperature_rule_id == -1) {
       continue;
     }
     const auto& temperature = grammar_->GetRule(state.active_temperature_rule_id).temperature;
     XGRAMMAR_DCHECK(temperature.has_value());
+    if (syntax_temperature.has_value() && temperature.value() != syntax_temperature.value()) {
+      has_temperature_conflict = true;
+    }
     if (!syntax_temperature.has_value() || temperature.value() > syntax_temperature.value()) {
       syntax_temperature = temperature;
     }
+  }
+  if (has_temperature_conflict && !has_warned_temperature_conflict_) {
+    XGRAMMAR_LOG(WARNING) << "Multiple active grammar paths specify different temperatures. "
+                             "Using the maximum temperature "
+                          << syntax_temperature.value() << ".";
+    has_warned_temperature_conflict_ = true;
   }
   return syntax_temperature.has_value() ? syntax_temperature : default_temperature_;
 }

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -102,8 +102,7 @@ bool TraverseDraftTreeRecursive(
       if (!matcher.IsTerminated()) {
         matcher.FillNextTokenBitmask(token_bitmask, current_position);
         if (temperatures != nullptr) {
-          temperatures[current_position] =
-              matcher.GetTemperature().value_or(std::numeric_limits<float>::quiet_NaN());
+          temperatures[current_position] = matcher.GetTemperature().value_or(-1.0f);
         }
 
         if (retrieve_next_token[current_position] != -1) {
@@ -2070,11 +2069,7 @@ bool GrammarMatcher::TraverseDraftTree(
   if (temperatures != nullptr) {
     XGRAMMAR_CHECK(retrieve_next_token->shape[0] == temperatures->shape[0])
         << "The temperatures size must match the number of nodes in the tree";
-    std::fill_n(
-        reinterpret_cast<float*>(temperatures->data),
-        temperatures->shape[0],
-        std::numeric_limits<float>::quiet_NaN()
-    );
+    std::fill_n(reinterpret_cast<float*>(temperatures->data), temperatures->shape[0], -1.0f);
   }
   XGRAMMAR_CHECK(retrieve_next_sibling->shape[0] > 0 && retrieve_next_sibling->data != nullptr)
       << "The draft tree must not be empty";
@@ -2135,15 +2130,31 @@ void BatchGrammarMatcher::BatchFillNextTokenBitmask(
   pimpl_->BatchFillNextTokenBitmask(matchers, next_token_bitmask, indices, debug_print);
 }
 
-std::vector<std::optional<float>> BatchGrammarMatcher::BatchGetTemperature(
-    const std::vector<GrammarMatcher>& matchers
+void BatchGrammarMatcher::BatchFillTemperature(
+    const std::vector<GrammarMatcher>& matchers,
+    DLTensor* temperatures,
+    const std::optional<std::vector<int32_t>>& indices
 ) {
-  std::vector<std::optional<float>> temperatures;
-  temperatures.reserve(matchers.size());
-  for (const auto& matcher : matchers) {
-    temperatures.push_back(matcher.GetTemperature());
+  XGRAMMAR_CHECK(
+      temperatures->ndim == 1 && temperatures->dtype.code == kDLFloat &&
+      temperatures->dtype.bits == 32
+  ) << "The temperatures tensor must be a 1D float32 tensor";
+  XGRAMMAR_CHECK(
+      temperatures->device.device_type == kDLCPU ||
+      temperatures->device.device_type == kDLCUDAHost ||
+      temperatures->device.device_type == kDLROCMHost
+  ) << "The temperatures tensor must be on CPU";
+  if (indices.has_value()) {
+    XGRAMMAR_CHECK(indices->size() == matchers.size())
+        << "The indices size must match the number of matchers";
   }
-  return temperatures;
+  auto* temperatures_data = reinterpret_cast<float*>(temperatures->data);
+  for (int64_t i = 0; i < static_cast<int64_t>(matchers.size()); ++i) {
+    int64_t position = indices.has_value() ? (*indices)[i] : i;
+    XGRAMMAR_CHECK(position >= 0 && position < temperatures->shape[0])
+        << "The index " << position << " is out of bounds for the temperatures tensor";
+    temperatures_data[position] = matchers[i].GetTemperature().value_or(-1.0f);
+  }
 }
 
 std::vector<uint8_t> BatchGrammarMatcher::BatchAcceptString(

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -8,6 +8,7 @@
 #include <picojson.h>
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -148,7 +149,8 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
   // name[max_tokens=10] ::= ..., name[capture] ::= ..., name[capture="x"] ::= ...,
   // name[capture_hidden_suffix_bytes=3] ::= ..., name[capture_hidden_stop_bytes=3] ::= ...,
   // name[capture_hidden_body_rule_id=1, capture_hidden_marker_rule_id=2] ::= ...,
-  // name[stop_capture="marker"] ::= ..., name[lazy] ::= ..., or a comma-separated combination.
+  // name[stop_capture="marker"] ::= ..., name[lazy] ::= ..., name[temperature=0.7] ::= ..., or a
+  // comma-separated combination.
   // The bracket group is treated as an attribute block only when it is followed by "::=";
   // otherwise it is left to be lexed as a character class.
   if (*cur_ == '[') {
@@ -179,6 +181,8 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
     bool has_capture_hidden_marker_rule_id = false;
     bool has_stop_capture = false;
     bool has_lazy = false;
+    bool has_temperature = false;
+    double temperature_value = 0;
     int64_t max_tokens_value = -1;
     int64_t capture_hidden_suffix_bytes_value = 0;
     int64_t capture_hidden_stop_bytes_value = 0;
@@ -224,6 +228,35 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
       ++delta;
       return true;
     };
+    auto parse_float_value = [&](double* value) {
+      skip_space();
+      if (Peek(delta) != '=') {
+        return false;
+      }
+      ++delta;
+      skip_space();
+      std::string text;
+      while (true) {
+        char c = Peek(delta);
+        if ((c >= '0' && c <= '9') || c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-') {
+          text.push_back(c);
+          ++delta;
+        } else {
+          break;
+        }
+      }
+      if (text.empty()) {
+        return false;
+      }
+      try {
+        *value = std::stod(text);
+      } catch (const std::out_of_range&) {
+        *value = std::numeric_limits<double>::infinity();
+      } catch (const std::exception&) {
+        return false;
+      }
+      return true;
+    };
     // Parse a comma-separated attribute list. Each attribute may appear at most once.
     while (matched) {
       skip_space();
@@ -256,6 +289,9 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
         }
       } else if (!has_lazy && match_keyword("lazy")) {
         has_lazy = true;
+      } else if (!has_temperature && match_keyword("temperature")) {
+        has_temperature = true;
+        matched = parse_float_value(&temperature_value);
       } else {
         matched = false;
       }
@@ -314,6 +350,12 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
           (has_capture_hidden_marker_rule_id && capture_hidden_marker_rule_id_value > kMaxInt32)) {
         ReportLexerError("The rule attribute value is too large", start_line, start_column);
       }
+      if (has_temperature && !(std::isfinite(temperature_value) && temperature_value >= 0 &&
+                               temperature_value <= std::numeric_limits<float>::max())) {
+        ReportLexerError(
+            "The temperature must be a finite non-negative number", start_line, start_column
+        );
+      }
       Consume(delta);
       Token token{TokenType::Identifier, identifier, identifier, start_line, start_column};
       token.max_tokens = static_cast<int32_t>(max_tokens_value);
@@ -325,6 +367,9 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
           static_cast<int32_t>(capture_hidden_marker_rule_id_value);
       token.stop_capture_name = stop_capture_value;
       token.is_lazy = has_lazy;
+      if (has_temperature) {
+        token.temperature = static_cast<float>(temperature_value);
+      }
       return token;
     }
   }
@@ -1388,6 +1433,7 @@ EBNFParser::ParsedRule EBNFParser::ParseRule() {
   int32_t capture_hidden_marker_rule_id = Peek().capture_hidden_marker_rule_id;
   std::string stop_capture_name = Peek().stop_capture_name;
   bool is_lazy = Peek().is_lazy;
+  std::optional<float> temperature = Peek().temperature;
   Consume();
 
   PeekAndConsume(TokenType::Assign, "Expect ::=");
@@ -1404,6 +1450,7 @@ EBNFParser::ParsedRule EBNFParser::ParseRule() {
   result.rule.max_tokens = max_tokens;
   result.rule.capture_name = capture_name;
   result.rule.is_lazy = is_lazy;
+  result.rule.temperature = temperature;
   result.suffix_stop_info.hidden_suffix_bytes = capture_hidden_suffix_bytes;
   result.suffix_stop_info.hidden_stop_bytes = capture_hidden_stop_bytes;
   result.suffix_stop_info.body_rule_id = capture_hidden_body_rule_id;
@@ -1453,6 +1500,7 @@ Grammar EBNFParser::Parse(
     builder_.UpdateCaptureName(rule.name, rule.capture_name);
     builder_.UpdateSuffixStopInfo(rule.name, parsed_rule.suffix_stop_info);
     builder_.UpdateLazy(rule.name, rule.is_lazy);
+    builder_.UpdateRuleTemperature(builder_.GetRuleId(rule.name), rule.temperature);
   }
 
   return builder_.Get(root_rule_name);

--- a/cpp/grammar_parser.h
+++ b/cpp/grammar_parser.h
@@ -10,6 +10,7 @@
 #include <xgrammar/xgrammar.h>
 
 #include <any>
+#include <optional>
 
 namespace xgrammar {
 
@@ -73,6 +74,8 @@ class EBNFLexer {
     std::string stop_capture_name = {};
     // Whether the identifier is a rule name carrying the [lazy] attribute, e.g. r[lazy] ::= ...
     bool is_lazy = false;
+    // The sampling temperature attached to a rule-definition identifier via name[temperature=T].
+    std::optional<float> temperature = std::nullopt;
   };
 
   EBNFLexer();

--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -7,6 +7,10 @@
 
 #include <picojson.h>
 
+#include <iomanip>
+#include <limits>
+#include <sstream>
+
 #include "support/encoding.h"
 
 namespace xgrammar {
@@ -15,7 +19,7 @@ std::string GrammarPrinter::PrintRule(const Rule& rule, const SuffixStopInfo* su
   std::string res = rule.name;
   // Print the attributes as one comma-separated bracket group, re-parseable by the EBNF lexer.
   if (rule.max_tokens >= 0 || !rule.capture_name.empty() || suffix_stop_info != nullptr ||
-      rule.is_lazy) {
+      rule.is_lazy || rule.temperature.has_value()) {
     std::string attributes;
     auto append_attribute = [&](const std::string& attribute) {
       if (!attributes.empty()) {
@@ -52,6 +56,12 @@ std::string GrammarPrinter::PrintRule(const Rule& rule, const SuffixStopInfo* su
     }
     if (rule.is_lazy) {
       append_attribute("lazy");
+    }
+    if (rule.temperature.has_value()) {
+      std::ostringstream temperature;
+      temperature << std::setprecision(std::numeric_limits<float>::max_digits10)
+                  << rule.temperature.value();
+      append_attribute("temperature=" + temperature.str());
     }
     res += "[" + attributes + "]";
   }

--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <memory>
@@ -519,6 +520,7 @@ struct Definition {
   bool is_terminal = false;
   bool lazy = false;
   std::optional<Node> suffix;
+  std::optional<float> temperature;
   Location suffix_location;
   std::optional<Node> stop;
   Location stop_location;
@@ -836,6 +838,29 @@ class LarkParser {
         Location stop_capture_location = name_node.location;
         definition->stop_capture_name = std::move(name_node.text);
         definition->stop_capture_location = stop_capture_location;
+      } else if (key.text == "temperature") {
+        Consume(TokenType::kEquals, "expected '=' after temperature attribute");
+        Token value = Consume(TokenType::kNumber, "expected number after temperature=");
+        if (definition->temperature.has_value()) {
+          RaiseLarkError(
+              source_, key.location, "temperature attribute is specified more than once"
+          );
+        }
+        try {
+          size_t parsed_length = 0;
+          float temperature = std::stof(value.text, &parsed_length);
+          if (parsed_length != value.text.size() || !std::isfinite(temperature) ||
+              temperature < 0) {
+            RaiseLarkError(
+                source_, value.location, "temperature must be a finite non-negative number"
+            );
+          }
+          definition->temperature = temperature;
+        } catch (const std::exception&) {
+          RaiseLarkError(
+              source_, value.location, "temperature must be a finite non-negative number"
+          );
+        }
       } else {
         RaiseLarkError(
             source_,
@@ -1325,7 +1350,9 @@ class LarkCompiler {
     CompileIgnore();
 
     const Definition& start_definition = *definition_by_name_.at("start");
-    std::optional<int32_t> dynamic_start_body = CompileDynamicStart(start_definition);
+    std::optional<int32_t> dynamic_start_body = start_definition.temperature.has_value()
+                                                    ? std::nullopt
+                                                    : CompileDynamicStart(start_definition);
 
     for (const auto& definition : document_.definitions) {
       if (definition.is_terminal) {
@@ -1350,7 +1377,9 @@ class LarkCompiler {
         continue;
       }
       int32_t body_expr_id;
-      if (definition.name == "start") {
+      if (definition.temperature.has_value()) {
+        body_expr_id = CompileTemperatureRule(definition);
+      } else if (definition.name == "start") {
         if (dynamic_start_body.has_value()) {
           if (definition.max_tokens.has_value()) {
             RaiseLarkError(
@@ -1377,17 +1406,30 @@ class LarkCompiler {
       } else {
         body_expr_id = CompileNode(definition.body, definition.name, false);
       }
-      builder_.UpdateRuleBody(rule_ids_.at(definition.name), body_expr_id);
+      int32_t rule_id = rule_ids_.at(definition.name);
+      builder_.UpdateRuleBody(rule_id, body_expr_id);
       if (definition.capture_name.has_value()) {
-        builder_.UpdateCaptureName(rule_ids_.at(definition.name), definition.capture_name.value());
+        builder_.UpdateCaptureName(rule_id, definition.capture_name.value());
       }
+      builder_.UpdateRuleTemperature(rule_id, definition.temperature);
     }
 
     auto start_it = rule_ids_.find("start");
     if (start_it == rule_ids_.end()) {
       RaiseLarkError(source_, {1, 1}, "no start rule found");
     }
-    return DeadCodeEliminator::Apply(GrammarNormalizer().Apply(builder_.Get(start_it->second)));
+    int32_t root_rule_id = start_it->second;
+    if (start_definition.temperature.has_value() && skip_rule_id_ != -1) {
+      std::vector<int32_t> elements;
+      if (allow_initial_skip_) {
+        elements.push_back(builder_.AddRuleRef(skip_rule_id_));
+      }
+      elements.push_back(builder_.AddRuleRef(root_rule_id));
+      elements.push_back(builder_.AddRuleRef(skip_rule_id_));
+      root_rule_id =
+          builder_.AddRuleWithHint("start_with_skip", builder_.AddSequence(std::move(elements)));
+    }
+    return DeadCodeEliminator::Apply(GrammarNormalizer().Apply(builder_.Get(root_rule_id)));
   }
 
  private:
@@ -1411,6 +1453,23 @@ class LarkCompiler {
 
   static bool HasLazySemantics(const Definition& definition) {
     return definition.lazy || definition.suffix.has_value() || definition.stop.has_value();
+  }
+
+  int32_t CompileTemperatureRule(const Definition& definition) {
+    const Node* body = UnwrapSingle(&definition.body);
+    if (body->kind == Node::Kind::kJson || body->kind == Node::Kind::kNestedLark ||
+        body->kind == Node::Kind::kGrammarRef) {
+      return CompileNode(*body, definition.name, false, false);
+    }
+    try {
+      return CompileNode(definition.body, definition.name, true, false);
+    } catch (const std::exception& error) {
+      RaiseLarkError(
+          source_,
+          definition.location,
+          std::string(error.what()) + "; temperature is only supported on terminals and subgrammars"
+      );
+    }
   }
 
   void ExpandImports() {
@@ -1817,7 +1876,9 @@ class LarkCompiler {
     }
   }
 
-  int32_t CompileNode(const Node& node, const std::string& rule_hint, bool terminal_mode) {
+  int32_t CompileNode(
+      const Node& node, const std::string& rule_hint, bool terminal_mode, bool append_skip = true
+  ) {
     switch (node.kind) {
       case Node::Kind::kSequence: {
         if (node.children.empty()) {
@@ -1826,7 +1887,7 @@ class LarkCompiler {
         std::vector<int32_t> elements;
         elements.reserve(node.children.size());
         for (const Node& child : node.children) {
-          elements.push_back(CompileNode(child, rule_hint, terminal_mode));
+          elements.push_back(CompileNode(child, rule_hint, terminal_mode, append_skip));
         }
         return elements.size() == 1 ? elements[0] : builder_.AddSequence(elements);
       }
@@ -1834,12 +1895,13 @@ class LarkCompiler {
         std::vector<int32_t> choices;
         choices.reserve(node.children.size());
         for (const Node& child : node.children) {
-          choices.push_back(CompileNode(child, rule_hint, terminal_mode));
+          choices.push_back(CompileNode(child, rule_hint, terminal_mode, append_skip));
         }
         return choices.size() == 1 ? choices[0] : builder_.AddChoices(choices);
       }
       case Node::Kind::kRepeat: {
-        int32_t child = CompileNode(node.children[0], rule_hint + "_repeat", terminal_mode);
+        int32_t child =
+            CompileNode(node.children[0], rule_hint + "_repeat", terminal_mode, append_skip);
         return builder_.AddRepeatFromExpr(
             rule_hint + "_repeat", child, node.min_repeat, node.max_repeat
         );
@@ -1856,13 +1918,15 @@ class LarkCompiler {
         }
         int32_t result = builder_.AddRuleRef(rule_ids_.at(node.text));
         // Lazy rules are compiled like terminals (lexemes), so they also take a trailing skip.
-        bool skip_after =
-            definition_it->second->is_terminal || HasLazySemantics(*definition_it->second);
-        return !terminal_mode && skip_after ? AppendSkip(result) : result;
+        // Temperature rules are also compiled like terminals.
+        bool is_lexeme = definition_it->second->is_terminal ||
+                         HasLazySemantics(*definition_it->second) ||
+                         definition_it->second->temperature.has_value();
+        return !terminal_mode && append_skip && is_lexeme ? AppendSkip(result) : result;
       }
       case Node::Kind::kString: {
         int32_t result = CompileStringLiteral(node);
-        return !terminal_mode && !node.text.empty() ? AppendSkip(result) : result;
+        return !terminal_mode && append_skip && !node.text.empty() ? AppendSkip(result) : result;
       }
       case Node::Kind::kRange: {
         auto begin = ParseUTF8(node.text.c_str());
@@ -1875,14 +1939,14 @@ class LarkCompiler {
           RaiseLarkError(source_, node.location, "character range start must not exceed end");
         }
         int32_t result = builder_.AddCharacterClass({{begin[0], end[0]}});
-        return terminal_mode ? result : AppendSkip(result);
+        return terminal_mode || !append_skip ? result : AppendSkip(result);
       }
       case Node::Kind::kRegex: {
         std::string pattern = PrepareRegexPattern(node);
         try {
           int32_t root = SubGrammarAdder::Apply(&builder_, Grammar::FromRegex(pattern));
           int32_t result = builder_.AddRuleRef(root);
-          return terminal_mode ? result : AppendSkip(result);
+          return terminal_mode || !append_skip ? result : AppendSkip(result);
         } catch (const std::exception& error) {
           RaiseLarkError(
               source_,
@@ -1898,7 +1962,7 @@ class LarkCompiler {
         try {
           int32_t root = SubGrammarAdder::Apply(&builder_, Grammar::FromJSONSchema(node.text));
           int32_t result = builder_.AddRuleRef(root);
-          return terminal_mode ? result : AppendSkip(result);
+          return terminal_mode || !append_skip ? result : AppendSkip(result);
         } catch (const std::exception& error) {
           RaiseLarkError(
               source_,
@@ -1915,7 +1979,7 @@ class LarkCompiler {
           LarkCompiler compiler(source_, *node.nested, tokenizer_info_, named_grammars_);
           int32_t root = SubGrammarAdder::Apply(&builder_, compiler.Compile());
           int32_t result = builder_.AddRuleRef(root);
-          return terminal_mode ? result : AppendSkip(result);
+          return terminal_mode || !append_skip ? result : AppendSkip(result);
         } catch (const std::exception& error) {
           RaiseLarkError(
               source_,
@@ -1931,7 +1995,7 @@ class LarkCompiler {
         SpecialTokenSet token_set = ResolveSpecialToken(node.text, node.location);
         int32_t result = token_set.excluded ? builder_.AddExcludeTokenSet(token_set.token_ids)
                                             : builder_.AddTokenSet(token_set.token_ids);
-        return AppendSkip(result);
+        return append_skip ? AppendSkip(result) : result;
       }
       case Node::Kind::kRegexExt:
         RaiseLarkError(source_, node.location, "structured %regex is not supported");
@@ -1946,7 +2010,8 @@ class LarkCompiler {
               SubGrammarAdder::Apply(&builder_, ResolveNamedGrammar(name, node.location));
           root_it = named_grammar_roots_.emplace(name, root).first;
         }
-        return AppendSkip(builder_.AddRuleRef(root_it->second));
+        int32_t result = builder_.AddRuleRef(root_it->second);
+        return append_skip ? AppendSkip(result) : result;
       }
       case Node::Kind::kNot:
         RaiseLarkError(

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v15";
+  static constexpr const char kXGrammarSerializeVersion[] = "v16";
 };
 
 /*!

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -602,9 +602,20 @@ TVM_FFI_STATIC_INIT_BLOCK() {
               matchers.push_back(matchers_ref[i].as<GrammarMatcherObj>()->value);
             }
             DLTensor* bitmask = batch_token_bitmask.cast<DLTensor*>();
-            auto temperatures = o->value.BatchFillNextTokenBitmask(
+            o->value.BatchFillNextTokenBitmask(
                 &matchers, bitmask, OptionalInt32VectorFromView(indices), debug_print
             );
+          }
+      )
+      .def_static(
+          "batch_get_temperature",
+          [](ffi::Array<O> matchers_ref) {
+            std::vector<GrammarMatcher> matchers;
+            matchers.reserve(matchers_ref.size());
+            for (int64_t i = 0; i < static_cast<int64_t>(matchers_ref.size()); ++i) {
+              matchers.push_back(matchers_ref[i].as<GrammarMatcherObj>()->value);
+            }
+            auto temperatures = BatchGrammarMatcher::BatchGetTemperature(matchers);
             ffi::Array<ffi::Any> result;
             for (const auto& temperature : temperatures) {
               result.push_back(OptionalFloatToAny(temperature));

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -7,6 +7,7 @@
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/any.h>
 #include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/stl.h>
 #include <tvm/ffi/string.h>
 #include <tvm/ffi/tvm_ffi.h>
 #include <xgrammar/xgrammar.h>
@@ -77,16 +78,6 @@ static std::optional<int64_t> OptionalIntFromView(ffi::AnyView v) {
 static std::optional<bool> OptionalBoolFromView(ffi::AnyView v) {
   if (v == nullptr) return std::nullopt;
   return static_cast<bool>(v.cast<int64_t>());
-}
-
-static std::optional<float> OptionalFloatFromView(ffi::AnyView v) {
-  if (v == nullptr) return std::nullopt;
-  return static_cast<float>(v.cast<double>());
-}
-
-static ffi::Any OptionalFloatToAny(const std::optional<float>& value) {
-  if (!value.has_value()) return ffi::Any(nullptr);
-  return ffi::Any(static_cast<double>(value.value()));
 }
 
 static std::optional<std::vector<int32_t>> OptionalInt32VectorFromView(ffi::AnyView v) {
@@ -231,14 +222,14 @@ class GrammarMatcherObj : public ffi::Object {
       ffi::AnyView override_stop_tokens_opt,
       bool terminate_without_stop_token,
       int64_t max_rollback_tokens,
-      ffi::AnyView default_temperature_opt
+      std::optional<float> default_temperature
   )
       : value(
             compiled_grammar_ref.as<CompiledGrammarObj>()->value,
             OptionalIntVectorFromView(override_stop_tokens_opt),
             terminate_without_stop_token,
             static_cast<int>(max_rollback_tokens),
-            OptionalFloatFromView(default_temperature_opt)
+            default_temperature
         ) {}
 
   static constexpr bool _type_mutable = true;
@@ -615,12 +606,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
             for (int64_t i = 0; i < static_cast<int64_t>(matchers_ref.size()); ++i) {
               matchers.push_back(matchers_ref[i].as<GrammarMatcherObj>()->value);
             }
-            auto temperatures = BatchGrammarMatcher::BatchGetTemperature(matchers);
-            ffi::Array<ffi::Any> result;
-            for (const auto& temperature : temperatures) {
-              result.push_back(OptionalFloatToAny(temperature));
-            }
-            return result;
+            return BatchGrammarMatcher::BatchGetTemperature(matchers);
           }
       )
       .def_static(
@@ -679,7 +665,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   // GrammarMatcher: init(compiled_grammar, override_stop_tokens_opt, terminate_without_stop,
   // max_rollback_tokens, default_temperature)
   refl::ObjectDef<GrammarMatcherObj>()
-      .def(refl::init<O, ffi::AnyView, bool, int64_t, ffi::AnyView>())
+      .def(refl::init<O, ffi::AnyView, bool, int64_t, std::optional<float>>())
       .def(
           "accept_token",
           [](GrammarMatcherObj* o, int64_t token_id, bool debug_print) {
@@ -771,10 +757,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
             return static_cast<int64_t>(o->value.GetMaxRollbackTokens());
           }
       )
-      .def(
-          "temperature",
-          [](const GrammarMatcherObj* o) { return OptionalFloatToAny(o->value.GetTemperature()); }
-      )
+      .def("temperature", [](const GrammarMatcherObj* o) { return o->value.GetTemperature(); })
       .def(
           "stop_token_ids",
           [](const GrammarMatcherObj* o) {

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -79,6 +79,16 @@ static std::optional<bool> OptionalBoolFromView(ffi::AnyView v) {
   return static_cast<bool>(v.cast<int64_t>());
 }
 
+static std::optional<float> OptionalFloatFromView(ffi::AnyView v) {
+  if (v == nullptr) return std::nullopt;
+  return static_cast<float>(v.cast<double>());
+}
+
+static ffi::Any OptionalFloatToAny(const std::optional<float>& value) {
+  if (!value.has_value()) return ffi::Any(nullptr);
+  return ffi::Any(static_cast<double>(value.value()));
+}
+
 static std::optional<std::vector<int32_t>> OptionalInt32VectorFromView(ffi::AnyView v) {
   if (v == nullptr) return std::nullopt;
   ffi::Array<int64_t> array = v.cast<ffi::Array<int64_t>>();
@@ -220,13 +230,15 @@ class GrammarMatcherObj : public ffi::Object {
       ffi::ObjectRef compiled_grammar_ref,
       ffi::AnyView override_stop_tokens_opt,
       bool terminate_without_stop_token,
-      int64_t max_rollback_tokens
+      int64_t max_rollback_tokens,
+      ffi::AnyView default_temperature_opt
   )
       : value(
             compiled_grammar_ref.as<CompiledGrammarObj>()->value,
             OptionalIntVectorFromView(override_stop_tokens_opt),
             terminate_without_stop_token,
-            static_cast<int>(max_rollback_tokens)
+            static_cast<int>(max_rollback_tokens),
+            OptionalFloatFromView(default_temperature_opt)
         ) {}
 
   static constexpr bool _type_mutable = true;
@@ -590,9 +602,14 @@ TVM_FFI_STATIC_INIT_BLOCK() {
               matchers.push_back(matchers_ref[i].as<GrammarMatcherObj>()->value);
             }
             DLTensor* bitmask = batch_token_bitmask.cast<DLTensor*>();
-            o->value.BatchFillNextTokenBitmask(
+            auto temperatures = o->value.BatchFillNextTokenBitmask(
                 &matchers, bitmask, OptionalInt32VectorFromView(indices), debug_print
             );
+            ffi::Array<ffi::Any> result;
+            for (const auto& temperature : temperatures) {
+              result.push_back(OptionalFloatToAny(temperature));
+            }
+            return result;
           }
       )
       .def_static(
@@ -649,9 +666,9 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       });
 
   // GrammarMatcher: init(compiled_grammar, override_stop_tokens_opt, terminate_without_stop,
-  // max_rollback_tokens)
+  // max_rollback_tokens, default_temperature)
   refl::ObjectDef<GrammarMatcherObj>()
-      .def(refl::init<O, ffi::AnyView, bool, int64_t>())
+      .def(refl::init<O, ffi::AnyView, bool, int64_t, ffi::AnyView>())
       .def(
           "accept_token",
           [](GrammarMatcherObj* o, int64_t token_id, bool debug_print) {
@@ -686,17 +703,21 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              ffi::AnyView retrieve_next_sibling,
              ffi::AnyView draft_tokens,
              ffi::AnyView token_bitmask,
-             double time_threshold) {
+             double time_threshold,
+             ffi::AnyView temperatures) {
             DLTensor* retrieve_next_token_ptr = retrieve_next_token.cast<DLTensor*>();
             DLTensor* retrieve_next_sibling_ptr = retrieve_next_sibling.cast<DLTensor*>();
             DLTensor* draft_tokens_ptr = draft_tokens.cast<DLTensor*>();
             DLTensor* token_bitmask_ptr = token_bitmask.cast<DLTensor*>();
+            DLTensor* temperatures_ptr =
+                temperatures == nullptr ? nullptr : temperatures.cast<DLTensor*>();
             return o->value.TraverseDraftTree(
                 retrieve_next_token_ptr,
                 retrieve_next_sibling_ptr,
                 draft_tokens_ptr,
                 token_bitmask_ptr,
-                time_threshold
+                time_threshold,
+                temperatures_ptr
             );
           }
       )
@@ -738,6 +759,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           [](const GrammarMatcherObj* o) {
             return static_cast<int64_t>(o->value.GetMaxRollbackTokens());
           }
+      )
+      .def(
+          "temperature",
+          [](const GrammarMatcherObj* o) { return OptionalFloatToAny(o->value.GetTemperature()); }
       )
       .def(
           "stop_token_ids",

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -599,14 +599,17 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           }
       )
       .def_static(
-          "batch_get_temperature",
-          [](ffi::Array<O> matchers_ref) {
+          "batch_fill_temperature",
+          [](ffi::Array<O> matchers_ref, ffi::AnyView temperatures, ffi::AnyView indices) {
             std::vector<GrammarMatcher> matchers;
             matchers.reserve(matchers_ref.size());
             for (int64_t i = 0; i < static_cast<int64_t>(matchers_ref.size()); ++i) {
               matchers.push_back(matchers_ref[i].as<GrammarMatcherObj>()->value);
             }
-            return BatchGrammarMatcher::BatchGetTemperature(matchers);
+            DLTensor* temperatures_ptr = temperatures.cast<DLTensor*>();
+            BatchGrammarMatcher::BatchFillTemperature(
+                matchers, temperatures_ptr, OptionalInt32VectorFromView(indices)
+            );
           }
       )
       .def_static(

--- a/docs/defining_structures/ebnf_grammar.md
+++ b/docs/defining_structures/ebnf_grammar.md
@@ -178,6 +178,27 @@ root       ::= identifier ("," identifier){0,4}
 identifier ::= [a-zA-Z_] [a-zA-Z0-9_]*
 ```
 
+## Rule Options
+
+### Sampling Temperature
+
+The `temperature` rule option selects the sampling temperature while a rule is active:
+
+```text
+root ::= "answer:" value
+value[temperature=0.7] ::= [a-z]+
+```
+
+`temperature` must be a finite non-negative number. An inner explicit temperature overrides an
+inherited outer temperature. At ambiguous positions, different active temperatures produce a
+warning once and `matcher.temperature` returns the maximum. If no active rule specifies a
+temperature, it returns the matcher's `default_temperature`; if neither is configured, it returns
+`None`.
+
+Use `BatchGrammarMatcher.batch_get_temperature` to query multiple matchers. During speculative
+decoding, the optional `temperatures` tensor passed to `GrammarMatcher.traverse_draft_tree`
+receives the effective temperature for each tree node.
+
 ## Macros
 
 Macros look like function calls inside a grammar rule. For example:

--- a/docs/defining_structures/ebnf_grammar.md
+++ b/docs/defining_structures/ebnf_grammar.md
@@ -195,9 +195,10 @@ warning once and `matcher.temperature` returns the maximum. If no active rule sp
 temperature, it returns the matcher's `default_temperature`; if neither is configured, it returns
 `None`.
 
-Use `BatchGrammarMatcher.batch_get_temperature` to query multiple matchers. During speculative
-decoding, the optional `temperatures` tensor passed to `GrammarMatcher.traverse_draft_tree`
-receives the effective temperature for each tree node.
+Use `BatchGrammarMatcher.batch_fill_temperature` to fill the temperatures of multiple matchers
+into a pre-allocated tensor. During speculative decoding, the optional `temperatures` tensor
+passed to `GrammarMatcher.traverse_draft_tree` receives the effective temperature for each tree
+node. In both tensors, `-1` means there is no effective temperature.
 
 ## Macros
 

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -348,6 +348,33 @@ grammar = xgr.Grammar.from_lark(
   Each named grammar is compiled once and shared.
 - `@name` references may only appear in rules, not in terminals.
 
+## Sampling Temperature
+
+The `temperature` rule attribute selects the sampling temperature while a terminal-like rule or
+named subgrammar is active:
+
+```python
+grammar = xgr.Grammar.from_lark(
+    """
+    start: "answer:" value
+    value[temperature=0.7]: /[a-z]+/
+    """
+)
+compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(grammar)
+matcher = xgr.GrammarMatcher(compiled, default_temperature=0.2)
+```
+
+`temperature` must be a finite non-negative number. It is supported on rules that can be compiled
+as terminals and on rules whose body is a `%json`, `%lark`, or `@name` subgrammar. An inner
+explicit temperature overrides an inherited outer temperature. When ambiguous parse paths have
+different active temperatures, `matcher.temperature` returns the maximum. If no active rule has a
+temperature, it returns `default_temperature`; if neither is configured, it returns `None`.
+
+`BatchGrammarMatcher.batch_fill_next_token_bitmask` returns one optional temperature per matcher.
+For speculative decoding, pass a one-dimensional CPU `float32` tensor through the
+`temperatures` argument of `GrammarMatcher.traverse_draft_tree`. The tensor receives one value per
+tree node; `NaN` marks a node with no configured temperature or a node that was not visited.
+
 ## Dynamic Tool-Call Dispatch
 
 A common pattern for tool calling lets the model produce free text until a trigger string (such

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -365,10 +365,10 @@ different active temperatures, `matcher.temperature` emits a warning once and re
 If no active rule has a temperature, it returns `default_temperature`; if neither is configured,
 it returns `None`.
 
-`BatchGrammarMatcher.batch_fill_next_token_bitmask` returns one optional temperature per matcher.
-For speculative decoding, pass a one-dimensional CPU `float32` tensor through the
-`temperatures` argument of `GrammarMatcher.traverse_draft_tree`. The tensor receives one value per
-tree node; `NaN` marks a node with no configured temperature or a node that was not visited.
+`BatchGrammarMatcher.batch_get_temperature` returns one optional temperature per matcher. For
+speculative decoding, pass a one-dimensional CPU `float32` tensor through the `temperatures`
+argument of `GrammarMatcher.traverse_draft_tree`. The tensor receives one value per tree node;
+`NaN` marks a node with no configured temperature or a node that was not visited.
 
 ## Dynamic Tool-Call Dispatch
 

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -361,8 +361,9 @@ matcher = xgr.GrammarMatcher(compiled, default_temperature=0.2)
 `temperature` must be a finite non-negative number. It is supported on rules that can be compiled
 as terminals and on rules whose body is a `%json`, `%lark`, or `@name` subgrammar. An inner
 explicit temperature overrides an inherited outer temperature. When ambiguous parse paths have
-different active temperatures, `matcher.temperature` returns the maximum. If no active rule has a
-temperature, it returns `default_temperature`; if neither is configured, it returns `None`.
+different active temperatures, `matcher.temperature` emits a warning once and returns the maximum.
+If no active rule has a temperature, it returns `default_temperature`; if neither is configured,
+it returns `None`.
 
 `BatchGrammarMatcher.batch_fill_next_token_bitmask` returns one optional temperature per matcher.
 For speculative decoding, pass a one-dimensional CPU `float32` tensor through the

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -240,47 +240,39 @@ The `%ignore` expression may be a terminal name, a string, a regex, or a combina
 first lexeme of the output. Multiple `%grammar_options` declarations are merged; unknown option
 names are rejected.
 
-## Inline JSON Schema
+### `%json`
 
 `%json { ... }` embeds a JSON Schema and behaves like a rule reference: the element matches any
 JSON value conforming to the schema, converted through XGrammar's JSON Schema converter.
 
-```python
-grammar = xgr.Grammar.from_lark(
-    r"""
-    start: "<tool_call>" arguments "</tool_call>"
-    arguments: %json {
-      "type": "object",
-      "properties": {"city": {"type": "string"}},
-      "required": ["city"],
-      "additionalProperties": false
-    }
-    """
-)
+```text
+start: "<tool_call>" arguments "</tool_call>"
+arguments: %json {
+  "type": "object",
+  "properties": {"city": {"type": "string"}},
+  "required": ["city"],
+  "additionalProperties": false
+}
 ```
 
 `%json` may appear inside sequences, alternatives, and repetition. Whitespace outside the JSON
 value is controlled by the surrounding Lark grammar; whitespace inside the value follows the JSON
 Schema converter's normal behavior. `%json` cannot be used inside terminals.
 
-## Nested Grammars
+### `%lark`
 
 `%lark { ... }` embeds a complete Lark grammar as one element. The nested grammar has its own
 independent namespace: it must define its own `start` rule, and it may declare its own imports,
 `%ignore`, and `%grammar_options` without affecting the outer grammar. Rule names may be reused
 across the boundary.
 
-```python
-grammar = xgr.Grammar.from_lark(
-    r"""
-    start: "[" %lark {
-      %import common.WS
-      %ignore WS
-      start: item ":" %json {"type": "integer"}
-      item: "x" | "(" item ")"
-    } "]"
-    """
-)
+```text
+start: "[" %lark {
+  %import common.WS
+  %ignore WS
+  start: item ":" %json {"type": "integer"}
+  item: "x" | "(" item ")"
+} "]"
 ```
 
 Multiple `%lark` blocks may appear in the same rule. Nested grammars may use every feature of the
@@ -348,7 +340,9 @@ grammar = xgr.Grammar.from_lark(
   Each named grammar is compiled once and shared.
 - `@name` references may only appear in rules, not in terminals.
 
-## Sampling Temperature
+## Rule Options
+
+### Sampling Temperature
 
 The `temperature` rule attribute selects the sampling temperature while a terminal-like rule or
 named subgrammar is active:

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -365,10 +365,11 @@ different active temperatures, `matcher.temperature` emits a warning once and re
 If no active rule has a temperature, it returns `default_temperature`; if neither is configured,
 it returns `None`.
 
-`BatchGrammarMatcher.batch_get_temperature` returns one optional temperature per matcher. For
-speculative decoding, pass a one-dimensional CPU `float32` tensor through the `temperatures`
-argument of `GrammarMatcher.traverse_draft_tree`. The tensor receives one value per tree node;
-`NaN` marks a node with no configured temperature or a node that was not visited.
+`BatchGrammarMatcher.batch_fill_temperature` fills a pre-allocated one-dimensional CPU `float32`
+tensor with one temperature per matcher; the entry of a matcher without an effective temperature
+is set to `-1`. For speculative decoding, pass a one-dimensional CPU `float32` tensor through the
+`temperatures` argument of `GrammarMatcher.traverse_draft_tree`. The tensor receives one value per
+tree node; `-1` marks a node with no configured temperature or a node that was not visited.
 
 ## Dynamic Tool-Call Dispatch
 

--- a/docs/using_xgrammar/engine_integration.md
+++ b/docs/using_xgrammar/engine_integration.md
@@ -94,6 +94,9 @@ also accepts an `indices` parameter to fill only a subset of the bitmask rows, m
 [`batch_accept_string`](xgrammar.BatchGrammarMatcher.batch_accept_string) and
 [`batch_rollback`](xgrammar.BatchGrammarMatcher.batch_rollback) are the batch versions of the
 corresponding [`xgr.GrammarMatcher`](xgrammar.GrammarMatcher) methods.
+[`batch_get_temperature`](xgrammar.BatchGrammarMatcher.batch_get_temperature) collects the
+effective sampling temperature of each matcher in one pass, for grammars that use the
+`temperature` rule attribute.
 
 ## Speculative Decoding
 

--- a/docs/using_xgrammar/engine_integration.md
+++ b/docs/using_xgrammar/engine_integration.md
@@ -94,8 +94,9 @@ also accepts an `indices` parameter to fill only a subset of the bitmask rows, m
 [`batch_accept_string`](xgrammar.BatchGrammarMatcher.batch_accept_string) and
 [`batch_rollback`](xgrammar.BatchGrammarMatcher.batch_rollback) are the batch versions of the
 corresponding [`xgr.GrammarMatcher`](xgrammar.GrammarMatcher) methods.
-[`batch_get_temperature`](xgrammar.BatchGrammarMatcher.batch_get_temperature) collects the
-effective sampling temperature of each matcher in one pass, for grammars that use the
+[`batch_fill_temperature`](xgrammar.BatchGrammarMatcher.batch_fill_temperature) fills a
+`float32` CPU tensor with the effective sampling temperature of each matcher in one pass
+(`-1` for matchers without a configured temperature), for grammars that use the
 `temperature` rule attribute.
 
 ## Speculative Decoding

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -131,7 +131,8 @@ class GrammarMatcher {
    *        If the traversal exceeds this threshold, it returns false.
    *        A value <= 0 disables the timeout (default: -1.0).
    * \param temperatures Optional DLTensor to store the effective temperature for each node
-   *        (1D float32 with num_nodes elements). NaN represents no effective temperature.
+   *        (1D float32 with num_nodes elements). -1 represents no effective temperature; it is
+   *        also written for nodes that were not visited or were rejected.
    * \return true if the traversal completed successfully, false if it timed out.
    */
   bool TraverseDraftTree(
@@ -243,12 +244,17 @@ class BatchGrammarMatcher {
   );
 
   /*!
-   * \brief Get the effective sampling temperature for each matcher.
+   * \brief Fill the effective sampling temperature of each matcher into a tensor.
    * \param matchers The array of GrammarMatcher objects.
-   * \return The effective sampling temperature for each matcher.
+   * \param temperatures The pre-allocated 1D float32 CPU tensor to store the result. The entry of
+   * a matcher without an effective temperature is set to -1.
+   * \param indices The optional array of indices to specify which element each matcher writes to.
+   * If not provided, matchers[i] writes to temperatures[i].
    */
-  static std::vector<std::optional<float>> BatchGetTemperature(
-      const std::vector<GrammarMatcher>& matchers
+  static void BatchFillTemperature(
+      const std::vector<GrammarMatcher>& matchers,
+      DLTensor* temperatures,
+      const std::optional<std::vector<int32_t>>& indices = std::nullopt
   );
 
   /*!

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -234,13 +234,21 @@ class BatchGrammarMatcher {
     of the bitmask tensor. If not provided, all matchers will write to the corresponding
     indices(matchers[i] to next_token_bitmask[i]).
     \param debug_print Whether to print debug information. Default is false.
-    \return The effective sampling temperature for each matcher.
   */
-  std::vector<std::optional<float>> BatchFillNextTokenBitmask(
+  void BatchFillNextTokenBitmask(
       std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
       const std::optional<std::vector<int32_t>>& indices = std::nullopt,
       bool debug_print = false
+  );
+
+  /*!
+   * \brief Get the effective sampling temperature for each matcher.
+   * \param matchers The array of GrammarMatcher objects.
+   * \return The effective sampling temperature for each matcher.
+   */
+  static std::vector<std::optional<float>> BatchGetTemperature(
+      const std::vector<GrammarMatcher>& matchers
   );
 
   /*!

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -71,12 +71,17 @@ class GrammarMatcher {
    * CompiledGrammar.
    * \param compiled_grammar The compiled grammar. It is obtained through
    * CreateCompiledGrammar as a result of preprocessing the grammar and tokenizer.
+   * \param override_stop_tokens Optional stop token ids that replace those from the tokenizer.
+   * \param terminate_without_stop_token Whether to terminate when the root rule is complete.
+   * \param max_rollback_tokens Deprecated and unused.
+   * \param default_temperature The temperature used when no active rule specifies one.
    */
   GrammarMatcher(
       const CompiledGrammar& compiled_grammar,
       std::optional<std::vector<int>> override_stop_tokens = std::nullopt,
       bool terminate_without_stop_token = false,
-      int max_rollback_tokens = -1
+      int max_rollback_tokens = -1,
+      std::optional<float> default_temperature = std::nullopt
   );
 
   /*!
@@ -125,6 +130,8 @@ class GrammarMatcher {
    * \param time_threshold Maximum allowed time in seconds for the DFS traversal.
    *        If the traversal exceeds this threshold, it returns false.
    *        A value <= 0 disables the timeout (default: -1.0).
+   * \param temperatures Optional DLTensor to store the effective temperature for each node
+   *        (1D float32 with num_nodes elements). NaN represents no effective temperature.
    * \return true if the traversal completed successfully, false if it timed out.
    */
   bool TraverseDraftTree(
@@ -132,7 +139,8 @@ class GrammarMatcher {
       const DLTensor* retrieve_next_sibling,
       const DLTensor* draft_tokens,
       DLTensor* token_bitmask,
-      double time_threshold = -1.0
+      double time_threshold = -1.0,
+      DLTensor* temperatures = nullptr
   );
 
   /*!
@@ -192,6 +200,9 @@ class GrammarMatcher {
   /*! \brief Get the maximum number of rollback tokens allowed. */
   int GetMaxRollbackTokens() const;
 
+  /*! \brief Get the effective sampling temperature for the next token. */
+  std::optional<float> GetTemperature() const;
+
   const std::vector<int>& GetStopTokenIds() const;
 
   /*! \brief Print the internal state of the matcher. This is only used for debugging. The
@@ -223,8 +234,9 @@ class BatchGrammarMatcher {
     of the bitmask tensor. If not provided, all matchers will write to the corresponding
     indices(matchers[i] to next_token_bitmask[i]).
     \param debug_print Whether to print debug information. Default is false.
+    \return The effective sampling temperature for each matcher.
   */
-  void BatchFillNextTokenBitmask(
+  std::vector<std::optional<float>> BatchFillNextTokenBitmask(
       std::vector<GrammarMatcher>* matchers,
       DLTensor* next_token_bitmask,
       const std::optional<std::vector<int32_t>>& indices = std::nullopt,

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -563,7 +563,7 @@ class BatchGrammarMatcher(XGRObject):
         bitmask: ArrayLike,
         indices: Optional[List[int]] = None,
         debug_print: bool = False,
-    ) -> List[Optional[float]]:
+    ) -> None:
         """Fill the next token bitmask for multiple matchers.
 
         Parameters
@@ -584,21 +584,30 @@ class BatchGrammarMatcher(XGRObject):
         debug_print : bool, default: False
             Whether to print information about generated bitmask. Helpful for debugging.
 
-        Returns
-        -------
-        temperatures : List[Optional[float]]
-            The effective sampling temperature for each matcher.
-
         Raises
         ------
         RuntimeError
             If the bitmask is invalid (not on CPU, not int32, shape mismatch).
         """
         matcher_handles = [matcher._handle for matcher in matchers]
+        self._handle.batch_fill_next_token_bitmask(matcher_handles, bitmask, indices, debug_print)
 
-        result = self._handle.batch_fill_next_token_bitmask(
-            matcher_handles, bitmask, indices, debug_print
-        )
+    @staticmethod
+    def batch_get_temperature(matchers: List["GrammarMatcher"]) -> List[Optional[float]]:
+        """Get the effective sampling temperature for multiple matchers.
+
+        Parameters
+        ----------
+        matchers : List[GrammarMatcher]
+            The list of matchers to query.
+
+        Returns
+        -------
+        temperatures : List[Optional[float]]
+            The effective sampling temperature for each matcher.
+        """
+        matcher_handles = [matcher._handle for matcher in matchers]
+        result = _core.BatchGrammarMatcher.batch_get_temperature(matcher_handles)
         return [None if value is None else float(value) for value in result]
 
     @staticmethod

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -227,6 +227,7 @@ class GrammarMatcher(XGRObject):
         override_stop_tokens: Optional[Union[int, List[int]]] = None,
         terminate_without_stop_token: bool = False,
         max_rollback_tokens: int = -1,
+        default_temperature: Optional[float] = None,
     ) -> None:
         """Construct the grammar matcher.
 
@@ -248,6 +249,9 @@ class GrammarMatcher(XGRObject):
 
             The maximum number of rollback tokens allowed. The rollback operation is useful for
             jump-forward decoding and speculative decoding.
+
+        default_temperature : Optional[float], default: None
+            The sampling temperature used when the active grammar rule does not specify one.
         """
         if not isinstance(compiled_grammar, CompiledGrammar):
             raise ValueError("The grammar should be compiled before passing it to GrammarMatcher.")
@@ -268,6 +272,7 @@ class GrammarMatcher(XGRObject):
                 override_stop_tokens,
                 terminate_without_stop_token,
                 max_rollback_tokens,
+                None if default_temperature is None else float(default_temperature),
             )
         )
 
@@ -363,6 +368,7 @@ class GrammarMatcher(XGRObject):
         draft_tokens: torch.Tensor,
         token_bitmask: torch.Tensor,
         time_threshold: float = -1.0,
+        temperatures: Optional[torch.Tensor] = None,
     ) -> bool:
         """Traverse a draft token tree and fill the token bitmask for each node.
 
@@ -382,6 +388,10 @@ class GrammarMatcher(XGRObject):
             Maximum allowed time in seconds for the traversal. If the traversal
             exceeds this threshold, it returns False. A value <= 0 disables the timeout
             (default: -1.0).
+        temperatures : Optional[torch.Tensor], default: None
+            Optional 1D float32 CPU tensor with one element per node. It is filled with the
+            effective temperature for each visited node. ``NaN`` means that no temperature
+            is configured.
 
         Returns
         -------
@@ -389,7 +399,12 @@ class GrammarMatcher(XGRObject):
             True if the traversal completed successfully, False if it timed out.
         """
         return self._handle.traverse_draft_tree(
-            retrieve_next_token, retrieve_next_sibling, draft_tokens, token_bitmask, time_threshold
+            retrieve_next_token,
+            retrieve_next_sibling,
+            draft_tokens,
+            token_bitmask,
+            time_threshold,
+            temperatures,
         )
 
     def find_jump_forward_string(self) -> str:
@@ -495,6 +510,12 @@ class GrammarMatcher(XGRObject):
         return -1
 
     @property
+    def temperature(self) -> Optional[float]:
+        """The effective sampling temperature for the next token."""
+        result = self._handle.temperature()
+        return None if result is None else float(result)
+
+    @property
     def stop_token_ids(self) -> List[int]:
         """The ids of the stop tokens used in the matcher. If specified, the provided stop tokens
         will be used. Otherwise, the stop tokens will be detected from the vocabulary.
@@ -542,7 +563,7 @@ class BatchGrammarMatcher(XGRObject):
         bitmask: ArrayLike,
         indices: Optional[List[int]] = None,
         debug_print: bool = False,
-    ) -> None:
+    ) -> List[Optional[float]]:
         """Fill the next token bitmask for multiple matchers.
 
         Parameters
@@ -563,6 +584,11 @@ class BatchGrammarMatcher(XGRObject):
         debug_print : bool, default: False
             Whether to print information about generated bitmask. Helpful for debugging.
 
+        Returns
+        -------
+        temperatures : List[Optional[float]]
+            The effective sampling temperature for each matcher.
+
         Raises
         ------
         RuntimeError
@@ -570,7 +596,10 @@ class BatchGrammarMatcher(XGRObject):
         """
         matcher_handles = [matcher._handle for matcher in matchers]
 
-        self._handle.batch_fill_next_token_bitmask(matcher_handles, bitmask, indices, debug_print)
+        result = self._handle.batch_fill_next_token_bitmask(
+            matcher_handles, bitmask, indices, debug_print
+        )
+        return [None if value is None else float(value) for value in result]
 
     @staticmethod
     def batch_accept_token(

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -390,8 +390,8 @@ class GrammarMatcher(XGRObject):
             (default: -1.0).
         temperatures : Optional[torch.Tensor], default: None
             Optional 1D float32 CPU tensor with one element per node. It is filled with the
-            effective temperature for each visited node. ``NaN`` means that no temperature
-            is configured.
+            effective temperature for each visited node. ``-1`` means that no effective
+            temperature is configured, or that the node was not visited or was rejected.
 
         Returns
         -------
@@ -593,22 +593,34 @@ class BatchGrammarMatcher(XGRObject):
         self._handle.batch_fill_next_token_bitmask(matcher_handles, bitmask, indices, debug_print)
 
     @staticmethod
-    def batch_get_temperature(matchers: List["GrammarMatcher"]) -> List[Optional[float]]:
-        """Get the effective sampling temperature for multiple matchers.
+    def batch_fill_temperature(
+        matchers: List["GrammarMatcher"],
+        temperatures: torch.Tensor,
+        indices: Optional[List[int]] = None,
+    ) -> None:
+        """Fill the effective sampling temperature of multiple matchers into a tensor.
 
         Parameters
         ----------
         matchers : List[GrammarMatcher]
             The list of matchers to query.
 
-        Returns
-        -------
-        temperatures : List[Optional[float]]
-            The effective sampling temperature for each matcher.
+        temperatures : torch.Tensor
+            A pre-allocated 1D float32 CPU tensor. The entry of a matcher without an
+            effective temperature is set to ``-1``.
+
+        indices : Optional[List[int]], default: None
+            A list of indices to specify which element each matcher writes to. If None,
+            matchers[i] writes to temperatures[i].
+
+        Raises
+        ------
+        RuntimeError
+            If the temperatures tensor is invalid (not on CPU, not float32, not 1D, or too
+            small), or if the sizes of matchers and indices do not match.
         """
         matcher_handles = [matcher._handle for matcher in matchers]
-        result = _core.BatchGrammarMatcher.batch_get_temperature(matcher_handles)
-        return [None if value is None else float(value) for value in result]
+        _core.BatchGrammarMatcher.batch_fill_temperature(matcher_handles, temperatures, indices)
 
     @staticmethod
     def batch_accept_token(

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -901,11 +901,6 @@ def test_lark_large_choice_grammar() -> None:
             'start[budget=10]: "a"', "attribute 'budget' is not supported", id="unknown-attribute"
         ),
         pytest.param(
-            'start[temperature=0.7]: "a"',
-            "attribute 'temperature' is not supported",
-            id="temperature-attribute",
-        ),
-        pytest.param(
             'start[capture=""]: "a"', "capture name must not be empty", id="empty-capture-name"
         ),
         pytest.param(

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -44,7 +44,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v15"
+    assert xgr.get_serialization_version() == "v16"
 
 
 def test_serialize_grammar():
@@ -52,7 +52,10 @@ def test_serialize_grammar():
     grammar = construct_grammar()
     serialized = grammar.serialize_json()
     expected_json = {
-        "rules": [["rule1", 4, -1, False, -1, "", False], ["root", 8, -1, False, -1, "", False]],
+        "rules": [
+            ["rule1", 4, -1, False, -1, "", False, None],
+            ["root", 8, -1, False, -1, "", False, None],
+        ],
         "suffix_stop_infos": [],
         "grammar_expr_data": [0, 5, 8, 12, 14, 18, 21, 24, 28],
         "grammar_expr_indptr": [
@@ -65,7 +68,7 @@ def test_serialize_grammar():
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v15",
+        "__VERSION__": "v16",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -74,7 +77,10 @@ def test_serialize_grammar():
 def test_serialize_grammar_exception():
     """Test Grammar serialization produces expected JSON string."""
     expected_json = {
-        "rules": [["rule1", 4, 9, True, -1, "", False], ["root", 8, -1, False, -1, "", False]],
+        "rules": [
+            ["rule1", 4, 9, True, -1, "", False, None],
+            ["root", 8, -1, False, -1, "", False, None],
+        ],
         "suffix_stop_infos": [],
         "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 28, 31],
         "grammar_expr_indptr": [
@@ -86,14 +92,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v15",
+        "__VERSION__": "v16",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v15"
+    expected_json["__VERSION__"] = "v16"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -145,7 +151,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v15"}'
+        '"__VERSION__":"v16"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -199,7 +205,10 @@ def test_serialize_compiled_grammar():
 
     expected_json = {
         "grammar": {
-            "rules": [["rule1", 4, 9, True, -1, "", False], ["root", 8, -1, False, -1, "", False]],
+            "rules": [
+                ["rule1", 4, 9, True, -1, "", False, None],
+                ["root", 8, -1, False, -1, "", False, None],
+            ],
             "suffix_stop_infos": [],
             "grammar_expr_data": [0, 2, 7, 10, 14, 18, 21, 24, 28, 31],
             "grammar_expr_indptr": [
@@ -261,7 +270,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v15",
+        "__VERSION__": "v16",
     }
 
     class AdaptiveTokenMask(BaseModel):

--- a/tests/python/test_temperature.py
+++ b/tests/python/test_temperature.py
@@ -107,7 +107,7 @@ def test_inner_temperature_overrides_outer_temperature() -> None:
     assert matcher.temperature == pytest.approx(0.1)
 
 
-def test_ambiguous_paths_use_maximum_temperature() -> None:
+def test_ambiguous_paths_use_maximum_temperature(capfd: pytest.CaptureFixture[str]) -> None:
     compiled_grammar = _compile_lark(
         'start: left | right\nleft[temperature=0.2]: "a"+\n' 'right[temperature=0.9]: "a" "b"'
     )
@@ -118,6 +118,9 @@ def test_ambiguous_paths_use_maximum_temperature() -> None:
     assert matcher.temperature == pytest.approx(0.9)
     assert matcher.accept_string("a")
     assert matcher.temperature == pytest.approx(0.2)
+
+    captured = capfd.readouterr()
+    assert captured.err.count("Multiple active grammar paths specify different temperatures") == 1
 
 
 def test_temperature_works_with_ignored_tokens() -> None:

--- a/tests/python/test_temperature.py
+++ b/tests/python/test_temperature.py
@@ -173,7 +173,7 @@ def test_temperature_survives_serialization_and_cached_compilation() -> None:
 
 
 @pytest.mark.parametrize("max_threads", [1, 2])
-def test_batch_matcher_returns_temperatures(max_threads: int) -> None:
+def test_batch_get_temperature(max_threads: int) -> None:
     grammar_temperature = xgr.GrammarMatcher(
         _compile_lark('start[temperature=0.2]: "a"'), default_temperature=0.8
     )
@@ -182,13 +182,16 @@ def test_batch_matcher_returns_temperatures(max_threads: int) -> None:
     matchers = [grammar_temperature, default_temperature, no_temperature]
     bitmask = xgr.allocate_token_bitmask(3, len(VOCAB))
 
-    temperatures = xgr.BatchGrammarMatcher(max_threads).batch_fill_next_token_bitmask(
+    fill_result = xgr.BatchGrammarMatcher(max_threads).batch_fill_next_token_bitmask(
         matchers, bitmask, indices=[2, 0, 1]
     )
+    temperatures = xgr.BatchGrammarMatcher.batch_get_temperature(matchers)
 
+    assert fill_result is None
     assert temperatures[0] == pytest.approx(0.2)
     assert temperatures[1] == pytest.approx(0.4)
     assert temperatures[2] is None
+    assert xgr.BatchGrammarMatcher.batch_get_temperature([]) == []
 
 
 def test_traverse_draft_tree_fills_temperatures() -> None:

--- a/tests/python/test_temperature.py
+++ b/tests/python/test_temperature.py
@@ -1,0 +1,245 @@
+import math
+from typing import Dict, Optional, Union
+
+import pytest
+import torch
+
+import xgrammar as xgr
+
+VOCAB = ["a", "b", "x", "z", " "]
+TOKENIZER_INFO = xgr.TokenizerInfo(VOCAB, vocab_size=len(VOCAB), stop_token_ids=[])
+
+
+def _compile_lark(
+    grammar: str,
+    *,
+    named_grammars: Optional[Dict[str, Union[xgr.Grammar, str]]] = None,
+    cache_enabled: bool = False,
+) -> xgr.CompiledGrammar:
+    grammar_object = xgr.Grammar.from_lark(
+        grammar, tokenizer_info=TOKENIZER_INFO, named_grammars=named_grammars
+    )
+    return xgr.GrammarCompiler(TOKENIZER_INFO, cache_enabled=cache_enabled).compile_grammar(
+        grammar_object
+    )
+
+
+def test_temperature_defaults_to_none() -> None:
+    compiled_grammar = _compile_lark('start: "a"')
+    matcher = xgr.GrammarMatcher(compiled_grammar)
+
+    assert matcher.temperature is None
+    assert matcher.accept_string("a")
+    assert matcher.temperature is None
+
+
+def test_default_temperature() -> None:
+    compiled_grammar = _compile_lark('start: "a"')
+    matcher = xgr.GrammarMatcher(compiled_grammar, default_temperature=0.25)
+
+    assert matcher.temperature == pytest.approx(0.25)
+    assert matcher.accept_string("a")
+    assert matcher.temperature == pytest.approx(0.25)
+
+
+@pytest.mark.parametrize("temperature", [-0.1, math.inf, -math.inf, math.nan])
+def test_invalid_default_temperature(temperature: float) -> None:
+    compiled_grammar = _compile_lark('start: "a"')
+
+    with pytest.raises(RuntimeError, match="finite non-negative"):
+        xgr.GrammarMatcher(compiled_grammar, default_temperature=temperature)
+
+
+@pytest.mark.parametrize(
+    "temperature, expected", [(0.0, 0.0), (0.125, 0.125), (1e-2, 0.01), (2.0, 2.0)]
+)
+def test_lark_temperature_number_forms(temperature: float, expected: float) -> None:
+    compiled_grammar = _compile_lark(f'start[temperature={temperature}]: "a"')
+    matcher = xgr.GrammarMatcher(compiled_grammar, default_temperature=0.5)
+
+    assert matcher.temperature == pytest.approx(expected)
+
+
+def test_temperature_enters_and_leaves_named_subgrammar() -> None:
+    item_grammar = xgr.Grammar.from_lark('start: "x"+')
+    compiled_grammar = _compile_lark(
+        'start: "a" value "z"\nvalue[temperature=0.6]: @item', named_grammars={"item": item_grammar}
+    )
+    matcher = xgr.GrammarMatcher(compiled_grammar, default_temperature=0.1)
+
+    assert matcher.temperature == pytest.approx(0.1)
+    assert matcher.accept_string("a")
+    assert matcher.temperature == pytest.approx(0.6)
+    assert matcher.accept_string("xx")
+    assert matcher.temperature == pytest.approx(0.6)
+    assert matcher.accept_string("z")
+    assert matcher.temperature == pytest.approx(0.1)
+
+    matcher.rollback()
+    assert matcher.temperature == pytest.approx(0.6)
+    matcher.reset()
+    assert matcher.temperature == pytest.approx(0.1)
+
+
+@pytest.mark.parametrize(
+    "body, value", [('%json {"type": "integer"}', "1"), ('%lark { start: "x" }', "x")]
+)
+def test_temperature_on_inline_subgrammar(body: str, value: str) -> None:
+    compiled_grammar = _compile_lark(f'start: "a" value "z"\nvalue[temperature=0.6]: {body}')
+    matcher = xgr.GrammarMatcher(compiled_grammar, default_temperature=0.1)
+
+    assert matcher.accept_string("a")
+    assert matcher.temperature == pytest.approx(0.6)
+    assert matcher.accept_string(value + "z")
+    assert matcher.temperature == pytest.approx(0.1)
+
+
+def test_inner_temperature_overrides_outer_temperature() -> None:
+    item_grammar = xgr.Grammar.from_lark('start[temperature=0.3]: "x"')
+    compiled_grammar = _compile_lark(
+        'start: "a" value "z"\nvalue[temperature=0.6]: @item', named_grammars={"item": item_grammar}
+    )
+    matcher = xgr.GrammarMatcher(compiled_grammar, default_temperature=0.1)
+
+    assert matcher.accept_string("a")
+    assert matcher.temperature == pytest.approx(0.3)
+    assert matcher.accept_string("x")
+    assert matcher.temperature == pytest.approx(0.1)
+
+
+def test_ambiguous_paths_use_maximum_temperature() -> None:
+    compiled_grammar = _compile_lark(
+        'start: left | right\nleft[temperature=0.2]: "a"+\n' 'right[temperature=0.9]: "a" "b"'
+    )
+    matcher = xgr.GrammarMatcher(compiled_grammar, default_temperature=0.1)
+
+    assert matcher.temperature == pytest.approx(0.9)
+    assert matcher.accept_string("a")
+    assert matcher.temperature == pytest.approx(0.9)
+    assert matcher.accept_string("a")
+    assert matcher.temperature == pytest.approx(0.2)
+
+
+def test_temperature_works_with_ignored_tokens() -> None:
+    compiled_grammar = _compile_lark(
+        '%import common.WS\n%ignore WS\nstart: hot "z"\nhot[temperature=0.6]: "x"'
+    )
+    matcher = xgr.GrammarMatcher(compiled_grammar, default_temperature=0.1)
+
+    assert matcher.temperature == pytest.approx(0.6)
+    assert matcher.accept_string("x")
+    assert matcher.temperature == pytest.approx(0.1)
+    assert matcher.accept_string(" ")
+    assert matcher.temperature == pytest.approx(0.1)
+
+
+@pytest.mark.parametrize(
+    "grammar, message",
+    [
+        ('start[temperature=-0.1]: "a"', "temperature must be a finite non-negative number"),
+        ('start[temperature=1e999]: "a"', "temperature must be a finite non-negative number"),
+        (
+            'start[temperature=0.1, temperature=0.2]: "a"',
+            "temperature attribute is specified more than once",
+        ),
+        ('start[temperature=abc]: "a"', "expected number after temperature="),
+        (
+            'start: complex\ncomplex[temperature=0.5]: "a" child\nchild: "b"',
+            "temperature is only supported on terminals and subgrammars",
+        ),
+    ],
+)
+def test_invalid_lark_temperature(grammar: str, message: str) -> None:
+    with pytest.raises(RuntimeError, match=message):
+        xgr.Grammar.from_lark(grammar, tokenizer_info=TOKENIZER_INFO)
+
+
+def test_temperature_survives_serialization_and_cached_compilation() -> None:
+    grammar = xgr.Grammar.from_lark('start[temperature=0.75]: "a"')
+    serialized = grammar.serialize_json()
+    restored = xgr.Grammar.deserialize_json(serialized)
+    compiler = xgr.GrammarCompiler(TOKENIZER_INFO, cache_enabled=True)
+
+    assert "[temperature=0.75]" in str(restored)
+    compiled_grammar = compiler.compile_grammar(restored)
+    restored_compiled_grammar = xgr.CompiledGrammar.deserialize_json(
+        compiled_grammar.serialize_json(), TOKENIZER_INFO
+    )
+    matcher = xgr.GrammarMatcher(restored_compiled_grammar)
+    assert matcher.temperature == pytest.approx(0.75)
+
+
+@pytest.mark.parametrize("max_threads", [1, 2])
+def test_batch_matcher_returns_temperatures(max_threads: int) -> None:
+    grammar_temperature = xgr.GrammarMatcher(
+        _compile_lark('start[temperature=0.2]: "a"'), default_temperature=0.8
+    )
+    default_temperature = xgr.GrammarMatcher(_compile_lark('start: "a"'), default_temperature=0.4)
+    no_temperature = xgr.GrammarMatcher(_compile_lark('start: "a"'))
+    matchers = [grammar_temperature, default_temperature, no_temperature]
+    bitmask = xgr.allocate_token_bitmask(3, len(VOCAB))
+
+    temperatures = xgr.BatchGrammarMatcher(max_threads).batch_fill_next_token_bitmask(
+        matchers, bitmask, indices=[2, 0, 1]
+    )
+
+    assert temperatures[0] == pytest.approx(0.2)
+    assert temperatures[1] == pytest.approx(0.4)
+    assert temperatures[2] is None
+
+
+def test_traverse_draft_tree_fills_temperatures() -> None:
+    item_grammar = xgr.Grammar.from_lark('start: "x"+')
+    compiled_grammar = _compile_lark(
+        'start: "a" value "z"\nvalue[temperature=0.6]: @item', named_grammars={"item": item_grammar}
+    )
+    matcher = xgr.GrammarMatcher(compiled_grammar, default_temperature=0.1)
+    retrieve_next_token = torch.tensor([1, 2, 3, -1], dtype=torch.int64)
+    retrieve_next_sibling = torch.full((4,), -1, dtype=torch.int64)
+    draft_tokens = torch.tensor([0, 0, 2, 3], dtype=torch.int64)
+    bitmask = xgr.allocate_token_bitmask(4, len(VOCAB))
+    temperatures = torch.empty(4, dtype=torch.float32)
+
+    completed = matcher.traverse_draft_tree(
+        retrieve_next_token, retrieve_next_sibling, draft_tokens, bitmask, temperatures=temperatures
+    )
+
+    assert completed
+    torch.testing.assert_close(temperatures, torch.tensor([0.1, 0.6, 0.6, 0.1]))
+    assert matcher.temperature == pytest.approx(0.1)
+
+
+def test_traverse_draft_tree_uses_nan_for_missing_and_rejected_nodes() -> None:
+    compiled_grammar = _compile_lark('start: "a"')
+    matcher = xgr.GrammarMatcher(compiled_grammar)
+    retrieve_next_token = torch.tensor([1, -1], dtype=torch.int64)
+    retrieve_next_sibling = torch.full((2,), -1, dtype=torch.int64)
+    draft_tokens = torch.tensor([1, 0], dtype=torch.int64)
+    bitmask = xgr.allocate_token_bitmask(2, len(VOCAB))
+    temperatures = torch.zeros(2, dtype=torch.float32)
+
+    assert matcher.traverse_draft_tree(
+        retrieve_next_token, retrieve_next_sibling, draft_tokens, bitmask, temperatures=temperatures
+    )
+    assert torch.isnan(temperatures).all()
+
+
+@pytest.mark.parametrize(
+    "temperatures", [torch.empty(2, dtype=torch.float64), torch.empty((2, 1), dtype=torch.float32)]
+)
+def test_traverse_draft_tree_validates_temperature_tensor(temperatures: torch.Tensor) -> None:
+    compiled_grammar = _compile_lark('start: "a"')
+    matcher = xgr.GrammarMatcher(compiled_grammar)
+    retrieve_next_token = torch.tensor([1, -1], dtype=torch.int64)
+    retrieve_next_sibling = torch.full((2,), -1, dtype=torch.int64)
+    draft_tokens = torch.tensor([0, 0], dtype=torch.int64)
+    bitmask = xgr.allocate_token_bitmask(2, len(VOCAB))
+
+    with pytest.raises(RuntimeError, match="temperatures tensor"):
+        matcher.traverse_draft_tree(
+            retrieve_next_token,
+            retrieve_next_sibling,
+            draft_tokens,
+            bitmask,
+            temperatures=temperatures,
+        )

--- a/tests/python/test_temperature.py
+++ b/tests/python/test_temperature.py
@@ -211,7 +211,7 @@ def test_temperature_survives_serialization_and_cached_compilation() -> None:
 
 
 @pytest.mark.parametrize("max_threads", [1, 2])
-def test_batch_get_temperature(max_threads: int) -> None:
+def test_batch_fill_temperature(max_threads: int) -> None:
     grammar_temperature = xgr.GrammarMatcher(
         _compile_lark('start[temperature=0.2]: "a"'), default_temperature=0.8
     )
@@ -219,17 +219,35 @@ def test_batch_get_temperature(max_threads: int) -> None:
     no_temperature = xgr.GrammarMatcher(_compile_lark('start: "a"'))
     matchers = [grammar_temperature, default_temperature, no_temperature]
     bitmask = xgr.allocate_token_bitmask(3, len(VOCAB))
+    temperatures = torch.zeros(3, dtype=torch.float32)
 
     fill_result = xgr.BatchGrammarMatcher(max_threads).batch_fill_next_token_bitmask(
         matchers, bitmask, indices=[2, 0, 1]
     )
-    temperatures = xgr.BatchGrammarMatcher.batch_get_temperature(matchers)
+    xgr.BatchGrammarMatcher.batch_fill_temperature(matchers, temperatures)
 
     assert fill_result is None
-    assert temperatures[0] == pytest.approx(0.2)
-    assert temperatures[1] == pytest.approx(0.4)
-    assert temperatures[2] is None
-    assert xgr.BatchGrammarMatcher.batch_get_temperature([]) == []
+    torch.testing.assert_close(temperatures, torch.tensor([0.2, 0.4, -1.0]))
+
+
+def test_batch_fill_temperature_with_indices() -> None:
+    grammar_temperature = xgr.GrammarMatcher(_compile_lark('start[temperature=0.2]: "a"'))
+    no_temperature = xgr.GrammarMatcher(_compile_lark('start: "a"'))
+    matchers = [grammar_temperature, no_temperature]
+    temperatures = torch.zeros(3, dtype=torch.float32)
+
+    xgr.BatchGrammarMatcher.batch_fill_temperature(matchers, temperatures, indices=[2, 0])
+
+    torch.testing.assert_close(temperatures, torch.tensor([-1.0, 0.0, 0.2]))
+
+    with pytest.raises(RuntimeError, match="indices size"):
+        xgr.BatchGrammarMatcher.batch_fill_temperature(matchers, temperatures, indices=[0])
+    with pytest.raises(RuntimeError, match="out of bounds"):
+        xgr.BatchGrammarMatcher.batch_fill_temperature(matchers, temperatures, indices=[0, 3])
+    with pytest.raises(RuntimeError, match="temperatures tensor"):
+        xgr.BatchGrammarMatcher.batch_fill_temperature(
+            matchers, torch.zeros(3, dtype=torch.float64)
+        )
 
 
 def test_traverse_draft_tree_fills_temperatures() -> None:
@@ -253,7 +271,7 @@ def test_traverse_draft_tree_fills_temperatures() -> None:
     assert matcher.temperature == pytest.approx(0.1)
 
 
-def test_traverse_draft_tree_uses_nan_for_missing_and_rejected_nodes() -> None:
+def test_traverse_draft_tree_uses_minus_one_for_missing_and_rejected_nodes() -> None:
     compiled_grammar = _compile_lark('start: "a"')
     matcher = xgr.GrammarMatcher(compiled_grammar)
     retrieve_next_token = torch.tensor([1, -1], dtype=torch.int64)
@@ -265,7 +283,7 @@ def test_traverse_draft_tree_uses_nan_for_missing_and_rejected_nodes() -> None:
     assert matcher.traverse_draft_tree(
         retrieve_next_token, retrieve_next_sibling, draft_tokens, bitmask, temperatures=temperatures
     )
-    assert torch.isnan(temperatures).all()
+    torch.testing.assert_close(temperatures, torch.tensor([-1.0, -1.0]))
 
 
 @pytest.mark.parametrize(

--- a/tests/python/test_temperature.py
+++ b/tests/python/test_temperature.py
@@ -24,6 +24,10 @@ def _compile_lark(
     )
 
 
+def _compile_ebnf(grammar: str) -> xgr.CompiledGrammar:
+    return xgr.GrammarCompiler(TOKENIZER_INFO).compile_grammar(xgr.Grammar.from_ebnf(grammar))
+
+
 def test_temperature_defaults_to_none() -> None:
     compiled_grammar = _compile_lark('start: "a"')
     matcher = xgr.GrammarMatcher(compiled_grammar)
@@ -58,6 +62,40 @@ def test_lark_temperature_number_forms(temperature: float, expected: float) -> N
     matcher = xgr.GrammarMatcher(compiled_grammar, default_temperature=0.5)
 
     assert matcher.temperature == pytest.approx(expected)
+
+
+def test_ebnf_temperature_enters_and_leaves_rule() -> None:
+    compiled_grammar = _compile_ebnf('root ::= "a" value "z"\nvalue[temperature=0.6] ::= "x"+')
+    matcher = xgr.GrammarMatcher(compiled_grammar, default_temperature=0.1)
+
+    assert matcher.temperature == pytest.approx(0.1)
+    assert matcher.accept_string("a")
+    assert matcher.temperature == pytest.approx(0.6)
+    assert matcher.accept_string("xx")
+    assert matcher.temperature == pytest.approx(0.6)
+    assert matcher.accept_string("z")
+    assert matcher.temperature == pytest.approx(0.1)
+
+
+@pytest.mark.parametrize(
+    "grammar, message",
+    [
+        ('root[temperature=-0.1] ::= "a"', "finite non-negative"),
+        ('root[temperature=1e999] ::= "a"', "finite non-negative"),
+        # A non-numeric value makes the bracket group fall back to character class lexing, the
+        # same as other unrecognized rule attributes.
+        ('root[temperature=abc] ::= "a"', "Assign should be preceded by an identifier"),
+    ],
+)
+def test_invalid_ebnf_temperature(grammar: str, message: str) -> None:
+    with pytest.raises(RuntimeError, match=message):
+        xgr.Grammar.from_ebnf(grammar)
+
+
+def test_ebnf_temperature_combines_with_other_attributes() -> None:
+    grammar = xgr.Grammar.from_ebnf('root[max_tokens=3, temperature=0.5] ::= "a"*')
+    assert "max_tokens=3" in str(grammar)
+    assert "temperature=0.5" in str(grammar)
 
 
 def test_temperature_enters_and_leaves_named_subgrammar() -> None:


### PR DESCRIPTION
## Summary
- add `[temperature=VALUE]` attributes for Lark terminals and subgrammars, including nested override and ambiguous-path handling
- expose effective temperatures through `GrammarMatcher`, `BatchGrammarMatcher`, and draft-tree traversal APIs
- preserve temperature metadata through grammar transformations and serialization, with documentation and 28 focused Python tests

## Test plan
- [x] `pre-commit run --all-files`
- [x] `ruff check python/xgrammar/matcher.py tests/python/test_temperature.py tests/python/test_serialization.py`
- [x] `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 pytest -q tests/python/test_temperature.py tests/python/test_lark.py tests/python/test_grammar_matcher_basic.py tests/python/test_speculative_decoding.py tests/python/test_serialization.py tests/python/test_grammar_parser.py` (349 passed)