### PR TITLE
fix: bump lower bound of `apache-tvm-ffi`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 keywords = ["machine learning", "inference"]
 requires-python = ">=3.8, <4"
 dependencies = [
-  "apache-tvm-ffi>=0.1.9",
+  "apache-tvm-ffi>=0.1.10",
   "pydantic",
   "torch>=1.10.0",
   # Keep the transformers bound in sync with docs/requirements.txt and the CI workflows.
@@ -50,7 +50,7 @@ test = [
 metal = ["mlx-lm; platform_system == 'Darwin' and platform_machine == 'arm64'"]
 
 [build-system]
-requires = ["scikit-build-core>=0.10.0", "apache-tvm-ffi>=0.1.9"]
+requires = ["scikit-build-core>=0.10.0", "apache-tvm-ffi>=0.1.10"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
Fix #756. 

The root cause of the syntax error is that `apache-tvm-ffi<=0.1.9` does not correctly convert the `std::optional<T>` types (newly added in temperature support #730) into python `Optional[T]` type hints. The type mapping issue was fixed in `apache-tvm-ffi==0.1.10`.