### PR TITLE
[Fix] Reduce wheel size from ~45 MB to ~1 MB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,20 +90,25 @@ else()
   target_compile_definitions(xgrammar PUBLIC XGRAMMAR_ENABLE_CPPTRACE=0)
 endif()
 
-install(TARGETS xgrammar)
-install(
-  DIRECTORY ${CMAKE_SOURCE_DIR}/include/xgrammar
-  DESTINATION include
-  FILES_MATCHING
-  PATTERN "*.h"
-)
-# Install DLPack headers from the submodule
-install(
-  DIRECTORY ${CMAKE_SOURCE_DIR}/3rdparty/dlpack/include/dlpack
-  DESTINATION include
-  FILES_MATCHING
-  PATTERN "*.h"
-)
+# Install the static library and headers for C++ users building from source with `cmake --install`.
+# Skip when building Python wheels via scikit-build-core (which defines SKBUILD): everything
+# installed here would be bundled into the wheel, and the static library alone adds tens of MB.
+if(NOT SKBUILD)
+  install(TARGETS xgrammar)
+  install(
+    DIRECTORY ${CMAKE_SOURCE_DIR}/include/xgrammar
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN "*.h"
+  )
+  # Install DLPack headers from the submodule
+  install(
+    DIRECTORY ${CMAKE_SOURCE_DIR}/3rdparty/dlpack/include/dlpack
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN "*.h"
+  )
+endif()
 
 if(XGRAMMAR_BUILD_PYTHON_BINDINGS)
   add_subdirectory(${PROJECT_SOURCE_DIR}/cpp)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,4 +1,9 @@
-set(CMAKE_BUILD_TYPE RelWithDebInfo)
+# Only a default: an unconditional set() here would shadow the CMAKE_BUILD_TYPE cache variable and
+# silently override -DCMAKE_BUILD_TYPE=... (e.g. the build type scikit-build-core passes for wheel
+# builds).
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
 set(XGRAMMAR_BUILD_PYTHON_BINDINGS ON)
 set(XGRAMMAR_ENABLE_COVERAGE OFF)
 set(XGRAMMAR_BUILD_CXX_TESTS OFF)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,10 @@ build.verbose = true
 # CMake configuration
 cmake.version = "CMakeLists.txt"
 cmake.args = []
-cmake.build-type = "RelWithDebInfo"
+# Use Release for wheels: debug info would multiply the binary size by >10x, and no error
+# reporting path needs it. Error messages carry file:line via __FILE__/__LINE__ macros,
+# which are preserved in any build type.
+cmake.build-type = "Release"
 
 # Logging
 logging.level = "INFO"


### PR DESCRIPTION
## Problem

The Linux x86_64 wheel grew from 8.9 MB (v0.1.27) to 34.8 MB (v0.1.28) and is now 48.5 MB (v0.2.5). Of those 48.5 MB, only about 1 MB is actually needed at runtime. Two independent causes:

1. **The wheel bundles `xgrammar/lib/libxgrammar.a` (70 MB uncompressed) and all C++ headers.** #472 added `install(TARGETS xgrammar)` + header install rules so C++ users can `cmake --install`, but scikit-build-core puts everything CMake installs into the wheel. The bundled static library has no consumer: nothing in the Python package references it, it contains LTO bitcode objects (unusable with a different compiler), and no CMake package config is exported so `find_package(xgrammar)` cannot find it anyway.
2. **Wheels are built with full debug info and never stripped.** `cmake/config.cmake` starts with an unconditional `set(CMAKE_BUILD_TYPE RelWithDebInfo)`, which is a normal-variable assignment that shadows the `CMAKE_BUILD_TYPE` cache variable — so the `cmake.build-type` setting in pyproject.toml never took effect. In the v0.2.5 wheel, `libxgrammar_bindings.so` is 57 MB unstripped, of which only ~2.4 MB is code (.text); the rest is debug sections. No error-reporting path uses this debug info: cpptrace is OFF in wheels, and error messages get their `file:line` from `__FILE__`/`__LINE__` macros, which are compile-time string literals preserved in any build type.

## Changes

- `CMakeLists.txt`: wrap the static-library/header install rules in `if(NOT SKBUILD)`. Source builds with `cmake --install` are unaffected; wheel builds (where scikit-build-core defines `SKBUILD`) no longer bundle them.
- `cmake/config.cmake`: only set `CMAKE_BUILD_TYPE` as a default when none is specified, so `-DCMAKE_BUILD_TYPE=...` (including the one passed by scikit-build-core) is respected.
- `pyproject.toml`: set `cmake.build-type = "Release"` for wheels.

## Results

- Locally built Linux x86_64 wheel: **48.45 MB → 1.15 MB** (compressed); `libxgrammar_bindings.so` 57 MB → 2.8 MB uncompressed, no debug info.
- Error messages still carry `file:line`, verified with the built wheel:
  - invalid EBNF → `... cpp/grammar_parser.cc:759: EBNF parser error at ...`
  - wrong bitmask dtype → `... cpp/grammar_matcher.cc:158: Check failed: ...`
- `test_grammar_parser.py`, `test_grammar_matcher_basic.py`, `test_json_schema_converter.py` against the installed wheel: 624 passed.

## Test plan

- [x] Build wheel locally and inspect contents (no `lib/`, no `include/`, binaries without debug info)
- [x] End-to-end smoke test: TokenizerInfo → GrammarCompiler → GrammarMatcher → token bitmask
- [x] Verify error messages keep file:line in Release
- [x] Run unit tests against the built wheel
- [ ] CI wheel builds pass on all platforms