### PR TITLE
Remove deprecation marker from compile_structural_tag overload

### DIFF
--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -3,7 +3,6 @@
 from typing import Any, Dict, List, Optional, Tuple, Type, Union, overload
 
 from pydantic import BaseModel
-from typing_extensions import deprecated
 
 from .base import XGRObject, _core
 from .grammar import (
@@ -244,10 +243,6 @@ class GrammarCompiler(XGRObject):
     ) -> CompiledGrammar: ...
 
     @overload
-    @deprecated(
-        "compile_structural_tag(tags, triggers) is deprecated. Compile structural tag with the "
-        "StructuralTag class instead."
-    )
     def compile_structural_tag(
         self, tags: List[StructuralTagItem], triggers: List[str]
     ) -> CompiledGrammar: ...


### PR DESCRIPTION
## Summary
- remove the deprecation marker from the two-argument `compile_structural_tag` overload
- remove the now-unused `typing_extensions.deprecated` import

This is mainly because the deprecation warning will let the linter think the whole function is deprecated, where they aren't.

## Test plan
- `python -m ruff check python/xgrammar/compiler.py`
- `python -m py_compile python/xgrammar/compiler.py`