### PR TITLE
Support parametric Lark rules

### DIFF
--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -1700,6 +1700,7 @@ class ParametricExpander {
       PendingInstance instance = std::move(pending_.front());
       pending_.pop_front();
       const Definition& base = *definitions_.at(instance.base_name);
+      ValidateParametricDefinition(base);
       Definition generated = base;
       generated.name = instance.generated_name;
       generated.is_parametric = false;
@@ -1835,6 +1836,35 @@ class ParametricExpander {
     }
   }
 
+  void ValidateParametricDefinition(const Definition& definition) {
+    if (!validated_parametric_definitions_.insert(definition.name).second) {
+      return;
+    }
+    ValidateParametricNode(definition.body);
+  }
+
+  void ValidateParametricNode(const Node& node) {
+    if (node.kind == Node::Kind::kName) {
+      auto target = definitions_.find(node.text);
+      if (target == definitions_.end()) {
+        RaiseLarkError(source_, node.location, "unknown name '" + node.text + "'");
+      }
+      if (node.parameter.has_value()) {
+        if (!target->second->is_parametric) {
+          RaiseLarkError(source_, node.location, "rule '" + node.text + "' is not parametric");
+        }
+        ValidateParametricDefinition(*target->second);
+      } else if (target->second->is_parametric) {
+        RaiseLarkError(
+            source_, node.location, "parametric rule '" + node.text + "' requires a parameter"
+        );
+      }
+    }
+    for (const Node& child : node.children) {
+      ValidateParametricNode(child);
+    }
+  }
+
   Node RewriteNode(const Node& node, std::optional<uint64_t> current, bool terminal_context) {
     if (node.condition.has_value()) {
       if (terminal_context) {
@@ -1966,6 +1996,7 @@ class ParametricExpander {
   Document* document_;
   std::unordered_map<std::string, const Definition*> definitions_;
   std::unordered_set<std::string> used_names_;
+  std::unordered_set<std::string> validated_parametric_definitions_;
   std::unordered_map<std::string, std::string> instances_;
   std::deque<PendingInstance> pending_;
 };

--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -12,6 +12,8 @@
 #include <cctype>
 #include <cmath>
 #include <cstdint>
+#include <deque>
+#include <iomanip>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -316,6 +318,18 @@ class LarkLexer {
     if (source_[position_] == '+' || source_[position_] == '-') {
       Advance();
     }
+    if (PeekChar(0) == '0' && (PeekChar(1) == 'x' || PeekChar(1) == 'X')) {
+      Advance();
+      Advance();
+      size_t digits_start = position_;
+      while (std::isxdigit(static_cast<unsigned char>(PeekChar(0)))) {
+        Advance();
+      }
+      if (position_ == digits_start) {
+        RaiseLarkError(source_, location, "expected hexadecimal digits after '0x'");
+      }
+      return {TokenType::kNumber, source_.substr(start, position_ - start), "", location};
+    }
     while (std::isdigit(static_cast<unsigned char>(PeekChar(0)))) {
       Advance();
     }
@@ -487,6 +501,132 @@ class LarkLexer {
 
 struct Document;
 
+struct ParamRef {
+  uint8_t start = 0;
+  uint8_t end = 64;
+
+  uint64_t Mask() const {
+    int width = static_cast<int>(end) - static_cast<int>(start);
+    if (width == 64) {
+      return std::numeric_limits<uint64_t>::max();
+    }
+    return ((uint64_t{1} << width) - 1) << start;
+  }
+
+  uint64_t Evaluate(uint64_t value) const { return (value & Mask()) >> start; }
+};
+
+struct ParamExpr {
+  enum class Kind { kConst, kSelf, kIncr, kDecr, kBitAnd, kBitOr };
+
+  Kind kind = Kind::kConst;
+  uint64_t value = 0;
+  ParamRef reference;
+  Location location;
+
+  bool NeedsCurrentValue() const { return kind != Kind::kConst; }
+
+  uint64_t Evaluate(std::optional<uint64_t> current, const std::string& source) const {
+    if (kind == Kind::kConst) {
+      return value;
+    }
+    if (!current.has_value()) {
+      RaiseLarkError(source, location, "parameter expression requires a parametric caller");
+    }
+    uint64_t result = current.value();
+    switch (kind) {
+      case Kind::kConst:
+        return value;
+      case Kind::kSelf:
+        return result;
+      case Kind::kIncr:
+        return (result & reference.Mask()) == reference.Mask()
+                   ? result
+                   : result + (uint64_t{1} << reference.start);
+      case Kind::kDecr:
+        return (result & reference.Mask()) == 0 ? result
+                                                : result - (uint64_t{1} << reference.start);
+      case Kind::kBitAnd:
+        return result & value;
+      case Kind::kBitOr:
+        return result | value;
+    }
+    return result;
+  }
+};
+
+struct ParamCond {
+  enum class Kind {
+    kTrue,
+    kNE,
+    kEQ,
+    kLE,
+    kLT,
+    kGE,
+    kGT,
+    kBitCountNE,
+    kBitCountEQ,
+    kBitCountLE,
+    kBitCountLT,
+    kBitCountGE,
+    kBitCountGT,
+    kAnd,
+    kOr,
+    kNot,
+  };
+
+  Kind kind = Kind::kTrue;
+  ParamRef reference;
+  uint64_t value = 0;
+  std::vector<ParamCond> children;
+  Location location;
+
+  bool IsAlwaysTrue() const { return kind == Kind::kTrue; }
+
+  bool Evaluate(uint64_t current) const {
+    uint64_t selected = reference.Evaluate(current);
+    uint64_t bit_count = 0;
+    for (uint64_t remaining = selected; remaining != 0; remaining &= remaining - 1) {
+      ++bit_count;
+    }
+    switch (kind) {
+      case Kind::kTrue:
+        return true;
+      case Kind::kNE:
+        return selected != value;
+      case Kind::kEQ:
+        return selected == value;
+      case Kind::kLE:
+        return selected <= value;
+      case Kind::kLT:
+        return selected < value;
+      case Kind::kGE:
+        return selected >= value;
+      case Kind::kGT:
+        return selected > value;
+      case Kind::kBitCountNE:
+        return bit_count != value;
+      case Kind::kBitCountEQ:
+        return bit_count == value;
+      case Kind::kBitCountLE:
+        return bit_count <= value;
+      case Kind::kBitCountLT:
+        return bit_count < value;
+      case Kind::kBitCountGE:
+        return bit_count >= value;
+      case Kind::kBitCountGT:
+        return bit_count > value;
+      case Kind::kAnd:
+        return children[0].Evaluate(current) && children[1].Evaluate(current);
+      case Kind::kOr:
+        return children[0].Evaluate(current) || children[1].Evaluate(current);
+      case Kind::kNot:
+        return !children[0].Evaluate(current);
+    }
+    return false;
+  }
+};
+
 struct Node {
   enum class Kind {
     kSequence,
@@ -502,6 +642,7 @@ struct Node {
     kSpecialToken,
     kGrammarRef,
     kNot,
+    kNever,
   };
 
   Kind kind = Kind::kSequence;
@@ -513,11 +654,14 @@ struct Node {
   int32_t max_repeat = 0;
   std::vector<Node> children;
   std::shared_ptr<Document> nested;
+  std::optional<ParamExpr> parameter;
+  std::optional<ParamCond> condition;
 };
 
 struct Definition {
   std::string name;
   bool is_terminal = false;
+  bool is_parametric = false;
   bool lazy = false;
   std::optional<Node> suffix;
   std::optional<float> temperature;
@@ -726,6 +870,16 @@ class LarkParser {
     result.is_terminal = IsTerminalName(name_token.text);
     result.location = name_token.location;
 
+    if (Match(TokenType::kDoubleColon)) {
+      Token parameter = Consume(TokenType::kName, "expected '_' after '::' in rule definition");
+      if (parameter.text != "_") {
+        RaiseLarkError(source_, parameter.location, "expected '_' after '::' in rule definition");
+      }
+      if (result.is_terminal) {
+        RaiseLarkError(source_, name_token.location, "terminals cannot be parametric");
+      }
+      result.is_parametric = true;
+    }
     if (Peek().type == TokenType::kLBracket) {
       if (result.is_terminal) {
         RaiseLarkError(source_, Peek().location, "attributes are only supported on rules");
@@ -734,9 +888,6 @@ class LarkParser {
     }
     if (Peek().type == TokenType::kDot) {
       RaiseLarkError(source_, Peek().location, "rule and terminal priorities are not supported");
-    }
-    if (Peek().type == TokenType::kDoubleColon) {
-      RaiseLarkError(source_, Peek().location, "parametric grammar is not supported");
     }
     if (Peek().type == TokenType::kLBrace) {
       RaiseLarkError(source_, Peek().location, "Lark templates are not supported");
@@ -937,13 +1088,13 @@ class LarkParser {
     if (Peek().type == TokenType::kAnd) {
       RaiseLarkError(source_, Peek().location, "terminal intersection '&' is not supported");
     }
-    if (Peek().type == TokenType::kIf) {
-      RaiseLarkError(source_, Peek().location, "parametric %if conditions are not supported");
-    }
     Node result;
     result.kind = Node::Kind::kSequence;
     result.location = location;
     result.children = std::move(elements);
+    if (Match(TokenType::kIf)) {
+      result.condition = ParseParamCondition();
+    }
     return result;
   }
 
@@ -965,6 +1116,192 @@ class LarkParser {
     } catch (const std::exception&) {
       RaiseLarkError(source_, token.location, "invalid repetition count");
     }
+  }
+
+  uint64_t ParseParamValue() {
+    Token token = Consume(TokenType::kNumber, "expected parameter value");
+    if (token.text.empty() || token.text[0] == '+' || token.text[0] == '-') {
+      RaiseLarkError(
+          source_,
+          token.location,
+          "parameter values must be unsigned decimal or hexadecimal integers"
+      );
+    }
+    int base = token.text.size() > 2 && token.text[0] == '0' &&
+                       (token.text[1] == 'x' || token.text[1] == 'X')
+                   ? 16
+                   : 10;
+    try {
+      size_t parsed = 0;
+      uint64_t value = std::stoull(token.text, &parsed, base);
+      if (parsed != token.text.size()) {
+        RaiseLarkError(source_, token.location, "invalid 64-bit parameter value");
+      }
+      return value;
+    } catch (const std::exception&) {
+      RaiseLarkError(source_, token.location, "invalid 64-bit parameter value");
+    }
+  }
+
+  uint8_t ParseBitIndex(bool allow_end) {
+    Location location = Peek().location;
+    uint64_t value = ParseParamValue();
+    uint64_t maximum = allow_end ? 64 : 63;
+    if (value > maximum) {
+      RaiseLarkError(
+          source_,
+          location,
+          "bit index " + std::to_string(value) +
+              " is too large; must be <= " + std::to_string(maximum)
+      );
+    }
+    return static_cast<uint8_t>(value);
+  }
+
+  ParamRef ParseParamReference() {
+    if (Peek().type == TokenType::kName && Peek().text == "_") {
+      ++position_;
+      return {0, 64};
+    }
+    if (!Match(TokenType::kLBracket)) {
+      RaiseLarkError(source_, Peek().location, "expected '_' or '[start_bit:stop_bit]'");
+    }
+    Location location = Peek().location;
+    uint8_t start = ParseBitIndex(false);
+    Consume(TokenType::kColon, "expected ':' in bit range");
+    uint8_t end = ParseBitIndex(true);
+    Consume(TokenType::kRBracket, "expected ']' after bit range");
+    if (end <= start) {
+      RaiseLarkError(
+          source_,
+          location,
+          "end bit index " + std::to_string(end) + " must be > start bit index " +
+              std::to_string(start)
+      );
+    }
+    return {start, end};
+  }
+
+  ParamExpr ParseParamExpression() {
+    Location location = Peek().location;
+    if (Peek().type == TokenType::kNumber) {
+      ParamExpr result;
+      result.kind = ParamExpr::Kind::kConst;
+      result.value = ParseParamValue();
+      result.location = location;
+      return result;
+    }
+    Token function = Consume(TokenType::kName, "expected parameter expression");
+    ParamExpr result;
+    result.location = location;
+    if (function.text == "_") {
+      result.kind = ParamExpr::Kind::kSelf;
+      return result;
+    }
+
+    static const std::unordered_set<std::string> kKnownFunctions = {
+        "incr", "decr", "bit_and", "bit_or", "set_bit", "clear_bit"
+    };
+    if (!kKnownFunctions.count(function.text)) {
+      RaiseLarkError(
+          source_, function.location, "unknown parameter expression '" + function.text + "'"
+      );
+    }
+    Consume(TokenType::kLParen, "expected '(' after parameter function");
+    if (function.text == "incr" || function.text == "decr") {
+      result.kind = function.text == "incr" ? ParamExpr::Kind::kIncr : ParamExpr::Kind::kDecr;
+      result.reference = ParseParamReference();
+    } else if (function.text == "bit_and" || function.text == "bit_or") {
+      result.kind = function.text == "bit_and" ? ParamExpr::Kind::kBitAnd : ParamExpr::Kind::kBitOr;
+      result.value = ParseParamValue();
+    } else if (function.text == "set_bit" || function.text == "clear_bit") {
+      uint8_t bit = ParseBitIndex(false);
+      result.kind = function.text == "set_bit" ? ParamExpr::Kind::kBitOr : ParamExpr::Kind::kBitAnd;
+      result.value = uint64_t{1} << bit;
+      if (function.text == "clear_bit") {
+        result.value = ~result.value;
+      }
+    }
+    Consume(TokenType::kRParen, "expected ')' after parameter expression");
+    return result;
+  }
+
+  ParamCond ParseParamCondition() {
+    Token function = Consume(TokenType::kName, "expected condition after %if");
+    ParamCond result;
+    result.location = function.location;
+    if (function.text == "true") {
+      result.kind = ParamCond::Kind::kTrue;
+      if (Match(TokenType::kLParen)) {
+        Consume(TokenType::kRParen, "expected ')' after true(");
+      }
+      return result;
+    }
+
+    static const std::unordered_set<std::string> kKnownFunctions = {
+        "ne",           "eq",           "le",           "lt",           "ge",
+        "gt",           "bit_count_ne", "bit_count_eq", "bit_count_le", "bit_count_lt",
+        "bit_count_ge", "bit_count_gt", "and",          "or",           "not",
+        "bit_clear",    "bit_set",      "is_zeros",     "is_ones",
+    };
+    if (!kKnownFunctions.count(function.text)) {
+      RaiseLarkError(source_, function.location, "unknown condition '" + function.text + "'");
+    }
+    Consume(TokenType::kLParen, "expected '(' after condition function");
+    auto parse_comparison = [&](ParamCond::Kind kind) {
+      result.kind = kind;
+      result.reference = ParseParamReference();
+      Consume(TokenType::kComma, "expected ',' in condition");
+      result.value = ParseParamValue();
+    };
+    if (function.text == "ne") {
+      parse_comparison(ParamCond::Kind::kNE);
+    } else if (function.text == "eq") {
+      parse_comparison(ParamCond::Kind::kEQ);
+    } else if (function.text == "le") {
+      parse_comparison(ParamCond::Kind::kLE);
+    } else if (function.text == "lt") {
+      parse_comparison(ParamCond::Kind::kLT);
+    } else if (function.text == "ge") {
+      parse_comparison(ParamCond::Kind::kGE);
+    } else if (function.text == "gt") {
+      parse_comparison(ParamCond::Kind::kGT);
+    } else if (function.text == "bit_count_ne" || function.text == "bit_count_eq" ||
+               function.text == "bit_count_le" || function.text == "bit_count_lt" ||
+               function.text == "bit_count_ge" || function.text == "bit_count_gt") {
+      static const std::unordered_map<std::string, ParamCond::Kind> kinds = {
+          {"bit_count_ne", ParamCond::Kind::kBitCountNE},
+          {"bit_count_eq", ParamCond::Kind::kBitCountEQ},
+          {"bit_count_le", ParamCond::Kind::kBitCountLE},
+          {"bit_count_lt", ParamCond::Kind::kBitCountLT},
+          {"bit_count_ge", ParamCond::Kind::kBitCountGE},
+          {"bit_count_gt", ParamCond::Kind::kBitCountGT},
+      };
+      result.kind = kinds.at(function.text);
+      result.reference = ParseParamReference();
+      Consume(TokenType::kComma, "expected ',' in condition");
+      result.value = ParseBitIndex(false);
+    } else if (function.text == "and" || function.text == "or") {
+      result.kind = function.text == "and" ? ParamCond::Kind::kAnd : ParamCond::Kind::kOr;
+      result.children.push_back(ParseParamCondition());
+      Consume(TokenType::kComma, "expected ',' in condition");
+      result.children.push_back(ParseParamCondition());
+    } else if (function.text == "not") {
+      result.kind = ParamCond::Kind::kNot;
+      result.children.push_back(ParseParamCondition());
+    } else if (function.text == "bit_clear" || function.text == "bit_set") {
+      uint8_t bit = ParseBitIndex(false);
+      result.kind = ParamCond::Kind::kEQ;
+      result.reference = {bit, static_cast<uint8_t>(bit + 1)};
+      result.value = function.text == "bit_set" ? 1 : 0;
+    } else if (function.text == "is_zeros" || function.text == "is_ones") {
+      result.kind = ParamCond::Kind::kEQ;
+      result.reference = ParseParamReference();
+      result.value =
+          function.text == "is_ones" ? result.reference.Mask() >> result.reference.start : 0;
+    }
+    Consume(TokenType::kRParen, "expected ')' after condition");
+    return result;
   }
 
   Node ParseExpr() {
@@ -1072,8 +1409,8 @@ class LarkParser {
       result.kind = Node::Kind::kName;
       result.location = token.location;
       result.text = NormalizeRuleName(token.text);
-      if (Peek().type == TokenType::kDoubleColon) {
-        RaiseLarkError(source_, Peek().location, "parametric grammar is not supported");
+      if (Match(TokenType::kDoubleColon)) {
+        result.parameter = ParseParamExpression();
       }
       if (Peek().type == TokenType::kLBrace && Peek(1).type != TokenType::kComma &&
           Peek(1).type != TokenType::kNumber) {
@@ -1326,6 +1663,313 @@ struct NamedGrammarRegistry {
   std::vector<std::string> active;
 };
 
+class ParametricExpander {
+ public:
+  ParametricExpander(const std::string& source, Document* document)
+      : source_(source), document_(document) {}
+
+  void Expand() {
+    IndexOriginalDefinitions();
+    ValidateDefinitions();
+
+    bool has_parametric_definition = std::any_of(
+        document_->definitions.begin(),
+        document_->definitions.end(),
+        [](const Definition& definition) { return definition.is_parametric; }
+    );
+    if (!has_parametric_definition) {
+      ValidateNoOrphanParameterSyntax();
+      return;
+    }
+
+    std::vector<Definition> expanded;
+    expanded.reserve(document_->definitions.size());
+    for (const Definition& definition : document_->definitions) {
+      if (definition.is_parametric) {
+        continue;
+      }
+      Definition copy = definition;
+      copy.body = RewriteNode(copy.body, std::nullopt, false);
+      expanded.push_back(std::move(copy));
+    }
+    for (Node& ignore : document_->ignores) {
+      ignore = RewriteNode(ignore, std::nullopt, true);
+    }
+
+    while (!pending_.empty()) {
+      PendingInstance instance = std::move(pending_.front());
+      pending_.pop_front();
+      const Definition& base = *definitions_.at(instance.base_name);
+      Definition generated = base;
+      generated.name = instance.generated_name;
+      generated.is_parametric = false;
+      generated.body = RewriteNode(base.body, instance.value, false);
+      expanded.push_back(std::move(generated));
+    }
+    document_->definitions = std::move(expanded);
+  }
+
+ private:
+  static constexpr size_t kMaxInstances = 4096;
+
+  struct PendingInstance {
+    std::string base_name;
+    uint64_t value;
+    std::string generated_name;
+  };
+
+  static Node NeverNode(const Location& location) {
+    Node result;
+    result.kind = Node::Kind::kNever;
+    result.location = location;
+    return result;
+  }
+
+  static bool NeedsCurrentParameter(const Node& node) {
+    if (node.parameter.has_value() && node.parameter->NeedsCurrentValue()) {
+      return true;
+    }
+    if (node.condition.has_value() && !node.condition->IsAlwaysTrue()) {
+      return true;
+    }
+    return std::any_of(node.children.begin(), node.children.end(), NeedsCurrentParameter);
+  }
+
+  void IndexOriginalDefinitions() {
+    for (const Definition& definition : document_->definitions) {
+      if (!definitions_.emplace(definition.name, &definition).second) {
+        RaiseLarkError(
+            source_, definition.location, "duplicate rule or terminal '" + definition.name + "'"
+        );
+      }
+      used_names_.insert(definition.name);
+    }
+  }
+
+  void ValidateDefinitions() const {
+    for (const Definition& definition : document_->definitions) {
+      if (definition.is_terminal) {
+        ValidateTerminalNode(definition.body);
+        continue;
+      }
+      if (definition.name == "start" && definition.is_parametric) {
+        RaiseLarkError(source_, definition.location, "start rule cannot be parametric");
+      }
+      if (definition.is_parametric) {
+        if (definition.lazy || definition.suffix.has_value() || definition.stop.has_value()) {
+          RaiseLarkError(
+              source_,
+              definition.location,
+              "stop-like behavior is not supported for parametric rules"
+          );
+        }
+        if (definition.temperature.has_value()) {
+          RaiseLarkError(
+              source_, definition.location, "temperature is not supported for parametric rules"
+          );
+        }
+        if (definition.max_tokens.has_value()) {
+          RaiseLarkError(
+              source_, definition.location, "max_tokens is not supported for parametric rules"
+          );
+        }
+        if (!NeedsCurrentParameter(definition.body)) {
+          RaiseLarkError(
+              source_,
+              definition.location,
+              "parametric rule '" + definition.name + "' does not depend on its parameter"
+          );
+        }
+      } else if (NeedsCurrentParameter(definition.body)) {
+        RaiseLarkError(
+            source_,
+            definition.location,
+            "non-parametric rule '" + definition.name +
+                "' contains an expression that requires a caller parameter"
+        );
+      }
+    }
+    for (const Node& ignore : document_->ignores) {
+      ValidateTerminalNode(ignore);
+    }
+  }
+
+  void ValidateTerminalNode(const Node& node) const {
+    if (node.parameter.has_value()) {
+      RaiseLarkError(
+          source_,
+          node.parameter->location,
+          "parameterized rule references cannot be used in terminals"
+      );
+    }
+    if (node.condition.has_value()) {
+      RaiseLarkError(source_, node.condition->location, "%if cannot be used in terminals");
+    }
+    for (const Node& child : node.children) {
+      ValidateTerminalNode(child);
+    }
+  }
+
+  void ValidateNoOrphanParameterSyntax() const {
+    for (const Definition& definition : document_->definitions) {
+      ValidateReferencesWithoutExpansion(definition.body);
+    }
+    for (const Node& ignore : document_->ignores) {
+      ValidateReferencesWithoutExpansion(ignore);
+    }
+  }
+
+  void ValidateReferencesWithoutExpansion(const Node& node) const {
+    if (node.parameter.has_value()) {
+      auto target = definitions_.find(node.text);
+      if (target == definitions_.end()) {
+        RaiseLarkError(source_, node.location, "unknown name '" + node.text + "'");
+      }
+      RaiseLarkError(source_, node.location, "rule '" + node.text + "' is not parametric");
+    }
+    if (node.condition.has_value() && !node.condition->IsAlwaysTrue()) {
+      RaiseLarkError(source_, node.condition->location, "%if condition requires a parametric rule");
+    }
+    for (const Node& child : node.children) {
+      ValidateReferencesWithoutExpansion(child);
+    }
+  }
+
+  Node RewriteNode(const Node& node, std::optional<uint64_t> current, bool terminal_context) {
+    if (node.condition.has_value()) {
+      if (terminal_context) {
+        RaiseLarkError(source_, node.condition->location, "%if cannot be used in terminals");
+      }
+      if (!node.condition->IsAlwaysTrue() && !current.has_value()) {
+        RaiseLarkError(
+            source_, node.condition->location, "%if condition requires a parametric rule"
+        );
+      }
+      if (current.has_value() && !node.condition->Evaluate(current.value())) {
+        return NeverNode(node.location);
+      }
+    }
+
+    Node result = node;
+    result.condition.reset();
+    switch (node.kind) {
+      case Node::Kind::kName: {
+        auto target = definitions_.find(node.text);
+        if (node.parameter.has_value()) {
+          if (terminal_context) {
+            RaiseLarkError(
+                source_,
+                node.parameter->location,
+                "parameterized rule references cannot be used in terminals"
+            );
+          }
+          if (target == definitions_.end()) {
+            RaiseLarkError(source_, node.location, "unknown name '" + node.text + "'");
+          }
+          if (!target->second->is_parametric) {
+            RaiseLarkError(source_, node.location, "rule '" + node.text + "' is not parametric");
+          }
+          uint64_t value = node.parameter->Evaluate(current, source_);
+          result.text = Schedule(node.text, value, node.location);
+          result.parameter.reset();
+        } else if (target != definitions_.end() && target->second->is_parametric) {
+          RaiseLarkError(
+              source_, node.location, "parametric rule '" + node.text + "' requires a parameter"
+          );
+        }
+        return result;
+      }
+      case Node::Kind::kChoice: {
+        result.children.clear();
+        for (const Node& child : node.children) {
+          Node rewritten = RewriteNode(child, current, terminal_context);
+          if (rewritten.kind != Node::Kind::kNever) {
+            result.children.push_back(std::move(rewritten));
+          }
+        }
+        if (result.children.empty()) {
+          return NeverNode(node.location);
+        }
+        if (result.children.size() == 1) {
+          return std::move(result.children[0]);
+        }
+        return result;
+      }
+      case Node::Kind::kSequence: {
+        result.children.clear();
+        for (const Node& child : node.children) {
+          Node rewritten = RewriteNode(child, current, terminal_context);
+          if (rewritten.kind == Node::Kind::kNever) {
+            return NeverNode(node.location);
+          }
+          result.children.push_back(std::move(rewritten));
+        }
+        return result;
+      }
+      case Node::Kind::kRepeat: {
+        Node rewritten = RewriteNode(node.children[0], current, terminal_context);
+        if (rewritten.kind == Node::Kind::kNever) {
+          if (node.min_repeat == 0) {
+            result.kind = Node::Kind::kSequence;
+            result.children.clear();
+            return result;
+          }
+          return NeverNode(node.location);
+        }
+        result.children = {std::move(rewritten)};
+        return result;
+      }
+      case Node::Kind::kNot:
+        result.children = {RewriteNode(node.children[0], current, terminal_context)};
+        return result;
+      case Node::Kind::kNestedLark:
+      case Node::Kind::kString:
+      case Node::Kind::kRegex:
+      case Node::Kind::kRange:
+      case Node::Kind::kJson:
+      case Node::Kind::kRegexExt:
+      case Node::Kind::kSpecialToken:
+      case Node::Kind::kGrammarRef:
+      case Node::Kind::kNever:
+        return result;
+    }
+    return result;
+  }
+
+  std::string Schedule(const std::string& base_name, uint64_t value, const Location& location) {
+    std::string key = base_name + '\0' + std::to_string(value);
+    auto existing = instances_.find(key);
+    if (existing != instances_.end()) {
+      return existing->second;
+    }
+    if (instances_.size() >= kMaxInstances) {
+      RaiseLarkError(
+          source_,
+          location,
+          "parametric grammar exceeds the limit of " + std::to_string(kMaxInstances) +
+              " reachable rule instances"
+      );
+    }
+
+    std::ostringstream name;
+    name << base_name << "__param_" << std::hex << std::setw(16) << std::setfill('0') << value;
+    std::string generated_name = name.str();
+    while (!used_names_.insert(generated_name).second) {
+      generated_name += "_";
+    }
+    instances_[key] = generated_name;
+    pending_.push_back({base_name, value, generated_name});
+    return generated_name;
+  }
+
+  const std::string& source_;
+  Document* document_;
+  std::unordered_map<std::string, const Definition*> definitions_;
+  std::unordered_set<std::string> used_names_;
+  std::unordered_map<std::string, std::string> instances_;
+  std::deque<PendingInstance> pending_;
+};
+
 class LarkCompiler {
  public:
   LarkCompiler(
@@ -1342,6 +1986,7 @@ class LarkCompiler {
   Grammar Compile() {
     ExpandImports();
     ParseOptions();
+    ParametricExpander(source_, &document_).Expand();
     IndexDefinitions();
     ValidateTerminalCycles();
 
@@ -1846,6 +2491,8 @@ class LarkCompiler {
         RaiseLarkError(
             source_, node.location, "regular-expression complement '~' is not supported"
         );
+      case Node::Kind::kNever:
+        RaiseLarkError(source_, node.location, "empty language cannot be used in terminals");
     }
     RaiseLarkError(source_, node.location, "unsupported terminal node");
   }
@@ -2038,6 +2685,13 @@ class LarkCompiler {
         RaiseLarkError(
             source_, node.location, "regular-expression complement '~' is not supported"
         );
+      case Node::Kind::kNever: {
+        if (never_rule_id_ == -1) {
+          never_rule_id_ = builder_.AddEmptyRuleWithHint("lark_never");
+          builder_.UpdateRuleBody(never_rule_id_, builder_.AddRuleRef(never_rule_id_));
+        }
+        return builder_.AddRuleRef(never_rule_id_);
+      }
     }
     RaiseLarkError(source_, node.location, "unsupported grammar node");
   }
@@ -2560,6 +3214,7 @@ class LarkCompiler {
   std::unordered_map<std::string, int32_t> rule_ids_;
   std::unordered_map<std::string, int32_t> named_grammar_roots_;
   int32_t skip_rule_id_ = -1;
+  int32_t never_rule_id_ = -1;
   bool allow_initial_skip_ = false;
   std::unordered_set<std::string> dynamic_unused_rules_;
 };

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -175,6 +175,88 @@ Repetition operators follow an element (a literal, a name, or a group):
 Zero counts such as `x{0}` are allowed and match the empty string. Ranges with the upper bound
 below the lower bound are rejected.
 
+## Parametric Rules
+
+A rule can carry one unsigned 64-bit parameter. Declare it with `::_`, pass an initial value from
+an ordinary rule, and use `%if` to enable alternatives based on the current value:
+
+```text
+start: permutation::0
+
+permutation::_: "" %if is_ones([0:3])
+               | "a" permutation::set_bit(0) %if bit_clear(0)
+               | "b" permutation::set_bit(1) %if bit_clear(1)
+               | "c" permutation::set_bit(2) %if bit_clear(2)
+```
+
+This grammar accepts every permutation of `a`, `b`, and `c` exactly once. Parameters are compile-time
+state: `Grammar.from_lark` expands only reachable `(rule, value)` pairs into ordinary grammar rules.
+The resulting `Grammar` uses the existing matcher, optimizer, EBNF printer, and JSON serialization
+without a parameter-aware runtime.
+
+Parameter values may be decimal or hexadecimal (`15`, `0xf`, or
+`0xffffffffffffffff`). `_` means the current value. Bit slices use `[start:end]`, where `start` is
+inclusive, `end` is exclusive, and valid indices cover the complete range `[0:64]`.
+
+### Parameter Expressions
+
+An expression after `rule::` computes the parameter passed to that rule:
+
+| Expression | Result for current value `p` |
+| --- | --- |
+| `value` | The decimal or hexadecimal constant `value` |
+| `_` | `p` |
+| `set_bit(k)` | `p` with bit `k` set |
+| `clear_bit(k)` | `p` with bit `k` cleared |
+| `bit_or(value)` | `p \| value` |
+| `bit_and(value)` | `p & value` |
+| `incr([start:end])` | Increment the selected field, saturating when all its bits are set |
+| `decr([start:end])` | Decrement the selected field, saturating when all its bits are clear |
+
+For example, this rule accepts exactly five `item` occurrences:
+
+```text
+start: list::0
+list::_: "item" list::incr([0:3]) %if lt([0:3], 5)
+      | "" %if eq([0:3], 5)
+```
+
+### Conditions
+
+`%if condition` applies to one alternative. A false condition removes that alternative for the
+current rule instance.
+
+| Condition | Meaning |
+| --- | --- |
+| `true` or `true()` | Always true |
+| `bit_clear(k)`, `bit_set(k)` | Bit `k` is clear or set |
+| `is_zeros(slice)`, `is_ones(slice)` | Every bit in the slice is clear or set |
+| `eq(slice, value)`, `ne(slice, value)` | Unsigned equality or inequality |
+| `lt(slice, value)`, `le(slice, value)` | Unsigned less-than or less-than-or-equal |
+| `gt(slice, value)`, `ge(slice, value)` | Unsigned greater-than or greater-than-or-equal |
+| `bit_count_eq(slice, k)`, `bit_count_ne(slice, k)` | Set-bit count equality or inequality |
+| `bit_count_lt(slice, k)`, `bit_count_le(slice, k)` | Set-bit count comparison |
+| `bit_count_gt(slice, k)`, `bit_count_ge(slice, k)` | Set-bit count comparison |
+| `and(left, right)`, `or(left, right)`, `not(condition)` | Boolean composition |
+
+Use `_` wherever a condition expects a slice to select all 64 bits:
+
+```text
+start: pick::0
+pick::_: "" %if bit_count_ge(_, 1)
+      | "a" pick::set_bit(0) %if and(bit_clear(0), bit_count_lt(_, 3))
+      | "b" pick::set_bit(1) %if and(bit_clear(1), bit_count_lt(_, 3))
+      | "c" pick::set_bit(2) %if and(bit_clear(2), bit_count_lt(_, 3))
+```
+
+Parameterized calls are only valid for parametric rules, and a parametric rule must use its current
+parameter. Terminals cannot contain parameterized calls or `%if`. Stop-like behavior,
+`temperature`, and `max_tokens` are not supported on parametric rules.
+
+Compilation is limited to 4096 reachable rule instances per Lark document. Grammars whose state
+transitions exceed that limit are rejected with a located error instead of consuming unbounded
+time or memory. Each nested `%lark` document has its own parameter namespace and instance limit.
+
 ## Directives
 
 ### `%import common`

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -251,7 +251,8 @@ pick::_: "" %if bit_count_ge(_, 1)
 
 Parameterized calls are only valid for parametric rules, and a parametric rule must use its current
 parameter. Terminals cannot contain parameterized calls or `%if`. Stop-like behavior,
-`temperature`, and `max_tokens` are not supported on parametric rules.
+`temperature`, and `max_tokens` are not supported on parametric rules. The `capture` and
+`max_chars` attributes are supported and apply to every invocation of the parametric rule.
 
 Compilation is limited to 4096 reachable rule instances per Lark document. Grammars whose state
 transitions exceed that limit are rejected with a located error instead of consuming unbounded

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -390,6 +390,248 @@ def test_lark_default_disallows_initial_skip_but_allows_trailing_skip() -> None:
     _assert_language(grammar, ["ab", "a b", "ab  "], [" ab", "a\nb"])
 
 
+def test_lark_parametric_permutations() -> None:
+    grammar = """
+        start: perm::0x0
+        perm::_: "" %if is_ones([0:3])
+              | "a" perm::set_bit(0) %if bit_clear(0)
+              | "b" perm::set_bit(1) %if bit_clear(1)
+              | "c" perm::set_bit(2) %if bit_clear(2)
+    """
+    _assert_language(
+        grammar, ["abc", "acb", "bac", "bca", "cab", "cba"], ["", "a", "ab", "aabc", "abcc", "abcd"]
+    )
+
+
+def test_lark_parametric_saturating_counters_and_bit_operations() -> None:
+    grammar = """
+        start: counter::0 "|" bits::0
+        counter::_: "b" counter::incr([0:3]) %if lt([0:3], 5)
+                 | "" %if eq([0:3], 5)
+        bits::_: "x" bits::bit_or(0x3) %if is_zeros([0:2])
+              | "y" bits::clear_bit(0) %if eq([0:2], 3)
+              | "" %if eq(_, 2)
+    """
+    _assert_language(grammar, ["bbbbb|xy"], ["|xy", "bbbb|xy", "bbbbb|x", "bbbbb|xyy"])
+
+
+def test_lark_parametric_conditions_and_round_trips() -> None:
+    grammar = r"""
+        start: state::0
+        state::_: "a" state::set_bit(0) %if and(bit_clear(0), bit_count_lt(_, 2))
+               | "b" state::set_bit(1) %if and(bit_clear(1), bit_count_lt(_, 2))
+               | "!" state::bit_and(0x2) %if and(bit_set(0), or(is_zeros([1:2]), bit_set(1)))
+               | "" %if not(ne(_, 2))
+    """
+    grammar_obj = xgr.Grammar.from_lark(grammar)
+    restored_ebnf = xgr.Grammar.from_ebnf(str(grammar_obj))
+    restored_json = xgr.Grammar.deserialize_json(grammar_obj.serialize_json())
+    accepted = ["b", "ab!", "ba!", "a!b"]
+    rejected = ["", "a", "aa", "bb", "ab", "b!", "ab!!"]
+    for candidate in [grammar_obj, restored_ebnf, restored_json]:
+        _assert_grammar_language(candidate, accepted, rejected)
+
+
+def test_lark_parametric_is_local_to_nested_grammar() -> None:
+    grammar = """
+        start: "A" %lark {
+          start: choose::0
+          choose::_: "x" choose::set_bit(0) %if bit_clear(0)
+                  | "y" %if bit_set(0)
+        } "B"
+    """
+    _assert_language(grammar, ["AxyB"], ["AyB", "AxB", "AxxyB"])
+
+
+def test_lark_parametric_decrement_self_reference_and_high_bit() -> None:
+    grammar = """
+        start: countdown::3 "|" high::0
+        countdown::_: "d" countdown::decr([0:2]) %if gt([0:2], 0)
+                    | bridge::_ %if eq([0:2], 0)
+        bridge::_: "z" %if eq(_, 0)
+        high::_: "h" high::set_bit(63) %if bit_clear(63)
+              | "" %if bit_set(63)
+    """
+    _assert_language(grammar, ["dddz|h"], ["ddz|h", "ddddz|h", "dddz|", "dddz|hh"])
+
+
+def test_lark_parametric_increment_and_decrement_saturate() -> None:
+    grammar = """
+        start: high::3 low::0
+        high::_: "H" high_done::incr([0:2])
+        high_done::_: "+" %if eq(_, 3)
+        low::_: "L" low_done::decr([0:2])
+        low_done::_: "-" %if eq(_, 0)
+    """
+    _assert_language(grammar, ["H+L-"], ["H+L", "HL-", "H+L--"])
+
+
+def test_lark_parametric_false_only_state_is_empty_language() -> None:
+    grammar = """
+        start: dead::0 | "ok"
+        dead::_: "bad" %if bit_set(0)
+    """
+    grammar_obj = xgr.Grammar.from_lark(grammar)
+    candidates = [
+        grammar_obj,
+        xgr.Grammar.from_ebnf(str(grammar_obj)),
+        xgr.Grammar.deserialize_json(grammar_obj.serialize_json()),
+    ]
+    for candidate in candidates:
+        _assert_grammar_language(candidate, ["ok"], ["", "bad", "badok", "😀"])
+
+
+def test_lark_parametric_unsigned_comparisons() -> None:
+    grammar = """
+        start: checks::5
+        checks::_: "eq" %if eq([0:3], 5)
+                | "ne" %if ne([0:3], 4)
+                | "lt" %if lt([0:3], 6)
+                | "le" %if le([0:3], 5)
+                | "gt" %if gt([0:3], 4)
+                | "ge" %if ge([0:3], 5)
+                | "always" %if true()
+                | "bare" %if true
+                | "eq_false" %if eq([0:3], 4)
+                | "ne_false" %if ne([0:3], 5)
+                | "lt_false" %if lt([0:3], 5)
+                | "le_false" %if le([0:3], 4)
+                | "gt_false" %if gt([0:3], 5)
+                | "ge_false" %if ge([0:3], 6)
+    """
+    _assert_language(
+        grammar,
+        ["eq", "ne", "lt", "le", "gt", "ge", "always", "bare"],
+        ["eq_false", "ne_false", "lt_false", "le_false", "gt_false", "ge_false"],
+    )
+
+
+def test_lark_parametric_bit_count_comparisons_and_u64_literal() -> None:
+    grammar = """
+        start: counts::0xb full::0xffffffffffffffff
+        counts::_: "E" %if bit_count_eq([0:4], 3)
+                | "N" %if bit_count_ne([0:4], 2)
+                | "L" %if bit_count_lt([0:4], 4)
+                | "l" %if bit_count_le([0:4], 3)
+                | "G" %if bit_count_gt([0:4], 2)
+                | "g" %if bit_count_ge([0:4], 3)
+                | "x" %if bit_count_eq([0:4], 2)
+                | "y" %if bit_count_ne([0:4], 3)
+        full::_: "F" %if is_ones(_)
+    """
+    _assert_language(grammar, ["EF", "NF", "LF", "lF", "GF", "gF"], ["xF", "yF", "F"])
+
+
+def test_lark_parametric_generated_names_do_not_collide() -> None:
+    grammar = """
+        start: pick::0
+        pick::_: "x" pick::set_bit(0) %if bit_clear(0)
+               | "" %if bit_set(0)
+        pick__param_0000000000000000: "reserved"
+    """
+    _assert_language(grammar, ["x"], ["", "reserved", "xx"])
+
+
+@pytest.mark.parametrize(
+    "grammar, message",
+    [
+        pytest.param(
+            'start: foo::0\nfoo: "a"',
+            "rule 'foo' is not parametric",
+            id="argument-to-ordinary-rule",
+        ),
+        pytest.param(
+            'start: foo\nfoo::_: "a" %if true',
+            "does not depend on its parameter",
+            id="unused-parameter",
+        ),
+        pytest.param(
+            'start: foo\nfoo: bar\nbar::_: "a" %if bit_set(0)',
+            "requires a parameter",
+            id="missing-argument",
+        ),
+        pytest.param(
+            "start: foo\nfoo: bar::_\nbar::_: bar::_",
+            "requires a caller parameter",
+            id="caller-has-no-parameter",
+        ),
+        pytest.param(
+            'BAR: "b" %if true\nstart: BAR',
+            "%if cannot be used in terminals",
+            id="condition-in-terminal",
+        ),
+        pytest.param(
+            'BAR: foo::0\nstart: BAR\nfoo::_: "x" %if eq(_, 0)',
+            "parameterized rule references cannot be used in terminals",
+            id="argument-in-terminal",
+        ),
+        pytest.param(
+            'start: foo::0\nfoo::_: "a" %if eq([3:3], 0)',
+            "must be > start bit index",
+            id="empty-bit-range",
+        ),
+        pytest.param(
+            'start: foo::0\nfoo::_: "a" %if eq([64:64], 0)',
+            "must be <= 63",
+            id="bit-range-start-too-large",
+        ),
+        pytest.param(
+            'start: foo::0\nfoo::_: "a" %if eq([0:65], 0)',
+            "must be <= 64",
+            id="bit-range-end-too-large",
+        ),
+        pytest.param(
+            'start: foo::0\nfoo::_: "a" %if eq(0, 0)',
+            "expected '_' or '[start_bit:stop_bit]'",
+            id="bit-range-brackets-required",
+        ),
+        pytest.param(
+            'start: foo::0\nfoo::_: "a" %if unknown(_, 0)',
+            "unknown condition 'unknown'",
+            id="unknown-condition",
+        ),
+        pytest.param(
+            "start: foo::unknown(0)\nfoo::_: foo::_",
+            "unknown parameter expression 'unknown'",
+            id="unknown-expression",
+        ),
+        pytest.param(
+            "start: foo::set_bit(64)\nfoo::_: foo::_", "must be <= 63", id="bit-index-too-large"
+        ),
+        pytest.param(
+            "start: foo::18446744073709551616\nfoo::_: foo::_",
+            "invalid 64-bit parameter value",
+            id="parameter-overflow",
+        ),
+        pytest.param(
+            "start::_: start::_", "start rule cannot be parametric", id="parametric-start"
+        ),
+        pytest.param(
+            'start: foo::0\nfoo::_[stop="x"]: foo::_',
+            "stop-like behavior is not supported",
+            id="parametric-stop",
+        ),
+        pytest.param(
+            "start: foo::0\nfoo::_[temperature=1]: foo::_",
+            "temperature is not supported",
+            id="parametric-temperature",
+        ),
+        pytest.param(
+            "start: foo::0\nfoo::_[max_tokens=1]: foo::_",
+            "max_tokens is not supported",
+            id="parametric-max-tokens",
+        ),
+        pytest.param(
+            'start: counter::0\ncounter::_: "x" counter::incr(_)',
+            "exceeds the limit of 4096 reachable rule instances",
+            id="reachable-instance-limit",
+        ),
+    ],
+)
+def test_lark_parametric_validation_errors(grammar: str, message: str) -> None:
+    _assert_lark_error(grammar, message)
+
+
 @pytest.mark.parametrize(
     "schema, accepted, rejected",
     [
@@ -923,17 +1165,9 @@ def test_lark_large_choice_grammar() -> None:
         pytest.param(
             'start: foo{x}\nfoo: "a"', "Lark templates are not supported", id="template-reference"
         ),
-        pytest.param(
-            'start::0: "a"', "parametric grammar is not supported", id="parametric-definition"
-        ),
-        pytest.param(
-            "start: foo::0", "parametric grammar is not supported", id="parametric-reference"
-        ),
-        pytest.param(
-            'start: "a" %if enabled',
-            "parametric %if conditions are not supported",
-            id="parametric-if",
-        ),
+        pytest.param('start::0: "a"', "expected '_' after '::'", id="parametric-definition"),
+        pytest.param("start: foo::0", "unknown name 'foo'", id="parametric-reference"),
+        pytest.param('start: "a" %if enabled', "unknown condition 'enabled'", id="parametric-if"),
         pytest.param(
             'start: A & B\nA: "a"\nB: "b"', "intersection '&' is not supported", id="intersection"
         ),

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -466,6 +466,91 @@ def test_lark_parametric_increment_and_decrement_saturate() -> None:
     _assert_language(grammar, ["H+L-"], ["H+L", "HL-", "H+L--"])
 
 
+def test_lark_parametric_nested_empty_rule_chain() -> None:
+    grammar = """
+        start: perm::0 "X"
+        perm::_: empty_a::_ empty_b::_ %if is_zeros([10:12])
+              | "a" perm::set_bit(0) %if bit_clear(0)
+              | "b" perm::set_bit(1) %if bit_clear(1)
+              | "c" perm::set_bit(2) %if bit_clear(2)
+        empty_a::_: "" %if is_ones([0:1])
+        empty_b::_: empty_c::_ %if is_ones([1:2])
+        empty_c::_: "" %if is_ones([2:3])
+    """
+    _assert_language(
+        grammar, ["abcX", "acbX", "bacX", "bcaX", "cabX", "cbaX"], ["X", "abX", "abc", "aabcX"]
+    )
+
+
+def test_lark_parametric_unconditional_recursion() -> None:
+    grammar = """
+        start: seen::0
+        seen::_: "" %if is_ones([0:3])
+              | "a" seen::set_bit(0)
+              | "b" seen::set_bit(1)
+              | "c" seen::set_bit(2)
+    """
+    _assert_language(grammar, ["abc", "caba", "aaabbbc"], ["", "a", "ab", "aaaa", "abcaax"])
+
+
+def test_lark_parametric_independent_bit_slice_counters() -> None:
+    grammar = """
+        start: counts::0
+        counts::_: "a" counts::incr([0:2]) %if lt([0:2], 2)
+                | "b" counts::incr([2:4]) %if lt([2:4], 2)
+                | "c" counts::incr([4:7]) %if lt([4:7], 3)
+                | "" %if and(eq([0:2], 2), and(eq([2:4], 2), eq([4:7], 3)))
+    """
+    _assert_language(
+        grammar, ["aabbccc", "cabcbac", "ccbabac"], ["", "aabbcc", "aaabbbccc", "aabbcccc"]
+    )
+
+
+def test_lark_parametric_long_counter() -> None:
+    count = 900
+    grammar = f"""
+        start: count_up::0 "X"
+        count_up::_: "a" count_up::incr([0:10]) %if lt([0:10], {count})
+                  | count_down::_ %if eq([0:10], {count})
+        count_down::_: "b" count_down::decr([0:10]) %if gt([0:10], 0)
+                    | "" %if eq([0:10], 0)
+    """
+    accepted = "a" * count + "b" * count + "X"
+    _assert_language(
+        grammar,
+        [accepted],
+        ["a" * (count - 1) + "b" * count + "X", "a" * count + "b" * (count - 1) + "X"],
+    )
+
+
+def test_lark_parametric_conditions_inside_groups_and_repetitions() -> None:
+    grammar = """
+        start: choice::0 "|" choice::1
+        choice::_: ("a" %if bit_clear(0) | "b" %if bit_set(0)) ("x" %if bit_set(0))?
+    """
+    _assert_language(grammar, ["a|b", "a|bx"], ["b|b", "ax|b", "a|a", "a|bxx"])
+
+
+def test_lark_parametric_capture_and_max_chars_attributes() -> None:
+    capture_grammar = """
+        start: item::0
+        item::_[capture="item"]: "a" item::set_bit(0) %if bit_clear(0)
+                                | "b" %if bit_set(0)
+    """
+    compiled = _compile_lark(capture_grammar)
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_string("ab")
+    assert matcher.is_terminated()
+    assert matcher.get_captures() == [("item", b"b"), ("item", b"ab")]
+
+    budget_grammar = """
+        start: item::0
+        item::_[max_chars=2]: "a" item::incr(_) %if lt(_, 3)
+                            | ""
+    """
+    _assert_language(budget_grammar, ["", "a", "aa"], ["aaa", "aaaa"])
+
+
 def test_lark_parametric_false_only_state_is_empty_language() -> None:
     grammar = """
         start: dead::0 | "ok"
@@ -602,6 +687,28 @@ def test_lark_parametric_generated_names_do_not_collide() -> None:
             "start: foo::18446744073709551616\nfoo::_: foo::_",
             "invalid 64-bit parameter value",
             id="parameter-overflow",
+        ),
+        pytest.param(
+            'start: state::0\nstate::_: "ok" %if bit_clear(0) | missing %if bit_set(0)',
+            "unknown name 'missing'",
+            id="unknown-name-in-false-branch",
+        ),
+        pytest.param(
+            'start: state::0\nstate::_: "ok" %if bit_clear(0) | plain::_ %if bit_set(0)\nplain: "x"',
+            "rule 'plain' is not parametric",
+            id="argument-to-ordinary-rule-in-false-branch",
+        ),
+        pytest.param(
+            'start: state::0\nstate::_: "ok" %if bit_clear(0) | other %if bit_set(0)\n'
+            'other::_: "x" %if bit_set(0)',
+            "parametric rule 'other' requires a parameter",
+            id="missing-argument-in-false-branch",
+        ),
+        pytest.param(
+            'start: state::0\nstate::_: "ok" %if bit_clear(0) | other::_ %if bit_set(0)\n'
+            "other::_: missing %if bit_set(0)",
+            "unknown name 'missing'",
+            id="invalid-rule-reachable-only-through-false-branch",
         ),
         pytest.param(
             "start::_: start::_", "start rule cannot be parametric", id="parametric-start"

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 
 import pytest


### PR DESCRIPTION
## Summary

- add unsigned 64-bit parameters to Lark rules with reachable compile-time state expansion
- support bit updates, saturating counters, comparisons, bit-count predicates, and boolean conditions
- validate every statically reachable parametric definition, including references hidden behind false conditions
- document supported rule attributes, reject invalid contexts with located errors, and cap expansion at 4096 reachable instances

## Testing

- full Lark suite: 377 passed
- full Python suite without external-token cases: 3098 passed, 1 skipped, 622 deselected
- C++ suite: 61 passed
- parametric rule suite: 42 passed
- pre-commit run on all files
- Sphinx documentation build
- differential acceptance corpus: 5 grammars, 9064 candidates
