### PR TITLE
Reject unresolved JSON Schema references

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1439,6 +1439,9 @@ Result<RefSpec, SchemaError> SchemaParser::ParseRef(const picojson::object& sche
   }
   RefSpec spec;
   spec.uri = schema.at("$ref").get<std::string>();
+  if (spec.uri.empty()) {
+    spec.uri = "#";
+  }
   return ResultOk(std::move(spec));
 }
 
@@ -1458,8 +1461,10 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::ResolveRef(
   }
 
   if (uri.size() < 2 || uri[0] != '#' || uri[1] != '/') {
-    XGRAMMAR_LOG(WARNING) << "URI should either be '#' or start with '#/' but got " << uri;
-    return ResultOk(SchemaSpec::Make(AnySpec{}, "", "any"));
+    return ResultErr<SchemaError>(
+        SchemaErrorType::kInvalidSchema,
+        "Unsupported $ref '" + uri + "': only local references '#' and '#/...' are supported"
+    );
   }
 
   std::vector<std::string> parts;

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -734,6 +734,37 @@ def test_reference_schema():
     )
 
 
+@pytest.mark.parametrize(
+    "uri",
+    ["https://example.com/schema.json", "other.json", "other.json#/$defs/value", "#named-anchor"],
+)
+def test_external_reference_is_rejected(uri):
+    with pytest.raises(RuntimeError) as error:
+        xgr.Grammar.from_json_schema(json.dumps({"$ref": uri}), any_whitespace=False)
+
+    message = str(error.value)
+    assert "only local references '#' and '#/...' are supported" in message
+    assert f"Unsupported $ref '{uri}'" in message
+
+
+def test_empty_reference_resolves_to_root():
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "child": {"$ref": ""}},
+        "required": ["name"],
+    }
+
+    check_schema_with_instance(
+        schema, {"name": "root", "child": {"name": "leaf"}}, any_whitespace=False
+    )
+    check_schema_with_instance(
+        schema,
+        {"name": "root", "child": {"child": {"name": "leaf"}}},
+        is_accepted=False,
+        any_whitespace=False,
+    )
+
+
 def test_union():
     class Cat(BaseModel):
         name: str

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 
 import pytest


### PR DESCRIPTION
## Summary

- reject external document references and unresolved named anchors instead of emitting unconstrained grammars
- treat an empty reference URI as a root self-reference
- preserve existing local JSON Pointer and recursive-reference support

## Root cause

Non-local reference URIs fell back to an unconstrained schema after logging a warning. Invalid input could therefore silently widen accepted output.

## Validation

- reference parity: four unsupported URI forms rejected; empty URI resolves to root
- Python core suite: 3064 passed, 1 skipped, 622 deselected
- JSON Schema converter suite: 523 passed
- serialization suite: 13 passed, 1 deselected
- C++ Debug/InternalCheck: 61 passed
- pre-commit: passed

Depends on #773 for the shared Python 3.8 test compatibility commit; that commit will leave this diff when #773 lands.