### PR TITLE
Accelerate large structural tag compilation

### DIFF
--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -22,6 +22,7 @@
 #include "fsm.h"
 #include "grammar_functor.h"
 #include "grammar_impl.h"
+#include "structural_tag.h"
 #include "support/dynamic_bitset.h"
 #include "support/int_set.h"
 #include "support/logging.h"
@@ -1172,7 +1173,8 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
 }
 
 CompiledGrammar GrammarCompilerSub::CompileStructuralTag(const std::string& structural_tag_json) {
-  auto result = Grammar::FromStructuralTag(structural_tag_json, tokenizer_info_);
+  auto result =
+      StructuralTagToGrammar(structural_tag_json, tokenizer_info_, max_threads_).ToVariant();
   XGRAMMAR_CHECK(std::holds_alternative<Grammar>(result))
       << GetMessageFromVariantError(std::get<1>(result));
   return MultiThreadCompileGrammar(std::get<0>(result));

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1197,7 +1197,6 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(
   }
 
   const int32_t num_tasks = static_cast<int32_t>(adaptive_token_mask_tasks.size());
-  std::vector<std::optional<AdaptiveTokenMask>> adaptive_token_masks(num_tasks);
   auto compute_adaptive_token_mask = [&](int32_t task_id) {
     const auto& task = adaptive_token_mask_tasks[task_id];
     auto grammar_matcher = GrammarMatcherForTokenMaskCache(
@@ -1207,7 +1206,7 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(
         tokenizer_info_,
         rule_level_cache_
     );
-    adaptive_token_masks[task_id] = grammar_matcher.GetAdaptiveTokenMask(task.is_root_rule);
+    return grammar_matcher.GetAdaptiveTokenMask(task.is_root_rule);
   };
 
   const int32_t num_task_groups = static_cast<int32_t>(adaptive_token_mask_task_groups.size());
@@ -1215,29 +1214,40 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(
   if (num_threads == 1) {
     for (const auto& task_group : adaptive_token_mask_task_groups) {
       for (int32_t task_id : task_group) {
-        compute_adaptive_token_mask(task_id);
+        const auto& task = adaptive_token_mask_tasks[task_id];
+        compiled_grammar_impl->adaptive_token_mask_cache.emplace(
+            task.state, compute_adaptive_token_mask(task_id)
+        );
       }
     }
   } else {
     std::atomic<int32_t> next_task_group_id{0};
+    // Build maps independently so workers perform node allocation in parallel. Merging transfers
+    // the completed nodes into the final cache without copying their masks.
+    using AdaptiveTokenMaskMap = decltype(compiled_grammar_impl->adaptive_token_mask_cache);
+    std::vector<AdaptiveTokenMaskMap> worker_results(num_threads);
+    for (auto& worker_result : worker_results) {
+      worker_result.reserve((num_tasks + num_threads - 1) / num_threads);
+    }
     for (int32_t thread_id = 0; thread_id < num_threads; ++thread_id) {
-      thread_pool->Execute([&]() {
+      thread_pool->Execute([&, thread_id]() {
+        auto& worker_result = worker_results[thread_id];
         int32_t task_group_id;
         while ((task_group_id = next_task_group_id.fetch_add(1, std::memory_order_relaxed)) <
                num_task_groups) {
           for (int32_t task_id : adaptive_token_mask_task_groups[task_group_id]) {
-            compute_adaptive_token_mask(task_id);
+            const auto& task = adaptive_token_mask_tasks[task_id];
+            worker_result.emplace(task.state, compute_adaptive_token_mask(task_id));
           }
         }
       });
     }
     thread_pool->Wait();
-  }
-
-  for (int32_t task_id = 0; task_id < num_tasks; ++task_id) {
-    compiled_grammar_impl->adaptive_token_mask_cache.emplace(
-        adaptive_token_mask_tasks[task_id].state, std::move(adaptive_token_masks[task_id]).value()
-    );
+    auto& result = compiled_grammar_impl->adaptive_token_mask_cache;
+    result.reserve(num_tasks);
+    for (auto& worker_result : worker_results) {
+      result.merge(worker_result);
+    }
   }
 
   return CompiledGrammar(compiled_grammar_impl);

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1063,7 +1063,7 @@ class GrammarCompilerSub {
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
-  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
+  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized, max_threads_);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -6,6 +6,7 @@
 #include <xgrammar/compiler.h>
 
 #include <algorithm>
+#include <atomic>
 #include <bitset>
 #include <cctype>
 #include <cstddef>
@@ -1042,7 +1043,7 @@ class GrammarCompilerSub {
 
  private:
   /*! \brief The main logic. Compile the grammar with multi-threading. */
-  CompiledGrammar MultiThreadCompileGrammar(Grammar grammar);
+  CompiledGrammar MultiThreadCompileGrammar(Grammar grammar, ThreadPool* thread_pool = nullptr);
   /*! \brief Optimization for TagDispatch.
    *  \param compiled_grammar_impl the compiled_grammar to be optimized.
    *  \param tag_dispatch_rule_id_to_second_slicing_bitset Return value. Mapping from the rule_id to
@@ -1062,9 +1063,17 @@ class GrammarCompilerSub {
   std::optional<RuleLevelCache> rule_level_cache_;
 };
 
-CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
+CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(
+    Grammar grammar_unoptimized, ThreadPool* thread_pool
+) {
+  std::optional<ThreadPool> owned_thread_pool;
+  if (max_threads_ > 1 && thread_pool == nullptr) {
+    owned_thread_pool.emplace(max_threads_);
+    thread_pool = &owned_thread_pool.value();
+  }
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
-  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized, max_threads_);
+  compiled_grammar_impl->grammar =
+      GrammarOptimizer::Apply(grammar_unoptimized, max_threads_, thread_pool);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
@@ -1082,17 +1091,7 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   // 2. All byte strings (with element_in_string=0, 1, 2, ...)
   // since other positions will be expanded to the above positions
 
-  // TODO(Charlie): Figure out how to support ThreadPool and std::mutex in WebAssembly.
-  // Only declare ThreadPool and mutex if max_threads > 1, so when max_threads = 1, we do
-  // not need ThreadPool or std::mutex, which throws error in runtime in WebAssembly.
-  std::optional<ThreadPool> thread_pool;
-  std::optional<std::mutex> adaptive_token_mask_cache_mutex;
-  if (max_threads_ > 1) {
-    thread_pool.emplace(max_threads_);
-    adaptive_token_mask_cache_mutex.emplace();
-  }
-
-  auto add_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
+  auto compute_and_add_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
     auto grammar_matcher = GrammarMatcherForTokenMaskCache(
         compiled_grammar_impl->grammar,
         state,
@@ -1100,31 +1099,47 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
         tokenizer_info_,
         rule_level_cache_
     );
-    auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask(is_root_rule);
-    if (max_threads_ > 1) {
-      std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex.value());
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
-    } else {
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
-    }
+    compiled_grammar_impl->adaptive_token_mask_cache.emplace(
+        state, grammar_matcher.GetAdaptiveTokenMask(is_root_rule)
+    );
   };
-
-  auto add_task_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
-    // Execute depending on whether we use thread_pool
-    if (max_threads_ > 1) {
-      thread_pool->Execute([add_adaptive_token_mask, state, is_root_rule]() {
-        add_adaptive_token_mask(state, is_root_rule);
-      });
-    } else {
-      add_adaptive_token_mask(state, is_root_rule);
-    }
-  };
-
   auto root_rule_id = compiled_grammar_impl->grammar->GetRootRuleId();
+  if (max_threads_ == 1) {
+    for (int32_t rule_id = 0;
+         rule_id < static_cast<int>(compiled_grammar_impl->grammar->NumRules());
+         ++rule_id) {
+      auto rule = compiled_grammar_impl->grammar->GetRule(rule_id);
+      const auto& rule_fsm = compiled_grammar_impl->grammar->per_rule_fsms[rule_id];
+      XGRAMMAR_DCHECK(rule_fsm.has_value());
+      auto cur_stack_element =
+          ParserState(rule_id, rule.body_expr_id, 0, ParserState::kNoPrevInputPos, 0);
+      std::unordered_set<int> reachable_states;
+      rule_fsm->GetFsm().GetReachableStates(&reachable_states);
+      for (int i : reachable_states) {
+        cur_stack_element.element_id = i;
+        if (rule_fsm->GetFsm().IsScanableState(i)) {
+          compute_and_add_adaptive_token_mask(cur_stack_element, rule_id == root_rule_id);
+        }
+      }
+    }
+    return CompiledGrammar(compiled_grammar_impl);
+  }
+
+  struct AdaptiveTokenMaskTask {
+    ParserState state;
+    bool is_root_rule;
+  };
+  using AdaptiveTokenMaskCacheKey = std::tuple<uint64_t, int32_t, int32_t, int32_t>;
+  std::vector<AdaptiveTokenMaskTask> adaptive_token_mask_tasks;
+  std::vector<std::vector<int32_t>> adaptive_token_mask_task_groups;
+  std::unordered_map<AdaptiveTokenMaskCacheKey, int32_t> cache_key_to_task_group;
+
+  bool has_char_budget_rules = false;
 
   for (int32_t rule_id = 0; rule_id < static_cast<int>(compiled_grammar_impl->grammar->NumRules());
        ++rule_id) {
     auto rule = compiled_grammar_impl->grammar->GetRule(rule_id);
+    has_char_budget_rules = has_char_budget_rules || rule.max_chars >= 0;
     const auto& rule_fsm = compiled_grammar_impl->grammar->per_rule_fsms[rule_id];
     XGRAMMAR_DCHECK(rule_fsm.has_value());
     auto cur_stack_element =
@@ -1136,12 +1151,93 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
       if (!rule_fsm->GetFsm().IsScanableState(i)) {
         continue;
       }
-      add_task_adaptive_token_mask(cur_stack_element, rule_id == root_rule_id);
+      adaptive_token_mask_tasks.push_back({cur_stack_element, rule_id == root_rule_id});
     }
   }
 
-  if (max_threads_ > 1) {
-    thread_pool->Join();
+  // Keep equivalent rule-cache misses in one worker so the first task populates the cache before
+  // the rest run. Different cache keys remain dynamically balanced across all workers.
+  auto add_task_group = [&](int32_t task_id) {
+    const auto& state = adaptive_token_mask_tasks[task_id].state;
+    if (!rule_level_cache_.has_value() || has_char_budget_rules) {
+      adaptive_token_mask_task_groups.push_back({task_id});
+      return;
+    }
+
+    const auto& fsm_hash = compiled_grammar_impl->grammar->per_rule_fsm_hashes[state.rule_id];
+    if (!fsm_hash.has_value()) {
+      adaptive_token_mask_task_groups.push_back({task_id});
+      return;
+    }
+
+    int32_t normalized_state_id = -1;
+    for (const auto& [original_state_id, new_state_id] :
+         compiled_grammar_impl->grammar->per_rule_fsm_new_state_ids[state.rule_id]) {
+      if (original_state_id == state.element_id) {
+        normalized_state_id = new_state_id;
+        break;
+      }
+    }
+    XGRAMMAR_DCHECK(normalized_state_id != -1);
+    const auto& fsm = compiled_grammar_impl->grammar->per_rule_fsms[state.rule_id].value();
+    AdaptiveTokenMaskCacheKey cache_key{
+        fsm_hash.value(), normalized_state_id, fsm.GetNodeNum(), fsm.GetEdgeNum()
+    };
+    auto [it, inserted] = cache_key_to_task_group.emplace(
+        cache_key, static_cast<int32_t>(adaptive_token_mask_task_groups.size())
+    );
+    if (inserted) {
+      adaptive_token_mask_task_groups.push_back({});
+    }
+    adaptive_token_mask_task_groups[it->second].push_back(task_id);
+  };
+  for (int32_t task_id = 0; task_id < static_cast<int32_t>(adaptive_token_mask_tasks.size());
+       ++task_id) {
+    add_task_group(task_id);
+  }
+
+  const int32_t num_tasks = static_cast<int32_t>(adaptive_token_mask_tasks.size());
+  std::vector<std::optional<AdaptiveTokenMask>> adaptive_token_masks(num_tasks);
+  auto compute_adaptive_token_mask = [&](int32_t task_id) {
+    const auto& task = adaptive_token_mask_tasks[task_id];
+    auto grammar_matcher = GrammarMatcherForTokenMaskCache(
+        compiled_grammar_impl->grammar,
+        task.state,
+        tag_dispatch_rule_id_to_second_slicing_bitset,
+        tokenizer_info_,
+        rule_level_cache_
+    );
+    adaptive_token_masks[task_id] = grammar_matcher.GetAdaptiveTokenMask(task.is_root_rule);
+  };
+
+  const int32_t num_task_groups = static_cast<int32_t>(adaptive_token_mask_task_groups.size());
+  const int32_t num_threads = std::max(1, std::min(max_threads_, num_task_groups));
+  if (num_threads == 1) {
+    for (const auto& task_group : adaptive_token_mask_task_groups) {
+      for (int32_t task_id : task_group) {
+        compute_adaptive_token_mask(task_id);
+      }
+    }
+  } else {
+    std::atomic<int32_t> next_task_group_id{0};
+    for (int32_t thread_id = 0; thread_id < num_threads; ++thread_id) {
+      thread_pool->Execute([&]() {
+        int32_t task_group_id;
+        while ((task_group_id = next_task_group_id.fetch_add(1, std::memory_order_relaxed)) <
+               num_task_groups) {
+          for (int32_t task_id : adaptive_token_mask_task_groups[task_group_id]) {
+            compute_adaptive_token_mask(task_id);
+          }
+        }
+      });
+    }
+    thread_pool->Wait();
+  }
+
+  for (int32_t task_id = 0; task_id < num_tasks; ++task_id) {
+    compiled_grammar_impl->adaptive_token_mask_cache.emplace(
+        adaptive_token_mask_tasks[task_id].state, std::move(adaptive_token_masks[task_id]).value()
+    );
   }
 
   return CompiledGrammar(compiled_grammar_impl);
@@ -1173,11 +1269,17 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
 }
 
 CompiledGrammar GrammarCompilerSub::CompileStructuralTag(const std::string& structural_tag_json) {
+  std::optional<ThreadPool> thread_pool;
+  if (max_threads_ > 1) {
+    thread_pool.emplace(max_threads_);
+  }
+  ThreadPool* thread_pool_ptr = thread_pool.has_value() ? &thread_pool.value() : nullptr;
   auto result =
-      StructuralTagToGrammar(structural_tag_json, tokenizer_info_, max_threads_).ToVariant();
+      StructuralTagToGrammar(structural_tag_json, tokenizer_info_, max_threads_, thread_pool_ptr)
+          .ToVariant();
   XGRAMMAR_CHECK(std::holds_alternative<Grammar>(result))
       << GetMessageFromVariantError(std::get<1>(result));
-  return MultiThreadCompileGrammar(std::get<0>(result));
+  return MultiThreadCompileGrammar(std::get<0>(result), thread_pool_ptr);
 }
 
 CompiledGrammar GrammarCompilerSub::CompileRegex(const std::string& regex) {

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1308,7 +1308,7 @@ class GrammarFSMBuilderImpl {
   explicit GrammarFSMBuilderImpl(FSM& target_fsm, const std::string* rule_name = nullptr)
       : target_fsm_(target_fsm), rule_name_(rule_name) {}
 
-  static void Apply(Grammar* grammar, int max_threads) {
+  static void Apply(Grammar* grammar, int max_threads, ThreadPool* thread_pool) {
     FSM complete_fsm;
     std::vector<std::optional<FSMWithStartEndWithSize>> per_rule_fsms((*grammar)->NumRules());
     std::vector<int> state_mapping;
@@ -1323,16 +1323,20 @@ class GrammarFSMBuilderImpl {
     } else {
       std::vector<std::optional<FSMWithStartEnd>> built_rule_fsms(num_rules);
       std::atomic<int> next_rule_id{0};
-      ThreadPool thread_pool(num_threads);
+      std::optional<ThreadPool> owned_thread_pool;
+      if (thread_pool == nullptr) {
+        owned_thread_pool.emplace(num_threads);
+        thread_pool = &owned_thread_pool.value();
+      }
       for (int thread_id = 0; thread_id < num_threads; ++thread_id) {
-        thread_pool.Execute([&]() {
+        thread_pool->Execute([&]() {
           int rule_id;
           while ((rule_id = next_rule_id.fetch_add(1, std::memory_order_relaxed)) < num_rules) {
             built_rule_fsms[rule_id] = BuildRuleFSM(*grammar, rule_id);
           }
         });
       }
-      thread_pool.Join();
+      thread_pool->Wait();
       for (int i = 0; i < num_rules; ++i) {
         per_rule_fsms[i] = built_rule_fsms[i]->AddToCompleteFSM(&complete_fsm, &state_mapping);
       }
@@ -3071,7 +3075,7 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
 
 class GrammarOptimizerImpl {
  public:
-  static Grammar Apply(const Grammar& grammar, int max_threads) {
+  static Grammar Apply(const Grammar& grammar, int max_threads, ThreadPool* thread_pool) {
     // ByteStringFuser and RuleInliner rewrite the grammar in place, so work on a private copy: the
     // input grammar may be shared (e.g. a cached grammar) and must not be mutated. Copy the impl
     // directly (contiguous vector copies) instead of going through GrammarBuilder, which would
@@ -3086,7 +3090,7 @@ class GrammarOptimizerImpl {
     result->allow_empty_rule_ids = AllowEmptyRuleAnalyzer::Apply(result);
     ValidateLazyRules(result);
     RepetitionNormalizer::Apply(&result);
-    GrammarFSMBuilder::Apply(&result, max_threads);
+    GrammarFSMBuilder::Apply(&result, max_threads, thread_pool);
     result->optimized = true;
     return result;
   }
@@ -4035,10 +4039,16 @@ Grammar StructureNormalizer::Apply(const Grammar& grammar) {
 
 /*************************** Forward grammar optimizers to their impl ***************************/
 
-void GrammarFSMBuilder::Apply(Grammar* grammar) { GrammarFSMBuilderImpl::Apply(grammar, 1); }
+void GrammarFSMBuilder::Apply(Grammar* grammar) {
+  GrammarFSMBuilderImpl::Apply(grammar, 1, nullptr);
+}
 
 void GrammarFSMBuilder::Apply(Grammar* grammar, int max_threads) {
-  GrammarFSMBuilderImpl::Apply(grammar, max_threads);
+  GrammarFSMBuilderImpl::Apply(grammar, max_threads, nullptr);
+}
+
+void GrammarFSMBuilder::Apply(Grammar* grammar, int max_threads, ThreadPool* thread_pool) {
+  GrammarFSMBuilderImpl::Apply(grammar, max_threads, thread_pool);
 }
 
 void RepetitionNormalizer::Apply(Grammar* grammar) { RepetitionNormalizerImpl().Apply(grammar); }
@@ -4131,11 +4141,15 @@ Grammar RepetitionRangeExpander::Apply(const Grammar& grammar) {
 }
 
 Grammar GrammarOptimizer::Apply(const Grammar& grammar) {
-  return GrammarOptimizerImpl::Apply(grammar, 1);
+  return GrammarOptimizerImpl::Apply(grammar, 1, nullptr);
 }
 
 Grammar GrammarOptimizer::Apply(const Grammar& grammar, int max_threads) {
-  return GrammarOptimizerImpl::Apply(grammar, max_threads);
+  return GrammarOptimizerImpl::Apply(grammar, max_threads, nullptr);
+}
+
+Grammar GrammarOptimizer::Apply(const Grammar& grammar, int max_threads, ThreadPool* thread_pool) {
+  return GrammarOptimizerImpl::Apply(grammar, max_threads, thread_pool);
 }
 
 void ByteStringFuser::Apply(Grammar* grammar) { ByteStringFuserImpl().Apply(grammar); }

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -8,6 +8,7 @@
 #include <xgrammar/xgrammar.h>
 
 #include <array>
+#include <atomic>
 #include <bitset>
 #include <cstdint>
 #include <map>
@@ -28,6 +29,7 @@
 #include "support/container.h"
 #include "support/encoding.h"
 #include "support/logging.h"
+#include "support/thread_pool.h"
 #include "xgrammar/grammar.h"
 
 namespace xgrammar {
@@ -1306,14 +1308,34 @@ class GrammarFSMBuilderImpl {
   explicit GrammarFSMBuilderImpl(FSM& target_fsm, const std::string* rule_name = nullptr)
       : target_fsm_(target_fsm), rule_name_(rule_name) {}
 
-  static void Apply(Grammar* grammar) {
+  static void Apply(Grammar* grammar, int max_threads) {
     FSM complete_fsm;
     std::vector<std::optional<FSMWithStartEndWithSize>> per_rule_fsms((*grammar)->NumRules());
     std::vector<int> state_mapping;
 
-    for (int i = 0; i < (*grammar)->NumRules(); ++i) {
-      auto rule_fsm = BuildRuleFSM(*grammar, i);
-      per_rule_fsms[i] = rule_fsm.AddToCompleteFSM(&complete_fsm, &state_mapping);
+    const int num_rules = (*grammar)->NumRules();
+    const int num_threads = std::max(1, std::min(max_threads, num_rules));
+    if (num_threads == 1) {
+      for (int i = 0; i < num_rules; ++i) {
+        auto rule_fsm = BuildRuleFSM(*grammar, i);
+        per_rule_fsms[i] = rule_fsm.AddToCompleteFSM(&complete_fsm, &state_mapping);
+      }
+    } else {
+      std::vector<std::optional<FSMWithStartEnd>> built_rule_fsms(num_rules);
+      std::atomic<int> next_rule_id{0};
+      ThreadPool thread_pool(num_threads);
+      for (int thread_id = 0; thread_id < num_threads; ++thread_id) {
+        thread_pool.Execute([&]() {
+          int rule_id;
+          while ((rule_id = next_rule_id.fetch_add(1, std::memory_order_relaxed)) < num_rules) {
+            built_rule_fsms[rule_id] = BuildRuleFSM(*grammar, rule_id);
+          }
+        });
+      }
+      thread_pool.Join();
+      for (int i = 0; i < num_rules; ++i) {
+        per_rule_fsms[i] = built_rule_fsms[i]->AddToCompleteFSM(&complete_fsm, &state_mapping);
+      }
     }
 
     for (int i = 0; i < (*grammar)->NumRules(); ++i) {
@@ -1361,6 +1383,9 @@ class GrammarFSMBuilderImpl {
       const std::vector<std::pair<std::string, int>>& string_trigger_rules,
       bool loop_after_dispatch,
       const std::vector<std::string>& excluded_strings
+  );
+  static std::optional<FSMWithStartEnd> BuildByteStringRuleRefByteStringChoices(
+      const GrammarExpr& expr, const Grammar& grammar
   );
 
  private:
@@ -1717,9 +1742,74 @@ FSMWithStartEnd GrammarFSMBuilderImpl::BuildRuleFSM(const Grammar& grammar, int 
   return BuildExpressionFSM(grammar->GetGrammarExpr(rule.body_expr_id), grammar, &rule.name);
 }
 
+std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildByteStringRuleRefByteStringChoices(
+    const GrammarExpr& expr, const Grammar& grammar
+) {
+  constexpr int kMinChoiceCount = 64;
+  if (expr.type != ExprType::kChoices || expr.size() < kMinChoiceCount) {
+    return std::nullopt;
+  }
+
+  std::vector<std::string> prefixes;
+  std::vector<int32_t> rule_ids;
+  std::vector<std::string> suffixes;
+  prefixes.reserve(expr.size());
+  rule_ids.reserve(expr.size());
+  suffixes.reserve(expr.size());
+  for (int32_t choice_id : expr) {
+    const auto& choice = grammar->GetGrammarExpr(choice_id);
+    if (choice.type != ExprType::kSequence || choice.size() != 3) {
+      return std::nullopt;
+    }
+    const auto& prefix = grammar->GetGrammarExpr(choice[0]);
+    const auto& rule_ref = grammar->GetGrammarExpr(choice[1]);
+    const auto& suffix = grammar->GetGrammarExpr(choice[2]);
+    if (prefix.type != ExprType::kByteString || rule_ref.type != ExprType::kRuleRef ||
+        rule_ref.size() != 1 || suffix.type != ExprType::kByteString) {
+      return std::nullopt;
+    }
+    prefixes.push_back(grammar->GetByteString(prefix));
+    rule_ids.push_back(rule_ref[0]);
+    suffixes.push_back(grammar->GetByteString(suffix));
+  }
+
+  std::vector<int32_t> prefix_end_states;
+  auto trie =
+      TrieFSMBuilder::Build(prefixes, std::vector<std::string>{}, &prefix_end_states, true, false);
+  XGRAMMAR_DCHECK(trie.has_value());
+  FSM fsm = std::move(trie->GetFsm());
+  const int start_state = trie->GetStart();
+  const int end_state = fsm.AddState();
+
+  std::map<std::string, int32_t> suffix_start_states;
+  std::set<std::tuple<int32_t, int32_t, int32_t>> added_rule_edges;
+  for (int i = 0; i < expr.size(); ++i) {
+    auto [it, inserted] = suffix_start_states.emplace(suffixes[i], end_state);
+    if (inserted) {
+      int32_t current_state = end_state;
+      for (auto byte = suffixes[i].rbegin(); byte != suffixes[i].rend(); ++byte) {
+        int32_t previous_state = fsm.AddState();
+        uint8_t value = static_cast<uint8_t>(*byte);
+        fsm.AddEdge(previous_state, current_state, value, value);
+        current_state = previous_state;
+      }
+      it->second = current_state;
+    }
+    auto edge = std::make_tuple(prefix_end_states[i], it->second, rule_ids[i]);
+    if (added_rule_edges.insert(edge).second) {
+      fsm.AddRuleEdge(prefix_end_states[i], it->second, rule_ids[i]);
+    }
+  }
+
+  return FSMWithStartEnd(fsm, start_state, {end_state});
+}
+
 FSMWithStartEnd GrammarFSMBuilderImpl::BuildExpressionFSM(
     const GrammarExpr& expr, const Grammar& grammar, const std::string* rule_name
 ) {
+  if (auto specialized = BuildByteStringRuleRefByteStringChoices(expr, grammar)) {
+    return std::move(*specialized);
+  }
   FSM result_fsm;
   int start_state = result_fsm.AddState();
   std::vector<int32_t> end_states;
@@ -2981,7 +3071,7 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
 
 class GrammarOptimizerImpl {
  public:
-  static Grammar Apply(const Grammar& grammar) {
+  static Grammar Apply(const Grammar& grammar, int max_threads) {
     // ByteStringFuser and RuleInliner rewrite the grammar in place, so work on a private copy: the
     // input grammar may be shared (e.g. a cached grammar) and must not be mutated. Copy the impl
     // directly (contiguous vector copies) instead of going through GrammarBuilder, which would
@@ -2996,7 +3086,7 @@ class GrammarOptimizerImpl {
     result->allow_empty_rule_ids = AllowEmptyRuleAnalyzer::Apply(result);
     ValidateLazyRules(result);
     RepetitionNormalizer::Apply(&result);
-    GrammarFSMBuilder::Apply(&result);
+    GrammarFSMBuilder::Apply(&result, max_threads);
     result->optimized = true;
     return result;
   }
@@ -3161,6 +3251,7 @@ class GrammarFSMHasherImpl {
   std::vector<std::vector<int32_t>> ref_graph_from_referee_to_referrer_;
   std::vector<std::vector<FSMEdge>> sorted_edges_;
   std::vector<bool> has_inward_edges_;
+  std::vector<int32_t> fsm_state_offsets_;
 
   /*!
    * \brief The worklist of fsms that are ready to be hashed: fsms whose references are all
@@ -3312,6 +3403,16 @@ void GrammarFSMHasherImpl::Apply(Grammar* grammar) {
     }
   }
 
+  fsm_state_offsets_.resize((*grammar)->NumRules());
+  int32_t state_offset = 0;
+  for (int32_t rule_id = 0; rule_id < (*grammar)->NumRules(); ++rule_id) {
+    fsm_state_offsets_[rule_id] = state_offset;
+    if (grammar->ImplPtr()->per_rule_fsms[rule_id].has_value()) {
+      state_offset += grammar->ImplPtr()->per_rule_fsms[rule_id]->GetNodeNum();
+    }
+  }
+  XGRAMMAR_DCHECK(state_offset == grammar->ImplPtr()->complete_fsm.NumStates());
+
   // Get the reference graph.
   ref_graph_from_referee_to_referrer_ = RuleRefGraphFinder().Apply(*grammar);
   ref_graph_from_referrer_to_referee_ = std::vector<std::vector<int32_t>>((*grammar)->NumRules());
@@ -3401,18 +3502,28 @@ std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index)
   XGRAMMAR_DCHECK(fsm_index >= 0 && fsm_index < (*grammar_)->NumRules())
       << "Invalid fsm index: " << fsm_index << " num_rules: " << (*grammar_)->NumRules();
   XGRAMMAR_DCHECK(grammar_->ImplPtr()->per_rule_fsms[fsm_index].has_value());
-  const auto& fsm = grammar_->ImplPtr()->per_rule_fsms[fsm_index].value().GetFsm();
-  std::map<int32_t, int32_t> original_state_id_to_new_id;
-  original_state_id_to_new_id[fsm.GetStart()] = 0;
-  std::queue<int32_t> bfs_queue;
+  const auto& sized_fsm = grammar_->ImplPtr()->per_rule_fsms[fsm_index].value();
+  const auto& fsm = sized_fsm.GetFsm();
+  const int32_t state_offset = fsm_state_offsets_[fsm_index];
+  std::vector<int32_t> original_state_id_to_new_id(sized_fsm.GetNodeNum(), -1);
+  auto mapped_id = [&](int32_t state_id) -> int32_t& {
+    XGRAMMAR_DCHECK(
+        state_id >= state_offset &&
+        state_id < state_offset + static_cast<int32_t>(original_state_id_to_new_id.size())
+    );
+    return original_state_id_to_new_id[state_id - state_offset];
+  };
+  mapped_id(fsm.GetStart()) = 0;
+  int32_t next_new_state_id = 1;
+  std::vector<int32_t> bfs_queue;
+  bfs_queue.reserve(sized_fsm.GetNodeNum());
   std::set<std::pair<uint64_t, int32_t>> hash_and_target;
-  bfs_queue.push(fsm.GetStart());
+  bfs_queue.push_back(fsm.GetStart());
   // Perform a bfs to hash all the edges.
-  while (!bfs_queue.empty()) {
-    int current_old_state_id = bfs_queue.front();
+  for (size_t queue_index = 0; queue_index < bfs_queue.size(); ++queue_index) {
+    int current_old_state_id = bfs_queue[queue_index];
     bool is_start = current_old_state_id == fsm.GetStart();
-    int current_new_state_id = original_state_id_to_new_id[current_old_state_id];
-    bfs_queue.pop();
+    int current_new_state_id = mapped_id(current_old_state_id);
 
     // Check if the current state is an end state.
     if (fsm.IsEndState(current_old_state_id)) {
@@ -3471,23 +3582,21 @@ std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index)
 
     // Hash them.
     for (const auto& [hash, target] : hash_and_target) {
-      if (original_state_id_to_new_id.find(target) == original_state_id_to_new_id.end()) {
-        original_state_id_to_new_id[target] =
-            static_cast<int32_t>(original_state_id_to_new_id.size());
-        bfs_queue.push(target);
+      if (mapped_id(target) == -1) {
+        mapped_id(target) = next_new_state_id++;
+        bfs_queue.push_back(target);
       }
-      int32_t target_new_id = original_state_id_to_new_id[target];
+      int32_t target_new_id = mapped_id(target);
       hash_result = HashCombine(hash_result, current_new_state_id, hash, target_new_id);
     }
 
     // Then, check the edges which are not rule/repeat references.
     for (const auto& edge : sorted_edges_[current_old_state_id]) {
-      if (original_state_id_to_new_id.find(edge.target) == original_state_id_to_new_id.end()) {
-        original_state_id_to_new_id[edge.target] =
-            static_cast<int32_t>(original_state_id_to_new_id.size());
-        bfs_queue.push(edge.target);
+      if (mapped_id(edge.target) == -1) {
+        mapped_id(edge.target) = next_new_state_id++;
+        bfs_queue.push_back(edge.target);
       }
-      int32_t target_new_id = original_state_id_to_new_id[edge.target];
+      int32_t target_new_id = mapped_id(edge.target);
       if (edge.IsRuleRef() || edge.IsRepeatRef()) {
         continue;
       }
@@ -3501,9 +3610,15 @@ std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index)
     }
   }
   std::vector<std::pair<int32_t, int32_t>> new_id_mapping;
-  new_id_mapping.reserve(original_state_id_to_new_id.size());
-  for (const auto& [original_state_id, new_state_id] : original_state_id_to_new_id) {
-    new_id_mapping.emplace_back(original_state_id, new_state_id);
+  new_id_mapping.reserve(next_new_state_id);
+  for (int32_t local_state_id = 0;
+       local_state_id < static_cast<int32_t>(original_state_id_to_new_id.size());
+       ++local_state_id) {
+    if (original_state_id_to_new_id[local_state_id] != -1) {
+      new_id_mapping.emplace_back(
+          local_state_id + state_offset, original_state_id_to_new_id[local_state_id]
+      );
+    }
   }
   grammar_->ImplPtr()->per_rule_fsm_new_state_ids[fsm_index] = new_id_mapping;
   return {true, hash_result};
@@ -3514,18 +3629,28 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
   XGRAMMAR_DCHECK(fsm_index >= 0 && fsm_index < (*grammar_)->NumRules())
       << "Invalid fsm index: " << fsm_index << " num_rules: " << (*grammar_)->NumRules();
   XGRAMMAR_DCHECK(grammar_->ImplPtr()->per_rule_fsms[fsm_index].has_value());
-  const auto& fsm = grammar_->ImplPtr()->per_rule_fsms[fsm_index].value().GetFsm();
-  std::map<int32_t, int32_t> original_state_id_to_new_id;
-  original_state_id_to_new_id[fsm.GetStart()] = 0;
-  std::queue<int32_t> bfs_queue;
+  const auto& sized_fsm = grammar_->ImplPtr()->per_rule_fsms[fsm_index].value();
+  const auto& fsm = sized_fsm.GetFsm();
+  const int32_t state_offset = fsm_state_offsets_[fsm_index];
+  std::vector<int32_t> original_state_id_to_new_id(sized_fsm.GetNodeNum(), -1);
+  auto mapped_id = [&](int32_t state_id) -> int32_t& {
+    XGRAMMAR_DCHECK(
+        state_id >= state_offset &&
+        state_id < state_offset + static_cast<int32_t>(original_state_id_to_new_id.size())
+    );
+    return original_state_id_to_new_id[state_id - state_offset];
+  };
+  mapped_id(fsm.GetStart()) = 0;
+  int32_t next_new_state_id = 1;
+  std::vector<int32_t> bfs_queue;
+  bfs_queue.reserve(sized_fsm.GetNodeNum());
   std::set<std::pair<int32_t, int32_t>> hash_and_target;
-  bfs_queue.push(fsm.GetStart());
+  bfs_queue.push_back(fsm.GetStart());
 
   // Perform a bfs to hash all the edges.
-  while (!bfs_queue.empty()) {
-    int current_old_state_id = bfs_queue.front();
-    int current_new_state_id = original_state_id_to_new_id[current_old_state_id];
-    bfs_queue.pop();
+  for (size_t queue_index = 0; queue_index < bfs_queue.size(); ++queue_index) {
+    int current_old_state_id = bfs_queue[queue_index];
+    int current_new_state_id = mapped_id(current_old_state_id);
 
     // Check if the current state is an end state.
     if (fsm.IsEndState(current_old_state_id)) {
@@ -3575,23 +3700,21 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
 
     // Hash them.
     for (const auto& [hash, target] : hash_and_target) {
-      if (original_state_id_to_new_id.find(target) == original_state_id_to_new_id.end()) {
-        original_state_id_to_new_id[target] =
-            static_cast<int32_t>(original_state_id_to_new_id.size());
-        bfs_queue.push(target);
+      if (mapped_id(target) == -1) {
+        mapped_id(target) = next_new_state_id++;
+        bfs_queue.push_back(target);
       }
-      int32_t target_new_id = original_state_id_to_new_id[target];
+      int32_t target_new_id = mapped_id(target);
       hash_result = HashCombine(hash_result, current_new_state_id, hash, target_new_id);
     }
 
     // Then, check the edges which are not rule/repeat references.
     for (const auto& edge : sorted_edges_[current_old_state_id]) {
-      if (original_state_id_to_new_id.find(edge.target) == original_state_id_to_new_id.end()) {
-        original_state_id_to_new_id[edge.target] =
-            static_cast<int32_t>(original_state_id_to_new_id.size());
-        bfs_queue.push(edge.target);
+      if (mapped_id(edge.target) == -1) {
+        mapped_id(edge.target) = next_new_state_id++;
+        bfs_queue.push_back(edge.target);
       }
-      int32_t target_new_id = original_state_id_to_new_id[edge.target];
+      int32_t target_new_id = mapped_id(edge.target);
       if (edge.IsRuleRef() || edge.IsRepeatRef()) {
         continue;
       }
@@ -3605,9 +3728,15 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
     }
   }
   std::vector<std::pair<int32_t, int32_t>> new_id_mapping;
-  new_id_mapping.reserve(original_state_id_to_new_id.size());
-  for (const auto& [original_state_id, new_state_id] : original_state_id_to_new_id) {
-    new_id_mapping.emplace_back(original_state_id, new_state_id);
+  new_id_mapping.reserve(next_new_state_id);
+  for (int32_t local_state_id = 0;
+       local_state_id < static_cast<int32_t>(original_state_id_to_new_id.size());
+       ++local_state_id) {
+    if (original_state_id_to_new_id[local_state_id] != -1) {
+      new_id_mapping.emplace_back(
+          local_state_id + state_offset, original_state_id_to_new_id[local_state_id]
+      );
+    }
   }
   grammar_->ImplPtr()->per_rule_fsm_new_state_ids[fsm_index] = new_id_mapping;
   return hash_result;
@@ -3906,7 +4035,11 @@ Grammar StructureNormalizer::Apply(const Grammar& grammar) {
 
 /*************************** Forward grammar optimizers to their impl ***************************/
 
-void GrammarFSMBuilder::Apply(Grammar* grammar) { GrammarFSMBuilderImpl::Apply(grammar); }
+void GrammarFSMBuilder::Apply(Grammar* grammar) { GrammarFSMBuilderImpl::Apply(grammar, 1); }
+
+void GrammarFSMBuilder::Apply(Grammar* grammar, int max_threads) {
+  GrammarFSMBuilderImpl::Apply(grammar, max_threads);
+}
 
 void RepetitionNormalizer::Apply(Grammar* grammar) { RepetitionNormalizerImpl().Apply(grammar); }
 
@@ -3998,7 +4131,11 @@ Grammar RepetitionRangeExpander::Apply(const Grammar& grammar) {
 }
 
 Grammar GrammarOptimizer::Apply(const Grammar& grammar) {
-  return GrammarOptimizerImpl::Apply(grammar);
+  return GrammarOptimizerImpl::Apply(grammar, 1);
+}
+
+Grammar GrammarOptimizer::Apply(const Grammar& grammar, int max_threads) {
+  return GrammarOptimizerImpl::Apply(grammar, max_threads);
 }
 
 void ByteStringFuser::Apply(Grammar* grammar) { ByteStringFuserImpl().Apply(grammar); }

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -383,6 +383,7 @@ class GrammarFSMBuilder {
 
  public:
   static void Apply(Grammar* grammar);
+  static void Apply(Grammar* grammar, int max_threads);
   static FSMWithStartEnd RuleRef(const GrammarExpr& expr);
   static FSMWithStartEnd CharacterClass(const GrammarExpr& expr);
   static FSMWithStartEnd ByteString(const GrammarExpr& expr);
@@ -440,6 +441,7 @@ class RepetitionRangeExpander {
 class GrammarOptimizer {
  public:
   static Grammar Apply(const Grammar& grammar);
+  static Grammar Apply(const Grammar& grammar, int max_threads);
 };
 
 /*!

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -22,6 +22,8 @@
 
 namespace xgrammar {
 
+class ThreadPool;
+
 /*!
  * \brief Base class for visitors and mutators of the BNF grammar.
  * \tparam T The type of the return value of visitor functions. Typical values:
@@ -384,6 +386,7 @@ class GrammarFSMBuilder {
  public:
   static void Apply(Grammar* grammar);
   static void Apply(Grammar* grammar, int max_threads);
+  static void Apply(Grammar* grammar, int max_threads, ThreadPool* thread_pool);
   static FSMWithStartEnd RuleRef(const GrammarExpr& expr);
   static FSMWithStartEnd CharacterClass(const GrammarExpr& expr);
   static FSMWithStartEnd ByteString(const GrammarExpr& expr);
@@ -442,6 +445,7 @@ class GrammarOptimizer {
  public:
   static Grammar Apply(const Grammar& grammar);
   static Grammar Apply(const Grammar& grammar, int max_threads);
+  static Grammar Apply(const Grammar& grammar, int max_threads, ThreadPool* thread_pool);
 };
 
 /*!

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -8,12 +8,16 @@
 #include <xgrammar/exception.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdint>
+#include <exception>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 
 #include "grammar_builder.h"
@@ -22,6 +26,7 @@
 #include "json_schema_converter.h"
 #include "support/logging.h"
 #include "support/recursion_guard.h"
+#include "support/thread_pool.h"
 #include "support/utils.h"
 #include "tokenizer_info_impl.h"
 #include "xgrammar/grammar.h"
@@ -1747,10 +1752,10 @@ std::optional<ISTError> StructuralTagAnalyzer::VisitSub(RepeatFormat* format) {
 
 class StructuralTagGrammarConverter {
  public:
-  static Result<Grammar, ISTError> Convert(const StructuralTag& structural_tag);
+  static Result<Grammar, ISTError> Convert(const StructuralTag& structural_tag, int max_threads);
 
  private:
-  StructuralTagGrammarConverter() = default;
+  explicit StructuralTagGrammarConverter(int max_threads) : max_threads_(max_threads) {}
 
   /*!
    * \brief Visit a Format and return the rule id of the added rule.
@@ -1779,6 +1784,9 @@ class StructuralTagGrammarConverter {
   Result<int, ISTError> VisitSub(const RepeatFormat& format);
   Result<int, ISTError> VisitSub(const DispatchFormat& format);
   Result<int, ISTError> VisitSub(const TokenDispatchFormat& format);
+  static std::string GetJSONSchemaFingerprint(const JSONSchemaFormat& format);
+  static Result<Grammar, ISTError> ConvertJSONSchemaFormat(const JSONSchemaFormat& format);
+  Result<int, ISTError> AddJSONSchemaGrammar(Grammar sub_grammar);
   Grammar AddRootRuleAndGetGrammar(int ref_rule_id);
 
   bool IsPrefix(const std::string& prefix, const std::string& full_str);
@@ -1792,6 +1800,7 @@ class StructuralTagGrammarConverter {
    * This enables deduplication of identical formats to reduce grammar size.
    */
   std::unordered_map<std::string, int> serialization_to_rule_id_;
+  int max_threads_;
 };
 
 bool StructuralTagGrammarConverter::IsPrefix(
@@ -1801,9 +1810,10 @@ bool StructuralTagGrammarConverter::IsPrefix(
          std::string_view(full_str).substr(0, prefix.size()) == prefix;
 }
 
-Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(const StructuralTag& structural_tag
+Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(
+    const StructuralTag& structural_tag, int max_threads
 ) {
-  StructuralTagGrammarConverter converter;
+  StructuralTagGrammarConverter converter(max_threads);
   auto result = converter.Visit(structural_tag.format, false);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
@@ -1825,17 +1835,7 @@ Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format,
   std::string fingerprint;
   if (deduplicate) {
     if (const auto* json_schema = std::get_if<JSONSchemaFormat>(&format)) {
-      fingerprint.reserve(
-          json_schema->json_schema.size() + json_schema->style.size() + sizeof(int) + 16
-      );
-      fingerprint.append(JSONSchemaFormat::type);
-      fingerprint.push_back('\0');
-      fingerprint.append(json_schema->json_schema);
-      fingerprint.push_back('\0');
-      fingerprint.append(json_schema->style);
-      fingerprint.push_back('\0');
-      fingerprint.push_back(json_schema->any_order ? '\1' : '\0');
-      fingerprint.append(std::to_string(json_schema->max_whitespace_cnt.value_or(-1)));
+      fingerprint = GetJSONSchemaFingerprint(*json_schema);
     } else {
       fingerprint = FormatToJSONValue(format).serialize();
     }
@@ -1865,12 +1865,36 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const ConstStringF
 }
 
 Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFormat& format) {
+  auto result = ConvertJSONSchemaFormat(format);
+  if (result.IsErr()) {
+    return ResultErr(std::move(result).UnwrapErr());
+  }
+  return AddJSONSchemaGrammar(std::move(result).Unwrap());
+}
+
+std::string StructuralTagGrammarConverter::GetJSONSchemaFingerprint(const JSONSchemaFormat& format
+) {
+  std::string fingerprint;
+  fingerprint.reserve(format.json_schema.size() + format.style.size() + sizeof(int) + 16);
+  fingerprint.append(JSONSchemaFormat::type);
+  fingerprint.push_back('\0');
+  fingerprint.append(format.json_schema);
+  fingerprint.push_back('\0');
+  fingerprint.append(format.style);
+  fingerprint.push_back('\0');
+  fingerprint.push_back(format.any_order ? '\1' : '\0');
+  fingerprint.append(std::to_string(format.max_whitespace_cnt.value_or(-1)));
+  return fingerprint;
+}
+
+Result<Grammar, ISTError> StructuralTagGrammarConverter::ConvertJSONSchemaFormat(
+    const JSONSchemaFormat& format
+) {
   auto json_format = JSONFormatFromString(format.style);
   if (!json_format.has_value()) {
     return ResultErr<ISTError>("Unsupported parsing type: " + format.style);
   }
-  // The whitespace cap comes from the JSONSchemaFormat node (per-tag).
-  auto sub_grammar = GrammarNormalizer::Apply(JSONSchemaToGrammar(
+  return ResultOk(GrammarNormalizer::Apply(JSONSchemaToGrammar(
       format.json_schema,
       /*any_whitespace=*/true,
       /*indent=*/std::nullopt,
@@ -1879,7 +1903,10 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFo
       /*max_whitespace_cnt=*/format.max_whitespace_cnt,
       /*any_order=*/format.any_order,
       /*json_format=*/*json_format
-  ));
+  )));
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::AddJSONSchemaGrammar(Grammar sub_grammar) {
   auto added_root_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
   return ResultOk(added_root_rule_id);
 }
@@ -1993,6 +2020,55 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTag
   std::vector<int> tag_content_rule_ids;
   tag_content_rule_ids.reserve(format.tags.size());
 
+  bool can_parallelize_json_schemas = max_threads_ > 1 && format.tags.size() > 1;
+  std::vector<int32_t> tag_to_schema_index(format.tags.size(), -1);
+  std::vector<const JSONSchemaFormat*> unique_schemas;
+  std::vector<std::string> schema_fingerprints(format.tags.size());
+  std::unordered_map<std::string, int32_t> fingerprint_to_schema_index;
+  if (can_parallelize_json_schemas) {
+    for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
+      const auto* schema = std::get_if<JSONSchemaFormat>(format.tags[it_tag].content.get());
+      if (schema == nullptr) {
+        can_parallelize_json_schemas = false;
+        break;
+      }
+      schema_fingerprints[it_tag] = GetJSONSchemaFingerprint(*schema);
+      auto [it, inserted] = fingerprint_to_schema_index.emplace(
+          schema_fingerprints[it_tag], static_cast<int32_t>(unique_schemas.size())
+      );
+      if (inserted) {
+        unique_schemas.push_back(schema);
+      }
+      tag_to_schema_index[it_tag] = it->second;
+    }
+  }
+
+  std::vector<std::optional<Result<Grammar, ISTError>>> schema_results;
+  std::vector<std::exception_ptr> schema_errors;
+  if (can_parallelize_json_schemas) {
+    int num_threads = std::min<int>(max_threads_, static_cast<int>(unique_schemas.size()));
+    schema_results.resize(unique_schemas.size());
+    schema_errors.resize(unique_schemas.size());
+    std::atomic<int32_t> next_schema_index{0};
+    ThreadPool schema_thread_pool(num_threads);
+    for (int thread_id = 0; thread_id < num_threads; ++thread_id) {
+      schema_thread_pool.Execute([&]() {
+        int32_t schema_index;
+        while ((schema_index = next_schema_index.fetch_add(1, std::memory_order_relaxed)) <
+               static_cast<int32_t>(unique_schemas.size())) {
+          try {
+            schema_results[schema_index].emplace(
+                ConvertJSONSchemaFormat(*unique_schemas[schema_index])
+            );
+          } catch (...) {
+            schema_errors[schema_index] = std::current_exception();
+          }
+        }
+      });
+    }
+    schema_thread_pool.Join();
+  }
+
   for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
     const auto& tag = format.tags[it_tag];
     if (!std::holds_alternative<std::string>(tag.begin)) {
@@ -2017,13 +2093,34 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTag
     }
     trigger_to_tag_ids[matched_trigger_id].push_back(it_tag);
 
-    auto result = Visit(*tag.content);
-    if (result.IsErr()) {
-      return result;
+    if (can_parallelize_json_schemas) {
+      const auto& fingerprint = schema_fingerprints[it_tag];
+      auto cached = serialization_to_rule_id_.find(fingerprint);
+      if (cached != serialization_to_rule_id_.end()) {
+        tag_content_rule_ids.push_back(cached->second);
+        continue;
+      }
+      int32_t schema_index = tag_to_schema_index[it_tag];
+      if (schema_errors[schema_index]) {
+        std::rethrow_exception(schema_errors[schema_index]);
+      }
+      auto result = std::move(schema_results[schema_index].value());
+      schema_results[schema_index].reset();
+      if (result.IsErr()) {
+        return ResultErr(std::move(result).UnwrapErr());
+      }
+      auto added = AddJSONSchemaGrammar(std::move(result).Unwrap());
+      int rule_id = std::move(added).Unwrap();
+      serialization_to_rule_id_[fingerprint] = rule_id;
+      tag_content_rule_ids.push_back(rule_id);
+    } else {
+      auto result = Visit(*tag.content);
+      if (result.IsErr()) {
+        return result;
+      }
+      tag_content_rule_ids.push_back(std::move(result).Unwrap());
     }
-    tag_content_rule_ids.push_back(std::move(result).Unwrap());
   }
-
   // Step 2. Special Case: at_least_one && stop_after_first.
   if (format.at_least_one && format.stop_after_first) {
     std::vector<int> choice_elements;
@@ -2426,7 +2523,9 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TokenDispatc
 /************** StructuralTag Conversion Public API **************/
 
 Result<Grammar, StructuralTagError> StructuralTagToGrammar(
-    const std::string& structural_tag_json, const std::optional<TokenizerInfo>& tokenizer_info
+    const std::string& structural_tag_json,
+    const std::optional<TokenizerInfo>& tokenizer_info,
+    int max_threads
 ) {
   auto structural_tag_result = StructuralTagParser::FromJSON(structural_tag_json);
   if (structural_tag_result.IsErr()) {
@@ -2444,7 +2543,7 @@ Result<Grammar, StructuralTagError> StructuralTagToGrammar(
     return ResultErr(std::move(err).value());
   }
 
-  auto result = StructuralTagGrammarConverter::Convert(structural_tag);
+  auto result = StructuralTagGrammarConverter::Convert(structural_tag, max_threads);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -1752,10 +1752,13 @@ std::optional<ISTError> StructuralTagAnalyzer::VisitSub(RepeatFormat* format) {
 
 class StructuralTagGrammarConverter {
  public:
-  static Result<Grammar, ISTError> Convert(const StructuralTag& structural_tag, int max_threads);
+  static Result<Grammar, ISTError> Convert(
+      const StructuralTag& structural_tag, int max_threads, ThreadPool* thread_pool
+  );
 
  private:
-  explicit StructuralTagGrammarConverter(int max_threads) : max_threads_(max_threads) {}
+  explicit StructuralTagGrammarConverter(int max_threads, ThreadPool* thread_pool)
+      : max_threads_(max_threads), thread_pool_(thread_pool) {}
 
   /*!
    * \brief Visit a Format and return the rule id of the added rule.
@@ -1801,6 +1804,7 @@ class StructuralTagGrammarConverter {
    */
   std::unordered_map<std::string, int> serialization_to_rule_id_;
   int max_threads_;
+  ThreadPool* thread_pool_;
 };
 
 bool StructuralTagGrammarConverter::IsPrefix(
@@ -1811,9 +1815,9 @@ bool StructuralTagGrammarConverter::IsPrefix(
 }
 
 Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(
-    const StructuralTag& structural_tag, int max_threads
+    const StructuralTag& structural_tag, int max_threads, ThreadPool* thread_pool
 ) {
-  StructuralTagGrammarConverter converter(max_threads);
+  StructuralTagGrammarConverter converter(max_threads, thread_pool);
   auto result = converter.Visit(structural_tag.format, false);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
@@ -2050,9 +2054,14 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTag
     schema_results.resize(unique_schemas.size());
     schema_errors.resize(unique_schemas.size());
     std::atomic<int32_t> next_schema_index{0};
-    ThreadPool schema_thread_pool(num_threads);
+    std::optional<ThreadPool> owned_thread_pool;
+    ThreadPool* active_thread_pool = thread_pool_;
+    if (active_thread_pool == nullptr) {
+      owned_thread_pool.emplace(num_threads);
+      active_thread_pool = &owned_thread_pool.value();
+    }
     for (int thread_id = 0; thread_id < num_threads; ++thread_id) {
-      schema_thread_pool.Execute([&]() {
+      active_thread_pool->Execute([&]() {
         int32_t schema_index;
         while ((schema_index = next_schema_index.fetch_add(1, std::memory_order_relaxed)) <
                static_cast<int32_t>(unique_schemas.size())) {
@@ -2066,7 +2075,7 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTag
         }
       });
     }
-    schema_thread_pool.Join();
+    active_thread_pool->Wait();
   }
 
   for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
@@ -2525,7 +2534,8 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TokenDispatc
 Result<Grammar, StructuralTagError> StructuralTagToGrammar(
     const std::string& structural_tag_json,
     const std::optional<TokenizerInfo>& tokenizer_info,
-    int max_threads
+    int max_threads,
+    ThreadPool* thread_pool
 ) {
   auto structural_tag_result = StructuralTagParser::FromJSON(structural_tag_json);
   if (structural_tag_result.IsErr()) {
@@ -2543,7 +2553,7 @@ Result<Grammar, StructuralTagError> StructuralTagToGrammar(
     return ResultErr(std::move(err).value());
   }
 
-  auto result = StructuralTagGrammarConverter::Convert(structural_tag, max_threads);
+  auto result = StructuralTagGrammarConverter::Convert(structural_tag, max_threads, thread_pool);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -1758,7 +1758,7 @@ class StructuralTagGrammarConverter {
    * \return The rule id of the added rule. If the visit fails, the error is returned.
    * \note This method uses serialization to deduplicate identical formats.
    */
-  Result<int, ISTError> Visit(const Format& format);
+  Result<int, ISTError> Visit(const Format& format, bool deduplicate = true);
   Result<int, ISTError> VisitSub(const ConstStringFormat& format);
   Result<int, ISTError> VisitSub(const JSONSchemaFormat& format);
   Result<int, ISTError> VisitSub(const AnyTextFormat& format);
@@ -1804,7 +1804,7 @@ bool StructuralTagGrammarConverter::IsPrefix(
 Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(const StructuralTag& structural_tag
 ) {
   StructuralTagGrammarConverter converter;
-  auto result = converter.Visit(structural_tag.format);
+  auto result = converter.Visit(structural_tag.format, false);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }
@@ -1821,19 +1821,34 @@ Grammar StructuralTagGrammarConverter::AddRootRuleAndGetGrammar(int ref_rule_id)
   return grammar_builder_.Get(root_rule_id);
 }
 
-Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format) {
-  std::string fingerprint = FormatToJSONValue(format).serialize();
+Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format, bool deduplicate) {
+  std::string fingerprint;
+  if (deduplicate) {
+    if (const auto* json_schema = std::get_if<JSONSchemaFormat>(&format)) {
+      fingerprint.reserve(
+          json_schema->json_schema.size() + json_schema->style.size() + sizeof(int) + 16
+      );
+      fingerprint.append(JSONSchemaFormat::type);
+      fingerprint.push_back('\0');
+      fingerprint.append(json_schema->json_schema);
+      fingerprint.push_back('\0');
+      fingerprint.append(json_schema->style);
+      fingerprint.push_back('\0');
+      fingerprint.push_back(json_schema->any_order ? '\1' : '\0');
+      fingerprint.append(std::to_string(json_schema->max_whitespace_cnt.value_or(-1)));
+    } else {
+      fingerprint = FormatToJSONValue(format).serialize();
+    }
 
-  // Check if we've already processed an identical format
-  auto it = serialization_to_rule_id_.find(fingerprint);
-  if (it != serialization_to_rule_id_.end()) {
-    return ResultOk(it->second);
+    auto it = serialization_to_rule_id_.find(fingerprint);
+    if (it != serialization_to_rule_id_.end()) {
+      return ResultOk(it->second);
+    }
   }
 
-  // Process the format and cache the result
   auto result =
       std::visit([&](auto&& arg) -> Result<int, ISTError> { return VisitSub(arg); }, format);
-  if (result.IsOk()) {
+  if (result.IsOk() && deduplicate) {
     int rule_id = std::move(result).Unwrap();
     serialization_to_rule_id_[fingerprint] = rule_id;
     return ResultOk(rule_id);

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -24,6 +24,8 @@
 
 namespace xgrammar {
 
+class ThreadPool;
+
 /******************** Structural Tag Definition ********************/
 
 // TODO(yixin): Consider moving the definition to Public API.
@@ -396,7 +398,8 @@ struct StructuralTag {
 Result<Grammar, StructuralTagError> StructuralTagToGrammar(
     const std::string& structural_tag_json,
     const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt,
-    int max_threads = 1
+    int max_threads = 1,
+    ThreadPool* thread_pool = nullptr
 );
 
 }  // namespace xgrammar

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -389,11 +389,14 @@ struct StructuralTag {
 /*!
  * \brief Convert a structural tag JSON string to a grammar.
  * \param structural_tag_json The JSON string of the structural tag.
+ * \param tokenizer_info Optional tokenizer metadata for resolving named special tokens.
+ * \param max_threads Maximum number of threads used to convert independent JSON schemas.
  * \return A grammar if the JSON is valid, otherwise an error message in std::string.
  */
 Result<Grammar, StructuralTagError> StructuralTagToGrammar(
     const std::string& structural_tag_json,
-    const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt
+    const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt,
+    int max_threads = 1
 );
 
 }  // namespace xgrammar

--- a/tests/python/test_grammar_fsm_builder.py
+++ b/tests/python/test_grammar_fsm_builder.py
@@ -181,6 +181,22 @@ def test_recursive_rule_ref_in_sequence():
     assert not _matcher_accepts(matcher, "())")
 
 
+def test_large_byte_prefix_rule_ref_suffix_choices():
+    prefixes = ["a" * length for length in range(1, 65)]
+    alternatives = []
+    for index, prefix in enumerate(prefixes):
+        suffix = "!" if index % 2 == 0 else "?"
+        alternatives.append(f'"{prefix}" body "{suffix}"')
+    grammar = "root ::= " + " | ".join(alternatives) + "\nbody ::= [0-9]"
+    matcher = _make_string_matcher(grammar)
+
+    for index, prefix in enumerate(prefixes):
+        suffix = "!" if index % 2 == 0 else "?"
+        assert _matcher_accepts(matcher, prefix + "7" + suffix)
+        assert not _matcher_accepts(matcher, prefix + "7" + ("?" if suffix == "!" else "!"))
+        assert not _matcher_accepts(matcher, prefix + suffix)
+
+
 # --- Empty sequence ---
 
 

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -161,7 +161,8 @@ def test_structural_tag():
         assert _is_grammar_accept_string(grammar, input, print_time=True)
 
 
-def test_structural_tag_compiler():
+@pytest.mark.parametrize("max_threads", [1, 8])
+def test_structural_tag_compiler(max_threads: int):
     class Schema1(BaseModel):
         arg1: str
         arg2: int
@@ -180,9 +181,19 @@ def test_structural_tag_compiler():
     # but here we use two triggers for testing such cases
     triggers = ["<function=f", "<function=g"]
 
-    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]))
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]), max_threads=max_threads)
     compiled_grammar = compiler.compile_structural_tag(tags, triggers)
     assert str(compiled_grammar.grammar) == expected_grammar_test_structural_tag_after_optimization
+
+
+def test_parallel_structural_tag_schema_error():
+    tags = [
+        xgr.StructuralTagItem(begin="<function=f>", schema='{"type":"object"}', end="</function>"),
+        xgr.StructuralTagItem(begin="<function=g>", schema="not-json", end="</function>"),
+    ]
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]), max_threads=8)
+    with pytest.raises(json.JSONDecodeError, match="Expecting value"):
+        compiler.compile_structural_tag(tags, ["<function="])
 
 
 @pytest.mark.hf_token_required


### PR DESCRIPTION
## 改动内容

这个请求优化大型结构标签语法的编译。结构标签语法是把“可调用函数名”和“函数参数的 JSON 数据结构规则”组合成生成约束的语法。

- 用共享前缀树构造大量函数分支，复用相同的文本前缀和后缀。
- 并行构造彼此独立的语法状态图。
- 并行转换各函数的 JSON Schema，再按原顺序合并。JSON Schema 是描述 JSON 数据结构及字段约束的规则。
- 避免重复生成结构标签指纹及重复解析 JSON Schema。
- 用连续数组保存语法状态，减少散列表分配。
- 复用编译线程，减少反复创建线程的开销。
- 每个工作线程直接构建自己的词元掩码结果表，最后移动合并。词元掩码是生成每个词元时用于排除不合法候选的布尔结果。
- 增加 64 个前缀相互重叠的函数分支测试。

## 性能结果

测试对象是固定的 400 函数结构标签语法，使用 Qwen3 词元表、发布构建和 8 个固定处理器核心。

### 本请求原有结果

以下两项只统计语法转换和状态图构造，不包含同一次调用中的词元掩码预计算，因此不能与完整编译时间混用：

- 首次编译中位数：XGrammar 为 `92.170 ms`，llguidance 为 `120.977 ms`，快 `23.8%`。llguidance 是另一个生成约束实现，这里作为对照。
- 跨语法复用规则缓存后的中位数：XGrammar 为 `90.472 ms`，llguidance 为 `121.391 ms`，快 `25.5%`。

### 新增的工作线程局部结果表

单独移除这项优化后再比较，它在大型结构标签的完整编译中将 `213.632 ms` 降至 `194.677 ms`，降低 `8.9%`。另外三种较小或不同类型输入没有稳定收益，最差为小型结构标签增加 `8.2%`；因此这项优化主要针对大型结构标签。

这项优化与单独请求 #783 的“跳过重复结构标签规范化”组合后，旧实验记录中的完整编译中位数为：

| 实现 | 完整编译时间 |
|---|---:|
| XGrammar：本请求加 #783 | `143.810 ms` |
| llguidance | `151.295 ms` |

组合后的 XGrammar 快 `4.95%`。该结果使用 15 个稳定样本；它是两个请求的组合结果，不是这个请求单独达到的结果。

## 正确性验证

- 大型结构标签相关测试：`39` 项通过。
- 结构标签转换测试：`1024` 项通过。
- 离线编译器测试：`11` 项通过，`9` 项跳过。
- 离线结构标签匹配测试：`9` 项通过，`12` 项跳过。
- 新增工作线程局部结果表后，针对编译器和结构标签匹配器再次运行：`20` 项通过，`21` 项跳过。
- 提交前格式与静态检查全部通过。

跳过的测试需要额外下载受访问限制的模型词表；本次改动不涉及这些模型。
