### PR TITLE
Remove compile-time budget warnings and clarify max_tokens relaxation docs

### DIFF
--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -2603,8 +2603,7 @@ class GrammarOptimizerImpl {
   /*!
    * \brief Committed-shortest (lazy) matching requires the whole rule body to compile into a
    * single per-rule FSM without rule references, so that the states of one occurrence are exactly
-   * the states with the rule's id. Also warn on lazy rules that can match empty: they commit at
-   * entry and always match the empty string.
+   * the states with the rule's id.
    */
   static void ValidateLazyRules(const Grammar& grammar) {
     for (int32_t i = 0; i < grammar->NumRules(); ++i) {
@@ -2613,13 +2612,6 @@ class GrammarOptimizerImpl {
         continue;
       }
       const auto& body = grammar->GetGrammarExpr(rule.body_expr_id);
-      if (std::binary_search(
-              grammar->allow_empty_rule_ids.begin(), grammar->allow_empty_rule_ids.end(), i
-          )) {
-        XGRAMMAR_LOG(WARNING) << "The lazy rule '" << rule.name
-                              << "' can match the empty string, so it always matches the empty "
-                                 "string (committed-shortest matching).";
-      }
       if (body.type == Grammar::Impl::GrammarExprType::kRegex) {
         continue;
       }

--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -2035,11 +2035,6 @@ class LarkCompiler {
    * at any position (such as arbitrary text) therefore never exceed the budget.
    */
   int32_t CompileMaxTokensRule(const Definition& definition) {
-    if (!IsAnyText(definition.body) && !ExtractLazyTrigger(definition).has_value()) {
-      XGRAMMAR_LOG(WARNING) << "max_tokens on rule '" << definition.name
-                            << "' is best-effort: the budget may be exceeded when the rule "
-                               "cannot end at the position where it runs out.";
-    }
     builder_.UpdateMaxTokens(rule_ids_.at(definition.name), definition.max_tokens.value());
     if (HasLazySemantics(definition)) {
       return CompileLazyRule(definition);

--- a/docs/defining_structures/ebnf_grammar.md
+++ b/docs/defining_structures/ebnf_grammar.md
@@ -267,9 +267,8 @@ character classes, `Regex` expressions, and supported repetitions or alternative
 elements. Bodies that still require rule references, recursion, or repetition ranges after
 normalization are rejected during compilation.
 
-A lazy rule that can match the empty string always commits to the empty match and produces a
-warning. Each occurrence commits independently, and `rollback`, `reset`, and `fork` restore the
-commit state.
+A lazy rule that can match the empty string always commits to the empty match. Each occurrence
+commits independently, and `rollback`, `reset`, and `fork` restore the commit state.
 
 ### Sampling Temperature
 

--- a/docs/defining_structures/ebnf_grammar.md
+++ b/docs/defining_structures/ebnf_grammar.md
@@ -201,8 +201,11 @@ answer ::= [0-9]+
 
 Once the budget is exhausted, the token mask forces the occurrence to end if its body can end at
 the current position. If it cannot end there, the budget is relaxed until the earliest valid
-boundary, so the output remains grammar-valid. The bound is therefore exact for bodies such as
-`[^]*` that can end at any position and best-effort for other bodies.
+boundary, so the output remains grammar-valid. If this relaxation causes a derivation to consume a
+token past its budget, the matcher logs a warning the first time, at most once per matcher. When
+authoring a budgeted rule, prefer a body that can end at every possible budget boundary. For
+example, `[^]*` can end at any position, so its budget is exact; bodies that cannot end where the
+budget runs out remain best-effort.
 
 The budget applies independently to every occurrence. To bound a whole repeated region, put the
 option on a wrapper rule. Nested budgets use the smallest active budget. Use a positive decimal

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -615,8 +615,8 @@ derivation may consume. Once the deadline passes, each mask forces the rule to e
 is possible at the current position; otherwise the budget is relaxed for one step and
 enforcement is retried, so the rule ends at the earliest possible position and the output
 always stays grammar-valid. When authoring a budgeted rule, prefer a body that can end at every
-possible budget boundary. The arbitrary-text form above can end at any position and therefore
-never exceeds its budget. For other bodies (e.g. `/(\S*\s)+/`) the budget is best-effort.
+possible budget boundary. For example, the arbitrary-text form above can end at any position, so
+its budget is exact; bodies that cannot end where the budget runs out remain best-effort.
 
 `max_tokens` composes with committed-shortest matching. With `lazy`, whichever of the lazy
 completion and the token deadline is reached first closes the occurrence. With `suffix` or

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -614,9 +614,10 @@ every predicted occurrence of the rule carries a deadline: the index of the last
 derivation may consume. Once the deadline passes, each mask forces the rule to end if ending
 is possible at the current position; otherwise the budget is relaxed for one step and
 enforcement is retried, so the rule ends at the earliest possible position and the output
-always stays grammar-valid. Bodies that can end at any position — such as the arbitrary-text
-form above — therefore never exceed their budget. For other bodies (e.g. `/(\S*\s)+/`) the
-budget is best-effort and a compile-time warning marks the rule.
+always stays grammar-valid. When authoring a budgeted rule, prefer a body that can end at every
+possible budget boundary. The arbitrary-text form above can end at any position and therefore
+never exceeds its budget. For other bodies (e.g. `/(\S*\s)+/`) the budget is best-effort and a
+compile-time warning marks the rule.
 
 `max_tokens` composes with committed-shortest matching. With `lazy`, whichever of the lazy
 completion and the token deadline is reached first closes the occurrence. With `suffix` or

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -524,7 +524,7 @@ Notes:
   middle of a sequence, quantifiers over multi-character strings, and repetition ranges like
   `{2,5}`) are rejected at compile time.
 - A lazy rule that can match the empty string always matches the empty string (for example
-  `foo[lazy]: /.*/`); the compiler emits a warning for this.
+  `foo[lazy]: /.*/`).
 - Lazy rules are compiled as lexemes: `%ignore` is not woven inside their bodies, and like
   terminals they take the ignored-token skip after them.
 - Each occurrence of the rule commits independently, and the commit is exact for validation
@@ -616,8 +616,7 @@ is possible at the current position; otherwise the budget is relaxed for one ste
 enforcement is retried, so the rule ends at the earliest possible position and the output
 always stays grammar-valid. When authoring a budgeted rule, prefer a body that can end at every
 possible budget boundary. The arbitrary-text form above can end at any position and therefore
-never exceeds its budget. For other bodies (e.g. `/(\S*\s)+/`) the budget is best-effort and a
-compile-time warning marks the rule.
+never exceeds its budget. For other bodies (e.g. `/(\S*\s)+/`) the budget is best-effort.
 
 `max_tokens` composes with committed-shortest matching. With `lazy`, whichever of the lazy
 completion and the token deadline is reached first closes the occurrence. With `suffix` or


### PR DESCRIPTION
## Summary
- remove the compile-time "best-effort" warning the Lark converter emitted for `max_tokens` rules whose bodies were not recognized as arbitrary text: the heuristic misfires on bodies that can in fact end at any position (e.g. `/[a-z]*/`), fires on every compilation even when the budget is never exceeded, and the EBNF frontend never had an equivalent; the matcher already logs a one-time runtime warning when a budget is actually relaxed past its deadline
- remove the optimizer warning for lazy rules that can match the empty string; the always-empty-match behavior is well defined and stays documented
- document the one-time runtime warning when a `max_tokens` rule exceeds its budget
- recommend rule bodies that can close at every possible budget boundary in both EBNF and Lark documentation

## Test plan
- [x] `pre-commit run` on the four changed files
- [x] compiling `start[max_tokens=5]: /(\S*\s)+/` and running the grammar optimizer on a nullable lazy rule produce no stderr output
- [x] `pytest tests/python/test_lark.py` (338 passed)
- [x] `make html` in `docs/`