### PR TITLE
feat: add on-demand token mask compilation

### DIFF
--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -168,7 +168,10 @@ picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl) {
   auto result = picojson::object{};
   result["grammar"] = AutoSerializeJSONValue(impl.grammar);
   result["tokenizer_metadata"] = impl.tokenizer_info->DumpMetadataValue();
-  std::lock_guard<std::mutex> lock(impl.adaptive_token_mask_cache_mutex);
+  std::unique_lock<std::mutex> lock(impl.adaptive_token_mask_cache_mutex, std::defer_lock);
+  if (impl.enable_dynamic_compilation) {
+    lock.lock();
+  }
   result["adaptive_token_mask_cache"] = AutoSerializeJSONValue(impl.adaptive_token_mask_cache);
   return picojson::value(result);
 }
@@ -207,7 +210,10 @@ std::optional<SerializationError> DeserializeJSONValue(
 /************** CompiledGrammar **************/
 
 std::size_t MemorySize(const CompiledGrammar::Impl& impl) {
-  std::lock_guard<std::mutex> lock(impl.adaptive_token_mask_cache_mutex);
+  std::unique_lock<std::mutex> lock(impl.adaptive_token_mask_cache_mutex, std::defer_lock);
+  if (impl.enable_dynamic_compilation) {
+    lock.lock();
+  }
   return MemorySize(impl.grammar) + MemorySize(impl.adaptive_token_mask_cache) +
          MemorySize(impl.tag_dispatch_rule_id_to_second_slicing_bitset);
 }
@@ -220,7 +226,9 @@ TokenizerInfo CompiledGrammar::GetTokenizerInfo() const { return pimpl_->GetToke
 
 /*! \brief Return the serialized JSON string of the compiled grammar. */
 std::string CompiledGrammar::SerializeJSON() const {
-  pimpl_->MaterializeAdaptiveTokenMaskCache();
+  if (pimpl_->enable_dynamic_compilation) {
+    pimpl_->MaterializeAdaptiveTokenMaskCache();
+  }
   return AutoSerializeJSON(*this, true);
 }
 

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -168,6 +168,7 @@ picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl) {
   auto result = picojson::object{};
   result["grammar"] = AutoSerializeJSONValue(impl.grammar);
   result["tokenizer_metadata"] = impl.tokenizer_info->DumpMetadataValue();
+  std::lock_guard<std::mutex> lock(impl.adaptive_token_mask_cache_mutex);
   result["adaptive_token_mask_cache"] = AutoSerializeJSONValue(impl.adaptive_token_mask_cache);
   return picojson::value(result);
 }
@@ -206,7 +207,9 @@ std::optional<SerializationError> DeserializeJSONValue(
 /************** CompiledGrammar **************/
 
 std::size_t MemorySize(const CompiledGrammar::Impl& impl) {
-  return MemorySize(impl.grammar) + MemorySize(impl.adaptive_token_mask_cache);
+  std::lock_guard<std::mutex> lock(impl.adaptive_token_mask_cache_mutex);
+  return MemorySize(impl.grammar) + MemorySize(impl.adaptive_token_mask_cache) +
+         MemorySize(impl.tag_dispatch_rule_id_to_second_slicing_bitset);
 }
 
 std::size_t CompiledGrammar::MemorySizeBytes() const { return MemorySize(*pimpl_); }
@@ -216,7 +219,10 @@ Grammar CompiledGrammar::GetGrammar() const { return pimpl_->GetGrammar(); }
 TokenizerInfo CompiledGrammar::GetTokenizerInfo() const { return pimpl_->GetTokenizerInfo(); }
 
 /*! \brief Return the serialized JSON string of the compiled grammar. */
-std::string CompiledGrammar::SerializeJSON() const { return AutoSerializeJSON(*this, true); }
+std::string CompiledGrammar::SerializeJSON() const {
+  pimpl_->MaterializeAdaptiveTokenMaskCache();
+  return AutoSerializeJSON(*this, true);
+}
 
 /*! \brief Deserialize a compiled grammar from a JSON string and tokenizer info. */
 std::variant<CompiledGrammar, SerializationError> CompiledGrammar::DeserializeJSON(

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -10,6 +10,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -22,6 +24,8 @@
 #include "xgrammar/exception.h"
 
 namespace xgrammar {
+
+class RuleLevelCache;
 
 /******************* CompiledGrammar Datastructures *******************/
 
@@ -118,6 +122,24 @@ class CompiledGrammar::Impl {
   /*! \brief Mapping from the parser state to the adaptive token mask. */
   std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache>
       adaptive_token_mask_cache;
+
+  /*! \brief Protects on-demand token mask cache insertion and cache serialization. */
+  mutable std::mutex adaptive_token_mask_cache_mutex;
+
+  /*! \brief Whether missing token mask cache entries should be generated on demand. */
+  bool enable_dynamic_compilation{false};
+
+  /*! \brief Reusable cache shared by grammars created from the same compiler. */
+  std::shared_ptr<RuleLevelCache> rule_level_cache;
+
+  /*! \brief Tag dispatch data needed to generate token masks on demand. */
+  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
+
+  /*! \brief Get an existing token mask or generate and cache it on demand. */
+  const AdaptiveTokenMask& GetAdaptiveTokenMask(const ParserState& state, bool is_root_rule);
+
+  /*! \brief Generate every token mask before serialization. */
+  void MaterializeAdaptiveTokenMaskCache();
 
   Grammar GetGrammar() const { return grammar; }
 

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1412,7 +1412,9 @@ class GrammarCompiler::Impl {
       int64_t max_memory_bytes,
       bool enable_dynamic_compilation
   )
-      : cache_enabled_(cache_enabled),
+      : grammar_level_cache_enabled_(
+            cache_enabled && (!enable_dynamic_compilation || max_memory_bytes == -1)
+        ),
         rule_level_cache_(
             cache_enabled
                 ? std::make_shared<RuleLevelCache>(
@@ -1483,8 +1485,8 @@ class GrammarCompiler::Impl {
     std::size_t operator()(const CompiledGrammar& value) const { return value.MemorySizeBytes(); }
   };
 
-  /*! \brief Whether the cache is enabled. */
-  const bool cache_enabled_;
+  /*! \brief Whether the grammar-level cache is enabled. */
+  const bool grammar_level_cache_enabled_;
 
   /*! \brief The crossing cache manager for compiled grammars. */
   std::shared_ptr<RuleLevelCache> rule_level_cache_;
@@ -1526,7 +1528,7 @@ CompiledGrammar GrammarCompiler::Impl::Compute(const UnionKey& key) {
 }
 
 CompiledGrammar GrammarCompiler::Impl::CompileBuiltinJSONGrammar() {
-  if (!cache_enabled_) {
+  if (!grammar_level_cache_enabled_) {
     return no_cache_compiler_.CompileBuiltinJSONGrammar();
   }
   return grammar_level_cache_.Get(BuiltinJSONGrammarKey{});
@@ -1541,7 +1543,7 @@ CompiledGrammar GrammarCompiler::Impl::CompileJSONSchema(
     std::optional<int> max_whitespace_cnt,
     bool any_order
 ) {
-  if (!cache_enabled_) {
+  if (!grammar_level_cache_enabled_) {
     return no_cache_compiler_.CompileJSONSchema(
         schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
     );
@@ -1553,21 +1555,21 @@ CompiledGrammar GrammarCompiler::Impl::CompileJSONSchema(
 
 CompiledGrammar GrammarCompiler::Impl::CompileStructuralTag(const std::string& structural_tag_json
 ) {
-  if (!cache_enabled_) {
+  if (!grammar_level_cache_enabled_) {
     return no_cache_compiler_.CompileStructuralTag(structural_tag_json);
   }
   return grammar_level_cache_.Get(StructuralTagKey{structural_tag_json});
 }
 
 CompiledGrammar GrammarCompiler::Impl::CompileRegex(const std::string& regex) {
-  if (!cache_enabled_) {
+  if (!grammar_level_cache_enabled_) {
     return no_cache_compiler_.CompileRegex(regex);
   }
   return grammar_level_cache_.Get(RegexKey{regex});
 }
 
 CompiledGrammar GrammarCompiler::Impl::CompileGrammar(const Grammar& grammar) {
-  if (!cache_enabled_) {
+  if (!grammar_level_cache_enabled_) {
     return no_cache_compiler_.CompileGrammar(grammar);
   }
   return grammar_level_cache_.Get(GrammarKey{grammar.ToString(), grammar->GetRootRule().name});
@@ -1576,7 +1578,7 @@ CompiledGrammar GrammarCompiler::Impl::CompileGrammar(const Grammar& grammar) {
 CompiledGrammar GrammarCompiler::Impl::CompileGrammar(
     const std::string& ebnf_str, std::string root_rule_name
 ) {
-  if (!cache_enabled_) {
+  if (!grammar_level_cache_enabled_) {
     return no_cache_compiler_.CompileGrammar(ebnf_str, root_rule_name);
   }
   return grammar_level_cache_.Get(GrammarKey{ebnf_str, root_rule_name});
@@ -1602,6 +1604,14 @@ int64_t GrammarCompiler::Impl::CacheLimitBytes() const {
 }
 
 /******************* GrammarCompiler *******************/
+
+GrammarCompiler::GrammarCompiler(
+    const TokenizerInfo& tokenizer_info,
+    int max_threads,
+    bool cache_enabled,
+    int64_t max_memory_bytes
+)
+    : GrammarCompiler(tokenizer_info, max_threads, cache_enabled, max_memory_bytes, false) {}
 
 GrammarCompiler::GrammarCompiler(
     const TokenizerInfo& tokenizer_info,

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -10,6 +10,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -45,7 +46,7 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
       const std::unordered_map<int32_t, DynamicBitset>&
           tag_dispatch_rule_id_to_second_slicing_bitset,
       const TokenizerInfo& tokenizer_info,
-      std::optional<RuleLevelCache>& rule_level_cache
+      const std::shared_ptr<RuleLevelCache>& rule_level_cache
   )
       : EarleyParser(grammar, init_state),
         init_rule_id_(init_state.rule_id),
@@ -129,7 +130,7 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
 
   const TokenizerInfo& tokenizer_info_;
 
-  std::optional<RuleLevelCache> rule_level_cache_;
+  std::shared_ptr<RuleLevelCache> rule_level_cache_;
 
   // Temporary data for GetAdaptiveTokenMask.
   std::vector<int32_t> tmp_accepted_indices_;
@@ -796,7 +797,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
 
   // Try to get the crossing cache.
   bool rule_level_cache_is_available =
-      rule_level_cache_.has_value() && grammar_->per_rule_fsm_hashes[init_rule_id_].has_value();
+      rule_level_cache_ != nullptr && grammar_->per_rule_fsm_hashes[init_rule_id_].has_value();
   std::optional<uint64_t> fsm_hash = std::nullopt;
   int32_t new_state_id = -1;
   std::optional<AdaptiveTokenMask> crossing_cache = std::nullopt;
@@ -992,6 +993,67 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   }
 }
 
+const AdaptiveTokenMask& CompiledGrammar::Impl::GetAdaptiveTokenMask(
+    const ParserState& state, bool is_root_rule
+) {
+  if (!enable_dynamic_compilation) {
+    auto iterator = adaptive_token_mask_cache.find(state);
+    XGRAMMAR_CHECK(iterator != adaptive_token_mask_cache.end())
+        << "The token mask cache is incomplete while dynamic compilation is disabled: " << state;
+    return iterator->second;
+  }
+
+  auto cache_state = ParserState(
+      state.rule_id,
+      state.sequence_id,
+      state.element_id,
+      ParserState::kNoPrevInputPos,
+      state.sub_element_id
+  );
+  {
+    std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex);
+    auto iterator = adaptive_token_mask_cache.find(cache_state);
+    if (iterator != adaptive_token_mask_cache.end()) {
+      return iterator->second;
+    }
+  }
+
+  auto generated_mask = GrammarMatcherForTokenMaskCache(
+                            grammar,
+                            cache_state,
+                            tag_dispatch_rule_id_to_second_slicing_bitset,
+                            tokenizer_info,
+                            rule_level_cache
+  )
+                            .GetAdaptiveTokenMask(is_root_rule);
+
+  std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex);
+  return adaptive_token_mask_cache.try_emplace(cache_state, std::move(generated_mask))
+      .first->second;
+}
+
+void CompiledGrammar::Impl::MaterializeAdaptiveTokenMaskCache() {
+  if (tokenizer_info.GetVocabSize() == 0) {
+    return;
+  }
+  auto root_rule_id = grammar->GetRootRuleId();
+  for (int32_t rule_id = 0; rule_id < static_cast<int32_t>(grammar->NumRules()); ++rule_id) {
+    auto rule = grammar->GetRule(rule_id);
+    const auto& rule_fsm = grammar->per_rule_fsms[rule_id];
+    XGRAMMAR_DCHECK(rule_fsm.has_value());
+    auto state = ParserState(rule_id, rule.body_expr_id, 0, ParserState::kNoPrevInputPos, 0);
+    std::unordered_set<int> reachable_states;
+    rule_fsm->GetFsm().GetReachableStates(&reachable_states);
+    for (int element_id : reachable_states) {
+      if (!rule_fsm->GetFsm().IsScanableState(element_id)) {
+        continue;
+      }
+      state.element_id = element_id;
+      GetAdaptiveTokenMask(state, rule_id == root_rule_id);
+    }
+  }
+}
+
 /******************* GrammarCompilerNoCache *******************/
 
 /*!
@@ -1002,11 +1064,13 @@ class GrammarCompilerSub {
   GrammarCompilerSub(
       const TokenizerInfo& tokenizer_info,
       int max_threads,
-      std::optional<RuleLevelCache> rule_level_cache
+      std::shared_ptr<RuleLevelCache> rule_level_cache,
+      bool enable_dynamic_compilation
   )
       : tokenizer_info_(tokenizer_info),
         max_threads_(max_threads),
-        rule_level_cache_(rule_level_cache) {}
+        rule_level_cache_(std::move(rule_level_cache)),
+        enable_dynamic_compilation_(enable_dynamic_compilation) {}
 
   CompiledGrammar CompileBuiltinJSONGrammar();
 
@@ -1047,13 +1111,20 @@ class GrammarCompilerSub {
   const int max_threads_;
 
   /*! \brief The manager of the rule level cache.*/
-  std::optional<RuleLevelCache> rule_level_cache_;
+  std::shared_ptr<RuleLevelCache> rule_level_cache_;
+
+  /*! \brief Whether token mask cache entries are generated on demand. */
+  const bool enable_dynamic_compilation_;
 };
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
   compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
+  compiled_grammar_impl->enable_dynamic_compilation = enable_dynamic_compilation_;
+  if (enable_dynamic_compilation_) {
+    compiled_grammar_impl->rule_level_cache = rule_level_cache_;
+  }
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
   }
@@ -1061,9 +1132,15 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   TagDispatchOptimization(compiled_grammar_impl, &tag_dispatch_rule_id_to_second_slicing_bitset);
 
   // If the compiler is cache-enabled, then we hash the grammars for crossing-grammar caching.
-  if (rule_level_cache_.has_value()) {
+  if (rule_level_cache_ != nullptr) {
     GrammarFSMHasher().Apply(&compiled_grammar_impl->grammar);
   }
+  if (enable_dynamic_compilation_) {
+    compiled_grammar_impl->tag_dispatch_rule_id_to_second_slicing_bitset =
+        std::move(tag_dispatch_rule_id_to_second_slicing_bitset);
+    return CompiledGrammar(compiled_grammar_impl);
+  }
+
   // Step 3. Compute the adaptive token mask cache
   // The token mask cache is computed for these positions in the grammar:
   // 1. All character class or character class star (with last_utf8_bytes=0, 1, 2, 3)
@@ -1332,19 +1409,22 @@ class GrammarCompiler::Impl {
       const TokenizerInfo& tokenizer_info,
       int max_threads,
       bool cache_enabled,
-      int64_t max_memory_bytes
+      int64_t max_memory_bytes,
+      bool enable_dynamic_compilation
   )
       : cache_enabled_(cache_enabled),
         rule_level_cache_(
             cache_enabled
-                ? std::optional<RuleLevelCache>(
+                ? std::make_shared<RuleLevelCache>(
                       max_memory_bytes == -1
                           ? static_cast<std::size_t>(-1)
                           : static_cast<std::size_t>(max_memory_bytes - max_memory_bytes / 3 * 2)
                   )
-                : std::nullopt
+                : nullptr
         ),
-        no_cache_compiler_(tokenizer_info, max_threads, rule_level_cache_),
+        no_cache_compiler_(
+            tokenizer_info, max_threads, rule_level_cache_, enable_dynamic_compilation
+        ),
         grammar_level_cache_(
             max_memory_bytes == -1 ? static_cast<std::size_t>(-1)
                                    : static_cast<std::size_t>(max_memory_bytes / 3 * 2),
@@ -1407,7 +1487,7 @@ class GrammarCompiler::Impl {
   const bool cache_enabled_;
 
   /*! \brief The crossing cache manager for compiled grammars. */
-  std::optional<RuleLevelCache> rule_level_cache_ = std::nullopt;
+  std::shared_ptr<RuleLevelCache> rule_level_cache_;
 
   /*! \brief The no cache compiler. */
   GrammarCompilerSub no_cache_compiler_;
@@ -1504,22 +1584,21 @@ CompiledGrammar GrammarCompiler::Impl::CompileGrammar(
 
 void GrammarCompiler::Impl::ClearCache() {
   grammar_level_cache_.Clear();
-  if (rule_level_cache_.has_value()) {
+  if (rule_level_cache_ != nullptr) {
     rule_level_cache_->ClearCache();
   }
 }
 
 int64_t GrammarCompiler::Impl::GetCacheSizeBytes() const {
   return static_cast<int64_t>(grammar_level_cache_.MemorySize()) +
-         static_cast<int64_t>(MemorySize(rule_level_cache_));
+         static_cast<int64_t>(rule_level_cache_ == nullptr ? 0 : MemorySize(*rule_level_cache_));
 }
 
 int64_t GrammarCompiler::Impl::CacheLimitBytes() const {
   const auto size = grammar_level_cache_.MaxMemorySize();
   if (size == grammar_level_cache_.kUnlimitedSize) return -1;
-  return static_cast<int64_t>(size) + (rule_level_cache_.has_value()
-                                           ? static_cast<int64_t>(rule_level_cache_->GetMaxSize())
-                                           : 0);
+  return static_cast<int64_t>(size) +
+         (rule_level_cache_ != nullptr ? static_cast<int64_t>(rule_level_cache_->GetMaxSize()) : 0);
 }
 
 /******************* GrammarCompiler *******************/
@@ -1528,10 +1607,12 @@ GrammarCompiler::GrammarCompiler(
     const TokenizerInfo& tokenizer_info,
     int max_threads,
     bool cache_enabled,
-    int64_t max_memory_bytes
+    int64_t max_memory_bytes,
+    bool enable_dynamic_compilation
 )
-    : pimpl_(std::make_shared<Impl>(tokenizer_info, max_threads, cache_enabled, max_memory_bytes)) {
-}
+    : pimpl_(std::make_shared<Impl>(
+          tokenizer_info, max_threads, cache_enabled, max_memory_bytes, enable_dynamic_compilation
+      )) {}
 
 CompiledGrammar GrammarCompiler::CompileJSONSchema(
     const std::string& schema,

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -3290,6 +3290,7 @@ class RuleLevelCache::Impl {
   friend size_t MemorySize(const Impl* impl) {
     int64_t total = 0;
     for (const auto& shard : impl->shards_) {
+      std::lock_guard<std::mutex> lock(shard.mutex);
       total += shard.current_cache_memory_size;
     }
     return total;
@@ -3306,7 +3307,7 @@ class RuleLevelCache::Impl {
   static constexpr size_t kNumShards = 16;
 
   struct Shard {
-    std::mutex mutex;
+    mutable std::mutex mutex;
     int64_t current_cache_memory_size = 0;
     // The cache map: (fsm_hash, node_id, ...) -> index in cache_list
     List<NodeType> cache_list;

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -1286,16 +1286,8 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
   std::vector<std::pair<ParserState, const AdaptiveTokenMask*>> latest_states_with_masks;
 
   for (const auto& state : latest_states) {
-    const AdaptiveTokenMask* adaptive_token_mask_pointer;
-    if (compiled_grammar_->enable_dynamic_compilation) {
-      adaptive_token_mask_pointer = &compiled_grammar_->GetAdaptiveTokenMask(
-          state, state.rule_id == grammar_->GetRootRuleId()
-      );
-    } else {
-      auto iterator = compiled_grammar_->adaptive_token_mask_cache.find(state);
-      XGRAMMAR_CHECK(iterator != compiled_grammar_->adaptive_token_mask_cache.end()) << state;
-      adaptive_token_mask_pointer = &iterator->second;
-    }
+    const AdaptiveTokenMask* adaptive_token_mask_pointer =
+        &compiled_grammar_->GetAdaptiveTokenMask(state, state.rule_id == grammar_->GetRootRuleId());
     const auto& adaptive_token_mask = *adaptive_token_mask_pointer;
     latest_states_with_masks.emplace_back(state, adaptive_token_mask_pointer);
     if (adaptive_token_mask.store_type == StoreType::kAcceptedBitset) {

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -1258,7 +1258,6 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
 ) {
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
   const auto& subtree_range = tokenizer_info_.GetTrieSubtreeNodesRange();
-  const auto& adaptive_token_mask_cache = compiled_grammar_->adaptive_token_mask_cache;
   // We need to have a copy, because scanable_state_history_ will be modified during the
   // FillNextTokenBitmask process, which can lead to undefined behavior.
   std::vector<ParserState> latest_states;
@@ -1284,14 +1283,21 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
                        << ", num of states=" << latest_states.size();
   }
 
-  std::vector<std::pair<ParserState, decltype(adaptive_token_mask_cache.cbegin())>>
-      latest_states_with_masks;
+  std::vector<std::pair<ParserState, const AdaptiveTokenMask*>> latest_states_with_masks;
 
   for (const auto& state : latest_states) {
-    auto adaptive_token_mask_it = adaptive_token_mask_cache.find(state);
-    XGRAMMAR_CHECK(adaptive_token_mask_it != adaptive_token_mask_cache.end()) << state;
-    const auto& adaptive_token_mask = adaptive_token_mask_it->second;
-    latest_states_with_masks.push_back(std::make_pair(state, adaptive_token_mask_it));
+    const AdaptiveTokenMask* adaptive_token_mask_pointer;
+    if (compiled_grammar_->enable_dynamic_compilation) {
+      adaptive_token_mask_pointer = &compiled_grammar_->GetAdaptiveTokenMask(
+          state, state.rule_id == grammar_->GetRootRuleId()
+      );
+    } else {
+      auto iterator = compiled_grammar_->adaptive_token_mask_cache.find(state);
+      XGRAMMAR_CHECK(iterator != compiled_grammar_->adaptive_token_mask_cache.end()) << state;
+      adaptive_token_mask_pointer = &iterator->second;
+    }
+    const auto& adaptive_token_mask = *adaptive_token_mask_pointer;
+    latest_states_with_masks.emplace_back(state, adaptive_token_mask_pointer);
     if (adaptive_token_mask.store_type == StoreType::kAcceptedBitset) {
       tmp_accepted_bitset_ |= adaptive_token_mask.accepted_bitset;
     } else if (adaptive_token_mask.store_type == StoreType::kAccepted) {
@@ -1301,8 +1307,8 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
     }
   }
 
-  for (const auto& [state, adaptive_token_mask_it] : latest_states_with_masks) {
-    const auto& adaptive_token_mask = adaptive_token_mask_it->second;
+  for (const auto& [state, adaptive_token_mask_pointer] : latest_states_with_masks) {
+    const auto& adaptive_token_mask = *adaptive_token_mask_pointer;
 
     // For each ParserState, we will check every uncertain token and put them into the accepted or
     // rejected list.

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -195,13 +195,15 @@ class GrammarCompilerObj : public ffi::Object {
       ffi::ObjectRef tokenizer_ref,
       int64_t max_threads,
       bool cache_enabled,
-      int64_t max_memory_bytes
+      int64_t max_memory_bytes,
+      bool enable_dynamic_compilation
   )
       : value(
             tokenizer_ref.as<TokenizerInfoObj>()->value,
             static_cast<int>(max_threads),
             cache_enabled,
-            max_memory_bytes
+            max_memory_bytes,
+            enable_dynamic_compilation
         ) {}
 
   static constexpr bool _type_mutable = true;
@@ -499,9 +501,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
         XGRAMMAR_FFI_TRY_END();
       });
 
-  // GrammarCompiler: init(tokenizer_info, max_threads, cache_enabled, max_memory_bytes)
+  // GrammarCompiler: init(tokenizer_info, max_threads, cache_enabled, max_memory_bytes,
+  // enable_dynamic_compilation)
   refl::ObjectDef<GrammarCompilerObj>()
-      .def(refl::init<O, int64_t, bool, int64_t>())
+      .def(refl::init<O, int64_t, bool, int64_t, bool>())
       .def(
           "compile_json_schema",
           [](GrammarCompilerObj* o,

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -195,6 +195,19 @@ class GrammarCompilerObj : public ffi::Object {
       ffi::ObjectRef tokenizer_ref,
       int64_t max_threads,
       bool cache_enabled,
+      int64_t max_memory_bytes
+  )
+      : value(
+            tokenizer_ref.as<TokenizerInfoObj>()->value,
+            static_cast<int>(max_threads),
+            cache_enabled,
+            max_memory_bytes
+        ) {}
+
+  GrammarCompilerObj(
+      ffi::ObjectRef tokenizer_ref,
+      int64_t max_threads,
+      bool cache_enabled,
       int64_t max_memory_bytes,
       bool enable_dynamic_compilation
   )
@@ -501,10 +514,17 @@ TVM_FFI_STATIC_INIT_BLOCK() {
         XGRAMMAR_FFI_TRY_END();
       });
 
-  // GrammarCompiler: init(tokenizer_info, max_threads, cache_enabled, max_memory_bytes,
-  // enable_dynamic_compilation)
+  // GrammarCompiler: preserve the existing initializer and expose dynamic compilation separately.
   refl::ObjectDef<GrammarCompilerObj>()
-      .def(refl::init<O, int64_t, bool, int64_t, bool>())
+      .def(refl::init<O, int64_t, bool, int64_t>())
+      .def_static(
+          "create_with_dynamic_compilation",
+          [](O tokenizer_ref, int64_t max_threads, bool cache_enabled, int64_t max_memory_bytes) {
+            return ffi::ObjectRef(ffi::make_object<GrammarCompilerObj>(
+                tokenizer_ref, max_threads, cache_enabled, max_memory_bytes, true
+            ));
+          }
+      )
       .def(
           "compile_json_schema",
           [](GrammarCompilerObj* o,

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -63,12 +63,14 @@ class GrammarCompiler {
    * \param max_threads The maximum number of threads to use for compiling grammars.
    * \param cache_enabled Whether to enable the cache.
    * \param max_memory_bytes The maximum memory usage in bytes.
+   * \param enable_dynamic_compilation Whether to generate token mask cache entries on demand.
    */
   GrammarCompiler(
       const TokenizerInfo& tokenizer_info,
       int max_threads = 8,
       bool cache_enabled = true,
-      int64_t max_memory_bytes = -1  // unlimited
+      int64_t max_memory_bytes = -1,  // unlimited
+      bool enable_dynamic_compilation = false
   );
 
   /*! \brief Get the compiled grammar for a JSON schema string. */

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -63,14 +63,28 @@ class GrammarCompiler {
    * \param max_threads The maximum number of threads to use for compiling grammars.
    * \param cache_enabled Whether to enable the cache.
    * \param max_memory_bytes The maximum memory usage in bytes.
-   * \param enable_dynamic_compilation Whether to generate token mask cache entries on demand.
    */
   GrammarCompiler(
       const TokenizerInfo& tokenizer_info,
       int max_threads = 8,
       bool cache_enabled = true,
-      int64_t max_memory_bytes = -1,  // unlimited
-      bool enable_dynamic_compilation = false
+      int64_t max_memory_bytes = -1  // unlimited
+  );
+
+  /*!
+   * \brief Construct a GrammarCompiler with configurable token mask compilation.
+   * \param tokenizer_info The tokenizer info.
+   * \param max_threads The maximum number of threads to use for compiling grammars.
+   * \param cache_enabled Whether to enable the cache.
+   * \param max_memory_bytes The maximum memory usage in bytes.
+   * \param enable_dynamic_compilation Whether to generate token mask cache entries on demand.
+   */
+  GrammarCompiler(
+      const TokenizerInfo& tokenizer_info,
+      int max_threads,
+      bool cache_enabled,
+      int64_t max_memory_bytes,
+      bool enable_dynamic_compilation
   );
 
   /*! \brief Get the compiled grammar for a JSON schema string. */

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -111,6 +111,7 @@ class GrammarCompiler(XGRObject):
         max_threads: int = 8,
         cache_enabled: bool = True,
         cache_limit_bytes: int = -1,
+        enable_dynamic_compilation: bool = False,
     ):
         """Construct the compiler.
 
@@ -128,6 +129,10 @@ class GrammarCompiler(XGRObject):
         cache_limit_bytes : int, default: -1
             The maximum memory usage for the cache in the specified unit.
             Note that the actual memory usage may slightly exceed this value.
+
+        enable_dynamic_compilation : bool, default: False
+            Whether to generate reusable token mask cache entries when they are first needed.
+            When False, all entries are generated while compiling the grammar.
         """
         if not isinstance(tokenizer_info, TokenizerInfo):
             raise ValueError(
@@ -137,7 +142,11 @@ class GrammarCompiler(XGRObject):
 
         self._init_handle(
             _core.GrammarCompiler(
-                tokenizer_info._handle, max_threads, cache_enabled, cache_limit_bytes
+                tokenizer_info._handle,
+                max_threads,
+                cache_enabled,
+                cache_limit_bytes,
+                enable_dynamic_compilation,
             )
         )
 

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -140,15 +140,18 @@ class GrammarCompiler(XGRObject):
                 "to GrammarCompiler."
             )
 
-        self._init_handle(
-            _core.GrammarCompiler(
-                tokenizer_info._handle,
-                max_threads,
-                cache_enabled,
-                cache_limit_bytes,
-                enable_dynamic_compilation,
+        if enable_dynamic_compilation:
+            self._init_handle(
+                _core.GrammarCompiler.create_with_dynamic_compilation(
+                    tokenizer_info._handle, max_threads, cache_enabled, cache_limit_bytes
+                )
             )
-        )
+        else:
+            self._init_handle(
+                _core.GrammarCompiler(
+                    tokenizer_info._handle, max_threads, cache_enabled, cache_limit_bytes
+                )
+            )
 
     def compile_json_schema(
         self,

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
+from xgrammar.base import _core
 from xgrammar.testing import _get_allow_empty_rule_ids
 
 
@@ -524,6 +525,13 @@ DYNAMIC_COMPILATION_CASES = [
 ]
 
 
+def test_grammar_compiler_four_argument_binding_constructor():
+    """Keep the existing four-argument native binding constructor callable."""
+    tokenizer_info = xgr.TokenizerInfo(["a"], stop_token_ids=[])
+    compiler_handle = _core.GrammarCompiler(tokenizer_info._handle, 1, True, -1)
+    compiler_handle.compile_builtin_json_grammar()
+
+
 @pytest.mark.parametrize(
     "compile_grammar,input_string",
     DYNAMIC_COMPILATION_CASES,
@@ -580,13 +588,14 @@ def test_dynamic_compilation_serialization_materializes_cache():
     assert dynamic_grammar.memory_size_bytes > initial_size
     restored_grammar = xgr.CompiledGrammar.deserialize_json(serialized, tokenizer_info)
 
-    expected_trace = _mask_trace(dynamic_grammar, "hello!")
-    actual_trace = _mask_trace(restored_grammar, "hello!")
-    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(
-        expected_trace, actual_trace
-    ):
-        assert actual_apply == expected_apply
-        torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+    for input_string in ["hello!", "hi?"]:
+        expected_trace = _mask_trace(dynamic_grammar, input_string)
+        actual_trace = _mask_trace(restored_grammar, input_string)
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(
+            expected_trace, actual_trace
+        ):
+            assert actual_apply == expected_apply
+            torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
 
 
 def test_dynamic_compilation_concurrent_mask_generation():
@@ -607,6 +616,43 @@ def test_dynamic_compilation_concurrent_mask_generation():
         ):
             assert actual_apply == expected_apply
             torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_dynamic_compilation_with_limited_cache():
+    """Keep compiler-owned cache memory bounded while masks are generated concurrently."""
+    tokenizer_info = xgr.TokenizerInfo(DYNAMIC_COMPILATION_VOCABULARY, stop_token_ids=[])
+    cache_limit = 64 * 1024
+    compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=True,
+        cache_limit_bytes=cache_limit,
+        enable_dynamic_compilation=True,
+    )
+    dynamic_grammar = _compile_builtin_json_for_dynamic_test(compiler)
+
+    # A bounded compiler does not retain a grammar whose size can grow after insertion.
+    assert compiler.get_cache_size_bytes() == 0
+
+    start_barrier = threading.Barrier(9)
+
+    def generate_masks():
+        start_barrier.wait()
+        return _mask_trace(dynamic_grammar, '{"name":"Ada"}')
+
+    def read_cache_sizes():
+        start_barrier.wait()
+        return [compiler.get_cache_size_bytes() for _ in range(100)]
+
+    with ThreadPoolExecutor(max_workers=9) as executor:
+        mask_futures = [executor.submit(generate_masks) for _ in range(8)]
+        size_future = executor.submit(read_cache_sizes)
+        for future in mask_futures:
+            future.result()
+        observed_sizes = size_future.result()
+
+    assert all(0 <= size <= cache_limit for size in observed_sizes)
+    assert 0 <= compiler.get_cache_size_bytes() <= cache_limit
 
 
 @pytest.mark.parametrize(

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -460,6 +460,155 @@ def _mask_trace(compiled_grammar: xgr.CompiledGrammar, input_str: str):
     return trace
 
 
+DYNAMIC_COMPILATION_VOCABULARY = [chr(value) for value in range(32, 127)] + [
+    "Ada",
+    "hello",
+    "42",
+    "<call>",
+]
+
+
+def _compile_ebnf_for_dynamic_test(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_grammar(
+        """
+root ::= greeting punctuation
+greeting ::= "hello" | "hi"
+punctuation ::= "!" | "?"
+"""
+    )
+
+
+def _compile_json_schema_for_dynamic_test(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_json_schema(
+        {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "scores": {"type": "array", "items": {"type": "integer"}},
+            },
+            "required": ["name", "scores"],
+            "additionalProperties": False,
+        },
+        any_whitespace=True,
+    )
+
+
+def _compile_regex_for_dynamic_test(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_regex(r"[A-Z][a-z]{2}[0-9]+")
+
+
+def _compile_builtin_json_for_dynamic_test(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_builtin_json_grammar()
+
+
+def _compile_structural_tag_for_dynamic_test(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_structural_tag(
+        {
+            "type": "structural_tag",
+            "format": {
+                "type": "dispatch",
+                "rules": [["<call>", {"type": "const_string", "value": "X"}]],
+                "loop": False,
+                "excludes": [],
+            },
+        }
+    )
+
+
+DYNAMIC_COMPILATION_CASES = [
+    (_compile_ebnf_for_dynamic_test, "hello!"),
+    (_compile_json_schema_for_dynamic_test, '{"name":"Ada","scores":[1,2]}'),
+    (_compile_regex_for_dynamic_test, "Ada42"),
+    (_compile_builtin_json_for_dynamic_test, '{"name":"Ada"}'),
+    (_compile_structural_tag_for_dynamic_test, "prefix<call>X"),
+]
+
+
+@pytest.mark.parametrize(
+    "compile_grammar,input_string",
+    DYNAMIC_COMPILATION_CASES,
+    ids=["ebnf", "json-schema", "regex", "builtin-json", "structural-tag"],
+)
+def test_dynamic_compilation_matches_precompiled_masks(compile_grammar, input_string):
+    """Compare every generated mask across all public grammar compilation paths."""
+    tokenizer_info = xgr.TokenizerInfo(DYNAMIC_COMPILATION_VOCABULARY, stop_token_ids=[])
+    precompiled_grammar = compile_grammar(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+    dynamically_compiled_grammar = compile_grammar(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+
+    expected_trace = _mask_trace(precompiled_grammar, input_string)
+    actual_trace = _mask_trace(dynamically_compiled_grammar, input_string)
+    assert len(actual_trace) == len(expected_trace)
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(
+        expected_trace, actual_trace
+    ):
+        assert actual_apply == expected_apply
+        torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_dynamic_compilation_populates_and_reuses_mask_cache():
+    """The first traversal fills reusable entries and the second traversal adds no entries."""
+    tokenizer_info = xgr.TokenizerInfo(DYNAMIC_COMPILATION_VOCABULARY, stop_token_ids=[])
+    dynamic_grammar = _compile_builtin_json_for_dynamic_test(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    precompiled_grammar = _compile_builtin_json_for_dynamic_test(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+
+    initial_size = dynamic_grammar.memory_size_bytes
+    assert initial_size < precompiled_grammar.memory_size_bytes
+    _mask_trace(dynamic_grammar, '{"name":"Ada"}')
+    populated_size = dynamic_grammar.memory_size_bytes
+    assert populated_size > initial_size
+    _mask_trace(dynamic_grammar, '{"name":"Ada"}')
+    assert dynamic_grammar.memory_size_bytes == populated_size
+
+
+def test_dynamic_compilation_serialization_materializes_cache():
+    """A lazily compiled grammar remains functional after a serialization round trip."""
+    tokenizer_info = xgr.TokenizerInfo(DYNAMIC_COMPILATION_VOCABULARY, stop_token_ids=[])
+    dynamic_grammar = _compile_ebnf_for_dynamic_test(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    initial_size = dynamic_grammar.memory_size_bytes
+
+    serialized = dynamic_grammar.serialize_json()
+    assert dynamic_grammar.memory_size_bytes > initial_size
+    restored_grammar = xgr.CompiledGrammar.deserialize_json(serialized, tokenizer_info)
+
+    expected_trace = _mask_trace(dynamic_grammar, "hello!")
+    actual_trace = _mask_trace(restored_grammar, "hello!")
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(
+        expected_trace, actual_trace
+    ):
+        assert actual_apply == expected_apply
+        torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_dynamic_compilation_concurrent_mask_generation():
+    """Generate the same initially uncached masks through concurrently shared grammar state."""
+    tokenizer_info = xgr.TokenizerInfo(DYNAMIC_COMPILATION_VOCABULARY, stop_token_ids=[])
+    dynamic_grammar = _compile_json_schema_for_dynamic_test(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    input_string = '{"name":"Ada","scores":[1,2]}'
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        traces = list(executor.map(lambda _: _mask_trace(dynamic_grammar, input_string), range(32)))
+
+    expected_trace = traces[0]
+    for actual_trace in traces[1:]:
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(
+            expected_trace, actual_trace
+        ):
+            assert actual_apply == expected_apply
+            torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
 @pytest.mark.parametrize(
     "grammar_str,accepted_inputs,rejected_inputs",
     HASHER_GRAPH_CASES,
@@ -480,6 +629,12 @@ def test_grammar_fsm_hasher_worklist_graphs(
         xgr.GrammarCompiler(tokenizer_info, max_threads=8, cache_enabled=True).compile_grammar(
             grammar_str
         ),
+        xgr.GrammarCompiler(
+            tokenizer_info, max_threads=1, cache_enabled=False, enable_dynamic_compilation=True
+        ).compile_grammar(grammar_str),
+        xgr.GrammarCompiler(
+            tokenizer_info, max_threads=8, cache_enabled=True, enable_dynamic_compilation=True
+        ).compile_grammar(grammar_str),
     ]
 
     for compiled in compiled_variants:


### PR DESCRIPTION
## Summary
- add an opt-in `enable_dynamic_compilation` flag to `GrammarCompiler`, retaining eager compilation as the default
- generate reusable adaptive token masks when matcher states are first visited, while keeping context-dependent token checks in the existing per-mask path
- make lazy cache insertion thread-safe and materialize the complete cache before serialization to preserve the existing format
- cover EBNF grammars, JSON Schema, regular expressions, built-in JSON, structural tags, cache reuse, serialization, and concurrent matching

## MaskBench results

Configuration: all 11,306 MaskBench schemas, Meta Llama 3.1 8B Instruct tokenizer, fixed random seed 0, 8 benchmark workers, and one XGrammar compiler thread per worker. Times are in microseconds. Mask generation time follows MaskBench and includes filling the mask and committing the current token.

Grammar compilation:
- average: eager 331,776.91; on-demand 3,977.67; LLGuidance 1,539.33
- median: eager 2,108; on-demand 806; LLGuidance 853
- p95: eager 1,948,814; on-demand 15,568; LLGuidance 4,034
- p99: eager 7,865,252; on-demand 44,236; LLGuidance 17,525

Token mask generation:
- average: eager 52.14; on-demand 267.71; LLGuidance 40.85
- median: eager 3; on-demand 6; LLGuidance 26
- p95: eager 85; on-demand 109; LLGuidance 81
- p99: eager 781; on-demand 1,171; LLGuidance 403

Eager and on-demand XGrammar compiled the same 11,211 schemas, failed the same 95 schemas, and measured the same 3,152,817 masks. On-demand compilation reduced average compilation time by 98.80%. It increased average mask time by 5.13x, median by 2.00x, p95 by 1.28x, and p99 by 1.50x. Summed across successful compilations and all masks, measured time decreased by 77.12% (3,883.94 seconds to 888.63 seconds).

LLGuidance 1.3.0 successfully compiled 9,307 schemas and failed 1,999, producing 2,858,781 mask measurements. Its figures therefore cover a smaller and different successful workload and are included as a reference rather than a direct same-sample comparison.

## Test plan
- [x] `python -m pytest tests/python/test_grammar_compiler.py -q` (28 passed)
- [x] matcher and serialization regression suites (282 passed)
- [x] Python static checks and repository formatting hooks
- [x] full MaskBench comparison for eager XGrammar, on-demand XGrammar, and LLGuidance