### PR TITLE
Reject inexact JSON Schema oneOf constraints

### DIFF
--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -51,10 +51,19 @@ Grammar Grammar::FromJSONSchema(
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
     bool print_converted_ebnf,
-    bool any_order
+    bool any_order,
+    bool coerce_one_of
 ) {
   auto grammar = GrammarNormalizer::Apply(JSONSchemaToGrammar(
-      schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+      schema,
+      any_whitespace,
+      indent,
+      separators,
+      strict_mode,
+      max_whitespace_cnt,
+      any_order,
+      JSONFormat::kJSON,
+      coerce_one_of
   ));
   if (print_converted_ebnf) {
     XGRAMMAR_LOG(INFO) << "Converted EBNF: " << grammar.ToString() << std::endl;

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1028,7 +1028,8 @@ class GrammarCompilerSub {
       std::optional<std::pair<std::string, std::string>> separators,
       bool strict_mode,
       std::optional<int> max_whitespace_cnt,
-      bool any_order
+      bool any_order,
+      bool coerce_one_of
   );
 
   CompiledGrammar CompileRegex(const std::string& regex);
@@ -1157,7 +1158,8 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
     std::optional<std::pair<std::string, std::string>> separators,
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
-    bool any_order
+    bool any_order,
+    bool coerce_one_of
 ) {
   return MultiThreadCompileGrammar(Grammar::FromJSONSchema(
       schema,
@@ -1167,7 +1169,8 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
       strict_mode,
       max_whitespace_cnt,
       /*print_converted_ebnf=*/false,
-      any_order
+      any_order,
+      coerce_one_of
   ));
 }
 
@@ -1260,6 +1263,7 @@ class GrammarCompilerCacheKeys {
     bool strict_mode;
     std::optional<int> max_whitespace_cnt;
     bool any_order;
+    bool coerce_one_of;
 
     XGRAMMAR_EQUAL_BY_MEMBERS(
         SchemaKey,
@@ -1269,7 +1273,8 @@ class GrammarCompilerCacheKeys {
         &SchemaKey::separators,
         &SchemaKey::strict_mode,
         &SchemaKey::max_whitespace_cnt,
-        &SchemaKey::any_order
+        &SchemaKey::any_order,
+        &SchemaKey::coerce_one_of
     );
   };
 
@@ -1310,7 +1315,8 @@ XGRAMMAR_HASH_BY_MEMBERS(
     &xgrammar::GrammarCompilerCacheKeys::SchemaKey::separators,
     &xgrammar::GrammarCompilerCacheKeys::SchemaKey::strict_mode,
     &xgrammar::GrammarCompilerCacheKeys::SchemaKey::max_whitespace_cnt,
-    &xgrammar::GrammarCompilerCacheKeys::SchemaKey::any_order
+    &xgrammar::GrammarCompilerCacheKeys::SchemaKey::any_order,
+    &xgrammar::GrammarCompilerCacheKeys::SchemaKey::coerce_one_of
 );
 
 XGRAMMAR_HASH_BY_MEMBERS(
@@ -1376,7 +1382,8 @@ class GrammarCompiler::Impl {
       std::optional<std::pair<std::string, std::string>> separators,
       bool strict_mode,
       std::optional<int> max_whitespace_cnt,
-      bool any_order
+      bool any_order,
+      bool coerce_one_of
   );
 
   CompiledGrammar CompileStructuralTag(const std::string& structural_tag_json);
@@ -1435,10 +1442,17 @@ CompiledGrammar GrammarCompiler::Impl::Compute(const UnionKey& key) {
           const auto& [ebnf_str, root_rule_name] = key;
           return this->no_cache_compiler_.CompileGrammar(ebnf_str, root_rule_name);
         } else if constexpr (std::is_same_v<KeyType, SchemaKey>) {
-          const auto& [schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order] =
+          const auto& [schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order, coerce_one_of] =
               key;
           return this->no_cache_compiler_.CompileJSONSchema(
-              schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+              schema,
+              any_whitespace,
+              indent,
+              separators,
+              strict_mode,
+              max_whitespace_cnt,
+              any_order,
+              coerce_one_of
           );
         } else if constexpr (std::is_same_v<KeyType, StructuralTagKey>) {
           const auto& [structural_tag_json] = key;
@@ -1470,15 +1484,30 @@ CompiledGrammar GrammarCompiler::Impl::CompileJSONSchema(
     std::optional<std::pair<std::string, std::string>> separators,
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
-    bool any_order
+    bool any_order,
+    bool coerce_one_of
 ) {
   if (!cache_enabled_) {
     return no_cache_compiler_.CompileJSONSchema(
-        schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+        schema,
+        any_whitespace,
+        indent,
+        separators,
+        strict_mode,
+        max_whitespace_cnt,
+        any_order,
+        coerce_one_of
     );
   }
   return grammar_level_cache_.Get(SchemaKey{
-      schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+      schema,
+      any_whitespace,
+      indent,
+      separators,
+      strict_mode,
+      max_whitespace_cnt,
+      any_order,
+      coerce_one_of
   });
 }
 
@@ -1551,10 +1580,18 @@ CompiledGrammar GrammarCompiler::CompileJSONSchema(
     std::optional<std::pair<std::string, std::string>> separators,
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
-    bool any_order
+    bool any_order,
+    bool coerce_one_of
 ) {
   return pimpl_->CompileJSONSchema(
-      schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+      schema,
+      any_whitespace,
+      indent,
+      separators,
+      strict_mode,
+      max_whitespace_cnt,
+      any_order,
+      coerce_one_of
   );
 }
 

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -168,7 +168,7 @@ bool HasMultipleInRange(int64_t start, int64_t end, int64_t multiple_of) {
 
 constexpr const char* kUnsupportedOneOfMessage =
     "oneOf with overlapping or non-provably-disjoint branches cannot be represented exactly; "
-    "falling back to anyOf semantics";
+    "set coerce_one_of=true to approximate oneOf with anyOf";
 
 bool IsSchemaAnnotationKey(const std::string& key) {
   static const std::unordered_set<std::string> kAnnotationKeys = {
@@ -656,6 +656,7 @@ class SchemaParser {
   struct Config {
     bool strict_mode = false;
     JSONFormat json_format;
+    bool coerce_one_of = false;
   };
 
   explicit SchemaParser(const picojson::value& root_schema, const Config& config)
@@ -821,17 +822,8 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
     result = SchemaSpec::Make(std::move(anyof_result).Unwrap(), cache_key, rule_name_hint);
   } else if (schema_obj.count("oneOf")) {
     auto oneof_result = ParseOneOf(schema_obj);
-    if (oneof_result.IsErr()) {
-      if (oneof_result.ErrRef().Type() != SchemaErrorType::kUnsupportedSchema) {
-        return ResultErr(std::move(oneof_result).UnwrapErr());
-      }
-      XGRAMMAR_LOG(WARNING) << oneof_result.ErrRef().what();
-      auto anyof_result = ParseAnyOf(schema_obj, "oneOf");
-      if (anyof_result.IsErr()) return ResultErr(std::move(anyof_result).UnwrapErr());
-      result = SchemaSpec::Make(std::move(anyof_result).Unwrap(), cache_key, rule_name_hint);
-    } else {
-      result = SchemaSpec::Make(std::move(oneof_result).Unwrap(), cache_key, rule_name_hint);
-    }
+    if (oneof_result.IsErr()) return ResultErr(std::move(oneof_result).UnwrapErr());
+    result = SchemaSpec::Make(std::move(oneof_result).Unwrap(), cache_key, rule_name_hint);
   } else if (schema_obj.count("allOf")) {
     auto allof_result = ParseAllOf(schema_obj);
     if (allof_result.IsErr()) return ResultErr(std::move(allof_result).UnwrapErr());
@@ -1516,19 +1508,39 @@ Result<OneOfSpec, SchemaError> SchemaParser::ParseOneOf(const picojson::object& 
 
   const auto& options = schema.at("oneOf").get<picojson::array>();
   if (options.empty()) {
-    return ResultErr<SchemaError>(SchemaErrorType::kUnsupportedSchema, kUnsupportedOneOfMessage);
+    return ResultErr<SchemaError>(
+        SchemaErrorType::kUnsatisfiableSchema, "oneOf is empty and cannot accept any value"
+    );
   }
 
+  picojson::array satisfiable_options;
   int idx = 0;
   for (const auto& option : options) {
     auto option_result = Parse(option, "case_" + std::to_string(idx));
-    if (option_result.IsErr()) return ResultErr(std::move(option_result).UnwrapErr());
+    if (option_result.IsErr()) {
+      if (option_result.ErrRef().Type() == SchemaErrorType::kUnsatisfiableSchema) {
+        ++idx;
+        continue;
+      }
+      return ResultErr(std::move(option_result).UnwrapErr());
+    }
     spec.options.push_back(std::move(option_result).Unwrap());
+    satisfiable_options.push_back(option);
     ++idx;
   }
 
-  if (!TryProvePairwiseDisjointOneOf(options)) {
-    return ResultErr<SchemaError>(SchemaErrorType::kUnsupportedSchema, kUnsupportedOneOfMessage);
+  if (spec.options.empty()) {
+    return ResultErr<SchemaError>(
+        SchemaErrorType::kUnsatisfiableSchema, "oneOf has no satisfiable branches"
+    );
+  }
+
+  if (satisfiable_options.size() > 1 && !TryProvePairwiseDisjointOneOf(satisfiable_options)) {
+    if (!config_.coerce_one_of) {
+      return ResultErr<SchemaError>(SchemaErrorType::kUnsupportedSchema, kUnsupportedOneOfMessage);
+    }
+    XGRAMMAR_LOG(WARNING) << kUnsupportedOneOfMessage
+                          << "; treating oneOf as anyOf because coerce_one_of is enabled";
   }
 
   return ResultOk(std::move(spec));
@@ -4054,13 +4066,14 @@ Grammar JSONSchemaToGrammar(
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
     bool any_order,
-    JSONFormat json_format
+    JSONFormat json_format,
+    bool coerce_one_of
 ) {
   picojson::value schema_value;
   std::string error = picojson::parse(schema_value, schema);
   XGRAMMAR_CHECK(error.empty()) << "Failed to parse JSON: " << error
                                 << ". The JSON string is:" << schema;
-  SchemaParser parser(schema_value, {strict_mode, json_format});
+  SchemaParser parser(schema_value, {strict_mode, json_format, coerce_one_of});
   auto spec_result = parser.Parse(schema_value, "root");
   if (spec_result.IsErr()) {
     XGRAMMAR_LOG(FATAL) << std::move(spec_result).UnwrapErr().what();
@@ -4115,7 +4128,8 @@ std::string JSONSchemaToEBNF(
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
     JSONFormat json_format,
-    bool any_order
+    bool any_order,
+    bool coerce_one_of
 ) {
   picojson::value schema_value;
   std::string err = picojson::parse(schema_value, schema);
@@ -4129,7 +4143,8 @@ std::string JSONSchemaToEBNF(
       strict_mode,
       max_whitespace_cnt,
       json_format,
-      any_order
+      any_order,
+      coerce_one_of
   );
 }
 
@@ -4141,10 +4156,11 @@ std::string JSONSchemaToEBNF(
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
     JSONFormat json_format,
-    bool any_order
+    bool any_order,
+    bool coerce_one_of
 ) {
   // Parse JSON Schema to SchemaSpec
-  SchemaParser parser(schema, {strict_mode, json_format});
+  SchemaParser parser(schema, {strict_mode, json_format, coerce_one_of});
   auto spec_result = parser.Parse(schema, "root");
   if (spec_result.IsErr()) {
     XGRAMMAR_LOG(FATAL) << std::move(spec_result).UnwrapErr().what();

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -516,7 +516,8 @@ Grammar JSONSchemaToGrammar(
     bool strict_mode = true,
     std::optional<int> max_whitespace_cnt = std::nullopt,
     bool any_order = false,
-    JSONFormat json_format = JSONFormat::kJSON
+    JSONFormat json_format = JSONFormat::kJSON,
+    bool coerce_one_of = false
 );
 
 // ==================== Public API functions (backward compatible) ====================
@@ -544,6 +545,8 @@ Grammar JSONSchemaToGrammar(
  * format of the object. If it's JSONFormat::kJSON, then it will generate a fully JSON-style
  * grammar. If it's JSONFormat::kXML, then it will generate a grammar with the root format is
  * XML-style, while the inner format is JSON-style. Default: JSONFormat::kJSON.
+ * \param coerce_one_of Whether unsupported oneOf constraints may be approximated as anyOf.
+ * Default: false.
  * \returns The EBNF grammar string.
  */
 
@@ -555,7 +558,8 @@ std::string JSONSchemaToEBNF(
     bool strict_mode = true,
     std::optional<int> max_whitespace_cnt = std::nullopt,
     JSONFormat json_format = JSONFormat::kJSON,
-    bool any_order = false
+    bool any_order = false,
+    bool coerce_one_of = false
 );
 
 /*!
@@ -581,6 +585,8 @@ std::string JSONSchemaToEBNF(
  * then it will generate a fully JSON-style grammar. If it's JSONFormat::kXML, then it will
  * generate a grammar with the root format is XML-style, while the inner format is JSON-style.
  * Default: JSONFormat::kJSON.
+ * \param coerce_one_of Whether unsupported oneOf constraints may be approximated as anyOf.
+ * Default: false.
  * \returns The EBNF grammar string.
  */
 std::string JSONSchemaToEBNF(
@@ -591,7 +597,8 @@ std::string JSONSchemaToEBNF(
     bool strict_mode = true,
     std::optional<int> max_whitespace_cnt = std::nullopt,
     JSONFormat json_format = JSONFormat::kJSON,
-    bool any_order = false
+    bool any_order = false,
+    bool coerce_one_of = false
 );
 
 /*!

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -361,7 +361,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              bool strict_mode,
              ffi::AnyView max_whitespace_cnt,
              bool print_converted_ebnf,
-             bool any_order) {
+             bool any_order,
+             bool coerce_one_of) {
             XGRAMMAR_FFI_TRY_BEGIN();
             auto g = Grammar::FromJSONSchema(
                 schema,
@@ -371,7 +372,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                 strict_mode,
                 OptionalIntFromView(max_whitespace_cnt),
                 print_converted_ebnf,
-                any_order
+                any_order,
+                coerce_one_of
             );
             return ffi::ObjectRef(ffi::make_object<GrammarObj>(std::move(g)));
             XGRAMMAR_FFI_TRY_END();
@@ -514,7 +516,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              ffi::AnyView separators,
              bool strict_mode,
              ffi::AnyView max_whitespace_cnt,
-             bool any_order) {
+             bool any_order,
+             bool coerce_one_of) {
             XGRAMMAR_FFI_TRY_BEGIN();
             CompiledGrammar cg = o->value.CompileJSONSchema(
                 schema,
@@ -523,7 +526,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                 OptionalSeparatorsFromView(separators),
                 strict_mode,
                 OptionalIntFromView(max_whitespace_cnt),
-                any_order
+                any_order,
+                coerce_one_of
             );
             return ffi::ObjectRef(ffi::make_object<CompiledGrammarObj>(std::move(cg)));
             XGRAMMAR_FFI_TRY_END();
@@ -786,7 +790,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              bool strict_mode,
              ffi::AnyView max_whitespace_cnt,
              ffi::String json_format,
-             bool any_order) {
+             bool any_order,
+             bool coerce_one_of) {
             auto format = JSONFormatFromString(json_format);
             if (!format.has_value()) {
               TVM_FFI_THROW(RuntimeError) << "Invalid json_format: " << std::string(json_format);
@@ -799,7 +804,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                 strict_mode,
                 OptionalIntFromView(max_whitespace_cnt),
                 *format,
-                any_order
+                any_order,
+                coerce_one_of
             ));
           }
       )

--- a/docs/defining_structures/json_generation.md
+++ b/docs/defining_structures/json_generation.md
@@ -62,6 +62,20 @@ person_schema = {
 compiled_grammar = compiler.compile_json_schema(json.dumps(person_schema))
 ```
 
+## Exact `oneOf` Handling
+
+`oneOf` requires each accepted value to match exactly one branch. XGrammar compiles it when the
+branches can be proven pairwise disjoint, including distinct primitive types, disjoint finite
+values, and object branches with distinct required discriminator values.
+
+Overlapping or non-provably-disjoint branches raise an error by default because treating them as
+`anyOf` would accept values that violate the schema. Applications that intentionally prefer that
+approximation can opt in explicitly:
+
+```python
+compiled_grammar = compiler.compile_json_schema(schema, coerce_one_of=True)
+```
+
 With the compiled grammar, we can instantiate a [`xgr.GrammarMatcher`](xgrammar.GrammarMatcher)
 and generate the token masks in the generation loop.
 

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -71,7 +71,10 @@ class GrammarCompiler {
       int64_t max_memory_bytes = -1  // unlimited
   );
 
-  /*! \brief Get the compiled grammar for a JSON schema string. */
+  /*!
+   * \brief Get the compiled grammar for a JSON schema string.
+   * \param coerce_one_of Whether unsupported oneOf constraints may be approximated as anyOf.
+   */
   CompiledGrammar CompileJSONSchema(
       const std::string& schema,
       bool any_whitespace = true,
@@ -79,7 +82,8 @@ class GrammarCompiler {
       std::optional<std::pair<std::string, std::string>> separators = std::nullopt,
       bool strict_mode = true,
       std::optional<int> max_whitespace_cnt = std::nullopt,
-      bool any_order = false
+      bool any_order = false,
+      bool coerce_one_of = false
   );
 
   /*! \brief Get the compiled grammar for pure JSON. */

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -113,6 +113,8 @@ class Grammar {
    *
    * This helps LLM to generate accurate output in the grammar-guided generation with JSON
    * schema. Default: true.
+   * \param coerce_one_of Whether unsupported oneOf constraints may be approximated as anyOf.
+   * Default: false.
    */
   static Grammar FromJSONSchema(
       const std::string& schema,
@@ -122,7 +124,8 @@ class Grammar {
       bool strict_mode = true,
       std::optional<int> max_whitespace_cnt = std::nullopt,
       bool print_converted_ebnf = false,
-      bool any_order = false
+      bool any_order = false,
+      bool coerce_one_of = false
   );
 
   /*!

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -150,6 +150,7 @@ class GrammarCompiler(XGRObject):
         strict_mode: bool = True,
         max_whitespace_cnt: Optional[int] = None,
         any_order: bool = False,
+        coerce_one_of: bool = False,
     ) -> CompiledGrammar:
         """Get CompiledGrammar from the specified JSON schema and format. The indent
         and separators parameters follow the same convention as in json.dumps().
@@ -194,6 +195,11 @@ class GrammarCompiler(XGRObject):
 
             Applies to every object, nested included.
 
+        coerce_one_of : bool, default: False
+            Whether unsupported ``oneOf`` constraints may be approximated as ``anyOf``. By
+            default, overlapping or non-provably-disjoint branches raise an error because their
+            exclusive semantics cannot be represented exactly.
+
         Returns
         -------
         compiled_grammar : CompiledGrammar
@@ -209,6 +215,7 @@ class GrammarCompiler(XGRObject):
                 strict_mode,
                 max_whitespace_cnt,
                 any_order,
+                coerce_one_of,
             )
         )
 

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -185,6 +185,7 @@ class Grammar(XGRObject):
         max_whitespace_cnt: Optional[int] = None,
         print_converted_ebnf: bool = False,
         any_order: bool = False,
+        coerce_one_of: bool = False,
     ) -> "Grammar":
         """Construct a grammar from JSON schema. Pydantic model or JSON schema string can be
         used to specify the schema.
@@ -249,6 +250,11 @@ class Grammar(XGRObject):
 
             Applies to every object, nested included.
 
+        coerce_one_of : bool, default: False
+            Whether unsupported ``oneOf`` constraints may be approximated as ``anyOf``. By
+            default, overlapping or non-provably-disjoint branches raise an error because their
+            exclusive semantics cannot be represented exactly.
+
         Returns
         -------
         grammar : Grammar
@@ -270,6 +276,7 @@ class Grammar(XGRObject):
                 max_whitespace_cnt,
                 print_converted_ebnf,
                 any_order,
+                coerce_one_of,
             )
         )
 

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -26,6 +26,7 @@ def _json_schema_to_ebnf(
     strict_mode: bool = True,
     json_format: Literal["json", "qwen_xml", "minimax_xml", "deepseek_xml", "glm_xml"] = "json",
     any_order: bool = False,
+    coerce_one_of: bool = False,
 ) -> str:
     """Convert JSON schema string to BNF grammar string. For test purposes.
 
@@ -61,6 +62,9 @@ def _json_schema_to_ebnf(
         "deepseek_xml", "glm_xml". Formats other than "json" generate an XML-style root object
         for tool calling, while the inner values remain JSON-style.
 
+    coerce_one_of : bool, default: False
+        Whether unsupported ``oneOf`` constraints may be approximated as ``anyOf``.
+
     Returns
     -------
     bnf_string : str
@@ -76,6 +80,7 @@ def _json_schema_to_ebnf(
         max_whitespace_cnt,
         json_format,
         any_order,
+        coerce_one_of,
     )
 
 

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -794,6 +794,34 @@ def test_anyof_oneof():
     check_schema_with_instance(schema, schema_rejected, is_accepted=False, any_whitespace=False)
 
 
+def test_oneof_unsupported_overlap_rejected_by_default():
+    schema = {"oneOf": [{"type": "integer"}, {"type": "number"}]}
+    error = "coerce_one_of"
+
+    with pytest.raises(RuntimeError, match=error):
+        xgr.Grammar.from_json_schema(schema, any_whitespace=False)
+    with pytest.raises(RuntimeError, match=error):
+        _json_schema_to_ebnf(schema, any_whitespace=False)
+    assert "root ::=" in _json_schema_to_ebnf(schema, any_whitespace=False, coerce_one_of=True)
+
+
+@pytest.mark.parametrize("coerce_one_of", [False, True])
+def test_oneof_empty_or_all_unsatisfiable_rejected(coerce_one_of: bool):
+    for schema in [{"oneOf": []}, {"oneOf": [False, False]}]:
+        with pytest.raises(RuntimeError, match="cannot accept|no satisfiable"):
+            xgr.Grammar.from_json_schema(schema, coerce_one_of=coerce_one_of)
+
+
+def test_oneof_ignores_unsatisfiable_branches():
+    schema = {"oneOf": [False, {"type": "string"}]}
+    check_schema_with_instance(schema, '"x"', any_whitespace=False)
+    check_schema_with_instance(schema, "1", is_accepted=False, any_whitespace=False)
+
+    schema = {"oneOf": [{"$ref": "#/$defs/value"}], "$defs": {"value": {"type": "integer"}}}
+    check_schema_with_instance(schema, "1", any_whitespace=False)
+    check_schema_with_instance(schema, '"x"', is_accepted=False, any_whitespace=False)
+
+
 def test_oneof_unsupported_overlap_warns_and_falls_back(capfd):
     def assert_oneof_falls_back(
         schema: Union[Dict[str, Any], str],
@@ -801,9 +829,11 @@ def test_oneof_unsupported_overlap_warns_and_falls_back(capfd):
         rejected_instances: Optional[List[str]] = None,
     ):
         schema_input = schema if isinstance(schema, str) else json.dumps(schema)
-        grammar = xgr.Grammar.from_json_schema(schema_input, any_whitespace=False)
+        grammar = xgr.Grammar.from_json_schema(
+            schema_input, any_whitespace=False, coerce_one_of=True
+        )
         captured = capfd.readouterr()
-        assert "falling back to anyOf semantics" in captured.err
+        assert "treating oneOf as anyOf because coerce_one_of is enabled" in captured.err
         for instance in accepted_instances or []:
             assert _is_grammar_accept_string(grammar, instance)
         for instance in rejected_instances or []:
@@ -858,7 +888,7 @@ def test_oneof_disjoint_cases(capfd):
     # verify the disjointness prover actually fired.
     def assert_no_fallback():
         captured = capfd.readouterr()
-        assert "falling back to anyOf semantics" not in captured.err
+        assert "treating oneOf as anyOf" not in captured.err
 
     schema = {"oneOf": [{"type": "string"}, {"type": "integer"}]}
     check_schema_with_instance(schema, '"x"', any_whitespace=False)
@@ -3408,6 +3438,20 @@ def test_compile_json_schema_any_order(cache_enabled: bool):
     assert "root_item" not in ordered
     assert "root_item" in any_order
     assert ordered != any_order
+
+
+@pytest.mark.parametrize("cache_enabled", [True, False])
+def test_compile_json_schema_coerce_one_of_is_part_of_cache_key(cache_enabled: bool):
+    tokenizer_info = xgr.TokenizerInfo([])
+    compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=cache_enabled)
+    schema = {"oneOf": [{"type": "integer"}, {"type": "number"}]}
+
+    coerced = compiler.compile_json_schema(schema, any_whitespace=False, coerce_one_of=True).grammar
+    assert _is_grammar_accept_string(coerced, "1")
+    assert _is_grammar_accept_string(coerced, "1.5")
+
+    with pytest.raises(RuntimeError, match="coerce_one_of"):
+        compiler.compile_json_schema(schema, any_whitespace=False)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 
 import pytest

--- a/web/src/xgrammar.ts
+++ b/web/src/xgrammar.ts
@@ -70,6 +70,8 @@ export class Testings {
    * JSON elements when anyWhitespace is true. Undefined means unlimited.
    * @param {"json" | "xml"} [jsonFormat="json"] The JSON schema output format.
    * @param {boolean} [anyOrder=false] Whether to allow object properties to appear in any order.
+   * @param {boolean} [coerceOneOf=false] Whether to approximate overlapping or
+   * non-provably-disjoint oneOf branches with anyOf semantics.
    * @returns {string} The EBNF grammar string.
    */
   static async _jsonSchemaToEBNF(
@@ -80,7 +82,8 @@ export class Testings {
     strictMode = true,
     maxWhitespaceCnt?: number,
     jsonFormat: "json" | "xml" = "json",
-    anyOrder: boolean = false
+    anyOrder: boolean = false,
+    coerceOneOf: boolean = false
   ): Promise<string> {
     const separatorsPair = toSeparatorPair(separators);
     await asyncInitBinding();
@@ -99,7 +102,8 @@ export class Testings {
       strictMode,
       maxWhitespaceCnt,
       formatEnum,
-      anyOrder
+      anyOrder,
+      coerceOneOf
     );
   }
 
@@ -247,6 +251,8 @@ export class Grammar {
    * @param {number} [maxWhitespaceCnt] Maximum number of whitespace characters allowed between
    * JSON elements when anyWhitespace is true. Undefined means unlimited.
    * @param {boolean} [anyOrder=false] Whether to allow object properties to appear in any order.
+   * @param {boolean} [coerceOneOf=false] Whether to approximate overlapping or
+   * non-provably-disjoint oneOf branches with anyOf semantics.
    * @returns {Grammar} The generated BNF grammar.
    */
   static async fromJSONSchema(
@@ -256,7 +262,8 @@ export class Grammar {
     separators?: [string, string],
     strictMode = true,
     maxWhitespaceCnt?: number,
-    anyOrder: boolean = false
+    anyOrder: boolean = false,
+    coerceOneOf: boolean = false
   ): Promise<Grammar> {
     const separatorsPair = toSeparatorPair(separators);
     await asyncInitBinding();
@@ -275,7 +282,8 @@ export class Grammar {
         strictMode,
         maxWhitespaceCnt,
         printConvertedEBNF,
-        anyOrder
+        anyOrder,
+        coerceOneOf
       ));
   }
 

--- a/web/src/xgrammar_binding.cc
+++ b/web/src/xgrammar_binding.cc
@@ -194,6 +194,7 @@ EMSCRIPTEN_BINDINGS(xgrammar) {
           bool,
           std::optional<int>,
           JSONFormat,
+          bool,
           bool
       )>(&JSONSchemaToEBNF)
   );

--- a/web/tests/grammar.test.ts
+++ b/web/tests/grammar.test.ts
@@ -86,6 +86,27 @@ d_1 ::= ("" | ("d"))
     expect(grammar0).not.toEqual(grammar2);
   });
 
+  test("Test overlapping oneOf handling", async () => {
+    const overlappingOneOf = JSON.stringify({
+      oneOf: [{ type: "integer" }, { type: "number" }],
+    });
+    await expect(
+      Testings._jsonSchemaToEBNF(overlappingOneOf, false)
+    ).rejects.toThrow("coerce_one_of");
+    const grammar = await Testings._jsonSchemaToEBNF(
+      overlappingOneOf,
+      false,
+      2,
+      undefined,
+      true,
+      undefined,
+      "json",
+      false,
+      true
+    );
+    expect(grammar).toContain("root ::=");
+  });
+
   test("Test indent Grammar.fromJSONSchema()", async () => {
     const grammar0 = (await Grammar.fromJSONSchema(schema, false, -1)).toString();
     const grammar1 = (await Grammar.fromJSONSchema(schema, false)).toString();


### PR DESCRIPTION
## Summary

- reject overlapping or non-provably-disjoint JSON Schema `oneOf` branches by default instead of silently applying `anyOf` semantics
- add an explicit `coerce_one_of` compatibility option across C++, Python, compiler caching, testing helpers, and Web bindings
- preserve exact compilation for proven-disjoint branches, ignore unsatisfiable branches, and reject empty or wholly unsatisfiable unions
- document strict and compatibility behavior

## Testing

- `524 passed` in `tests/python/test_json_schema_converter.py`
- `3065 passed, 1 skipped, 622 deselected` in the Python core suite
- `61 passed` in the C++ test suite
- release wheel build
- Sphinx HTML build
- Web TypeScript lint
- all pre-commit hooks
