### PR TITLE
Compile grammar objects directly when the cache has no result

### DIFF
--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1501,7 +1501,10 @@ CompiledGrammar GrammarCompiler::Impl::CompileGrammar(const Grammar& grammar) {
   if (!cache_enabled_) {
     return no_cache_compiler_.CompileGrammar(grammar);
   }
-  return grammar_level_cache_.Get(GrammarKey{grammar.ToString(), grammar->GetRootRule().name});
+  return grammar_level_cache_.Get(
+      GrammarKey{grammar.ToString(), grammar->GetRootRule().name},
+      [this, grammar](const UnionKey&) { return no_cache_compiler_.CompileGrammar(grammar); }
+  );
 }
 
 CompiledGrammar GrammarCompiler::Impl::CompileGrammar(

--- a/cpp/support/thread_safe_cache.h
+++ b/cpp/support/thread_safe_cache.h
@@ -281,8 +281,17 @@ class ThreadSafeLRUCache {
   std::size_t MaxMemorySize() const { return max_size_; }
   std::size_t MemorySize() const { return current_size_; }
 
-  Value Get(const Key& key) {
-    auto future = GetFuture(key);
+  Value Get(const Key& key) { return Get(key, std::cref(computer_)); }
+
+  /*!
+   * \brief Gets or computes the value for a key with a per-call miss computer.
+   * \param key The key to lookup.
+   * \param compute_on_miss The function used to compute the value if this call inserts the key.
+   * \return The cached or newly computed value.
+   */
+  template <typename ComputeOnMiss>
+  Value Get(const Key& key, ComputeOnMiss&& compute_on_miss) {
+    auto future = GetFuture(key, std::forward<ComputeOnMiss>(compute_on_miss));
     return future.get().value;
   }
 
@@ -307,8 +316,11 @@ class ThreadSafeLRUCache {
   }
 
  private:
-  std::shared_future<SizedValue> GetFuture(const Key& key) {
-    if (this->max_size_ == kUnlimitedSize) return GetFutureUnlimited(key);
+  template <typename ComputeOnMiss>
+  std::shared_future<SizedValue> GetFuture(const Key& key, ComputeOnMiss&& compute_on_miss) {
+    if (this->max_size_ == kUnlimitedSize) {
+      return GetFutureUnlimited(key, std::forward<ComputeOnMiss>(compute_on_miss));
+    }
     auto& map = cache_.GetMap();
 
     {
@@ -323,12 +335,14 @@ class ThreadSafeLRUCache {
       }
     }
 
-    auto task = std::packaged_task<SizedValue()>{[this, &key] {
-      auto value = computer_(key);
-      auto result = SizedValue{value, size_estimator_(value)};
-      current_size_ += result.size;
-      return result;
-    }};
+    auto task = std::packaged_task<SizedValue()>{
+        [this, &key, compute_on_miss = std::forward<ComputeOnMiss>(compute_on_miss)]() mutable {
+          auto value = compute_on_miss(key);
+          auto result = SizedValue{value, size_estimator_(value)};
+          current_size_ += result.size;
+          return result;
+        }
+    };
 
     auto lock_map = std::unique_lock{map_mutex_};
     auto [it, success] = map.try_emplace(key);
@@ -360,7 +374,10 @@ class ThreadSafeLRUCache {
     return future;
   }
 
-  std::shared_future<SizedValue> GetFutureUnlimited(const Key& key) {
+  template <typename ComputeOnMiss>
+  std::shared_future<SizedValue> GetFutureUnlimited(
+      const Key& key, ComputeOnMiss&& compute_on_miss
+  ) {
     auto& map = cache_.GetMap();
 
     {
@@ -369,12 +386,14 @@ class ThreadSafeLRUCache {
       if (it != map.end()) return it->second.value;
     }
 
-    auto task = std::packaged_task<SizedValue()>{[this, &key] {
-      auto value = computer_(key);
-      auto result = SizedValue{value, size_estimator_(value)};
-      current_size_ += result.size;
-      return result;
-    }};
+    auto task = std::packaged_task<SizedValue()>{
+        [this, &key, compute_on_miss = std::forward<ComputeOnMiss>(compute_on_miss)]() mutable {
+          auto value = compute_on_miss(key);
+          auto result = SizedValue{value, size_estimator_(value)};
+          current_size_ += result.size;
+          return result;
+        }
+    };
 
     auto lock_map = std::unique_lock{map_mutex_};
     auto [it, success] = map.try_emplace(key);

--- a/tests/cpp/test_thread_safe_cache.cc
+++ b/tests/cpp/test_thread_safe_cache.cc
@@ -250,4 +250,49 @@ namespace {
 //   }
 // }
 
+struct DoubleInteger {
+  int operator()(const int& key) const { return key * 2; }
+};
+
+struct IntegerSizeEstimator {
+  std::size_t operator()(const int&) const { return sizeof(int); }
+};
+
+TEST(ThreadSafeLRUCacheTest, ComputeOnMissOverride) {
+  using Cache = ThreadSafeLRUCache<int, int, DoubleInteger, IntegerSizeEstimator>;
+  auto check_cache = [](std::size_t max_size) {
+    Cache cache(max_size);
+    int custom_compute_count = 0;
+
+    EXPECT_EQ(
+        cache.Get(
+            3,
+            [&custom_compute_count](const int& key) {
+              ++custom_compute_count;
+              return key * 3;
+            }
+        ),
+        9
+    );
+    EXPECT_EQ(
+        cache.Get(
+            3,
+            [&custom_compute_count](const int&) {
+              ++custom_compute_count;
+              return -1;
+            }
+        ),
+        9
+    );
+    EXPECT_EQ(custom_compute_count, 1);
+    EXPECT_EQ(cache.Get(4), 8);
+
+    cache.Clear();
+    EXPECT_EQ(cache.Get(3), 6);
+  };
+
+  check_cache(Cache::kUnlimitedSize);
+  check_cache(1024);
+}
+
 }  // namespace

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -347,6 +347,24 @@ def test_grammar_compiler_crossing_cache_same_grammar():
     assert contexta.serialize_json() == contextb.serialize_json()
 
 
+def test_grammar_object_and_string_share_cache():
+    grammar = xgr.Grammar.from_ebnf('root ::= "a" | "b"')
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "ab"])
+    compiler = xgr.GrammarCompiler(tokenizer_info, max_threads=1)
+
+    compiled_from_object = compiler.compile_grammar(grammar)
+    cache_size_after_object = compiler.get_cache_size_bytes()
+    compiled_from_string = compiler.compile_grammar(str(grammar))
+
+    assert compiler.get_cache_size_bytes() == cache_size_after_object
+    assert compiled_from_object.serialize_json() == compiled_from_string.serialize_json()
+
+    compiled_without_cache = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, cache_enabled=False
+    ).compile_grammar(grammar)
+    assert compiled_from_object.serialize_json() == compiled_without_cache.serialize_json()
+
+
 @pytest.mark.hf_token_required
 def test_grammar_compiler_crossing_cache_different_grammar_with_same_fsm():
     grammar_a = """


### PR DESCRIPTION
## 改动

- 当语法缓存第一次插入某个键时，允许本次调用提供计算过程；保留现有的有限容量、无限容量和每个键只计算一次的行为。
- 当缓存中找不到结果时，直接编译已有的 `Grammar` 语法对象，避免“语法对象 -> 扩展巴科斯范式文本 -> 语法对象”的多余往返。扩展巴科斯范式（Extended Backus-Naur Form，EBNF）是描述语法规则的文本表示。
- 继续使用规范化文本作为缓存键，使语法对象和语法字符串仍能共享缓存结果。

## 性能

与主分支提交 `c5717178` 比较。输入是包含 400 个函数的结构化标签语法，使用 Qwen3-4B-Instruct-2507 语言模型的词表数据和 8 个固定处理器核心。两组交替运行，合计取 20 个样本。

- 首次编译 `Grammar` 对象且缓存未命中：中位数从 453.99 毫秒降到 320.66 毫秒，降低 29.4%，快 1.42 倍。
- 在已启动编译器中编译新语法：中位数从 441.83 毫秒降到 300.81 毫秒，降低 31.9%，快 1.47 倍。
- 已启动环境下语法构造加编译的全流程：中位数从 513.79 毫秒降到 374.16 毫秒，降低 27.2%，快 1.37 倍。

另外进行 10 轮 XGrammar 与 LLGuidance 1.7.6 对照。XGrammar 是本仓库的语法约束生成库，LLGuidance 是另一个语法约束生成实现。改动后，已启动环境下的语法编译分别为 399.4 毫秒和 118.3 毫秒；单次词元允许集合生成的中位数分别为 2.6 微秒和 609.0 微秒。

## 验证

- [x] C++ 语言测试：62 项通过。
- [x] Python 语言的语法编译器测试：12 项通过，排除需要远程词表的测试。
- [x] 所有改动文件通过提交前格式检查。
- [x] 新增有限容量和无限容量缓存首次计算的覆盖测试。
