### PR TITLE
Fix Python 3.8 test annotation compatibility

### DIFF
--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 
 import pytest


### PR DESCRIPTION
## Summary

- defer annotation evaluation in the character-budget tests
- keep the existing modern type annotation compatible with Python 3.8

## Root cause

The test suite is collected on Python 3.8, where `list[int]` is evaluated at function definition time and raises `TypeError`. Deferring annotations preserves the existing type information while allowing test collection on every supported Python version.

## Validation

- reproduced the Python 3.8 import failure before the change
- executed the same test module successfully with Python 3.8 after the change
- ran pre-commit checks for the modified file
- ran `git diff --check`
