### PR TITLE
Support grammar-level jump-forward control

### DIFF
--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -54,6 +54,10 @@ Grammar GrammarBuilder::Get(int32_t root_rule_id) {
   return Grammar(grammar_);
 }
 
+void GrammarBuilder::SetNoForcing(bool no_forcing) {
+  grammar_->no_forcing_ = grammar_->no_forcing_ || no_forcing;
+}
+
 int32_t GrammarBuilder::AddGrammarExpr(const GrammarExpr& grammar_expr) {
   grammar_->grammar_expr_indptr_.push_back(grammar_->grammar_expr_data_.size());
   grammar_->grammar_expr_data_.push_back(static_cast<int32_t>(grammar_expr.type));

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -65,6 +65,9 @@ class GrammarBuilder {
    */
   Grammar Get(int32_t root_rule_id);
 
+  /*! \brief Disable matcher jump-forward output. Enabling is monotonic across composed grammars. */
+  void SetNoForcing(bool no_forcing);
+
   /****************** GrammarExpr handling ******************/
 
   /*! \brief Add a grammar_expr and return the grammar_expr id. */

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -100,6 +100,9 @@ class GrammarFunctor {
   virtual void InitBuilder() {
     owned_builder_ = GrammarBuilder();
     builder_ = &owned_builder_;
+    if (!base_grammar_.IsNull()) {
+      builder_->SetNoForcing(base_grammar_->IsForcingDisabled());
+    }
   }
 
   virtual void InitBuilder(const Grammar& grammar) {
@@ -107,7 +110,12 @@ class GrammarFunctor {
     builder_ = &owned_builder_;
   }
 
-  virtual void InitBuilder(GrammarBuilder* builder) { builder_ = builder; }
+  virtual void InitBuilder(GrammarBuilder* builder) {
+    builder_ = builder;
+    if (!base_grammar_.IsNull()) {
+      builder_->SetNoForcing(base_grammar_->IsForcingDisabled());
+    }
+  }
 
   /*! \brief Visit a lookahead assertion expr referred by id. */
   virtual T VisitLookaheadAssertion(int32_t lookahead_assertion_id) {

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -153,6 +153,8 @@ class Grammar::Impl {
         << "root_rule_id " << root_rule_id_ << " is out of bound";
     return rules_[root_rule_id_];
   }
+  /*! \brief Whether matcher jump-forward output is disabled for this grammar. */
+  bool IsForcingDisabled() const { return no_forcing_; }
 
   /*! \brief The type of the grammar expr. */
   enum class GrammarExprType : int32_t {
@@ -363,6 +365,8 @@ class Grammar::Impl {
   std::vector<int32_t> grammar_expr_indptr_;
   /*! \brief The id of the root rule. */
   int32_t root_rule_id_ = -1;
+  /*! \brief Whether matchers should leave uniquely determined bytes to model tokenization. */
+  bool no_forcing_ = false;
 
  public:
   /******************* Aux information for matching *******************/
@@ -435,6 +439,8 @@ XGRAMMAR_MEMBER_TABLE(
     &Grammar::Impl::grammar_expr_data_,
     "root_rule_id",
     &Grammar::Impl::root_rule_id_,
+    "no_forcing",
+    &Grammar::Impl::no_forcing_,
     "complete_fsm",
     &Grammar::Impl::complete_fsm,
     "per_rule_fsms",

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -2036,6 +2036,9 @@ std::string GrammarMatcher::Impl::FindJumpForwardString() {
   XGRAMMAR_CHECK(!IsStopTokenAccepted())
       << "GrammarMatcher has terminated after accepting the stop token, but is trying to "
          "get the jump forward string";
+  if (grammar_->IsForcingDisabled()) {
+    return "";
+  }
 
   current_token_index_ = static_cast<int32_t>(token_length_history.size());
   if (budget_force_close_pending_) {

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -150,8 +150,8 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
   // name[capture="x"] ::= ...,
   // name[capture_hidden_suffix_bytes=3] ::= ..., name[capture_hidden_stop_bytes=3] ::= ...,
   // name[capture_hidden_body_rule_id=1, capture_hidden_marker_rule_id=2] ::= ...,
-  // name[stop_capture="marker"] ::= ..., name[lazy] ::= ..., name[temperature=0.7] ::= ..., or a
-  // comma-separated combination.
+  // name[stop_capture="marker"] ::= ..., name[lazy] ::= ..., name[no_forcing] ::= ...,
+  // name[temperature=0.7] ::= ..., or a comma-separated combination.
   // The bracket group is treated as an attribute block only when it is followed by "::=";
   // otherwise it is left to be lexed as a character class.
   if (*cur_ == '[') {
@@ -183,6 +183,7 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
     bool has_capture_hidden_marker_rule_id = false;
     bool has_stop_capture = false;
     bool has_lazy = false;
+    bool has_no_forcing = false;
     bool has_temperature = false;
     double temperature_value = 0;
     int64_t max_tokens_value = -1;
@@ -295,6 +296,8 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
         }
       } else if (!has_lazy && match_keyword("lazy")) {
         has_lazy = true;
+      } else if (!has_no_forcing && match_keyword("no_forcing")) {
+        has_no_forcing = true;
       } else if (!has_temperature && match_keyword("temperature")) {
         has_temperature = true;
         matched = parse_float_value(&temperature_value);
@@ -380,6 +383,7 @@ EBNFLexer::Token EBNFLexer::Impl::ParseIdentifierOrBooleanToken() {
           static_cast<int32_t>(capture_hidden_marker_rule_id_value);
       token.stop_capture_name = stop_capture_value;
       token.is_lazy = has_lazy;
+      token.no_forcing = has_no_forcing;
       if (has_temperature) {
         token.temperature = static_cast<float>(temperature_value);
       }
@@ -688,6 +692,7 @@ class EBNFParser {
   struct ParsedRule {
     Rule rule;
     SuffixStopInfo suffix_stop_info;
+    bool no_forcing = false;
   };
 
   // Parsing different parts of the grammar
@@ -1447,6 +1452,7 @@ EBNFParser::ParsedRule EBNFParser::ParseRule() {
   int32_t capture_hidden_marker_rule_id = Peek().capture_hidden_marker_rule_id;
   std::string stop_capture_name = Peek().stop_capture_name;
   bool is_lazy = Peek().is_lazy;
+  bool no_forcing = Peek().no_forcing;
   std::optional<float> temperature = Peek().temperature;
   Consume();
 
@@ -1471,6 +1477,7 @@ EBNFParser::ParsedRule EBNFParser::ParseRule() {
   result.suffix_stop_info.body_rule_id = capture_hidden_body_rule_id;
   result.suffix_stop_info.marker_rule_id = capture_hidden_marker_rule_id;
   result.suffix_stop_info.stop_capture_name = std::move(stop_capture_name);
+  result.no_forcing = no_forcing;
   return result;
 }
 
@@ -1517,6 +1524,7 @@ Grammar EBNFParser::Parse(
     builder_.UpdateSuffixStopInfo(rule.name, parsed_rule.suffix_stop_info);
     builder_.UpdateLazy(rule.name, rule.is_lazy);
     builder_.UpdateRuleTemperature(builder_.GetRuleId(rule.name), rule.temperature);
+    builder_.SetNoForcing(parsed_rule.no_forcing);
   }
 
   return builder_.Get(root_rule_name);

--- a/cpp/grammar_parser.h
+++ b/cpp/grammar_parser.h
@@ -76,6 +76,8 @@ class EBNFLexer {
     std::string stop_capture_name = {};
     // Whether the identifier is a rule name carrying the [lazy] attribute, e.g. r[lazy] ::= ...
     bool is_lazy = false;
+    // Whether this rule definition enables the grammar-wide no-forcing option.
+    bool no_forcing = false;
     // The sampling temperature attached to a rule-definition identifier via name[temperature=T].
     std::optional<float> temperature = std::nullopt;
   };

--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -15,11 +15,13 @@
 
 namespace xgrammar {
 
-std::string GrammarPrinter::PrintRule(const Rule& rule, const SuffixStopInfo* suffix_stop_info) {
+std::string GrammarPrinter::PrintRule(
+    const Rule& rule, const SuffixStopInfo* suffix_stop_info, bool no_forcing
+) {
   std::string res = rule.name;
   // Print the attributes as one comma-separated bracket group, re-parseable by the EBNF lexer.
   if (rule.max_tokens >= 0 || rule.max_chars >= 0 || !rule.capture_name.empty() ||
-      suffix_stop_info != nullptr || rule.is_lazy || rule.temperature.has_value()) {
+      suffix_stop_info != nullptr || rule.is_lazy || no_forcing || rule.temperature.has_value()) {
     std::string attributes;
     auto append_attribute = [&](const std::string& attribute) {
       if (!attributes.empty()) {
@@ -35,6 +37,9 @@ std::string GrammarPrinter::PrintRule(const Rule& rule, const SuffixStopInfo* su
     }
     if (!rule.capture_name.empty()) {
       append_attribute("capture=\"" + rule.capture_name + "\"");
+    }
+    if (no_forcing) {
+      append_attribute("no_forcing");
     }
     if (suffix_stop_info != nullptr && suffix_stop_info->hidden_suffix_bytes > 0) {
       append_attribute(
@@ -76,7 +81,11 @@ std::string GrammarPrinter::PrintRule(const Rule& rule, const SuffixStopInfo* su
 }
 
 std::string GrammarPrinter::PrintRule(int32_t rule_id) {
-  return PrintRule(grammar_->GetRule(rule_id), grammar_->GetSuffixStopInfo(rule_id));
+  return PrintRule(
+      grammar_->GetRule(rule_id),
+      grammar_->GetSuffixStopInfo(rule_id),
+      rule_id == grammar_->GetRootRuleId() && grammar_->IsForcingDisabled()
+  );
 }
 
 std::string GrammarPrinter::PrintGrammarExpr(const GrammarExpr& grammar_expr) {

--- a/cpp/grammar_printer.h
+++ b/cpp/grammar_printer.h
@@ -36,7 +36,9 @@ class GrammarPrinter {
   std::string ToString();
 
   /*! \brief Print a rule. */
-  std::string PrintRule(const Rule& rule, const SuffixStopInfo* suffix_stop_info);
+  std::string PrintRule(
+      const Rule& rule, const SuffixStopInfo* suffix_stop_info, bool no_forcing = false
+  );
   /*! \brief Print a rule corresponding to the given id. */
   std::string PrintRule(int32_t rule_id);
   /*! \brief Print a GrammarExpr. */

--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -1450,6 +1450,7 @@ class LarkCompiler {
       root_rule_id =
           builder_.AddRuleWithHint("start_with_skip", builder_.AddSequence(std::move(elements)));
     }
+    builder_.SetNoForcing(no_forcing_);
     return DeadCodeEliminator::Apply(GrammarNormalizer().Apply(builder_.Get(root_rule_id)));
   }
 
@@ -1523,7 +1524,12 @@ class LarkCompiler {
             RaiseLarkError(source_, location, "allow_initial_skip must be a boolean");
           }
           allow_initial_skip_ = allow_initial_skip_ || option.get<bool>();
-        } else if (key == "no_forcing" || key == "allow_invalid_utf8") {
+        } else if (key == "no_forcing") {
+          if (!option.is<bool>()) {
+            RaiseLarkError(source_, location, key + " must be a boolean");
+          }
+          no_forcing_ = no_forcing_ || option.get<bool>();
+        } else if (key == "allow_invalid_utf8") {
           if (!option.is<bool>()) {
             RaiseLarkError(source_, location, key + " must be a boolean");
           }
@@ -2561,6 +2567,7 @@ class LarkCompiler {
   std::unordered_map<std::string, int32_t> named_grammar_roots_;
   int32_t skip_rule_id_ = -1;
   bool allow_initial_skip_ = false;
+  bool no_forcing_ = false;
   std::unordered_set<std::string> dynamic_unused_rules_;
 };
 

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v16";
+  static constexpr const char kXGrammarSerializeVersion[] = "v17";
 };
 
 /*!

--- a/docs/defining_structures/ebnf_grammar.md
+++ b/docs/defining_structures/ebnf_grammar.md
@@ -189,6 +189,25 @@ value[max_tokens=32, max_chars=128, capture="answer", lazy, temperature=0.7] ::=
 Each option may appear at most once. Options without a value, such as `capture` and `lazy`, are
 written as bare names; the other options use `name=value`.
 
+### Jump-Forward Control
+
+`no_forcing` is a grammar-wide option written as a bare rule option:
+
+```text
+root[no_forcing] ::= "answer:" value
+value ::= [a-z]+
+```
+
+It makes
+[`GrammarMatcher.find_jump_forward_string`](xgrammar.GrammarMatcher.find_jump_forward_string)
+return an empty string while leaving token masks, accepted strings and tokens, captures, rollback,
+and reset behavior unchanged. Placing it on any rule enables it for the whole grammar.
+
+When `str(grammar)` prints a grammar with this option enabled, it writes `no_forcing` on the
+selected root rule. Parsing the printed EBNF restores the option, including after grammar
+serialization, optimization, nesting, union, or concatenation. Grammars without the option keep
+the existing EBNF output unchanged.
+
 ### Token Budgets
 
 The `max_tokens` option gives each occurrence of a rule a token budget:

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -233,12 +233,21 @@ The `%ignore` expression may be a terminal name, a string, a regex, or a combina
 `%grammar_options` takes a JSON object that configures the whole grammar:
 
 ```text
-%grammar_options {"allow_initial_skip": true}
+%grammar_options {"allow_initial_skip": true, "no_forcing": true}
 ```
 
 `allow_initial_skip` (boolean, default `false`) allows `%ignore` content to appear before the
-first lexeme of the output. Multiple `%grammar_options` declarations are merged; unknown option
-names are rejected.
+first lexeme of the output.
+
+`no_forcing` (boolean, default `false`) makes
+[`GrammarMatcher.find_jump_forward_string`](xgrammar.GrammarMatcher.find_jump_forward_string)
+return an empty string. It leaves token masks, accepted strings and tokens, captures, rollback, and
+reset behavior unchanged; only the optional jump-forward output is disabled.
+
+Multiple `%grammar_options` declarations are merged monotonically: once either boolean option is
+`true`, a later `false` declaration does not turn it off. An enabled `no_forcing` option in a
+nested or named grammar also disables jump-forward output for the containing matcher. Unknown
+option names and non-boolean values are rejected.
 
 ### `%json`
 
@@ -263,8 +272,9 @@ Schema converter's normal behavior. `%json` cannot be used inside terminals.
 
 `%lark { ... }` embeds a complete Lark grammar as one element. The nested grammar has its own
 independent namespace: it must define its own `start` rule, and it may declare its own imports,
-`%ignore`, and `%grammar_options` without affecting the outer grammar. Rule names may be reused
-across the boundary.
+`%ignore`, and `%grammar_options`. Rule names may be reused across the boundary. Initial-skip
+behavior remains local to the nested grammar; an enabled `no_forcing` option propagates to the
+containing matcher because jump-forward control is matcher-wide.
 
 ```text
 start: "[" %lark {

--- a/tests/cpp/test_lark_converter.cc
+++ b/tests/cpp/test_lark_converter.cc
@@ -112,6 +112,18 @@ TEST(LarkConverterTest, StringAndRegexFlags) {
   EXPECT_NE(printed.find("root"), std::string::npos);
 }
 
+TEST(LarkConverterTest, NoForcingOptionRoundTripsThroughEBNF) {
+  auto grammar = Grammar::FromLark(R"(
+    %grammar_options {"no_forcing": true}
+    start[capture="all"]: "abb"
+  )");
+  std::string printed = grammar.ToString();
+  EXPECT_NE(printed.find(R"(root[capture="all", no_forcing] ::=)"), std::string::npos);
+
+  auto reparsed = Grammar::FromEBNF(printed);
+  EXPECT_EQ(reparsed.ToString(), printed);
+}
+
 TEST(LarkConverterTest, DynamicRegexSuffixAndSuffixAttribute) {
   auto grammar = Grammar::FromLark(R"(
     start: (foo | bar)* tail

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -381,6 +381,75 @@ def test_lark_allow_initial_skip_options() -> None:
     _assert_language(grammar, ["ab", " a b", "\n\ta\n b  "], ["a c", " xab"])
 
 
+def test_lark_no_forcing_option_disables_jump_forward_only() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "bb", "c"])
+    default = _compile_lark('start[capture="all"]: "abb"', tokenizer_info)
+    explicitly_enabled = _compile_lark(
+        """
+        %grammar_options {"no_forcing": true}
+        %grammar_options {"no_forcing": false}
+        start[capture="all"]: "abb"
+        """,
+        tokenizer_info,
+    )
+    explicitly_disabled = _compile_lark(
+        """
+        %grammar_options {"no_forcing": false}
+        start[capture="all"]: "abb"
+        """,
+        tokenizer_info,
+    )
+
+    matchers = [
+        xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        for compiled in [default, explicitly_enabled, explicitly_disabled]
+    ]
+    enabled_control = xgr.GrammarMatcher(explicitly_enabled, terminate_without_stop_token=True)
+    all_matchers = [*matchers, enabled_control]
+
+    for matcher in all_matchers:
+        assert matcher.accept_token(0)
+
+    def next_mask(matcher: xgr.GrammarMatcher) -> list[int]:
+        mask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        matcher.fill_next_token_bitmask(mask)
+        return mask.tolist()
+
+    masks = [next_mask(matcher) for matcher in all_matchers]
+    assert masks[0] == masks[1] == masks[2] == masks[3]
+
+    assert matchers[0].find_jump_forward_string() == "bb"
+    assert matchers[1].find_jump_forward_string() == ""
+    assert matchers[2].find_jump_forward_string() == "bb"
+
+    assert matchers[1].get_captures() == enabled_control.get_captures() == []
+    assert next_mask(matchers[1]) == next_mask(enabled_control)
+
+    for matcher in all_matchers:
+        assert not matcher.accept_token(3)
+        assert matcher.accept_token(2)
+        assert matcher.is_terminated()
+        assert matcher.get_captures() == [("all", b"abb")]
+
+    for matcher in all_matchers:
+        matcher.rollback(1)
+        assert not matcher.is_terminated()
+        assert matcher.get_captures() == []
+
+    assert matchers[0].find_jump_forward_string() == "bb"
+    assert matchers[1].find_jump_forward_string() == ""
+    assert matchers[2].find_jump_forward_string() == "bb"
+    assert next_mask(matchers[1]) == next_mask(enabled_control)
+
+    for matcher in all_matchers:
+        matcher.reset()
+        assert matcher.get_captures() == []
+        assert not matcher.accept_string("c")
+        assert matcher.accept_string("abb")
+        assert matcher.is_terminated()
+        assert matcher.get_captures() == [("all", b"abb")]
+
+
 def test_lark_default_disallows_initial_skip_but_allows_trailing_skip() -> None:
     grammar = """
         %import common.WS_INLINE
@@ -1077,9 +1146,9 @@ def test_lark_large_choice_grammar() -> None:
             id="initial-skip-type",
         ),
         pytest.param(
-            '%grammar_options {"no_forcing": true}\nstart: "a"',
-            "%grammar_options option 'no_forcing' is not supported",
-            id="no-forcing-option",
+            '%grammar_options {"no_forcing": 1}\nstart: "a"',
+            "no_forcing must be a boolean",
+            id="no-forcing-type",
         ),
         pytest.param(
             '%grammar_options {"allow_invalid_utf8": true}\nstart: "a"',

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence
 
 import pytest
 
@@ -410,7 +410,7 @@ def test_lark_no_forcing_option_disables_jump_forward_only() -> None:
     for matcher in all_matchers:
         assert matcher.accept_token(0)
 
-    def next_mask(matcher: xgr.GrammarMatcher) -> list[int]:
+    def next_mask(matcher: xgr.GrammarMatcher) -> List[int]:
         mask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
         matcher.fill_next_token_bitmask(mask)
         return mask.tolist()
@@ -448,6 +448,84 @@ def test_lark_no_forcing_option_disables_jump_forward_only() -> None:
         assert matcher.accept_string("abb")
         assert matcher.is_terminated()
         assert matcher.get_captures() == [("all", b"abb")]
+
+
+def test_lark_no_forcing_survives_serialization_optimization_and_ebnf() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "bb", "c"])
+    grammar = xgr.Grammar.from_lark(
+        """
+        %grammar_options {"no_forcing": true}
+        start[capture="all"]: "abb"
+        """
+    )
+
+    serialized_grammar = grammar.serialize_json()
+    assert json.loads(serialized_grammar)["no_forcing"] is True
+    recovered_grammar = xgr.Grammar.deserialize_json(serialized_grammar)
+
+    printed = str(grammar)
+    assert 'root[capture="all", no_forcing] ::=' in printed
+    reparsed_grammar = xgr.Grammar.from_ebnf(printed)
+    assert str(reparsed_grammar) == printed
+
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+    compiled = compiler.compile_grammar(grammar)
+    assert json.loads(compiled.grammar.serialize_json())["no_forcing"] is True
+    serialized_compiled = compiled.serialize_json()
+    assert json.loads(serialized_compiled)["grammar"]["no_forcing"] is True
+    recovered_compiled = xgr.CompiledGrammar.deserialize_json(serialized_compiled, tokenizer_info)
+
+    compiled_variants = [
+        compiled,
+        compiler.compile_grammar(recovered_grammar),
+        compiler.compile_grammar(reparsed_grammar),
+        recovered_compiled,
+    ]
+    for compiled_variant in compiled_variants:
+        matcher = xgr.GrammarMatcher(compiled_variant, terminate_without_stop_token=True)
+        assert matcher.accept_string("a")
+        assert matcher.find_jump_forward_string() == ""
+        assert matcher.accept_string("bb")
+        assert matcher.get_captures() == [("all", b"abb")]
+
+
+def test_lark_no_forcing_propagates_through_nested_named_and_composed_grammars() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "bb", "c"])
+    enabled = xgr.Grammar.from_lark(
+        """
+        %grammar_options {"no_forcing": true}
+        start: "abb"
+        """
+    )
+    enabled_suffix = xgr.Grammar.from_lark(
+        """
+        %grammar_options {"no_forcing": true}
+        start: "bb"
+        """
+    )
+
+    nested = xgr.Grammar.from_lark(
+        """
+        start: %lark {
+          %grammar_options {"no_forcing": true}
+          start: "abb"
+        }
+        """
+    )
+    named = xgr.Grammar.from_lark("start: @child", named_grammars={"child": enabled})
+    union = xgr.Grammar.union(xgr.Grammar.from_ebnf('root ::= "c"'), enabled)
+    concat = xgr.Grammar.concat(xgr.Grammar.from_ebnf('root ::= "a"'), enabled_suffix)
+
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+    for grammar in [nested, named, union, concat]:
+        assert str(grammar).startswith("root[no_forcing] ::=")
+        matcher = xgr.GrammarMatcher(
+            compiler.compile_grammar(grammar), terminate_without_stop_token=True
+        )
+        assert matcher.accept_string("a")
+        assert matcher.find_jump_forward_string() == ""
+        assert matcher.accept_string("bb")
+        assert matcher.is_terminated()
 
 
 def test_lark_default_disallows_initial_skip_but_allows_trailing_skip() -> None:

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 
 import pytest

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -44,7 +44,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v16"
+    assert xgr.get_serialization_version() == "v17"
 
 
 def test_serialize_grammar():
@@ -64,11 +64,12 @@ def test_serialize_grammar():
             # fmt: on
         ],
         "root_rule_id": 1,
+        "no_forcing": False,
         "complete_fsm": None,
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v16",
+        "__VERSION__": "v17",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -89,17 +90,18 @@ def test_serialize_grammar_exception():
             # fmt: on
         ],
         "root_rule_id": 1,
+        "no_forcing": False,
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v16",
+        "__VERSION__": "v17",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v16"
+    expected_json["__VERSION__"] = "v17"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -151,7 +153,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v16"}'
+        '"__VERSION__":"v17"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -262,6 +264,7 @@ def test_serialize_compiled_grammar():
                 ]
             ],
             # fmt: on
+            "no_forcing": False,
             "optimized": True,
         },
         "tokenizer_metadata": {
@@ -270,7 +273,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v16",
+        "__VERSION__": "v17",
     }
 
     class AdaptiveTokenMask(BaseModel):


### PR DESCRIPTION
## Summary

- Accept the boolean `no_forcing` option in `%grammar_options`.
- Disable jump-forward string output without changing token masks, accepted input, captures, rollback, or reset behavior.
- Preserve the option through nested and named grammars, grammar composition, optimization, JSON serialization, and EBNF round trips.

## User impact

Applications can keep model tokenization in control even when the grammar has a uniquely determined continuation. Existing grammars retain their current behavior unless the option is explicitly enabled.

## Validation

- Python related modules: 392 passed
- Python full suite excluding tests that require external credentials: 3062 passed, 1 skipped, 622 deselected
- C++ suite: 62 of 62 passed
- Pre-commit checks on all changed files
