### PR TITLE
Support custom JSON Schema whitespace patterns

### DIFF
--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -6,6 +6,7 @@
 #include <xgrammar/grammar.h>
 
 #include <string>
+#include <utility>
 
 #include "grammar_functor.h"
 #include "grammar_parser.h"
@@ -51,10 +52,19 @@ Grammar Grammar::FromJSONSchema(
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
     bool print_converted_ebnf,
-    bool any_order
+    bool any_order,
+    std::optional<std::string> whitespace_pattern
 ) {
   auto grammar = GrammarNormalizer::Apply(JSONSchemaToGrammar(
-      schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+      schema,
+      any_whitespace,
+      indent,
+      separators,
+      strict_mode,
+      max_whitespace_cnt,
+      any_order,
+      JSONFormat::kJSON,
+      std::move(whitespace_pattern)
   ));
   if (print_converted_ebnf) {
     XGRAMMAR_LOG(INFO) << "Converted EBNF: " << grammar.ToString() << std::endl;

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1028,7 +1028,8 @@ class GrammarCompilerSub {
       std::optional<std::pair<std::string, std::string>> separators,
       bool strict_mode,
       std::optional<int> max_whitespace_cnt,
-      bool any_order
+      bool any_order,
+      std::optional<std::string> whitespace_pattern
   );
 
   CompiledGrammar CompileRegex(const std::string& regex);
@@ -1157,7 +1158,8 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
     std::optional<std::pair<std::string, std::string>> separators,
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
-    bool any_order
+    bool any_order,
+    std::optional<std::string> whitespace_pattern
 ) {
   return MultiThreadCompileGrammar(Grammar::FromJSONSchema(
       schema,
@@ -1167,7 +1169,8 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
       strict_mode,
       max_whitespace_cnt,
       /*print_converted_ebnf=*/false,
-      any_order
+      any_order,
+      std::move(whitespace_pattern)
   ));
 }
 
@@ -1260,6 +1263,7 @@ class GrammarCompilerCacheKeys {
     bool strict_mode;
     std::optional<int> max_whitespace_cnt;
     bool any_order;
+    std::optional<std::string> whitespace_pattern;
 
     XGRAMMAR_EQUAL_BY_MEMBERS(
         SchemaKey,
@@ -1269,7 +1273,8 @@ class GrammarCompilerCacheKeys {
         &SchemaKey::separators,
         &SchemaKey::strict_mode,
         &SchemaKey::max_whitespace_cnt,
-        &SchemaKey::any_order
+        &SchemaKey::any_order,
+        &SchemaKey::whitespace_pattern
     );
   };
 
@@ -1310,7 +1315,8 @@ XGRAMMAR_HASH_BY_MEMBERS(
     &xgrammar::GrammarCompilerCacheKeys::SchemaKey::separators,
     &xgrammar::GrammarCompilerCacheKeys::SchemaKey::strict_mode,
     &xgrammar::GrammarCompilerCacheKeys::SchemaKey::max_whitespace_cnt,
-    &xgrammar::GrammarCompilerCacheKeys::SchemaKey::any_order
+    &xgrammar::GrammarCompilerCacheKeys::SchemaKey::any_order,
+    &xgrammar::GrammarCompilerCacheKeys::SchemaKey::whitespace_pattern
 );
 
 XGRAMMAR_HASH_BY_MEMBERS(
@@ -1376,7 +1382,8 @@ class GrammarCompiler::Impl {
       std::optional<std::pair<std::string, std::string>> separators,
       bool strict_mode,
       std::optional<int> max_whitespace_cnt,
-      bool any_order
+      bool any_order,
+      std::optional<std::string> whitespace_pattern
   );
 
   CompiledGrammar CompileStructuralTag(const std::string& structural_tag_json);
@@ -1435,10 +1442,17 @@ CompiledGrammar GrammarCompiler::Impl::Compute(const UnionKey& key) {
           const auto& [ebnf_str, root_rule_name] = key;
           return this->no_cache_compiler_.CompileGrammar(ebnf_str, root_rule_name);
         } else if constexpr (std::is_same_v<KeyType, SchemaKey>) {
-          const auto& [schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order] =
+          const auto& [schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order, whitespace_pattern] =
               key;
           return this->no_cache_compiler_.CompileJSONSchema(
-              schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+              schema,
+              any_whitespace,
+              indent,
+              separators,
+              strict_mode,
+              max_whitespace_cnt,
+              any_order,
+              whitespace_pattern
           );
         } else if constexpr (std::is_same_v<KeyType, StructuralTagKey>) {
           const auto& [structural_tag_json] = key;
@@ -1470,15 +1484,30 @@ CompiledGrammar GrammarCompiler::Impl::CompileJSONSchema(
     std::optional<std::pair<std::string, std::string>> separators,
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
-    bool any_order
+    bool any_order,
+    std::optional<std::string> whitespace_pattern
 ) {
   if (!cache_enabled_) {
     return no_cache_compiler_.CompileJSONSchema(
-        schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+        schema,
+        any_whitespace,
+        indent,
+        separators,
+        strict_mode,
+        max_whitespace_cnt,
+        any_order,
+        std::move(whitespace_pattern)
     );
   }
   return grammar_level_cache_.Get(SchemaKey{
-      schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+      schema,
+      any_whitespace,
+      indent,
+      separators,
+      strict_mode,
+      max_whitespace_cnt,
+      any_order,
+      std::move(whitespace_pattern)
   });
 }
 
@@ -1551,10 +1580,18 @@ CompiledGrammar GrammarCompiler::CompileJSONSchema(
     std::optional<std::pair<std::string, std::string>> separators,
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
-    bool any_order
+    bool any_order,
+    std::optional<std::string> whitespace_pattern
 ) {
   return pimpl_->CompileJSONSchema(
-      schema, any_whitespace, indent, separators, strict_mode, max_whitespace_cnt, any_order
+      schema,
+      any_whitespace,
+      indent,
+      separators,
+      strict_mode,
+      max_whitespace_cnt,
+      any_order,
+      std::move(whitespace_pattern)
   );
 }
 

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1581,11 +1581,40 @@ Result<TypeArraySpec, SchemaError> SchemaParser::ParseTypeArray(
 
 // ==================== IndentManager Implementation ====================
 
+namespace {
+
+void ValidateWhitespacePattern(const std::string& pattern) {
+  Grammar grammar = Grammar::FromRegex(pattern);
+  GrammarFSMBuilder::Apply(&grammar);
+
+  auto is_json_whitespace = [](int32_t byte) {
+    return byte == ' ' || byte == '\t' || byte == '\n' || byte == '\r';
+  };
+  for (int32_t state = 0; state < grammar->complete_fsm.NumStates(); ++state) {
+    for (const auto& edge : grammar->complete_fsm.GetEdges(state)) {
+      if (!edge.IsCharRange()) {
+        continue;
+      }
+      if (edge.min < 0 || edge.max > 0xff) {
+        XGRAMMAR_LOG(FATAL) << "whitespace_pattern may match only JSON whitespace characters.";
+      }
+      for (int32_t byte = edge.min; byte <= edge.max; ++byte) {
+        if (!is_json_whitespace(byte)) {
+          XGRAMMAR_LOG(FATAL) << "whitespace_pattern may match only JSON whitespace characters.";
+        }
+      }
+    }
+  }
+}
+
+}  // namespace
+
 IndentManager::IndentManager(
     std::optional<int> indent,
     const std::string& separator,
     bool any_whitespace,
-    std::optional<int> max_whitespace_cnt
+    std::optional<int> max_whitespace_cnt,
+    std::optional<std::string> whitespace_pattern
 )
     : any_whitespace_(any_whitespace),
       enable_newline_(indent.has_value()),
@@ -1593,10 +1622,21 @@ IndentManager::IndentManager(
       separator_(separator),
       total_indent_(0),
       is_first_({true}),
-      max_whitespace_cnt_(max_whitespace_cnt) {
+      max_whitespace_cnt_(max_whitespace_cnt),
+      whitespace_pattern_(std::move(whitespace_pattern)) {
   if (max_whitespace_cnt.has_value() && max_whitespace_cnt.value() <= 0) {
     XGRAMMAR_LOG(FATAL) << "max_whitespace_cnt must be positive.";
   }
+}
+
+std::string IndentManager::WhitespacePattern() const {
+  if (whitespace_pattern_.has_value()) {
+    return *whitespace_pattern_;
+  }
+  if (!max_whitespace_cnt_.has_value()) {
+    return "[ \\n\\t]*";
+  }
+  return "[ \\n\\t]{0," + std::to_string(*max_whitespace_cnt_) + "}";
 }
 
 void IndentManager::StartIndent() {
@@ -1611,11 +1651,7 @@ void IndentManager::EndIndent() {
 
 std::string IndentManager::StartSeparator() {
   if (any_whitespace_) {
-    if (!max_whitespace_cnt_.has_value()) {
-      return "[ \\n\\t]*";
-    } else {
-      return "[ \\n\\t]{0," + std::to_string(max_whitespace_cnt_.value()) + "}";
-    }
+    return WhitespacePattern();
   }
   if (!enable_newline_) {
     return "\"\"";
@@ -1625,12 +1661,7 @@ std::string IndentManager::StartSeparator() {
 
 std::string IndentManager::MiddleSeparator() {
   if (any_whitespace_) {
-    std::string whitespace_part;
-    if (!max_whitespace_cnt_.has_value()) {
-      whitespace_part = "[ \\n\\t]*";
-    } else {
-      whitespace_part = "[ \\n\\t]{0," + std::to_string(max_whitespace_cnt_.value()) + "}";
-    }
+    std::string whitespace_part = WhitespacePattern();
     return whitespace_part + " \"" + separator_ + "\" " + whitespace_part;
   }
   if (!enable_newline_) {
@@ -1641,11 +1672,7 @@ std::string IndentManager::MiddleSeparator() {
 
 std::string IndentManager::EndSeparator() {
   if (any_whitespace_) {
-    if (!max_whitespace_cnt_.has_value()) {
-      return "[ \\n\\t]*";
-    } else {
-      return "[ \\n\\t]{0," + std::to_string(max_whitespace_cnt_.value()) + "}";
-    }
+    return WhitespacePattern();
   }
   if (!enable_newline_) {
     return "\"\"";
@@ -1655,11 +1682,7 @@ std::string IndentManager::EndSeparator() {
 
 std::string IndentManager::EmptySeparator() {
   if (any_whitespace_) {
-    if (!max_whitespace_cnt_.has_value()) {
-      return "[ \\n\\t]*";
-    } else {
-      return "[ \\n\\t]{0," + std::to_string(max_whitespace_cnt_.value()) + "}";
-    }
+    return WhitespacePattern();
   }
   return "\"\"";
 }
@@ -1668,18 +1691,9 @@ std::string IndentManager::NextSeparator(bool is_end) {
   if (any_whitespace_) {
     if (is_first_.back() || is_end) {
       is_first_.back() = false;
-      if (!max_whitespace_cnt_.has_value()) {
-        return "[ \\n\\t]*";
-      } else {
-        return "[ \\n\\t]{0," + std::to_string(max_whitespace_cnt_.value()) + "}";
-      }
+      return WhitespacePattern();
     } else {
-      std::string whitespace_part;
-      if (!max_whitespace_cnt_.has_value()) {
-        whitespace_part = "[ \\n\\t]*";
-      } else {
-        whitespace_part = "[ \\n\\t]{0," + std::to_string(max_whitespace_cnt_.value()) + "}";
-      }
+      std::string whitespace_part = WhitespacePattern();
       return whitespace_part + " \"" + separator_ + "\" " + whitespace_part;
     }
   }
@@ -1724,19 +1738,31 @@ JSONSchemaConverter::JSONSchemaConverter(
     bool any_whitespace,
     std::optional<int> max_whitespace_cnt,
     RefResolver ref_resolver,
-    bool any_order
+    bool any_order,
+    std::optional<std::string> whitespace_pattern
 )
     : indent_manager_(
           indent,
           separators.has_value() ? separators->first
                                  : (any_whitespace ? "," : (indent.has_value() ? "," : ", ")),
           any_whitespace,
-          max_whitespace_cnt
+          max_whitespace_cnt,
+          whitespace_pattern
       ),
       any_whitespace_(any_whitespace),
       max_whitespace_cnt_(max_whitespace_cnt),
+      whitespace_pattern_(std::move(whitespace_pattern)),
       any_order_(any_order),
       ref_resolver_(std::move(ref_resolver)) {
+  if (whitespace_pattern_.has_value() && !any_whitespace_) {
+    XGRAMMAR_LOG(FATAL) << "whitespace_pattern requires any_whitespace=True.";
+  }
+  if (whitespace_pattern_.has_value() && max_whitespace_cnt_.has_value()) {
+    XGRAMMAR_LOG(FATAL) << "whitespace_pattern and max_whitespace_cnt cannot both be specified.";
+  }
+  if (whitespace_pattern_.has_value()) {
+    ValidateWhitespacePattern(*whitespace_pattern_);
+  }
   std::string colon_sep =
       separators.has_value() ? separators->second : (any_whitespace ? ":" : ": ");
   std::string whitespace = GetWhitespacePattern();
@@ -1798,7 +1824,8 @@ void JSONSchemaConverter::AddBasicRules(const std::vector<std::string>& addition
       std::nullopt,
       any_whitespace_ ? "," : ", ",
       any_whitespace_,
-      any_whitespace_ ? max_whitespace_cnt_ : std::nullopt
+      any_whitespace_ ? max_whitespace_cnt_ : std::nullopt,
+      whitespace_pattern_
   );
 
   // basic_any - use "{}" as the cache key for empty schema
@@ -1986,6 +2013,9 @@ int32_t JSONSchemaConverter::AddSubGrammar(const Grammar& grammar) {
 }
 
 std::string JSONSchemaConverter::GetWhitespacePattern() const {
+  if (whitespace_pattern_.has_value()) {
+    return *whitespace_pattern_;
+  }
   if (!max_whitespace_cnt_.has_value()) {
     return "[ \\n\\t]*";
   }
@@ -1993,6 +2023,12 @@ std::string JSONSchemaConverter::GetWhitespacePattern() const {
 }
 
 int32_t JSONSchemaConverter::WhitespaceExpression() {
+  if (whitespace_pattern_.has_value()) {
+    if (!whitespace_expr_id_.has_value()) {
+      whitespace_expr_id_ = RegexExpression(*whitespace_pattern_);
+    }
+    return *whitespace_expr_id_;
+  }
   std::vector<CharacterClassElement> elements = {{' ', ' '}, {'\n', '\n'}, {'\t', '\t'}};
   if (!max_whitespace_cnt_.has_value()) {
     if (!whitespace_expr_id_.has_value()) {
@@ -4054,7 +4090,8 @@ Grammar JSONSchemaToGrammar(
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
     bool any_order,
-    JSONFormat json_format
+    JSONFormat json_format,
+    std::optional<std::string> whitespace_pattern
 ) {
   picojson::value schema_value;
   std::string error = picojson::parse(schema_value, schema);
@@ -4082,7 +4119,8 @@ Grammar JSONSchemaToGrammar(
           any_whitespace,
           max_whitespace_cnt,
           std::move(ref_resolver),
-          any_order
+          any_order,
+          whitespace_pattern
       );
       return converter.Convert(spec);
     }
@@ -4097,7 +4135,8 @@ Grammar JSONSchemaToGrammar(
           max_whitespace_cnt,
           std::move(ref_resolver),
           json_format,
-          any_order
+          any_order,
+          whitespace_pattern
       );
       return converter.Convert(spec);
     }
@@ -4115,7 +4154,8 @@ std::string JSONSchemaToEBNF(
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
     JSONFormat json_format,
-    bool any_order
+    bool any_order,
+    std::optional<std::string> whitespace_pattern
 ) {
   picojson::value schema_value;
   std::string err = picojson::parse(schema_value, schema);
@@ -4129,7 +4169,8 @@ std::string JSONSchemaToEBNF(
       strict_mode,
       max_whitespace_cnt,
       json_format,
-      any_order
+      any_order,
+      std::move(whitespace_pattern)
   );
 }
 
@@ -4141,7 +4182,8 @@ std::string JSONSchemaToEBNF(
     bool strict_mode,
     std::optional<int> max_whitespace_cnt,
     JSONFormat json_format,
-    bool any_order
+    bool any_order,
+    std::optional<std::string> whitespace_pattern
 ) {
   // Parse JSON Schema to SchemaSpec
   SchemaParser parser(schema, {strict_mode, json_format});
@@ -4163,7 +4205,13 @@ std::string JSONSchemaToEBNF(
   switch (json_format) {
     case JSONFormat::kJSON: {
       JSONSchemaConverter converter(
-          indent, separators, any_whitespace, max_whitespace_cnt, ref_resolver, any_order
+          indent,
+          separators,
+          any_whitespace,
+          max_whitespace_cnt,
+          ref_resolver,
+          any_order,
+          whitespace_pattern
       );
       return GrammarNormalizer::Apply(converter.Convert(spec)).ToString();
     }
@@ -4178,7 +4226,8 @@ std::string JSONSchemaToEBNF(
           max_whitespace_cnt,
           ref_resolver,
           json_format,
-          any_order
+          any_order,
+          whitespace_pattern
       );
       return GrammarNormalizer::Apply(converter.Convert(spec)).ToString();
     }

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -241,7 +241,8 @@ class IndentManager {
       std::optional<int> indent,
       const std::string& separator,
       bool any_whitespace,
-      std::optional<int> max_whitespace_cnt
+      std::optional<int> max_whitespace_cnt,
+      std::optional<std::string> whitespace_pattern = std::nullopt
   );
 
   void StartIndent();
@@ -260,6 +261,9 @@ class IndentManager {
   int64_t total_indent_;
   std::vector<bool> is_first_;
   std::optional<int> max_whitespace_cnt_;
+  std::optional<std::string> whitespace_pattern_;
+
+  std::string WhitespacePattern() const;
 
   friend class JSONSchemaConverter;
 };
@@ -281,7 +285,8 @@ class JSONSchemaConverter {
       bool any_whitespace,
       std::optional<int> max_whitespace_cnt,
       RefResolver ref_resolver = nullptr,
-      bool any_order = false
+      bool any_order = false,
+      std::optional<std::string> whitespace_pattern = std::nullopt
   );
 
   virtual ~JSONSchemaConverter() = default;
@@ -438,6 +443,7 @@ class JSONSchemaConverter {
   int32_t colon_expr_id_;
   bool any_whitespace_;
   std::optional<int> max_whitespace_cnt_;
+  std::optional<std::string> whitespace_pattern_;
   // When true, object properties may appear in any order (see GetAnyOrderRuleForProperties).
   // Applies to all objects (including nested ones). Default false preserves the fixed-order
   // behavior.
@@ -516,7 +522,8 @@ Grammar JSONSchemaToGrammar(
     bool strict_mode = true,
     std::optional<int> max_whitespace_cnt = std::nullopt,
     bool any_order = false,
-    JSONFormat json_format = JSONFormat::kJSON
+    JSONFormat json_format = JSONFormat::kJSON,
+    std::optional<std::string> whitespace_pattern = std::nullopt
 );
 
 // ==================== Public API functions (backward compatible) ====================
@@ -540,6 +547,9 @@ Grammar JSONSchemaToGrammar(
  * \param max_whitespace_cnt The maximum number of whitespace characters for the whitespace
  * which is used for indentation or JSON elements separation when any_whitespace is True. If
  * std::nullopt, it means unlimited. Default: std::nullopt.
+ * \param whitespace_pattern Optional regular expression defining the whitespace allowed between
+ * JSON elements. It may match only JSON whitespace characters and cannot be combined with
+ * max_whitespace_cnt.
  * \param json_format Define the root
  * format of the object. If it's JSONFormat::kJSON, then it will generate a fully JSON-style
  * grammar. If it's JSONFormat::kXML, then it will generate a grammar with the root format is
@@ -555,7 +565,8 @@ std::string JSONSchemaToEBNF(
     bool strict_mode = true,
     std::optional<int> max_whitespace_cnt = std::nullopt,
     JSONFormat json_format = JSONFormat::kJSON,
-    bool any_order = false
+    bool any_order = false,
+    std::optional<std::string> whitespace_pattern = std::nullopt
 );
 
 /*!
@@ -577,6 +588,9 @@ std::string JSONSchemaToEBNF(
  * \param max_whitespace_cnt The maximum number of whitespace characters for the whitespace
  * which is used for indentation or JSON elements separation when any_whitespace is True. If
  * std::nullopt, it means unlimited. Default: std::nullopt.
+ * \param whitespace_pattern Optional regular expression defining the whitespace allowed between
+ * JSON elements. It may match only JSON whitespace characters and cannot be combined with
+ * max_whitespace_cnt.
  * \param json_format Define the root format of the object. If it's JSONFormat::kJSON,
  * then it will generate a fully JSON-style grammar. If it's JSONFormat::kXML, then it will
  * generate a grammar with the root format is XML-style, while the inner format is JSON-style.
@@ -591,7 +605,8 @@ std::string JSONSchemaToEBNF(
     bool strict_mode = true,
     std::optional<int> max_whitespace_cnt = std::nullopt,
     JSONFormat json_format = JSONFormat::kJSON,
-    bool any_order = false
+    bool any_order = false,
+    std::optional<std::string> whitespace_pattern = std::nullopt
 );
 
 /*!

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -40,10 +40,17 @@ XMLToolCallingConverter::XMLToolCallingConverter(
     std::optional<int> max_whitespace_cnt,
     RefResolver ref_resolver,
     JSONFormat json_format,
-    bool any_order
+    bool any_order,
+    std::optional<std::string> whitespace_pattern
 )
     : JSONSchemaConverter(
-          indent, separators, any_whitespace, max_whitespace_cnt, ref_resolver, any_order
+          indent,
+          separators,
+          any_whitespace,
+          max_whitespace_cnt,
+          ref_resolver,
+          any_order,
+          std::move(whitespace_pattern)
       ),
       json_format_(json_format),
       nested_object_level_(0),

--- a/cpp/json_schema_converter_ext.h
+++ b/cpp/json_schema_converter_ext.h
@@ -30,7 +30,8 @@ class XMLToolCallingConverter : public JSONSchemaConverter {
       std::optional<int> max_whitespace_cnt,
       RefResolver ref_resolver = nullptr,
       JSONFormat json_format = JSONFormat::kQwenXML,
-      bool any_order = false
+      bool any_order = false,
+      std::optional<std::string> whitespace_pattern = std::nullopt
   );
 
   /*! \brief Convert SchemaSpec to grammar with XML format for root object. Note that this function

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -106,6 +106,11 @@ picojson::value JSONSchemaFormat::ToJSON() const {
   } else {
     obj["max_whitespace_cnt"] = picojson::value();
   }
+  if (whitespace_pattern.has_value()) {
+    obj["whitespace_pattern"] = picojson::value(*whitespace_pattern);
+  } else {
+    obj["whitespace_pattern"] = picojson::value();
+  }
   return picojson::value(std::move(obj));
 }
 
@@ -567,9 +572,21 @@ Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
     }
     max_whitespace_cnt = static_cast<int>(max_whitespace_cnt_it->second.get<int64_t>());
   }
+  std::optional<std::string> whitespace_pattern = std::nullopt;
+  auto whitespace_pattern_it = obj.find("whitespace_pattern");
+  if (whitespace_pattern_it != obj.end() && !whitespace_pattern_it->second.is<picojson::null>()) {
+    if (!whitespace_pattern_it->second.is<std::string>()) {
+      return ResultErr<ISTError>("whitespace_pattern must be a string or null");
+    }
+    whitespace_pattern = whitespace_pattern_it->second.get<std::string>();
+  }
   // here introduces a serialization/deserialization overhead; try to avoid it in the future.
   return ResultOk<JSONSchemaFormat>(
-      json_schema_it->second.serialize(false), style, any_order, max_whitespace_cnt
+      json_schema_it->second.serialize(false),
+      style,
+      any_order,
+      max_whitespace_cnt,
+      std::move(whitespace_pattern)
   );
 }
 
@@ -1863,7 +1880,8 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFo
       /*strict_mode=*/true,
       /*max_whitespace_cnt=*/format.max_whitespace_cnt,
       /*any_order=*/format.any_order,
-      /*json_format=*/*json_format
+      /*json_format=*/*json_format,
+      /*whitespace_pattern=*/format.whitespace_pattern
   ));
   auto added_root_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
   return ResultOk(added_root_rule_id);

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -89,16 +89,20 @@ struct JSONSchemaFormat {
   bool any_order = false;
   // Per-tag cap on consecutive whitespace characters in the JSON-schema content.
   std::optional<int> max_whitespace_cnt = std::nullopt;
+  // Per-tag regular expression for whitespace in the JSON-schema content.
+  std::optional<std::string> whitespace_pattern = std::nullopt;
   JSONSchemaFormat(
       std::string json_schema,
       std::string style = "json",
       bool any_order = false,
-      std::optional<int> max_whitespace_cnt = std::nullopt
+      std::optional<int> max_whitespace_cnt = std::nullopt,
+      std::optional<std::string> whitespace_pattern = std::nullopt
   )
       : json_schema(std::move(json_schema)),
         style(std::move(style)),
         any_order(any_order),
-        max_whitespace_cnt(max_whitespace_cnt) {}
+        max_whitespace_cnt(max_whitespace_cnt),
+        whitespace_pattern(std::move(whitespace_pattern)) {}
   picojson::value ToJSON() const;
 };
 

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -80,6 +80,11 @@ static std::optional<bool> OptionalBoolFromView(ffi::AnyView v) {
   return static_cast<bool>(v.cast<int64_t>());
 }
 
+static std::optional<std::string> OptionalStringFromView(ffi::AnyView v) {
+  if (v == nullptr) return std::nullopt;
+  return std::string(v.cast<ffi::String>());
+}
+
 static std::optional<std::vector<int32_t>> OptionalInt32VectorFromView(ffi::AnyView v) {
   if (v == nullptr) return std::nullopt;
   ffi::Array<int64_t> array = v.cast<ffi::Array<int64_t>>();
@@ -361,7 +366,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              bool strict_mode,
              ffi::AnyView max_whitespace_cnt,
              bool print_converted_ebnf,
-             bool any_order) {
+             bool any_order,
+             ffi::AnyView whitespace_pattern) {
             XGRAMMAR_FFI_TRY_BEGIN();
             auto g = Grammar::FromJSONSchema(
                 schema,
@@ -371,7 +377,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                 strict_mode,
                 OptionalIntFromView(max_whitespace_cnt),
                 print_converted_ebnf,
-                any_order
+                any_order,
+                OptionalStringFromView(whitespace_pattern)
             );
             return ffi::ObjectRef(ffi::make_object<GrammarObj>(std::move(g)));
             XGRAMMAR_FFI_TRY_END();
@@ -514,7 +521,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              ffi::AnyView separators,
              bool strict_mode,
              ffi::AnyView max_whitespace_cnt,
-             bool any_order) {
+             bool any_order,
+             ffi::AnyView whitespace_pattern) {
             XGRAMMAR_FFI_TRY_BEGIN();
             CompiledGrammar cg = o->value.CompileJSONSchema(
                 schema,
@@ -523,7 +531,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                 OptionalSeparatorsFromView(separators),
                 strict_mode,
                 OptionalIntFromView(max_whitespace_cnt),
-                any_order
+                any_order,
+                OptionalStringFromView(whitespace_pattern)
             );
             return ffi::ObjectRef(ffi::make_object<CompiledGrammarObj>(std::move(cg)));
             XGRAMMAR_FFI_TRY_END();
@@ -786,7 +795,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              bool strict_mode,
              ffi::AnyView max_whitespace_cnt,
              ffi::String json_format,
-             bool any_order) {
+             bool any_order,
+             ffi::AnyView whitespace_pattern) {
             auto format = JSONFormatFromString(json_format);
             if (!format.has_value()) {
               TVM_FFI_THROW(RuntimeError) << "Invalid json_format: " << std::string(json_format);
@@ -799,7 +809,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                 strict_mode,
                 OptionalIntFromView(max_whitespace_cnt),
                 *format,
-                any_order
+                any_order,
+                OptionalStringFromView(whitespace_pattern)
             ));
           }
       )

--- a/docs/defining_structures/json_generation.md
+++ b/docs/defining_structures/json_generation.md
@@ -62,6 +62,24 @@ person_schema = {
 compiled_grammar = compiler.compile_json_schema(json.dumps(person_schema))
 ```
 
+## Whitespace Control
+
+JSON Schema grammars allow spaces, tabs, and line feeds between elements by default. Use
+`whitespace_pattern` when the output needs a narrower layout. For example, the following grammar
+allows either no whitespace, one space, or a line feed followed by two spaces at every JSON
+separator:
+
+```python
+compiled_grammar = compiler.compile_json_schema(
+    Person,
+    whitespace_pattern=r"(?: |\n  )?",
+)
+```
+
+The pattern may contain only JSON whitespace characters: space, tab, carriage return, and line
+feed. It requires `any_whitespace=True` and cannot be combined with `max_whitespace_cnt`. An empty
+pattern (`whitespace_pattern=""`) enforces compact JSON with no whitespace between elements.
+
 With the compiled grammar, we can instantiate a [`xgr.GrammarMatcher`](xgrammar.GrammarMatcher)
 and generate the token masks in the generation loop.
 

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -79,7 +79,8 @@ class GrammarCompiler {
       std::optional<std::pair<std::string, std::string>> separators = std::nullopt,
       bool strict_mode = true,
       std::optional<int> max_whitespace_cnt = std::nullopt,
-      bool any_order = false
+      bool any_order = false,
+      std::optional<std::string> whitespace_pattern = std::nullopt
   );
 
   /*! \brief Get the compiled grammar for pure JSON. */

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -113,6 +113,9 @@ class Grammar {
    *
    * This helps LLM to generate accurate output in the grammar-guided generation with JSON
    * schema. Default: true.
+   * \param whitespace_pattern Optional regular expression defining the whitespace allowed between
+   * JSON elements. The pattern may match only space, tab, carriage return, and line feed. It
+   * requires any_whitespace=true and cannot be combined with max_whitespace_cnt.
    */
   static Grammar FromJSONSchema(
       const std::string& schema,
@@ -122,7 +125,8 @@ class Grammar {
       bool strict_mode = true,
       std::optional<int> max_whitespace_cnt = std::nullopt,
       bool print_converted_ebnf = false,
-      bool any_order = false
+      bool any_order = false,
+      std::optional<std::string> whitespace_pattern = std::nullopt
   );
 
   /*!

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -150,6 +150,7 @@ class GrammarCompiler(XGRObject):
         strict_mode: bool = True,
         max_whitespace_cnt: Optional[int] = None,
         any_order: bool = False,
+        whitespace_pattern: Optional[str] = None,
     ) -> CompiledGrammar:
         """Get CompiledGrammar from the specified JSON schema and format. The indent
         and separators parameters follow the same convention as in json.dumps().
@@ -194,6 +195,12 @@ class GrammarCompiler(XGRObject):
 
             Applies to every object, nested included.
 
+        whitespace_pattern : Optional[str], default: None
+            A regular expression that defines the whitespace allowed between JSON elements.
+            The pattern may contain only JSON whitespace characters (space, tab, carriage return,
+            and line feed). It requires ``any_whitespace=True`` and cannot be combined with
+            ``max_whitespace_cnt``.
+
         Returns
         -------
         compiled_grammar : CompiledGrammar
@@ -209,6 +216,7 @@ class GrammarCompiler(XGRObject):
                 strict_mode,
                 max_whitespace_cnt,
                 any_order,
+                whitespace_pattern,
             )
         )
 

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -185,6 +185,7 @@ class Grammar(XGRObject):
         max_whitespace_cnt: Optional[int] = None,
         print_converted_ebnf: bool = False,
         any_order: bool = False,
+        whitespace_pattern: Optional[str] = None,
     ) -> "Grammar":
         """Construct a grammar from JSON schema. Pydantic model or JSON schema string can be
         used to specify the schema.
@@ -249,6 +250,12 @@ class Grammar(XGRObject):
 
             Applies to every object, nested included.
 
+        whitespace_pattern : Optional[str], default: None
+            A regular expression that defines the whitespace allowed between JSON elements.
+            The pattern may contain only JSON whitespace characters (space, tab, carriage return,
+            and line feed). It requires ``any_whitespace=True`` and cannot be combined with
+            ``max_whitespace_cnt``.
+
         Returns
         -------
         grammar : Grammar
@@ -270,6 +277,7 @@ class Grammar(XGRObject):
                 max_whitespace_cnt,
                 print_converted_ebnf,
                 any_order,
+                whitespace_pattern,
             )
         )
 

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -49,6 +49,8 @@ class JSONSchemaFormat(BaseModel):
     Applies to every object, nested included."""
     max_whitespace_cnt: Optional[int] = None
     """Max consecutive whitespace characters in this content. None means no limit."""
+    whitespace_pattern: Optional[str] = None
+    """Regular expression for whitespace between JSON elements. None uses the default."""
 
 
 class AnyTextFormat(BaseModel):

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -26,6 +26,7 @@ def _json_schema_to_ebnf(
     strict_mode: bool = True,
     json_format: Literal["json", "qwen_xml", "minimax_xml", "deepseek_xml", "glm_xml"] = "json",
     any_order: bool = False,
+    whitespace_pattern: Optional[str] = None,
 ) -> str:
     """Convert JSON schema string to BNF grammar string. For test purposes.
 
@@ -56,6 +57,9 @@ def _json_schema_to_ebnf(
         If specified, it will limit the number of whitespace characters to at most max_whitespace_cnt.
         It should be a positive integer.
 
+    whitespace_pattern : Optional[str], default: None
+        A regular expression that defines the whitespace allowed between JSON elements.
+
     json_format : str, default: "json"
         The root format of the generated grammar. One of "json", "qwen_xml", "minimax_xml",
         "deepseek_xml", "glm_xml". Formats other than "json" generate an XML-style root object
@@ -76,6 +80,7 @@ def _json_schema_to_ebnf(
         max_whitespace_cnt,
         json_format,
         any_order,
+        whitespace_pattern,
     )
 
 

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2998,6 +2998,70 @@ basic_string_sub_4 ::= ((basic_string_sub_2))
     assert not _is_grammar_accept_string(grammar, '{    "key"  :  "value"    }')
 
 
+def test_custom_whitespace_pattern():
+    schema = {"type": "object", "properties": {"key": {"type": "string"}}, "required": ["key"]}
+    grammar = xgr.Grammar.from_json_schema(schema, whitespace_pattern=r"(?: |\n  )?")
+
+    for text in ('{"key":"value"}', '{ "key" : "value" }', '{\n  "key":\n  "value"\n  }'):
+        assert _is_grammar_accept_string(grammar, text)
+
+    for text in ('{  "key":"value"}', '{\n "key":"value"}', '{\t"key":"value"}'):
+        assert not _is_grammar_accept_string(grammar, text)
+
+    ebnf = _json_schema_to_ebnf(schema, whitespace_pattern=r"(?: |\n  )?")
+    assert "root ::=" in ebnf
+
+
+def test_custom_whitespace_pattern_empty_and_compiler_cache():
+    schema = {"type": "array", "items": {"type": "integer"}}
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]))
+
+    compact = compiler.compile_json_schema(schema, whitespace_pattern="").grammar
+    spaces = compiler.compile_json_schema(schema, whitespace_pattern=" *").grammar
+
+    assert _is_grammar_accept_string(compact, "[1,2]")
+    assert not _is_grammar_accept_string(compact, "[ 1, 2 ]")
+    assert _is_grammar_accept_string(spaces, "[1,2]")
+    assert _is_grammar_accept_string(spaces, "[ 1, 2 ]")
+    assert str(compact) != str(spaces)
+
+
+def test_custom_whitespace_pattern_json_whitespace():
+    schema = {"type": "array", "items": {"type": "integer"}}
+    grammar = xgr.Grammar.from_json_schema(schema, whitespace_pattern=r"[\t\r\n ]*")
+
+    assert _is_grammar_accept_string(grammar, "[\r\n\t 1,\r 2\n]")
+
+
+def test_custom_whitespace_pattern_qwen_xml():
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "integer"}, "b": {"type": "string"}},
+        "required": ["a", "b"],
+        "additionalProperties": False,
+    }
+    grammar = _json_schema_to_ebnf(schema, json_format="qwen_xml", whitespace_pattern=" ?")
+
+    prefix = "<parameter=a>1</parameter>"
+    suffix = "<parameter=b>x</parameter>"
+    assert _is_grammar_accept_string(grammar, prefix + suffix)
+    assert _is_grammar_accept_string(grammar, prefix + " " + suffix)
+    assert not _is_grammar_accept_string(grammar, prefix + "  " + suffix)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"any_whitespace": False, "whitespace_pattern": " *"}, "requires any_whitespace=True"),
+        ({"max_whitespace_cnt": 2, "whitespace_pattern": " *"}, "cannot both be specified"),
+        ({"whitespace_pattern": "[ x]*"}, "only JSON whitespace characters"),
+    ],
+)
+def test_custom_whitespace_pattern_invalid_options(kwargs, message):
+    with pytest.raises(RuntimeError, match=message):
+        xgr.Grammar.from_json_schema({"type": "integer"}, **kwargs)
+
+
 def test_utf8_in_enum():
     schema = {"type": "string", "enum": ["こんにちは", "😊", "你好", "hello", "\n"]}
     grammar = xgr.Grammar.from_json_schema(schema)

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
 
 import pytest

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -4140,12 +4140,17 @@ def test_json_schema_format_any_order_via_pydantic():
 _WS_SCHEMA = {"type": "object", "properties": {"a": {"type": "integer"}}, "required": ["a"]}
 
 
-def _ws_stag(*, max_whitespace_cnt: Optional[int] = None) -> StructuralTag:
+def _ws_stag(
+    *, max_whitespace_cnt: Optional[int] = None, whitespace_pattern: Optional[str] = None
+) -> StructuralTag:
     return StructuralTag(
         format=TagFormat(
             begin="<call>",
             content=JSONSchemaFormat(
-                json_schema=_WS_SCHEMA, style="json", max_whitespace_cnt=max_whitespace_cnt
+                json_schema=_WS_SCHEMA,
+                style="json",
+                max_whitespace_cnt=max_whitespace_cnt,
+                whitespace_pattern=whitespace_pattern,
             ),
             end="</call>",
         )
@@ -4166,6 +4171,26 @@ def test_structural_tag_max_whitespace_cnt():
     # Beyond the bound: accepted only without the limit.
     assert _is_grammar_accept_string(g_unbounded, _ws_instance(5))
     assert not _is_grammar_accept_string(g_bounded, _ws_instance(5))
+
+
+def test_structural_tag_whitespace_pattern():
+    grammar = xgr.Grammar.from_structural_tag(_ws_stag(whitespace_pattern=" ?"))
+
+    assert _is_grammar_accept_string(grammar, _ws_instance(0))
+    assert _is_grammar_accept_string(grammar, _ws_instance(1))
+    assert not _is_grammar_accept_string(grammar, _ws_instance(2))
+
+
+@pytest.mark.parametrize(
+    ("tag", "message"),
+    [
+        (_ws_stag(max_whitespace_cnt=2, whitespace_pattern=" ?"), "cannot both be specified"),
+        (_ws_stag(whitespace_pattern="[ x]*"), "only JSON whitespace characters"),
+    ],
+)
+def test_structural_tag_whitespace_pattern_invalid(tag: StructuralTag, message: str):
+    with pytest.raises(RuntimeError, match=message):
+        xgr.Grammar.from_structural_tag(tag)
 
 
 def test_structural_tag_per_tag_whitespace_independent():

--- a/web/src/structural_tag.ts
+++ b/web/src/structural_tag.ts
@@ -12,6 +12,7 @@ export interface ConstStringFormat {
 export interface JSONSchemaFormat {
   type: "json_schema";
   json_schema: JSONSchemaValue;
+  whitespace_pattern?: string;
 }
 
 export interface QwenXMLParameterFormat {

--- a/web/src/xgrammar.ts
+++ b/web/src/xgrammar.ts
@@ -70,6 +70,7 @@ export class Testings {
    * JSON elements when anyWhitespace is true. Undefined means unlimited.
    * @param {"json" | "xml"} [jsonFormat="json"] The JSON schema output format.
    * @param {boolean} [anyOrder=false] Whether to allow object properties to appear in any order.
+   * @param {string} [whitespacePattern] Regular expression for whitespace between JSON elements.
    * @returns {string} The EBNF grammar string.
    */
   static async _jsonSchemaToEBNF(
@@ -80,7 +81,8 @@ export class Testings {
     strictMode = true,
     maxWhitespaceCnt?: number,
     jsonFormat: "json" | "xml" = "json",
-    anyOrder: boolean = false
+    anyOrder: boolean = false,
+    whitespacePattern?: string
   ): Promise<string> {
     const separatorsPair = toSeparatorPair(separators);
     await asyncInitBinding();
@@ -99,7 +101,8 @@ export class Testings {
       strictMode,
       maxWhitespaceCnt,
       formatEnum,
-      anyOrder
+      anyOrder,
+      whitespacePattern
     );
   }
 
@@ -247,6 +250,7 @@ export class Grammar {
    * @param {number} [maxWhitespaceCnt] Maximum number of whitespace characters allowed between
    * JSON elements when anyWhitespace is true. Undefined means unlimited.
    * @param {boolean} [anyOrder=false] Whether to allow object properties to appear in any order.
+   * @param {string} [whitespacePattern] Regular expression for whitespace between JSON elements.
    * @returns {Grammar} The generated BNF grammar.
    */
   static async fromJSONSchema(
@@ -256,7 +260,8 @@ export class Grammar {
     separators?: [string, string],
     strictMode = true,
     maxWhitespaceCnt?: number,
-    anyOrder: boolean = false
+    anyOrder: boolean = false,
+    whitespacePattern?: string
   ): Promise<Grammar> {
     const separatorsPair = toSeparatorPair(separators);
     await asyncInitBinding();
@@ -275,7 +280,8 @@ export class Grammar {
         strictMode,
         maxWhitespaceCnt,
         printConvertedEBNF,
-        anyOrder
+        anyOrder,
+        whitespacePattern
       ));
   }
 
@@ -517,6 +523,7 @@ export class GrammarCompiler {
    * @param {number} [maxWhitespaceCnt] Maximum number of whitespace characters allowed between
    * JSON elements when anyWhitespace is true. Undefined means unlimited.
    * @param {boolean} [anyOrder=false] Whether to allow object properties to appear in any order.
+   * @param {string} [whitespacePattern] Regular expression for whitespace between JSON elements.
    * @returns {CompiledGrammar} The compiled grammar for the specified JSON schema.
    */
   async compileJSONSchema(
@@ -526,7 +533,8 @@ export class GrammarCompiler {
     separators?: [string, string],
     strictMode = true,
     maxWhitespaceCnt?: number,
-    anyOrder: boolean = false
+    anyOrder: boolean = false,
+    whitespacePattern?: string
   ): Promise<CompiledGrammar> {
     const separatorsPair = toSeparatorPair(separators);
     await asyncInitBinding();
@@ -542,7 +550,8 @@ export class GrammarCompiler {
         separatorsPair,
         strictMode,
         maxWhitespaceCnt,
-        anyOrder));
+        anyOrder,
+        whitespacePattern));
   }
 
   /**

--- a/web/src/xgrammar_binding.cc
+++ b/web/src/xgrammar_binding.cc
@@ -160,6 +160,7 @@ EMSCRIPTEN_BINDINGS(xgrammar) {
 
   // Register std::optional used in Grammar::FromJSONSchema
   register_optional<int>();
+  register_optional<std::string>();
   value_object<std::pair<std::string, std::string>>("StringPair")
       .field("first", &std::pair<std::string, std::string>::first)
       .field("second", &std::pair<std::string, std::string>::second);
@@ -184,19 +185,9 @@ EMSCRIPTEN_BINDINGS(xgrammar) {
   function("vecIntToView", &vecIntToView);
 
   // Testing methods
-  function(
-      "_JSONSchemaToEBNF",
-      select_overload<std::string(
-          const std::string&,
-          bool,
-          std::optional<int>,
-          std::optional<std::pair<std::string, std::string>>,
-          bool,
-          std::optional<int>,
-          JSONFormat,
-          bool
-      )>(&JSONSchemaToEBNF)
-  );
+  using JSONSchemaToEBNFFunction = std::
+      string(const std::string&, bool, std::optional<int>, std::optional<std::pair<std::string, std::string>>, bool, std::optional<int>, JSONFormat, bool, std::optional<std::string>);
+  function("_JSONSchemaToEBNF", select_overload<JSONSchemaToEBNFFunction>(&JSONSchemaToEBNF));
   function("DebugGetMaskedTokensFromBitmask", &Testing_DebugGetMaskedTokensFromBitmask);
   function("EBNFToGrammarNoNormalization", &_EBNFToGrammarNoNormalization);
 

--- a/web/tests/grammar.test.ts
+++ b/web/tests/grammar.test.ts
@@ -94,6 +94,16 @@ d_1 ::= ("" | ("d"))
     expect(grammar0).not.toEqual(grammar2);
   });
 
+  test("Test whitespace pattern Grammar.fromJSONSchema()", async () => {
+    const compact = (await Grammar.fromJSONSchema(
+      schema, true, -1, undefined, true, undefined, false, ""
+    )).toString();
+    const spaces = (await Grammar.fromJSONSchema(
+      schema, true, -1, undefined, true, undefined, false, " *"
+    )).toString();
+    expect(compact).not.toEqual(spaces);
+  });
+
   test("Test Grammar.builtinJSONGrammar()", async () => {
     const grammar = await Grammar.builtinJSONGrammar();
     const outputStr = grammar.toString();


### PR DESCRIPTION
## Summary

- add an optional `whitespace_pattern` regular expression to JSON Schema grammar and compiler APIs
- validate patterns against JSON whitespace and isolate compiler cache entries by pattern
- support the option in structural-tag JSON schema formats, XML-style output, Python, and Web bindings
- document compact and layout-specific usage

## Validation

- `pre-commit run --all-files`
- `ctest --test-dir build-debug --output-on-failure` (61 passed)
- `python -m pytest -q tests/python -m "not hf_token_required"` (3069 passed, 1 skipped, 622 deselected)
- `npm run lint`
- `docs/build_docs.sh`