### PR TITLE
Support Lark regex flags

### DIFF
--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -1228,6 +1228,84 @@ std::string RewriteRegexDots(const std::string& pattern, bool dot_matches_newlin
   return result;
 }
 
+class ASCIICaseInsensitiveRegexMutator final : public GrammarMutator {
+ public:
+  using GrammarMutator::Apply;
+
+ private:
+  using CharacterClassElement = GrammarBuilder::CharacterClassElement;
+
+  static bool IsASCIIAlpha(int32_t byte) {
+    return (byte >= 'a' && byte <= 'z') || (byte >= 'A' && byte <= 'Z');
+  }
+
+  static std::vector<CharacterClassElement> FoldCharacterRanges(const GrammarExpr& grammar_expr) {
+    std::vector<CharacterClassElement> ranges;
+    ranges.reserve((grammar_expr.data_len - 1) / 2 + 2);
+    for (int32_t i = 1; i + 1 < grammar_expr.data_len; i += 2) {
+      int32_t lower = grammar_expr[i];
+      int32_t upper = grammar_expr[i + 1];
+      ranges.push_back({lower, upper});
+
+      int32_t uppercase_lower = std::max<int32_t>(lower, 'A');
+      int32_t uppercase_upper = std::min<int32_t>(upper, 'Z');
+      if (uppercase_lower <= uppercase_upper) {
+        ranges.push_back({uppercase_lower + ('a' - 'A'), uppercase_upper + ('a' - 'A')});
+      }
+      int32_t lowercase_lower = std::max<int32_t>(lower, 'a');
+      int32_t lowercase_upper = std::min<int32_t>(upper, 'z');
+      if (lowercase_lower <= lowercase_upper) {
+        ranges.push_back({lowercase_lower - ('a' - 'A'), lowercase_upper - ('a' - 'A')});
+      }
+    }
+    std::sort(ranges.begin(), ranges.end(), [](const auto& lhs, const auto& rhs) {
+      return lhs.lower < rhs.lower || (lhs.lower == rhs.lower && lhs.upper < rhs.upper);
+    });
+    std::vector<CharacterClassElement> result;
+    for (const auto& range : ranges) {
+      if (!result.empty() && range.lower <= result.back().upper + 1) {
+        result.back().upper = std::max(result.back().upper, range.upper);
+      } else {
+        result.push_back(range);
+      }
+    }
+    return result;
+  }
+
+  int32_t VisitByteString(const GrammarExpr& grammar_expr) final {
+    std::vector<int32_t> sequence;
+    std::vector<int32_t> literal_bytes;
+    auto flush_literal = [&]() {
+      if (!literal_bytes.empty()) {
+        sequence.push_back(builder_->AddByteString(literal_bytes));
+        literal_bytes.clear();
+      }
+    };
+    for (int32_t byte : grammar_expr) {
+      if (!IsASCIIAlpha(byte)) {
+        literal_bytes.push_back(byte);
+        continue;
+      }
+      flush_literal();
+      int32_t lowercase = byte >= 'A' && byte <= 'Z' ? byte + ('a' - 'A') : byte;
+      int32_t uppercase = byte >= 'a' && byte <= 'z' ? byte - ('a' - 'A') : byte;
+      sequence.push_back(
+          builder_->AddCharacterClass({{uppercase, uppercase}, {lowercase, lowercase}})
+      );
+    }
+    flush_literal();
+    return sequence.size() == 1 ? sequence[0] : builder_->AddSequence(sequence);
+  }
+
+  int32_t VisitCharacterClass(const GrammarExpr& grammar_expr) final {
+    return builder_->AddCharacterClass(FoldCharacterRanges(grammar_expr), grammar_expr[0] != 0);
+  }
+
+  int32_t VisitCharacterClassStar(const GrammarExpr& grammar_expr) final {
+    return builder_->AddCharacterClassStar(FoldCharacterRanges(grammar_expr), grammar_expr[0] != 0);
+  }
+};
+
 std::optional<std::string> ParseFixedRegexLiteral(const std::string& pattern) {
   std::string result;
   for (size_t i = 0; i < pattern.size();) {
@@ -1659,19 +1737,35 @@ class LarkCompiler {
     return elements.size() == 1 ? elements[0] : builder_.AddSequence(elements);
   }
 
+  struct RegexFlags {
+    bool case_insensitive = false;
+    bool dot_all = false;
+  };
+
+  RegexFlags ParseRegexFlags(const Node& node) const {
+    RegexFlags result;
+    for (char flag : node.flags) {
+      if (flag == 'i') {
+        result.case_insensitive = true;
+      } else if (flag == 's') {
+        result.dot_all = true;
+      } else if (flag == 'u') {
+        // XGrammar regular expressions use Unicode codepoint semantics by default.
+      } else if (flag == 'l') {
+        RaiseLarkError(source_, node.location, "regular-expression flag 'l' is not supported");
+      } else {
+        RaiseLarkError(
+            source_,
+            node.location,
+            "regular-expression flag '" + std::string(1, flag) + "' is not supported"
+        );
+      }
+    }
+    return result;
+  }
+
   std::string PrepareRegexPattern(const Node& node) const {
-    if (node.flags.empty()) {
-      return RewriteRegexDots(node.text, false);
-    }
-    if (node.flags == "s") {
-      return RewriteRegexDots(node.text, true);
-    }
-    if (node.flags.find('l') != std::string::npos) {
-      RaiseLarkError(source_, node.location, "regular-expression flag 'l' is not supported");
-    }
-    RaiseLarkError(
-        source_, node.location, "only the regular-expression flag 's' is currently supported"
-    );
+    return RewriteRegexDots(node.text, ParseRegexFlags(node).dot_all);
   }
 
   static std::string EscapeRegexLiteral(const std::string& value) {
@@ -1789,6 +1883,13 @@ class LarkCompiler {
       case Node::Kind::kString:
         return StringLiteralToRegex(node);
       case Node::Kind::kRegex:
+        if (ParseRegexFlags(node).case_insensitive) {
+          RaiseLarkError(
+              source_,
+              node.location,
+              "regular-expression flag 'i' is not supported with suffix or stop attributes"
+          );
+        }
         return "(?:" + PrepareRegexPattern(node) + ")";
       case Node::Kind::kRange: {
         std::vector<TCodepoint> begin = ParseUTF8(node.text.c_str());
@@ -1963,9 +2064,13 @@ class LarkCompiler {
         return terminal_mode || !append_skip ? result : AppendSkip(result);
       }
       case Node::Kind::kRegex: {
-        std::string pattern = PrepareRegexPattern(node);
+        RegexFlags flags = ParseRegexFlags(node);
         try {
-          int32_t root = SubGrammarAdder::Apply(&builder_, Grammar::FromRegex(pattern));
+          Grammar grammar = Grammar::FromRegex(RewriteRegexDots(node.text, flags.dot_all));
+          if (flags.case_insensitive) {
+            grammar = ASCIICaseInsensitiveRegexMutator().Apply(grammar);
+          }
+          int32_t root = SubGrammarAdder::Apply(&builder_, grammar);
           int32_t result = builder_.AddRuleRef(root);
           return terminal_mode || !append_skip ? result : AppendSkip(result);
         } catch (const std::exception& error) {
@@ -2178,11 +2283,11 @@ class LarkCompiler {
           pattern.push_back(c);
         }
       }
-      if (node.flags == "s") {
-        return pattern == ".*";
-      }
-      if (!node.flags.empty()) {
+      if (node.flags.find_first_not_of("isu") != std::string::npos) {
         return false;
+      }
+      if (node.flags.find('s') != std::string::npos) {
+        return pattern == ".*";
       }
       return pattern == "(.|\\n)*" || pattern == "(\\n|.)*" || pattern == "(?s:.*)" ||
              pattern == "(?:.|\\n)*" || pattern == "(?:\\n|.)*" || pattern == "[\\s\\S]*";
@@ -2214,13 +2319,15 @@ class LarkCompiler {
     if (node.kind != Node::Kind::kRegex) {
       return std::nullopt;
     }
+    if (node.flags.find('i') != std::string::npos ||
+        node.flags.find_first_not_of("su") != std::string::npos) {
+      return std::nullopt;
+    }
     std::vector<std::string> prefixes;
-    if (node.flags.empty()) {
-      prefixes = {"(.|\\n)*", "(\\n|.)*", "(?:.|\\n)*", "(?:\\n|.)*", "[\\s\\S]*", "(?s:.*)"};
-    } else if (node.flags == "s") {
+    if (node.flags.find('s') != std::string::npos) {
       prefixes = {".*"};
     } else {
-      return std::nullopt;
+      prefixes = {"(.|\\n)*", "(\\n|.)*", "(?:.|\\n)*", "(?:\\n|.)*", "[\\s\\S]*", "(?s:.*)"};
     }
     for (const std::string& prefix : prefixes) {
       if (node.text.size() <= prefix.size() || node.text.compare(0, prefix.size(), prefix) != 0) {

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -138,12 +138,21 @@ regex converter (the same engine as [`xgr.Grammar.from_regex`](xgrammar.Grammar.
 supports character classes, alternation, groups, repetition (`*`, `+`, `?`, `{m,n}`), and the
 usual escapes. A `/` inside the pattern is written `\/`.
 
-`.` matches one Unicode character. By default it does not match newline; adding the `s` flag
-(`/pattern/s`) makes `.` match newline as well. `s` is currently the only supported regex flag.
+`.` matches one Unicode character. By default it does not match newline. Regular expressions
+support the following trailing flags, in any order:
+
+- `i`: match ASCII letters case-insensitively. Non-ASCII characters retain their original case.
+- `s`: make `.` match newline as well.
+- `u`: explicitly select Unicode semantics. This is a no-op because XGrammar regular expressions
+  already use Unicode codepoints.
+
+The `i` flag is supported in ordinary rules, terminals, and `lazy` rules, but not on a regular
+expression used with a `suffix` or `stop` attribute. The `l`, `m`, and `x` flags are not supported.
 
 ```text
 start: /a.b/      // accepts "acb", "a😀b"; rejects "a\nb"
 line: /a.b/s      // also accepts "a\nb"
+word: /hello/iu   // accepts "hello", "HELLO", and "HeLLo"
 ```
 
 ### Sequences, Alternatives, and Groups

--- a/tests/cpp/test_lark_converter.cc
+++ b/tests/cpp/test_lark_converter.cc
@@ -106,7 +106,7 @@ TEST(LarkConverterTest, NumericAndNamedSpecialTokens) {
 
 TEST(LarkConverterTest, StringAndRegexFlags) {
   auto grammar = Grammar::FromLark(R"(
-    start: "Ab-1"i /a.b/s
+    start: "Ab-1"i /a[^x].b/isu
   )");
   std::string printed = grammar.ToString();
   EXPECT_NE(printed.find("root"), std::string::npos);
@@ -159,9 +159,9 @@ TEST(LarkConverterTest, ErrorsContainSourceLocations) {
       "intersection '&' is not supported"
   );
   XGRAMMAR_EXPECT_THROW(
-      Grammar::FromLark("start: /abc/i"),
+      Grammar::FromLark("start: /abc/m"),
       XGrammarError,
-      "only the regular-expression flag 's' is currently supported"
+      "regular-expression flag 'm' is not supported"
   );
   XGRAMMAR_EXPECT_THROW(
       Grammar::FromLark("start: \"\\u00c4\"i"),

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -170,6 +170,30 @@ def _assert_lark_error(
             id="regex-dotall-preserves-character-class-dot",
         ),
         pytest.param(
+            r"start: /hello[0-2]\x21/iu",
+            ["hello0!", "HELLO1!", "HeLlO2!"],
+            ["hello3!", "hello1", "héllo1!"],
+            id="regex-ascii-case-insensitive-and-unicode-flags",
+        ),
+        pytest.param(
+            "start: /a.b/is",
+            ["a b", "A😀B", "a\nb"],
+            ["ab", "a\n\nb", "ä\nb"],
+            id="regex-case-insensitive-dotall-flags",
+        ),
+        pytest.param(
+            "start: /[^a-c]+/i",
+            ["Z", "09", "Ä"],
+            ["a", "B", "xyzC"],
+            id="regex-case-insensitive-negative-class",
+        ),
+        pytest.param(
+            "start: TOKEN\nTOKEN: /[A-Cx-z]+/i",
+            ["abc", "ABC", "XyZ", "cZ"],
+            ["", "d", "w", "abcd"],
+            id="regex-case-insensitive-terminal-range",
+        ),
+        pytest.param(
             'start: "a".."z"+ "0".."9"?',
             ["a", "xyz", "hello7"],
             ["", "A", "7", "abc78"],
@@ -606,6 +630,21 @@ def test_lark_dynamic_lazy_dotall_regex_suffix() -> None:
     )
 
 
+def test_lark_dynamic_lazy_dotall_unicode_regex_flags() -> None:
+    grammar = r"""
+        start: tool* tail
+        tail: TEXT
+        head[lazy]: /.*<call>/su
+        tool: head "ok" "</call>"
+        TEXT: /.*/su
+    """
+    _assert_language(
+        grammar,
+        ["line 1\nline 2", "x\n<call>ok</call>tail"],
+        ["<call>", "<call>bad</call>", "x\n<call>ok"],
+    )
+
+
 def test_lark_dynamic_fixed_string_suffix_attribute() -> None:
     grammar = r"""
         start: tool* tail
@@ -787,6 +826,17 @@ def test_lark_serialization_round_trip_for_core_and_dynamic_grammars() -> None:
     )
 
 
+def test_lark_regex_flags_ebnf_and_serialization_round_trip() -> None:
+    grammar = xgr.Grammar.from_lark("start: /ab[^x]/isu")
+    _assert_grammar_language(grammar, ["abz", "ABZ", "aB\n"], ["abx", "ABX", "ab"])
+
+    ebnf_restored = xgr.Grammar.from_ebnf(str(grammar))
+    _assert_grammar_language(ebnf_restored, ["abz", "ABZ", "aB\n"], ["abx", "ABX", "ab"])
+
+    json_restored = xgr.Grammar.deserialize_json(grammar.serialize_json())
+    _assert_grammar_language(json_restored, ["abz", "ABZ", "aB\n"], ["abx", "ABX", "ab"])
+
+
 def test_lark_serialization_round_trip_for_token_dispatch() -> None:
     tokenizer_info = xgr.TokenizerInfo(["plain", "<|call|>", "x", "</call>"])
     grammar = xgr.Grammar.from_lark(
@@ -944,12 +994,22 @@ def test_lark_large_choice_grammar() -> None:
             id="non-ascii-string-flag",
         ),
         pytest.param(
-            "start: /abc/i",
-            "only the regular-expression flag 's' is currently supported",
+            "start: /abc/m",
+            "regular-expression flag 'm' is not supported",
             id="unsupported-regex-flag",
         ),
         pytest.param(
             "start: /abc/l", "regular-expression flag 'l' is not supported", id="unsupported-l-flag"
+        ),
+        pytest.param(
+            "start: /abc/x",
+            "regular-expression flag 'x' is not supported",
+            id="unsupported-verbose-regex-flag",
+        ),
+        pytest.param(
+            "start: item\nitem[suffix=/end/i]: /[a-z]*/",
+            "regular-expression flag 'i' is not supported with suffix or stop attributes",
+            id="case-insensitive-regex-suffix",
         ),
         pytest.param(
             'start: "a"i.."z"', "flags are not allowed on character ranges", id="range-start-flag"


### PR DESCRIPTION
## Summary

- accept Lark regex flags `i`, `s`, and `u` in any order or combination
- implement ASCII case-insensitive matching across literals and positive/negative character classes
- preserve dot-all behavior for `s` and accept `u` as an explicit Unicode-semantics no-op
- keep lazy dispatch recognition compatible with `s`/`u` flag combinations

## Compatibility boundaries

The `i` implementation folds ASCII letters only. Non-ASCII characters retain their original case;
full Unicode case folding is outside this PR's scope.

Case-insensitive regexes used as `suffix` or `stop` attributes are rejected with a focused error
because that lowering path cannot preserve their semantics yet. Flags `l`, `m`, and `x` remain
unsupported and report the specific flag.

## Tests

- `tests/python/test_lark.py`: 346 passed
- Python suite excluding `hf_token_required`: 3067 passed, 1 skipped, 622 deselected
- C++ suite: 61/61 passed
- pre-commit hooks and `git diff --check`
- language parity corpus: 6 grammars and 36 common ASCII-semantics candidates agree; the
  documented Unicode folding boundary is asserted
