### PR TITLE
Add stateless token sequence validation

### DIFF
--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -496,6 +496,8 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   bool AcceptToken(int32_t token_id, bool debug_print = false);
 
+  int64_t ValidateTokens(const std::vector<int32_t>& token_ids) const;
+
   bool AcceptString(const std::string& input_str, bool debug_print = false);
 
   bool FillNextTokenBitmask(DLTensor* next_token_bitmask, int index, bool debug_print = false);
@@ -1511,6 +1513,47 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   }
   record_char_budget_relaxation_ = false;
   return FinishAccept(consumed_past_deadline);
+}
+
+int64_t GrammarMatcher::Impl::ValidateTokens(const std::vector<int32_t>& token_ids) const {
+  Impl trial(*this);
+  // Validation is observational and should not emit one-time budget warnings on behalf of the
+  // real matcher.
+  trial.budget_exceeded_warned_ = true;
+  trial.char_budget_exceeded_warned_ = true;
+
+  int32_t bitmask_size = GetBitmaskSize(tokenizer_info_.GetVocabSize());
+  std::vector<int32_t> bitmask_data(bitmask_size);
+  int64_t bitmask_shape[1] = {bitmask_size};
+  DLTensor bitmask;
+  bitmask.data = bitmask_data.data();
+  bitmask.device = DLDevice{kDLCPU, 0};
+  bitmask.ndim = 1;
+  bitmask.dtype = GetBitmaskDLType();
+  bitmask.shape = bitmask_shape;
+  bitmask.strides = nullptr;
+  bitmask.byte_offset = 0;
+
+  int64_t accepted = 0;
+  for (int32_t token_id : token_ids) {
+    if (trial.IsTerminated() || token_id < 0 || token_id >= tokenizer_info_.GetVocabSize()) {
+      break;
+    }
+    std::fill(bitmask_data.begin(), bitmask_data.end(), -1);
+    trial.FillNextTokenBitmask(&bitmask, 0, false);
+    uint32_t token_mask = uint32_t{1} << static_cast<uint32_t>(token_id % 32);
+    if ((static_cast<uint32_t>(bitmask_data[token_id / 32]) & token_mask) == 0) {
+      break;
+    }
+    if (!trial.AcceptToken(token_id)) {
+      break;
+    }
+    ++accepted;
+    if (trial.IsTerminated()) {
+      break;
+    }
+  }
+  return accepted;
 }
 
 bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug_print) {
@@ -2592,6 +2635,10 @@ GrammarMatcher::GrammarMatcher(
 
 bool GrammarMatcher::AcceptToken(int32_t token_id, bool debug_print) {
   return pimpl_->AcceptToken(token_id, debug_print);
+}
+
+int64_t GrammarMatcher::ValidateTokens(const std::vector<int32_t>& token_ids) const {
+  return pimpl_->ValidateTokens(token_ids);
 }
 
 bool GrammarMatcher::AcceptString(const std::string& input_str, bool debug_print) {

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <string>
 #include <variant>
@@ -673,6 +674,21 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           "accept_token",
           [](GrammarMatcherObj* o, int64_t token_id, bool debug_print) {
             return o->value.AcceptToken(static_cast<int32_t>(token_id), debug_print);
+          }
+      )
+      .def(
+          "validate_tokens",
+          [](const GrammarMatcherObj* o, const ffi::Array<int64_t>& token_ids) {
+            std::vector<int32_t> converted;
+            converted.reserve(token_ids.size());
+            for (int64_t token_id : token_ids) {
+              converted.push_back(
+                  token_id >= 0 && token_id <= std::numeric_limits<int32_t>::max()
+                      ? static_cast<int32_t>(token_id)
+                      : -1
+              );
+            }
+            return o->value.ValidateTokens(converted);
           }
       )
       .def(

--- a/docs/using_xgrammar/engine_integration.md
+++ b/docs/using_xgrammar/engine_integration.md
@@ -129,6 +129,12 @@ then roll back the rejected suffix with
 with independent states, duplicate the matcher with
 [`xgr.GrammarMatcher.fork`](xgrammar.GrammarMatcher.fork).
 
+For a linear candidate sequence,
+[`xgr.GrammarMatcher.validate_tokens`](xgrammar.GrammarMatcher.validate_tokens) returns the number
+of consecutive tokens that can be accepted from the current state. It performs validation on an
+isolated matcher state, so no rollback is needed and captures, budgets, and accepted-token history
+remain unchanged.
+
 **Jump-forward decoding.**
 [`xgr.GrammarMatcher.find_jump_forward_string`](xgrammar.GrammarMatcher.find_jump_forward_string)
 returns the longest string that certainly follows the current state under the grammar. The

--- a/include/xgrammar/matcher.h
+++ b/include/xgrammar/matcher.h
@@ -97,6 +97,16 @@ class GrammarMatcher {
   bool AcceptToken(int32_t token_id, bool debug_print = false);
 
   /*!
+   * \brief Validate a sequence of tokens without changing the matcher state.
+   * \param token_ids The token ids to validate in order.
+   * \return The number of consecutive tokens accepted before the first rejection or termination.
+   *
+   * \note A returned prefix does not need to complete the grammar. If a token terminates the
+   * matcher, that token is included in the returned count and validation stops.
+   */
+  int64_t ValidateTokens(const std::vector<int32_t>& token_ids) const;
+
+  /*!
    * \brief Accept a string and update the state of the matcher. The whole string is considered
    * as one step in rollback. It is used to complement the functionality of AcceptToken, and
    * AcceptToken should always be used to accept tokens.

--- a/python/xgrammar/matcher.py
+++ b/python/xgrammar/matcher.py
@@ -306,6 +306,27 @@ class GrammarMatcher(XGRObject):
         """
         return self._handle.accept_token(token_id, debug_print)
 
+    def validate_tokens(self, token_ids: List[int]) -> int:
+        """Return the length of the longest token prefix accepted from the current state.
+
+        Validation stops before the first rejected token. If a token terminates the matcher, that
+        token is included in the returned count and validation stops. The accepted prefix does not
+        need to complete the grammar.
+
+        This method does not change the matcher state.
+
+        Parameters
+        ----------
+        token_ids : List[int]
+            The token ids to validate in order.
+
+        Returns
+        -------
+        accepted_count : int
+            The number of consecutive tokens accepted.
+        """
+        return int(self._handle.validate_tokens(token_ids))
+
     def accept_string(self, input_str: Union[str, bytes], *, debug_print: bool = False) -> bool:
         """Accept a string and update the state of the matcher. The whole string is considered
         as one step in rollback. It is used to complement the functionality of accept_token, and

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -176,6 +176,50 @@ def test_token_operations():
     assert result == expected
 
 
+def test_validate_tokens_returns_longest_accepted_prefix_without_mutation():
+    vocab = ["<s>", "</s>", "a", "b", "c", "ab", "x"]
+    tokenizer_info = xgr.TokenizerInfo(vocab, stop_token_ids=[1])
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(
+        'root ::= captured\ncaptured[capture="value"] ::= "abc"', tokenizer_info
+    )
+
+    assert matcher.validate_tokens([]) == 0
+    assert matcher.validate_tokens([2, 3, 4]) == 3
+    assert matcher.validate_tokens([2, 3, 6, 4]) == 2
+    assert matcher.validate_tokens([5, 4, 1, 2]) == 3
+    assert matcher.validate_tokens([2, 1 << 40]) == 1
+
+    # Validation runs on an isolated state: it neither commits tokens nor records captures.
+    assert matcher.get_captures() == []
+    assert not matcher.is_completed()
+    assert not matcher.is_terminated()
+
+    assert matcher.accept_token(5)
+    assert matcher.validate_tokens([4, 1, 2]) == 2
+    assert matcher.validate_tokens([6]) == 0
+
+    # The already accepted prefix is unchanged after both successful and rejected validation.
+    assert not matcher.is_completed()
+    assert matcher.accept_token(4)
+    assert matcher.is_completed()
+    assert matcher.get_captures() == [("value", b"abc")]
+
+
+def test_validate_tokens_enforces_token_budgets():
+    vocab = ["<s>", "</s>", "a", "b", "!", "ab"]
+    tokenizer_info = xgr.TokenizerInfo(vocab, stop_token_ids=[1])
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(
+        'root ::= value "!"\nvalue[max_tokens=1] ::= [a-z]+', tokenizer_info
+    )
+
+    assert matcher.validate_tokens([2, 3, 4]) == 1
+    assert matcher.validate_tokens([5, 4, 1]) == 3
+
+    # Both validation paths leave the one-token budget unused on the original matcher.
+    assert matcher.accept_token(2)
+    assert matcher.validate_tokens([4, 1]) == 2
+
+
 def test_rollback():
     vocab = [
         # fmt: off

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 
 import pytest


### PR DESCRIPTION
## Summary

- add C++ and Python APIs that return the longest acceptable token prefix without mutating matcher state
- validate every token through the normal mask and acceptance paths so budgets, stop tokens, captures, and runtime constraints match decoding behavior
- document candidate-sequence validation and cover partial prefixes, termination, invalid IDs, state isolation, captures, and token budgets

## Testing

- `pre-commit run --files include/xgrammar/matcher.h cpp/grammar_matcher.cc cpp/tvm_ffi/tvm_ffi.cc python/xgrammar/matcher.py tests/python/test_grammar_matcher_basic.py docs/using_xgrammar/engine_integration.md`
- `.test-venv/bin/python -m pytest -q tests/python -m 'not hf_token_required'` (`3061 passed, 1 skipped, 622 deselected`)
- `ctest --test-dir build --output-on-failure` (`61/61` passed with Debug and internal checks enabled)
- `bash docs/build_docs.sh` (completed with one existing Pydantic schema warning)
- release wheel build and isolated wheel test environment
