### PR TITLE
fix: reject grammar atomic tokens via byte path when atomic match fails

### DIFF
--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <cstdint>
 #include <optional>
+#include <set>
 #include <thread>
 #include <utility>
 #include <variant>
@@ -457,10 +458,13 @@ class GrammarMatcher::Impl : public EarleyParser {
         compiled_grammar_(compiled_grammar),
         tokenizer_info_(compiled_grammar->tokenizer_info),
         stop_token_ids_(override_stop_tokens.value_or(tokenizer_info_.GetStopTokenIds())),
+        grammar_atomic_token_ids_(),
         terminate_without_stop_token_(terminate_without_stop_token),
         tmp_accepted_bitset_(tokenizer_info_.GetVocabSize()) {
     XGRAMMAR_CHECK(!override_stop_tokens.has_value() || !override_stop_tokens->empty())
         << "The override_stop_tokens should not be empty";
+
+    InitGrammarAtomicTokenIds();
   }
 
   bool AcceptToken(int32_t token_id, bool debug_print = false);
@@ -480,6 +484,8 @@ class GrammarMatcher::Impl : public EarleyParser {
   int GetMaxRollbackTokens() const { return -1; }
 
   const std::vector<int>& GetStopTokenIds() const { return stop_token_ids_; }
+
+  const std::set<int>& GetGrammarAtomicTokenIds() const { return grammar_atomic_token_ids_; }
 
   std::string _DebugPrintInternalState() const { return PrintStates(); }
 
@@ -522,9 +528,30 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   std::string PrintBitmask(int32_t* bitmask_data_ptr, const TokenizerInfo& tokenizer_info);
 
+  void InitGrammarAtomicTokenIds();
+
   CompiledGrammar compiled_grammar_;
   TokenizerInfo tokenizer_info_;
   std::vector<int> stop_token_ids_;
+
+  /*!
+   * \brief Token IDs declared in the grammar as atomic token literals.
+   *
+   * These IDs come from grammar expressions such as Token(...) and
+   * TokenTagDispatch trigger/exclude entries. During AcceptToken(), such a
+   * token must be accepted only via the atomic token path
+   * (AdvanceAtomicToken). It must not fall back to the byte path, even if its
+   * decoded string would match the current JSON/text state byte-by-byte.
+   *
+   * Example (moonshotai/Kimi-K2.5):
+   * - Token(163597) = "<|tool_call_begin|>"
+   * - Token(163599) = "<|tool_call_end|>"
+   *
+   * If JSON is still incomplete, atomic path rejects 163599, but byte path
+   * must not accept it as plain string content inside an open JSON string.
+   */
+  std::set<int> grammar_atomic_token_ids_;
+
   bool terminate_without_stop_token_;
   std::deque<int> token_length_history;
 
@@ -664,6 +691,10 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     PopLastStates(1);
   }
 
+  if (!atomic_success && grammar_atomic_token_ids_.count(token_id)) {
+    return false;
+  }
+
   // Phase 2: Try byte-by-byte path (from the same original state)
   int pos = 0;
   bool byte_path_success = true;
@@ -797,6 +828,26 @@ std::string GrammarMatcher::Impl::PrintBitmask(
      << ",\naccepted_ids=" << PrintTokenByIds(accepted_ids, tokenizer_info, kMaxPrintTokens)
      << ",\nrejected_ids=" << PrintTokenByIds(rejected_ids, tokenizer_info, kMaxPrintTokens) << ")";
   return ss.str();
+}
+
+void GrammarMatcher::Impl::InitGrammarAtomicTokenIds() {
+  for (int32_t expr_id = 0; expr_id < grammar_->NumGrammarExprs(); ++expr_id) {
+    auto expr = grammar_->GetGrammarExpr(expr_id);
+    if (expr.type == GrammarExprType::kToken) {
+      for (int32_t tid : expr) {
+        grammar_atomic_token_ids_.insert(tid);
+      }
+    } else if (expr.type == GrammarExprType::kTokenTagDispatch) {
+      auto ttd = grammar_->GetTokenTagDispatch(expr);
+      for (const auto& [tid, _rule] : ttd.trigger_rule_pairs) {
+        grammar_atomic_token_ids_.insert(tid);
+      }
+
+      for (int32_t tid : ttd.excludes) {
+        grammar_atomic_token_ids_.insert(tid);
+      }
+    }
+  }
 }
 
 bool GrammarMatcher::Impl::IsTokenBitmaskAllTrue(int32_t* bitmask_data_ptr) {

--- a/tests/python/test_token_edge.py
+++ b/tests/python/test_token_edge.py
@@ -1632,5 +1632,72 @@ def test_stag_any_tokens_exclude_redispatch():
     assert m.is_terminated()
 
 
+STAG_JSON_ATOMIC_VOCAB = [
+    "<s>",  # 0
+    "</s>",  # 1
+    "<tool>",  # 2
+    "<end>",  # 3
+    '{"',  # 4
+    "queries",  # 5
+    '":["',  # 6
+    "hello",  # 7
+    '","',  # 8
+    "]}",  # 9 invalid continuation inside an open JSON string
+    '"]}',  # 10 valid JSON suffix closing string/array/object
+]
+STAG_JSON_TOOL = 2
+STAG_JSON_END = 3
+
+
+def _stag_json_atomic_matcher(stag_json):
+    ti = xgr.TokenizerInfo(STAG_JSON_ATOMIC_VOCAB)
+    compiler = xgr.GrammarCompiler(ti)
+    compiled = compiler.compile_structural_tag(stag_json)
+    m = xgr.GrammarMatcher(compiled)
+    b = xgr.allocate_token_bitmask(1, ti.vocab_size)
+    return m, b, ti
+
+
+def test_stag_atomic_end_token_rejected_in_open_json_string():
+    """Atomic Token(<end>) must not be accepted via byte path inside open JSON."""
+    stag = {
+        "type": "structural_tag",
+        "format": {
+            "type": "sequence",
+            "elements": [
+                {"type": "token", "token": "<tool>"},
+                {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "type": "object",
+                        "properties": {"queries": {"type": "array", "items": {"type": "string"}}},
+                        "required": ["queries"],
+                    },
+                },
+                {"type": "token", "token": "<end>"},
+            ],
+        },
+    }
+    m, b, ti = _stag_json_atomic_matcher(stag)
+
+    broken_prefix = [
+        STAG_JSON_TOOL,  # <tool>
+        4,  # {"
+        5,  # queries
+        6,  # ":[
+        7,  # hello
+        8,  # ",
+        9,  # ]} inside the still-open second string
+    ]
+    for token_id in broken_prefix:
+        assert m.accept_token(token_id), (
+            f"Failed to accept setup token {token_id} " f"({STAG_JSON_ATOMIC_VOCAB[token_id]!r})"
+        )
+
+    assert not m.accept_token(STAG_JSON_END)
+    assert not m.is_completed()
+    assert not m.is_terminated()
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
There was found a bug when xgrammar accepts invalid json object `{"queries":["hello","]}`. This json missed `"` close bracket for the second element in the array. The bug in xgrammar was in `AcceptToken` that did byte-by-byte processing for atomic tokens. This PR fixes this issue introducing a special set of all atomic tokens and forbids to process them byte-by-byte.

### Testing Done

```python
import xgrammar, json
from transformers import AutoTokenizer

tok = AutoTokenizer.from_pretrained("moonshotai/Kimi-K2.5", trust_remote_code=True)
tok_info = xgrammar.TokenizerInfo.from_huggingface(tok, vocab_size=163840)
compiler = xgrammar.GrammarCompiler(tok_info)

def old_api():
    schema = '{"properties":{"queries":{"items":{"type":"string"},"type":"array"}},"required":["queries"],"type":"object"}'
    tag = xgrammar.StructuralTagItem(
        begin="<|tool_calls_section_begin|><|tool_call_begin|>functions.search:0<|tool_call_argument_begin|>",
        schema=schema,
        end="<|tool_call_end|><|tool_calls_section_end|>",
    )
    grammar = compiler.compile_structural_tag([tag], ["<|tool_calls_section_begin|>"])
    return grammar

def new_api():
    schema = {
        "type": "object",
        "properties": {
            "queries": {
                "type": "array",
                "items": {"type": "string"},
            },
        },
        "required": ["queries"],
    }
    structural_tag = {
        "type": "structural_tag",
        "format": {
            "type": "sequence",
            "elements": [
                {"type": "token", "token": "<|tool_calls_section_begin|>"},
                {"type": "token", "token": "<|tool_call_begin|>"},
                {"type": "const_string", "value": "functions.search:0"},
                {"type": "token", "token": "<|tool_call_argument_begin|>"},
                {"type": "json_schema", "json_schema": schema},
                {"type": "token", "token": "<|tool_call_end|>"},
                {"type": "token", "token": "<|tool_calls_section_end|>"},
            ],
        },
    }
    grammar = compiler.compile_structural_tag(structural_tag)
    return grammar

# This INVALID JSON is incorrectly accepted:
text = '<|tool_calls_section_begin|><|tool_call_begin|>functions.search:0<|tool_call_argument_begin|>{"queries":["hello","]}' + \
       '<|tool_call_end|><|tool_calls_section_end|>'
ids = tok.encode(text, allowed_special="all")
grammar = new_api()
matcher = xgrammar.GrammarMatcher(grammar)
all_accepted = all(matcher.accept_token(tid) for tid in ids)
if not all_accepted:
    print("OK")
else:
    print("FAIL")
    print(f"JSON valid: {json.loads('{\"queries\":[\"hello\",\"]}')}")  # raises JSONDecodeError
```

This test fails on current xgrammar but passes with this PR.

N.B. The bug still persists in case of old API. If old API is deprecated now then consider highlighting that for users since now it is also possible to use old API and the bug persists for it.