### PR TITLE
Add token-level jump-forward decoding

### DIFF
--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -504,6 +504,8 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   std::string FindJumpForwardString();
 
+  std::vector<int32_t> FindJumpForwardTokens();
+
   void Rollback(int num_tokens);
 
   bool IsTerminated() const;
@@ -2111,6 +2113,129 @@ std::string GrammarMatcher::Impl::FindJumpForwardString() {
   return result;
 }
 
+std::vector<int32_t> GrammarMatcher::Impl::FindJumpForwardTokens() {
+  const std::string jump_forward = FindJumpForwardString();
+  if (jump_forward.empty()) {
+    return {};
+  }
+
+  const auto& sorted_vocab = tokenizer_info_.GetSortedDecodedVocab();
+  const size_t max_token_bytes = tokenizer_info_.ImplPtr()->GetMaxTokenBytes();
+
+  constexpr int kUnreachable = std::numeric_limits<int>::max();
+  const size_t no_position = std::numeric_limits<size_t>::max();
+  std::vector<int> token_counts(jump_forward.size() + 1, kUnreachable);
+  std::vector<size_t> previous_positions(jump_forward.size() + 1, no_position);
+  std::vector<int32_t> previous_tokens(jump_forward.size() + 1, -1);
+  token_counts[0] = 0;
+  size_t farthest_position = 0;
+
+  for (size_t position = 0; position < jump_forward.size(); ++position) {
+    if (token_counts[position] == kUnreachable) {
+      continue;
+    }
+
+    std::string candidate;
+    candidate.reserve(std::min(max_token_bytes, jump_forward.size() - position));
+    const size_t end_limit = std::min(jump_forward.size(), position + max_token_bytes);
+    for (size_t end = position + 1; end <= end_limit; ++end) {
+      candidate.push_back(jump_forward[end - 1]);
+      auto match = std::lower_bound(
+          sorted_vocab.begin(),
+          sorted_vocab.end(),
+          candidate,
+          [](const std::pair<int32_t, std::string>& token, const std::string& value) {
+            return token.second < value;
+          }
+      );
+      if (match == sorted_vocab.end() || match->second != candidate) {
+        continue;
+      }
+
+      int32_t token_id = match->first;
+      for (++match; match != sorted_vocab.end() && match->second == candidate; ++match) {
+        token_id = std::min(token_id, match->first);
+      }
+      if (token_counts[position] + 1 < token_counts[end]) {
+        token_counts[end] = token_counts[position] + 1;
+        previous_positions[end] = position;
+        previous_tokens[end] = token_id;
+        farthest_position = std::max(farthest_position, end);
+      }
+    }
+  }
+
+  std::vector<std::pair<size_t, int32_t>> token_steps;
+  for (size_t position = farthest_position; position != 0;
+       position = previous_positions[position]) {
+    XGRAMMAR_DCHECK(previous_positions[position] != no_position);
+    token_steps.emplace_back(previous_positions[position], previous_tokens[position]);
+  }
+  std::reverse(token_steps.begin(), token_steps.end());
+
+  // Keep only token boundaries that cannot be changed by a grammar-valid continuation. For
+  // example, if "ab" is forced, "c" can follow, and "abc" is a vocabulary token, emitting an
+  // "ab" token now would choose a non-stable tokenization.
+  Impl after_jump_forward(*this);
+  after_jump_forward.capture_recording_ = false;
+  for (uint8_t byte : jump_forward) {
+    bool accepted = after_jump_forward.Advance(byte);
+    XGRAMMAR_DCHECK(accepted);
+  }
+  size_t stable_token_count = token_steps.size();
+  for (size_t index = 0; index < token_steps.size(); ++index) {
+    const size_t token_start = token_steps[index].first;
+    const std::string forced_suffix = jump_forward.substr(token_start);
+    auto candidate = std::lower_bound(
+        sorted_vocab.begin(),
+        sorted_vocab.end(),
+        forced_suffix,
+        [](const std::pair<int32_t, std::string>& token, const std::string& value) {
+          return token.second < value;
+        }
+    );
+    while (candidate != sorted_vocab.end() &&
+           candidate->second.compare(0, forced_suffix.size(), forced_suffix) == 0) {
+      if (candidate->second.size() > forced_suffix.size()) {
+        Impl extension_trial(after_jump_forward);
+        bool extension_is_valid = true;
+        for (size_t byte_index = forced_suffix.size(); byte_index < candidate->second.size();
+             ++byte_index) {
+          if (!extension_trial.Advance(
+                  static_cast<uint8_t>(candidate->second[byte_index]), /*debug_print=*/false
+              )) {
+            extension_is_valid = false;
+            break;
+          }
+        }
+        if (extension_is_valid) {
+          stable_token_count = index;
+          break;
+        }
+      }
+      ++candidate;
+    }
+    if (stable_token_count != token_steps.size()) {
+      break;
+    }
+  }
+
+  std::vector<int32_t> tokens;
+  tokens.reserve(stable_token_count);
+  for (size_t index = 0; index < stable_token_count; ++index) {
+    tokens.push_back(token_steps[index].second);
+  }
+
+  Impl trial(*this);
+  trial.capture_recording_ = false;
+  size_t accepted_count = 0;
+  while (accepted_count < tokens.size() && trial.AcceptToken(tokens[accepted_count])) {
+    ++accepted_count;
+  }
+  tokens.resize(accepted_count);
+  return tokens;
+}
+
 void GrammarMatcher::Impl::Rollback(int num_tokens) {
   XGRAMMAR_CHECK(num_tokens <= static_cast<int>(token_length_history.size()))
       << "Intended to rollback " << num_tokens << " tokens, but only the last "
@@ -2682,6 +2807,10 @@ bool GrammarMatcher::TraverseDraftTree(
 }
 
 std::string GrammarMatcher::FindJumpForwardString() { return pimpl_->FindJumpForwardString(); }
+
+std::vector<int32_t> GrammarMatcher::FindJumpForwardTokens() {
+  return pimpl_->FindJumpForwardTokens();
+}
 
 void GrammarMatcher::Rollback(int num_tokens) { pimpl_->Rollback(num_tokens); }
 

--- a/cpp/tokenizer_info.cc
+++ b/cpp/tokenizer_info.cc
@@ -327,6 +327,7 @@ TokenizerInfo::Impl::Impl(
 void TokenizerInfo::Impl::BuildTokenCharData() {
   token_char_counts_.assign(sorted_decoded_vocab_.size(), 0);
   int32_t max_chars = 0;
+  size_t max_bytes = 0;
   for (int32_t index = 0; index < static_cast<int32_t>(sorted_decoded_vocab_.size()); ++index) {
     int32_t count = 0;
     for (uint8_t byte : sorted_decoded_vocab_[index].second) {
@@ -334,8 +335,10 @@ void TokenizerInfo::Impl::BuildTokenCharData() {
     }
     token_char_counts_[index] = count;
     max_chars = std::max(max_chars, count);
+    max_bytes = std::max(max_bytes, sorted_decoded_vocab_[index].second.size());
   }
   max_token_chars_ = max_chars;
+  max_token_bytes_ = max_bytes;
 }
 
 const std::vector<int32_t>& TokenizerInfo::Impl::GetTokenCharCounts() const {

--- a/cpp/tokenizer_info_impl.h
+++ b/cpp/tokenizer_info_impl.h
@@ -3,6 +3,7 @@
 
 #include <picojson.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <unordered_set>
@@ -41,6 +42,7 @@ class TokenizerInfo::Impl {
   }
   const std::vector<int32_t>& GetTokenCharCounts() const;
   int32_t GetMaxTokenChars() const;
+  size_t GetMaxTokenBytes() const { return max_token_bytes_; }
   void BuildTokenCharData();
 
   std::string DumpMetadata() const;
@@ -84,6 +86,7 @@ class TokenizerInfo::Impl {
   std::vector<int32_t> token_id_to_sorted_vocab_index_;
   /*! \brief Unicode codepoint counts for the sorted decoded vocabulary. */
   int32_t max_token_chars_ = 0;
+  size_t max_token_bytes_ = 0;
   std::vector<int32_t> token_char_counts_;
 
   /*!

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -726,6 +726,16 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           [](GrammarMatcherObj* o) { return ffi::String(o->value.FindJumpForwardString()); }
       )
       .def(
+          "find_jump_forward_tokens",
+          [](GrammarMatcherObj* o) {
+            ffi::Array<int64_t> result;
+            for (int32_t token_id : o->value.FindJumpForwardTokens()) {
+              result.push_back(token_id);
+            }
+            return result;
+          }
+      )
+      .def(
           "rollback",
           [](GrammarMatcherObj* o, int64_t num_tokens) {
             o->value.Rollback(static_cast<int>(num_tokens));

--- a/docs/using_xgrammar/engine_integration.md
+++ b/docs/using_xgrammar/engine_integration.md
@@ -133,7 +133,12 @@ with independent states, duplicate the matcher with
 [`xgr.GrammarMatcher.find_jump_forward_string`](xgrammar.GrammarMatcher.find_jump_forward_string)
 returns the longest string that certainly follows the current state under the grammar. The
 engine can append this string to the output directly without LLM decoding, saving decoding
-steps.
+steps. When the engine works directly with token ids,
+[`xgr.GrammarMatcher.find_jump_forward_tokens`](xgrammar.GrammarMatcher.find_jump_forward_tokens)
+returns a minimum-length tokenization of the stable tokenizable prefix. It leaves a token pending
+when a grammar-valid continuation could extend across that token boundary. The returned tokens
+are verified against a matcher copy and can be submitted without changing the current matcher
+state.
 
 ## Real-World Integrations
 

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -146,10 +146,23 @@ class GrammarMatcher {
 
   /*!
    * \brief Find the jump-forward string for jump-forward decoding. This is the longest string that
-   will be valid according to the current syntax.
+   * will be valid according to the current syntax.
    * \note This method does not change the grammar state.
    */
   std::string FindJumpForwardString();
+
+  /*!
+   * \brief Find a compact token sequence for jump-forward decoding.
+   *
+   * The decoded bytes of the returned tokens form a stable tokenizable prefix of
+   * FindJumpForwardString(). A token is kept only when no grammar-valid continuation can extend
+   * across its boundary into another vocabulary token. Among tokenizations of the stable prefix,
+   * this method minimizes the number of tokens. Every returned token is verified on a matcher
+   * copy, so this method also respects token-level constraints without changing the matcher state.
+   *
+   * \return The token ids that can be accepted without model decoding.
+   */
+  std::vector<int32_t> FindJumpForwardTokens();
 
   /*!
    * \brief Rollback the matcher to a previous state.

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -421,6 +421,22 @@ class GrammarMatcher(XGRObject):
         """
         return str(self._handle.find_jump_forward_string())
 
+    def find_jump_forward_tokens(self) -> List[int]:
+        """Find token ids that can be used for jump-forward decoding.
+
+        The decoded bytes of the returned tokens form a stable tokenizable prefix of
+        :meth:`find_jump_forward_string`. A token is kept only when no grammar-valid continuation
+        can extend across its boundary into another vocabulary token. The result uses the fewest
+        tokens possible for that stable prefix, and every token is checked against a copy of the
+        matcher. The matcher state is not changed.
+
+        Returns
+        -------
+        jump_forward_tokens : List[int]
+            Token ids that can be appended without model decoding.
+        """
+        return list(self._handle.find_jump_forward_tokens())
+
     def rollback(self, num_tokens: int = 1) -> None:
         """Rollback the matcher to a previous state by several tokens.
 

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -484,6 +484,55 @@ sub_rule ::= "b"
     assert matcher.find_jump_forward_string() == "bb"
 
 
+def test_get_jump_forward_tokens_uses_fewest_tokens():
+    vocab = ["</s>", "a", "ab", "b", "bb", "c", "x", "y"]
+    tokenizer_info = xgr.TokenizerInfo(vocab, stop_token_ids=[0])
+    grammar = xgr.Grammar.from_ebnf('root ::= "abbbc" ("x" | "y")')
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+    expected = [vocab.index("ab"), vocab.index("bb"), vocab.index("c")]
+    assert matcher.find_jump_forward_tokens() == expected
+    assert matcher.find_jump_forward_tokens() == expected
+    for token_id in expected:
+        assert matcher.accept_token(token_id)
+    assert matcher.find_jump_forward_string() == ""
+
+
+def test_get_jump_forward_tokens_keeps_an_unstable_boundary_pending():
+    vocab = ["</s>", "a", "ab", "b", "abc", "c", "d"]
+    tokenizer_info = xgr.TokenizerInfo(vocab, stop_token_ids=[0])
+    grammar = xgr.Grammar.from_ebnf('root ::= "ab" ("c" | "d")')
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+    assert matcher.find_jump_forward_string() == "ab"
+    assert matcher.find_jump_forward_tokens() == []
+
+    stable_vocab = ["</s>", "a", "ab", "b", "c", "d"]
+    stable_tokenizer_info = xgr.TokenizerInfo(stable_vocab, stop_token_ids=[0])
+    stable_matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, stable_tokenizer_info)
+    assert stable_matcher.find_jump_forward_tokens() == [stable_vocab.index("ab")]
+
+
+def test_get_jump_forward_tokens_returns_longest_tokenizable_prefix():
+    vocab = ["</s>", "ab", "x"]
+    tokenizer_info = xgr.TokenizerInfo(vocab, stop_token_ids=[0])
+    grammar = xgr.Grammar.from_ebnf('root ::= "abc" ("x" | "y")')
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+    assert matcher.find_jump_forward_tokens() == [vocab.index("ab")]
+    assert matcher.accept_token(vocab.index("ab"))
+    assert matcher.find_jump_forward_string() == "c"
+
+
+def test_get_jump_forward_tokens_supports_utf8_and_duplicate_tokens():
+    vocab = ["</s>", "你", "你好", "你好", "好", "!", "?"]
+    tokenizer_info = xgr.TokenizerInfo(vocab, stop_token_ids=[0])
+    grammar = xgr.Grammar.from_ebnf('root ::= "你好" ("!" | "?")')
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+    assert matcher.find_jump_forward_tokens() == [2]
+
+
 def test_vocab_size():
     vocab = [
         # fmt: off

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 
 import pytest


### PR DESCRIPTION
## Summary

- Add `GrammarMatcher.find_jump_forward_tokens()` to the C++ and Python APIs.
- Tokenize the forced byte prefix with the fewest ordinary vocabulary tokens.
- Hold back token boundaries that a grammar-valid continuation could extend into a longer vocabulary token.
- Verify every returned token on a matcher copy so the query respects token-level constraints without changing matcher state.
- Precompute the maximum decoded-token byte length in `TokenizerInfo` to avoid a full vocabulary scan on each query.

## Root cause

The existing jump-forward API returns bytes only. Serving engines that operate on token ids must tokenize those bytes themselves, and a token ending at the current forced prefix may be unstable when a valid continuation can merge across that boundary.

## Behavior

The new method returns a stable, directly acceptable token prefix. It may return fewer bytes than `find_jump_forward_string()` when the vocabulary cannot represent the full prefix or when the final token boundary depends on the next grammar branch. It does not mutate the matcher.

This branch temporarily includes the Python 3.8 test annotation compatibility commit from #773. That commit will disappear from this diff after #773 merges.

## Validation

- Targeted jump-forward tests: 5 passed, including UTF-8, duplicate decoded tokens, partial tokenization, and unstable boundaries
- Behavioral parity cases: compact forced tokens `[2, 4, 5]`, unstable boundary `[]`, partial tokenization `[1]`
- Python core suite: 3062 passed, 1 skipped, 622 deselected
- C++ Debug + InternalCheck suite: 61/61 passed
- Release wheel build and isolated-wheel tests passed
- Standard Sphinx documentation build passed; one pre-existing Pydantic autodoc warning remained
- Pre-commit hooks and `git diff --check` passed