### PR TITLE
Reject unsupported JSON Schema formats

### DIFF
--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -51,10 +51,19 @@ Grammar Grammar::FromJSONSchema(
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
     bool print_converted_ebnf,
-    bool any_order
+    bool any_order,
+    bool allow_unsupported_formats
 ) {
   auto grammar = GrammarNormalizer::Apply(JSONSchemaToGrammar(
-      schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+      schema,
+      any_whitespace,
+      indent,
+      separators,
+      strict_mode,
+      max_whitespace_cnt,
+      any_order,
+      JSONFormat::kJSON,
+      allow_unsupported_formats
   ));
   if (print_converted_ebnf) {
     XGRAMMAR_LOG(INFO) << "Converted EBNF: " << grammar.ToString() << std::endl;

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1028,7 +1028,8 @@ class GrammarCompilerSub {
       std::optional<std::pair<std::string, std::string>> separators,
       bool strict_mode,
       std::optional<int> max_whitespace_cnt,
-      bool any_order
+      bool any_order,
+      bool allow_unsupported_formats
   );
 
   CompiledGrammar CompileRegex(const std::string& regex);
@@ -1157,7 +1158,8 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
     std::optional<std::pair<std::string, std::string>> separators,
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
-    bool any_order
+    bool any_order,
+    bool allow_unsupported_formats
 ) {
   return MultiThreadCompileGrammar(Grammar::FromJSONSchema(
       schema,
@@ -1167,7 +1169,8 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
       strict_mode,
       max_whitespace_cnt,
       /*print_converted_ebnf=*/false,
-      any_order
+      any_order,
+      allow_unsupported_formats
   ));
 }
 
@@ -1260,6 +1263,7 @@ class GrammarCompilerCacheKeys {
     bool strict_mode;
     std::optional<int> max_whitespace_cnt;
     bool any_order;
+    bool allow_unsupported_formats;
 
     XGRAMMAR_EQUAL_BY_MEMBERS(
         SchemaKey,
@@ -1269,7 +1273,8 @@ class GrammarCompilerCacheKeys {
         &SchemaKey::separators,
         &SchemaKey::strict_mode,
         &SchemaKey::max_whitespace_cnt,
-        &SchemaKey::any_order
+        &SchemaKey::any_order,
+        &SchemaKey::allow_unsupported_formats
     );
   };
 
@@ -1310,7 +1315,8 @@ XGRAMMAR_HASH_BY_MEMBERS(
     &xgrammar::GrammarCompilerCacheKeys::SchemaKey::separators,
     &xgrammar::GrammarCompilerCacheKeys::SchemaKey::strict_mode,
     &xgrammar::GrammarCompilerCacheKeys::SchemaKey::max_whitespace_cnt,
-    &xgrammar::GrammarCompilerCacheKeys::SchemaKey::any_order
+    &xgrammar::GrammarCompilerCacheKeys::SchemaKey::any_order,
+    &xgrammar::GrammarCompilerCacheKeys::SchemaKey::allow_unsupported_formats
 );
 
 XGRAMMAR_HASH_BY_MEMBERS(
@@ -1376,7 +1382,8 @@ class GrammarCompiler::Impl {
       std::optional<std::pair<std::string, std::string>> separators,
       bool strict_mode,
       std::optional<int> max_whitespace_cnt,
-      bool any_order
+      bool any_order,
+      bool allow_unsupported_formats
   );
 
   CompiledGrammar CompileStructuralTag(const std::string& structural_tag_json);
@@ -1435,10 +1442,17 @@ CompiledGrammar GrammarCompiler::Impl::Compute(const UnionKey& key) {
           const auto& [ebnf_str, root_rule_name] = key;
           return this->no_cache_compiler_.CompileGrammar(ebnf_str, root_rule_name);
         } else if constexpr (std::is_same_v<KeyType, SchemaKey>) {
-          const auto& [schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order] =
+          const auto& [schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order, allow_unsupported_formats] =
               key;
           return this->no_cache_compiler_.CompileJSONSchema(
-              schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+              schema,
+              any_whitespace,
+              indent,
+              separators,
+              strict_mode,
+              max_whitespace_cnt,
+              any_order,
+              allow_unsupported_formats
           );
         } else if constexpr (std::is_same_v<KeyType, StructuralTagKey>) {
           const auto& [structural_tag_json] = key;
@@ -1470,15 +1484,30 @@ CompiledGrammar GrammarCompiler::Impl::CompileJSONSchema(
     std::optional<std::pair<std::string, std::string>> separators,
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
-    bool any_order
+    bool any_order,
+    bool allow_unsupported_formats
 ) {
   if (!cache_enabled_) {
     return no_cache_compiler_.CompileJSONSchema(
-        schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+        schema,
+        any_whitespace,
+        indent,
+        separators,
+        strict_mode,
+        max_whitespace_cnt,
+        any_order,
+        allow_unsupported_formats
     );
   }
   return grammar_level_cache_.Get(SchemaKey{
-      schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+      schema,
+      any_whitespace,
+      indent,
+      separators,
+      strict_mode,
+      max_whitespace_cnt,
+      any_order,
+      allow_unsupported_formats
   });
 }
 
@@ -1551,10 +1580,18 @@ CompiledGrammar GrammarCompiler::CompileJSONSchema(
     std::optional<std::pair<std::string, std::string>> separators,
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
-    bool any_order
+    bool any_order,
+    bool allow_unsupported_formats
 ) {
   return pimpl_->CompileJSONSchema(
-      schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+      schema,
+      any_whitespace,
+      indent,
+      separators,
+      strict_mode,
+      max_whitespace_cnt,
+      any_order,
+      allow_unsupported_formats
   );
 }
 

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -656,6 +656,7 @@ class SchemaParser {
   struct Config {
     bool strict_mode = false;
     JSONFormat json_format;
+    bool allow_unsupported_formats = false;
   };
 
   explicit SchemaParser(const picojson::value& root_schema, const Config& config)
@@ -799,6 +800,37 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
   WarnUnsupportedKeywords(
       schema_obj, {"not", "if", "then", "else", "dependentRequired", "dependentSchemas"}
   );
+
+  if (schema_obj.count("format")) {
+    bool can_match_string = true;
+    auto type_it = schema_obj.find("type");
+    if (type_it != schema_obj.end()) {
+      can_match_string = false;
+      if (type_it->second.is<std::string>()) {
+        can_match_string = type_it->second.get<std::string>() == "string";
+      } else if (type_it->second.is<picojson::array>()) {
+        for (const auto& type : type_it->second.get<picojson::array>()) {
+          if (type.is<std::string>() && type.get<std::string>() == "string") {
+            can_match_string = true;
+            break;
+          }
+        }
+      }
+    }
+    if (can_match_string) {
+      const auto& format = schema_obj.at("format");
+      if (!format.is<std::string>()) {
+        return ResultErr<SchemaError>(SchemaErrorType::kInvalidSchema, "format must be a string");
+      }
+      const auto& format_name = format.get<std::string>();
+      if (!config_.allow_unsupported_formats &&
+          !JSONSchemaConverter::IsSupportedStringFormat(format_name)) {
+        return ResultErr<SchemaError>(
+            SchemaErrorType::kUnsupportedSchema, "Unsupported string format \"" + format_name + "\""
+        );
+      }
+    }
+  }
 
   SchemaSpecPtr result;
 
@@ -3222,6 +3254,10 @@ std::optional<std::string> JSONSchemaConverter::JSONFormatToRegexPattern(const s
   return it->second;
 }
 
+bool JSONSchemaConverter::IsSupportedStringFormat(const std::string& format) {
+  return JSONFormatToRegexPattern(format).has_value();
+}
+
 // ==================== Range Regex Generation ====================
 
 // Stateless utility that turns a numeric range into an anchored regex matching
@@ -4054,13 +4090,14 @@ Grammar JSONSchemaToGrammar(
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
     bool any_order,
-    JSONFormat json_format
+    JSONFormat json_format,
+    bool allow_unsupported_formats
 ) {
   picojson::value schema_value;
   std::string error = picojson::parse(schema_value, schema);
   XGRAMMAR_CHECK(error.empty()) << "Failed to parse JSON: " << error
                                 << ". The JSON string is:" << schema;
-  SchemaParser parser(schema_value, {strict_mode, json_format});
+  SchemaParser parser(schema_value, {strict_mode, json_format, allow_unsupported_formats});
   auto spec_result = parser.Parse(schema_value, "root");
   if (spec_result.IsErr()) {
     XGRAMMAR_LOG(FATAL) << std::move(spec_result).UnwrapErr().what();
@@ -4115,7 +4152,8 @@ std::string JSONSchemaToEBNF(
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
     JSONFormat json_format,
-    bool any_order
+    bool any_order,
+    bool allow_unsupported_formats
 ) {
   picojson::value schema_value;
   std::string err = picojson::parse(schema_value, schema);
@@ -4129,7 +4167,8 @@ std::string JSONSchemaToEBNF(
       strict_mode,
       max_whitespace_cnt,
       json_format,
-      any_order
+      any_order,
+      allow_unsupported_formats
   );
 }
 
@@ -4141,10 +4180,11 @@ std::string JSONSchemaToEBNF(
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
     JSONFormat json_format,
-    bool any_order
+    bool any_order,
+    bool allow_unsupported_formats
 ) {
   // Parse JSON Schema to SchemaSpec
-  SchemaParser parser(schema, {strict_mode, json_format});
+  SchemaParser parser(schema, {strict_mode, json_format, allow_unsupported_formats});
   auto spec_result = parser.Parse(schema, "root");
   if (spec_result.IsErr()) {
     XGRAMMAR_LOG(FATAL) << std::move(spec_result).UnwrapErr().what();

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -455,6 +455,7 @@ class JSONSchemaConverter {
   static const std::string kBasicObject;
   static const std::string kBasicEscape;
   static const std::string kBasicStringSub;
+  static bool IsSupportedStringFormat(const std::string& format);
 
  protected:
   GenerateCacheManager rule_cache_manager_;
@@ -516,7 +517,8 @@ Grammar JSONSchemaToGrammar(
     bool strict_mode = true,
     std::optional<int> max_whitespace_cnt = std::nullopt,
     bool any_order = false,
-    JSONFormat json_format = JSONFormat::kJSON
+    JSONFormat json_format = JSONFormat::kJSON,
+    bool allow_unsupported_formats = false
 );
 
 // ==================== Public API functions (backward compatible) ====================
@@ -544,6 +546,8 @@ Grammar JSONSchemaToGrammar(
  * format of the object. If it's JSONFormat::kJSON, then it will generate a fully JSON-style
  * grammar. If it's JSONFormat::kXML, then it will generate a grammar with the root format is
  * XML-style, while the inner format is JSON-style. Default: JSONFormat::kJSON.
+ * \param allow_unsupported_formats Whether unsupported string formats should be ignored instead
+ * of rejected. Default: false.
  * \returns The EBNF grammar string.
  */
 
@@ -555,7 +559,8 @@ std::string JSONSchemaToEBNF(
     bool strict_mode = true,
     std::optional<int> max_whitespace_cnt = std::nullopt,
     JSONFormat json_format = JSONFormat::kJSON,
-    bool any_order = false
+    bool any_order = false,
+    bool allow_unsupported_formats = false
 );
 
 /*!
@@ -581,6 +586,8 @@ std::string JSONSchemaToEBNF(
  * then it will generate a fully JSON-style grammar. If it's JSONFormat::kXML, then it will
  * generate a grammar with the root format is XML-style, while the inner format is JSON-style.
  * Default: JSONFormat::kJSON.
+ * \param allow_unsupported_formats Whether unsupported string formats should be ignored instead
+ * of rejected. Default: false.
  * \returns The EBNF grammar string.
  */
 std::string JSONSchemaToEBNF(
@@ -591,7 +598,8 @@ std::string JSONSchemaToEBNF(
     bool strict_mode = true,
     std::optional<int> max_whitespace_cnt = std::nullopt,
     JSONFormat json_format = JSONFormat::kJSON,
-    bool any_order = false
+    bool any_order = false,
+    bool allow_unsupported_formats = false
 );
 
 /*!

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -361,7 +361,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              bool strict_mode,
              ffi::AnyView max_whitespace_cnt,
              bool print_converted_ebnf,
-             bool any_order) {
+             bool any_order,
+             bool allow_unsupported_formats) {
             XGRAMMAR_FFI_TRY_BEGIN();
             auto g = Grammar::FromJSONSchema(
                 schema,
@@ -371,7 +372,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                 strict_mode,
                 OptionalIntFromView(max_whitespace_cnt),
                 print_converted_ebnf,
-                any_order
+                any_order,
+                allow_unsupported_formats
             );
             return ffi::ObjectRef(ffi::make_object<GrammarObj>(std::move(g)));
             XGRAMMAR_FFI_TRY_END();
@@ -514,7 +516,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              ffi::AnyView separators,
              bool strict_mode,
              ffi::AnyView max_whitespace_cnt,
-             bool any_order) {
+             bool any_order,
+             bool allow_unsupported_formats) {
             XGRAMMAR_FFI_TRY_BEGIN();
             CompiledGrammar cg = o->value.CompileJSONSchema(
                 schema,
@@ -523,7 +526,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                 OptionalSeparatorsFromView(separators),
                 strict_mode,
                 OptionalIntFromView(max_whitespace_cnt),
-                any_order
+                any_order,
+                allow_unsupported_formats
             );
             return ffi::ObjectRef(ffi::make_object<CompiledGrammarObj>(std::move(cg)));
             XGRAMMAR_FFI_TRY_END();
@@ -786,7 +790,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              bool strict_mode,
              ffi::AnyView max_whitespace_cnt,
              ffi::String json_format,
-             bool any_order) {
+             bool any_order,
+             bool allow_unsupported_formats) {
             auto format = JSONFormatFromString(json_format);
             if (!format.has_value()) {
               TVM_FFI_THROW(RuntimeError) << "Invalid json_format: " << std::string(json_format);
@@ -799,7 +804,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                 strict_mode,
                 OptionalIntFromView(max_whitespace_cnt),
                 *format,
-                any_order
+                any_order,
+                allow_unsupported_formats
             ));
           }
       )

--- a/docs/defining_structures/json_generation.md
+++ b/docs/defining_structures/json_generation.md
@@ -62,6 +62,26 @@ person_schema = {
 compiled_grammar = compiler.compile_json_schema(json.dumps(person_schema))
 ```
 
+## String Formats
+
+The JSON Schema converter enforces these built-in string formats:
+`email`, `date`, `time`, `date-time`, `duration`, `ipv4`, `ipv6`, `hostname`, `uuid`, `uri`,
+`uri-reference`, `uri-template`, `json-pointer`, and `relative-json-pointer`.
+
+An unsupported format is rejected by default because silently ignoring it would make the generated
+grammar less restrictive than the schema. To preserve an unsupported format as an annotation
+without enforcing it, opt in explicitly:
+
+```python
+compiled_grammar = compiler.compile_json_schema(
+    schema,
+    allow_unsupported_formats=True,
+)
+```
+
+This option only ignores unsupported format names. A `format` value must still be a string whenever
+the schema can match string values.
+
 With the compiled grammar, we can instantiate a [`xgr.GrammarMatcher`](xgrammar.GrammarMatcher)
 and generate the token masks in the generation loop.
 

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -79,7 +79,8 @@ class GrammarCompiler {
       std::optional<std::pair<std::string, std::string>> separators = std::nullopt,
       bool strict_mode = true,
       std::optional<int> max_whitespace_cnt = std::nullopt,
-      bool any_order = false
+      bool any_order = false,
+      bool allow_unsupported_formats = false
   );
 
   /*! \brief Get the compiled grammar for pure JSON. */

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -113,6 +113,8 @@ class Grammar {
    *
    * This helps LLM to generate accurate output in the grammar-guided generation with JSON
    * schema. Default: true.
+   * \param allow_unsupported_formats Whether unsupported string formats should be ignored instead
+   * of rejected. Default: false.
    */
   static Grammar FromJSONSchema(
       const std::string& schema,
@@ -122,7 +124,8 @@ class Grammar {
       bool strict_mode = true,
       std::optional<int> max_whitespace_cnt = std::nullopt,
       bool print_converted_ebnf = false,
-      bool any_order = false
+      bool any_order = false,
+      bool allow_unsupported_formats = false
   );
 
   /*!

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -150,6 +150,7 @@ class GrammarCompiler(XGRObject):
         strict_mode: bool = True,
         max_whitespace_cnt: Optional[int] = None,
         any_order: bool = False,
+        allow_unsupported_formats: bool = False,
     ) -> CompiledGrammar:
         """Get CompiledGrammar from the specified JSON schema and format. The indent
         and separators parameters follow the same convention as in json.dumps().
@@ -194,6 +195,10 @@ class GrammarCompiler(XGRObject):
 
             Applies to every object, nested included.
 
+        allow_unsupported_formats : bool, default: False
+            Whether unsupported string formats should be ignored instead of rejected. Invalid
+            non-string format values are always rejected when the schema can match strings.
+
         Returns
         -------
         compiled_grammar : CompiledGrammar
@@ -209,6 +214,7 @@ class GrammarCompiler(XGRObject):
                 strict_mode,
                 max_whitespace_cnt,
                 any_order,
+                allow_unsupported_formats,
             )
         )
 

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -185,6 +185,7 @@ class Grammar(XGRObject):
         max_whitespace_cnt: Optional[int] = None,
         print_converted_ebnf: bool = False,
         any_order: bool = False,
+        allow_unsupported_formats: bool = False,
     ) -> "Grammar":
         """Construct a grammar from JSON schema. Pydantic model or JSON schema string can be
         used to specify the schema.
@@ -249,6 +250,10 @@ class Grammar(XGRObject):
 
             Applies to every object, nested included.
 
+        allow_unsupported_formats : bool, default: False
+            Whether unsupported string formats should be ignored instead of rejected. Invalid
+            non-string format values are always rejected when the schema can match strings.
+
         Returns
         -------
         grammar : Grammar
@@ -270,6 +275,7 @@ class Grammar(XGRObject):
                 max_whitespace_cnt,
                 print_converted_ebnf,
                 any_order,
+                allow_unsupported_formats,
             )
         )
 

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -26,6 +26,7 @@ def _json_schema_to_ebnf(
     strict_mode: bool = True,
     json_format: Literal["json", "qwen_xml", "minimax_xml", "deepseek_xml", "glm_xml"] = "json",
     any_order: bool = False,
+    allow_unsupported_formats: bool = False,
 ) -> str:
     """Convert JSON schema string to BNF grammar string. For test purposes.
 
@@ -61,6 +62,9 @@ def _json_schema_to_ebnf(
         "deepseek_xml", "glm_xml". Formats other than "json" generate an XML-style root object
         for tool calling, while the inner values remain JSON-style.
 
+    allow_unsupported_formats : bool, default: False
+        Whether unsupported string formats should be ignored instead of rejected.
+
     Returns
     -------
     bnf_string : str
@@ -76,6 +80,7 @@ def _json_schema_to_ebnf(
         max_whitespace_cnt,
         json_format,
         any_order,
+        allow_unsupported_formats,
     )
 
 

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -1899,6 +1899,65 @@ def test_generate_range_regex():
     assert _generate_range_regex(10000000000, 10000000002) == r"^((1000000000[0-2]))$"
 
 
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"type": "string", "format": "my_custom_format"},
+        {"format": "my_custom_format"},
+        {"type": ["integer", "string"], "format": "my_custom_format"},
+        {
+            "type": "object",
+            "properties": {"value": {"type": "string", "format": "my_custom_format"}},
+        },
+    ],
+    ids=["string", "implicit-type", "type-array", "nested"],
+)
+def test_unsupported_string_format_is_rejected(schema):
+    with pytest.raises(RuntimeError, match="Unsupported string format.*my_custom_format"):
+        xgr.Grammar.from_json_schema(json.dumps(schema))
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"type": "integer", "format": "my_custom_format"},
+        {"type": ["integer", "null"], "format": "my_custom_format"},
+        {"type": "integer", "format": 1},
+    ],
+)
+def test_format_is_ignored_when_string_values_are_excluded(schema):
+    xgr.Grammar.from_json_schema(json.dumps(schema))
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [{"type": "string", "format": 1}, {"format": 1}, {"type": ["string", "null"], "format": 1}],
+)
+def test_string_format_must_be_a_string(schema):
+    with pytest.raises(RuntimeError, match="format must be a string"):
+        xgr.Grammar.from_json_schema(json.dumps(schema))
+
+
+def test_allow_unsupported_string_formats():
+    schema = {"type": "string", "format": "my_custom_format"}
+    schema_json = json.dumps(schema)
+
+    grammar = xgr.Grammar.from_json_schema(schema_json, allow_unsupported_formats=True)
+    assert _is_grammar_accept_string(grammar, '"anything"')
+
+    ebnf = _json_schema_to_ebnf(schema, allow_unsupported_formats=True)
+    assert "root ::=" in ebnf
+
+
+def test_allow_unsupported_formats_is_part_of_compiler_cache_key():
+    schema = json.dumps({"type": "string", "format": "my_custom_format"})
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]), cache_enabled=True)
+
+    compiler.compile_json_schema(schema, allow_unsupported_formats=True)
+    with pytest.raises(RuntimeError, match="Unsupported string format.*my_custom_format"):
+        compiler.compile_json_schema(schema)
+
+
 instance__accepted__test_email_format = [
     (r"simple@example.com", True),
     (r"very.common@example.com", True),

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 
 import pytest

--- a/web/src/xgrammar.ts
+++ b/web/src/xgrammar.ts
@@ -70,6 +70,8 @@ export class Testings {
    * JSON elements when anyWhitespace is true. Undefined means unlimited.
    * @param {"json" | "xml"} [jsonFormat="json"] The JSON schema output format.
    * @param {boolean} [anyOrder=false] Whether to allow object properties to appear in any order.
+   * @param {boolean} [allowUnsupportedFormats=false] Whether unsupported string formats should be
+   * ignored instead of rejected.
    * @returns {string} The EBNF grammar string.
    */
   static async _jsonSchemaToEBNF(
@@ -80,7 +82,8 @@ export class Testings {
     strictMode = true,
     maxWhitespaceCnt?: number,
     jsonFormat: "json" | "xml" = "json",
-    anyOrder: boolean = false
+    anyOrder: boolean = false,
+    allowUnsupportedFormats: boolean = false
   ): Promise<string> {
     const separatorsPair = toSeparatorPair(separators);
     await asyncInitBinding();
@@ -99,7 +102,8 @@ export class Testings {
       strictMode,
       maxWhitespaceCnt,
       formatEnum,
-      anyOrder
+      anyOrder,
+      allowUnsupportedFormats
     );
   }
 
@@ -247,6 +251,8 @@ export class Grammar {
    * @param {number} [maxWhitespaceCnt] Maximum number of whitespace characters allowed between
    * JSON elements when anyWhitespace is true. Undefined means unlimited.
    * @param {boolean} [anyOrder=false] Whether to allow object properties to appear in any order.
+   * @param {boolean} [allowUnsupportedFormats=false] Whether unsupported string formats should be
+   * ignored instead of rejected.
    * @returns {Grammar} The generated BNF grammar.
    */
   static async fromJSONSchema(
@@ -256,7 +262,8 @@ export class Grammar {
     separators?: [string, string],
     strictMode = true,
     maxWhitespaceCnt?: number,
-    anyOrder: boolean = false
+    anyOrder: boolean = false,
+    allowUnsupportedFormats: boolean = false
   ): Promise<Grammar> {
     const separatorsPair = toSeparatorPair(separators);
     await asyncInitBinding();
@@ -275,7 +282,8 @@ export class Grammar {
         strictMode,
         maxWhitespaceCnt,
         printConvertedEBNF,
-        anyOrder
+        anyOrder,
+        allowUnsupportedFormats
       ));
   }
 

--- a/web/src/xgrammar_binding.cc
+++ b/web/src/xgrammar_binding.cc
@@ -194,6 +194,7 @@ EMSCRIPTEN_BINDINGS(xgrammar) {
           bool,
           std::optional<int>,
           JSONFormat,
+          bool,
           bool
       )>(&JSONSchemaToEBNF)
   );

--- a/web/tests/grammar.test.ts
+++ b/web/tests/grammar.test.ts
@@ -86,6 +86,43 @@ d_1 ::= ("" | ("d"))
     expect(grammar0).not.toEqual(grammar2);
   });
 
+  test("Test unsupported JSON Schema formats", async () => {
+    const unsupportedFormat = JSON.stringify({
+      type: "string",
+      format: "custom-format",
+    });
+    await expect(
+      Testings._jsonSchemaToEBNF(unsupportedFormat, false)
+    ).rejects.toThrow("Unsupported string format");
+    const grammar = await Testings._jsonSchemaToEBNF(
+      unsupportedFormat,
+      false,
+      2,
+      undefined,
+      true,
+      undefined,
+      "json",
+      false,
+      true
+    );
+    expect(grammar).toContain("root ::=");
+
+    await expect(
+      Grammar.fromJSONSchema(unsupportedFormat, false)
+    ).rejects.toThrow("Unsupported string format");
+    const compiled = await Grammar.fromJSONSchema(
+      unsupportedFormat,
+      false,
+      2,
+      undefined,
+      true,
+      undefined,
+      false,
+      true
+    );
+    expect(compiled.toString()).toContain("root");
+  });
+
   test("Test indent Grammar.fromJSONSchema()", async () => {
     const grammar0 = (await Grammar.fromJSONSchema(schema, false, -1)).toString();
     const grammar1 = (await Grammar.fromJSONSchema(schema, false)).toString();


### PR DESCRIPTION
## Summary

- Reject unsupported string format names instead of silently widening the generated grammar.
- Add an explicit `allow_unsupported_formats` compatibility option across `Grammar`, `GrammarCompiler`, and the testing converter.
- Validate format value types when a schema can match strings, while preserving annotation behavior for schemas that exclude strings.
- Include the compatibility option in compiler cache keys and document the supported formats.

## Root cause

The converter attempted a format regex only for recognized names and otherwise fell through to the unconstrained string path. That made unsupported format constraints disappear without a diagnostic.

## Compatibility

The default now fails closed. Callers that intentionally use custom format annotations can pass `allow_unsupported_formats=True` to preserve the previous behavior. Existing positional arguments remain compatible because the new option is appended.

This branch temporarily includes the Python 3.8 test annotation compatibility commit from #773. That commit will disappear from this diff after #773 merges.

## Validation

- Targeted format diagnostics: 12 passed
- Python core suite: 3071 passed, 1 skipped, 622 deselected
- C++ suite: 61/61 passed
- Behavioral parity cases: 4 strict errors, 3 non-string accepts, 3 invalid-value errors, and matching opt-out acceptance
- Wheel build and isolated-wheel tests passed
- Sphinx HTML generation completed; one pre-existing autodoc warning remained
- Pre-commit hooks and `git diff --check` passed