### PR TITLE
Support structured substring regexes

### DIFF
--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <map>
 #include <memory>
 #include <optional>
 #include <set>
@@ -1839,7 +1840,9 @@ class LarkCompiler {
       case Node::Kind::kNestedLark:
         RaiseLarkError(source_, node.location, "nested %lark cannot be used in terminals");
       case Node::Kind::kRegexExt:
-        RaiseLarkError(source_, node.location, "structured %regex is not supported");
+        RaiseLarkError(
+            source_, node.location, "structured %regex cannot be used with suffix or stop"
+        );
       case Node::Kind::kGrammarRef:
         RaiseLarkError(source_, node.location, "named grammars cannot be used in terminals");
       case Node::Kind::kNot:
@@ -1848,6 +1851,142 @@ class LarkCompiler {
         );
     }
     RaiseLarkError(source_, node.location, "unsupported terminal node");
+  }
+
+  std::vector<std::string> ParseStructuredRegexChunks(const Node& node) const {
+    picojson::value value;
+    std::string error = picojson::parse(value, node.text);
+    if (!error.empty()) {
+      RaiseLarkError(source_, node.location, "failed to parse %regex: " + error);
+    }
+    if (!value.is<picojson::object>()) {
+      RaiseLarkError(source_, node.location, "%regex value must be an object");
+    }
+
+    const auto& object = value.get<picojson::object>();
+    std::vector<std::string> fields;
+    for (const auto& [key, field_value] : object) {
+      if (key != "substring_chunks" && key != "substring_chars" && key != "substring_words") {
+        RaiseLarkError(source_, node.location, "unknown field '" + key + "' in %regex");
+      }
+      if (!field_value.is<picojson::null>()) {
+        fields.push_back(key);
+      }
+    }
+    if (fields.empty()) {
+      RaiseLarkError(source_, node.location, "no fields set on %regex");
+    }
+    if (fields.size() != 1) {
+      RaiseLarkError(source_, node.location, "only one field can be set on %regex");
+    }
+
+    const std::string& field = fields[0];
+    const picojson::value& field_value = object.at(field);
+    if (field == "substring_words") {
+      if (!field_value.is<std::string>()) {
+        RaiseLarkError(source_, node.location, "substring_words must be a string");
+      }
+      RaiseLarkError(source_, node.location, "substring_words is not supported yet");
+    }
+    if (field == "substring_chars") {
+      if (!field_value.is<std::string>()) {
+        RaiseLarkError(source_, node.location, "substring_chars must be a string");
+      }
+      const std::string& text = field_value.get<std::string>();
+      std::vector<std::string> chunks;
+      for (size_t offset = 0; offset < text.size();) {
+        if (text[offset] == '\0') {
+          chunks.emplace_back(1, '\0');
+          ++offset;
+          continue;
+        }
+        auto [codepoint, length] = ParseNextUTF8(text.c_str() + offset);
+        if (codepoint == CharHandlingError::kInvalidUTF8) {
+          RaiseLarkError(source_, node.location, "substring_chars must be valid UTF-8");
+        }
+        chunks.push_back(text.substr(offset, length));
+        offset += length;
+      }
+      return chunks;
+    }
+
+    if (!field_value.is<picojson::array>()) {
+      RaiseLarkError(source_, node.location, "substring_chunks must be an array of strings");
+    }
+    std::vector<std::string> chunks;
+    const auto& array = field_value.get<picojson::array>();
+    chunks.reserve(array.size());
+    for (const picojson::value& chunk : array) {
+      if (!chunk.is<std::string>()) {
+        RaiseLarkError(source_, node.location, "substring_chunks must be an array of strings");
+      }
+      chunks.push_back(chunk.get<std::string>());
+    }
+    return chunks;
+  }
+
+  int32_t CompileStructuredRegex(const Node& node, const std::string& rule_hint) {
+    struct State {
+      int32_t length = 0;
+      int32_t suffix_link = -1;
+      std::map<std::string, int32_t> transitions;
+    };
+
+    std::vector<std::string> chunks = ParseStructuredRegexChunks(node);
+    std::vector<State> states(1);
+    int32_t last = 0;
+    for (const std::string& chunk : chunks) {
+      int32_t current = static_cast<int32_t>(states.size());
+      states.push_back({states[last].length + 1, -1, {}});
+
+      int32_t parent = last;
+      while (parent != -1 && !states[parent].transitions.count(chunk)) {
+        states[parent].transitions[chunk] = current;
+        parent = states[parent].suffix_link;
+      }
+      if (parent == -1) {
+        states[current].suffix_link = 0;
+      } else {
+        int32_t target = states[parent].transitions.at(chunk);
+        if (states[parent].length + 1 == states[target].length) {
+          states[current].suffix_link = target;
+        } else {
+          int32_t clone = static_cast<int32_t>(states.size());
+          states.push_back(states[target]);
+          states[clone].length = states[parent].length + 1;
+          while (parent != -1) {
+            auto transition = states[parent].transitions.find(chunk);
+            if (transition == states[parent].transitions.end() || transition->second != target) {
+              break;
+            }
+            transition->second = clone;
+            parent = states[parent].suffix_link;
+          }
+          states[target].suffix_link = clone;
+          states[current].suffix_link = clone;
+        }
+      }
+      last = current;
+    }
+
+    std::vector<int32_t> state_rule_ids;
+    state_rule_ids.reserve(states.size());
+    for (size_t index = 0; index < states.size(); ++index) {
+      state_rule_ids.push_back(builder_.AddEmptyRuleWithHint(rule_hint + "_substring"));
+    }
+    for (size_t index = 0; index < states.size(); ++index) {
+      std::vector<int32_t> choices{builder_.AddEmptyStr()};
+      choices.reserve(states[index].transitions.size() + 1);
+      for (const auto& [chunk, target] : states[index].transitions) {
+        int32_t target_ref = builder_.AddRuleRef(state_rule_ids[target]);
+        choices.push_back(
+            chunk.empty() ? target_ref
+                          : builder_.AddSequence({builder_.AddByteString(chunk), target_ref})
+        );
+      }
+      builder_.UpdateRuleBody(state_rule_ids[index], builder_.AddChoices(choices));
+    }
+    return builder_.AddRuleRef(state_rule_ids[0]);
   }
 
   const Grammar& ResolveNamedGrammar(const std::string& name, const Location& location) {
@@ -2018,8 +2157,10 @@ class LarkCompiler {
                                             : builder_.AddTokenSet(token_set.token_ids);
         return append_skip ? AppendSkip(result) : result;
       }
-      case Node::Kind::kRegexExt:
-        RaiseLarkError(source_, node.location, "structured %regex is not supported");
+      case Node::Kind::kRegexExt: {
+        int32_t result = CompileStructuredRegex(node, rule_hint);
+        return terminal_mode || !append_skip ? result : AppendSkip(result);
+      }
       case Node::Kind::kGrammarRef: {
         if (terminal_mode) {
           RaiseLarkError(source_, node.location, "named grammars cannot be used in terminals");

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -259,6 +259,28 @@ arguments: %json {
 value is controlled by the surrounding Lark grammar; whitespace inside the value follows the JSON
 Schema converter's normal behavior. `%json` cannot be used inside terminals.
 
+### Structured `%regex`
+
+`%regex` can match any contiguous sequence of a fixed list of chunks. The empty sequence is also
+accepted:
+
+```text
+start: %regex {"substring_chunks": ["abc", "de", "fg"]}
+```
+
+This example accepts `""`, `"abc"`, `"de"`, `"abcde"`, `"defg"`, and `"abcdefg"`, but not
+`"ab"` or `"cde"`.
+
+`substring_chars` splits a string into Unicode codepoints before applying the same operation:
+
+```text
+start: %regex {"substring_chars": "abc"}
+```
+
+It therefore accepts every codepoint-aligned substring such as `"a"`, `"bc"`, and `"abc"`.
+`substring_chunks` and `substring_chars` are supported in rules and terminal definitions.
+`substring_words`, which requires Unicode word-class segmentation, is not yet supported.
+
 ### `%lark`
 
 `%lark { ... }` embeds a complete Lark grammar as one element. The nested grammar has its own

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -446,6 +446,63 @@ def test_lark_inline_json_inside_sequence_and_repeat() -> None:
     )
 
 
+def test_lark_structured_regex_substring_chunks() -> None:
+    grammar = r"""
+        start: "A" SUB "B"
+        SUB: %regex {"substring_chunks":["abc","de","fg"]}
+    """
+    _assert_language(
+        grammar,
+        ["AB", "AabcB", "AdeB", "AfgB", "AabcdeB", "AdefgB", "AabcdefgB"],
+        ["AabB", "AcdeB", "AabcfgB", "AdeabcB"],
+    )
+
+
+def test_lark_structured_regex_substring_repeated_and_empty_chunks() -> None:
+    grammar = r'start: %regex {"substring_chunks":["a","","b","a","b"]}'
+    _assert_language(
+        grammar, ["", "a", "b", "ab", "ba", "aba", "bab", "abab"], ["aa", "bb", "abba", "baba"]
+    )
+
+
+def test_lark_structured_regex_substring_chars_ascii_and_unicode() -> None:
+    _assert_language(
+        'start: %regex {"substring_chars":"The fox."}',
+        ["", "The fox.", "he fo", "fox."],
+        ["Thefox", "he fx", "The fox.."],
+    )
+    _assert_language(
+        'start: %regex {"substring_chars":"a빠🙂b"}',
+        ["", "a", "빠", "🙂", "빠🙂", "🙂b", "a빠🙂b"],
+        ["a🙂", "빠b", "a빠b"],
+    )
+
+
+def test_lark_structured_regex_substring_chars_preserves_nul() -> None:
+    grammar = r'start: %regex {"substring_chars":"a\u0000b"}'
+    _assert_language(grammar, ["", "a", "\0", "b", "a\0", "\0b", "a\0b"], ["ab", "a\0\0b"])
+
+
+def test_lark_structured_regex_round_trip_and_serialization() -> None:
+    grammar = xgr.Grammar.from_lark(
+        'start: "A" %regex {"substring_chunks":["foo"," bar"," baz"]} "B"'
+    )
+    accepted = ["AB", "AfooB", "A bar bazB", "Afoo bar bazB"]
+    rejected = ["AfoB", "Afoo bazB"]
+    _assert_grammar_language(grammar, accepted, rejected)
+    _assert_grammar_language(xgr.Grammar.from_ebnf(str(grammar)), accepted, rejected)
+    _assert_grammar_language(
+        xgr.Grammar.deserialize_json(grammar.serialize_json()), accepted, rejected
+    )
+
+
+def test_lark_structured_regex_large_substring_chars() -> None:
+    source = "".join(chr(0x1000 + index) for index in range(4_000))
+    grammar = xgr.Grammar.from_lark(f'start: %regex {{"substring_chars":{json.dumps(source)}}}')
+    candidate = source[50:100]
+    _assert_grammar_language(grammar, [candidate], [candidate + "missing"])
+
+
 def test_lark_nested_lark_has_an_independent_namespace() -> None:
     grammar = """
         start: item %lark {
@@ -1025,9 +1082,40 @@ def test_lark_large_choice_grammar() -> None:
             id="nested-no-start",
         ),
         pytest.param(
-            'start: %regex {"substring_chars":"abc"}',
-            "structured %regex is not supported",
-            id="structured-regex",
+            'start: %regex {"substring_words":"abc def"}',
+            "substring_words is not supported yet",
+            id="substring-words",
+        ),
+        pytest.param(
+            "start: %regex []", "%regex value must be an object", id="structured-regex-not-object"
+        ),
+        pytest.param(
+            'start: %regex {"unknown":"abc"}',
+            "unknown field 'unknown' in %regex",
+            id="structured-regex-unknown-field",
+        ),
+        pytest.param(
+            "start: %regex {}", "no fields set on %regex", id="structured-regex-no-fields"
+        ),
+        pytest.param(
+            'start: %regex {"substring_chars":"abc","substring_chunks":["a"]}',
+            "only one field can be set on %regex",
+            id="structured-regex-multiple-fields",
+        ),
+        pytest.param(
+            'start: %regex {"substring_chars":["a"]}',
+            "substring_chars must be a string",
+            id="structured-regex-chars-type",
+        ),
+        pytest.param(
+            'start: %regex {"substring_chunks":"abc"}',
+            "substring_chunks must be an array of strings",
+            id="structured-regex-chunks-type",
+        ),
+        pytest.param(
+            'start: %regex {"substring_chunks":["a",1]}',
+            "substring_chunks must be an array of strings",
+            id="structured-regex-chunk-type",
         ),
         pytest.param("start: @other", "unknown named grammar '@other'", id="unknown-named-grammar"),
         pytest.param(


### PR DESCRIPTION
## Summary

- support `%regex {"substring_chunks": [...]}` nodes in Lark grammars
- support `%regex {"substring_chars": "..."}` with Unicode codepoint boundaries
- compile substring languages through a suffix automaton with linear state growth
- validate structured regex fields and types with located Lark diagnostics
- preserve EBNF and JSON serialization round trips

## Motivation

Structured substring regexes constrain generated text to a contiguous slice of known content
without enumerating every O(n^2) substring. This is useful for extractive generation and extends
the Lark frontend with a compact substring language.

This PR intentionally leaves `substring_words` unsupported because exact behavior requires a
complete Unicode alphanumeric property table, which XGrammar does not currently provide.

## Testing

- `tests/python/test_lark.py`: `351 passed`
- full Python suite excluding gated Hugging Face tests:
  `3072 passed, 1 skipped, 622 deselected`
- pre-commit hooks for all changed files
- language parity corpus: `5` grammars / `44` candidate strings agree
- 10,000-codepoint stress check:
  `Grammar.from_lark` about `0.048s`, compilation about `0.074s` in the local environment
