### PR TITLE
Skip redundant structural tag normalization

### DIFF
--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -22,6 +22,7 @@
 #include "fsm.h"
 #include "grammar_functor.h"
 #include "grammar_impl.h"
+#include "structural_tag.h"
 #include "support/dynamic_bitset.h"
 #include "support/int_set.h"
 #include "support/logging.h"
@@ -1172,10 +1173,11 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
 }
 
 CompiledGrammar GrammarCompilerSub::CompileStructuralTag(const std::string& structural_tag_json) {
-  auto result = Grammar::FromStructuralTag(structural_tag_json, tokenizer_info_);
+  auto result =
+      StructuralTagToGrammar(structural_tag_json, tokenizer_info_, /*normalize=*/false).ToVariant();
   XGRAMMAR_CHECK(std::holds_alternative<Grammar>(result))
       << GetMessageFromVariantError(std::get<1>(result));
-  return MultiThreadCompileGrammar(std::get<0>(result));
+  return MultiThreadCompileGrammar(RootRuleRenamer::Apply(std::get<0>(result)));
 }
 
 CompiledGrammar GrammarCompilerSub::CompileRegex(const std::string& regex) {

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -2411,7 +2411,9 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TokenDispatc
 /************** StructuralTag Conversion Public API **************/
 
 Result<Grammar, StructuralTagError> StructuralTagToGrammar(
-    const std::string& structural_tag_json, const std::optional<TokenizerInfo>& tokenizer_info
+    const std::string& structural_tag_json,
+    const std::optional<TokenizerInfo>& tokenizer_info,
+    bool normalize
 ) {
   auto structural_tag_result = StructuralTagParser::FromJSON(structural_tag_json);
   if (structural_tag_result.IsErr()) {
@@ -2433,7 +2435,10 @@ Result<Grammar, StructuralTagError> StructuralTagToGrammar(
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }
-  return ResultOk(GrammarNormalizer::Apply(std::move(result).Unwrap()));
+  if (normalize) {
+    return ResultOk(GrammarNormalizer::Apply(std::move(result).Unwrap()));
+  }
+  return ResultOk(std::move(result).Unwrap());
 }
 
 }  // namespace xgrammar

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -389,11 +389,14 @@ struct StructuralTag {
 /*!
  * \brief Convert a structural tag JSON string to a grammar.
  * \param structural_tag_json The JSON string of the structural tag.
+ * \param tokenizer_info Optional tokenizer metadata for resolving named special tokens.
+ * \param normalize Whether to normalize the converted grammar before returning it.
  * \return A grammar if the JSON is valid, otherwise an error message in std::string.
  */
 Result<Grammar, StructuralTagError> StructuralTagToGrammar(
     const std::string& structural_tag_json,
-    const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt
+    const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt,
+    bool normalize = true
 );
 
 }  // namespace xgrammar


### PR DESCRIPTION
## 改动

XGrammar 是本仓库的语法约束生成库。规范化是把等价语法整理成统一内部形状的过程。结构化标签中的每个参数结构描述已经单独规范化，而编译器随后还会运行完整语法优化。本改动只在编译器内部入口跳过中间的一次重复全量规范化；公开的结构化标签转语法接口仍保持原行为。

## 性能

独立对照中，这一项使 XGrammar 与外部参考实现的配对时间比例从 1.185 降至 1.104，改善约 6.8%，对应大型 400 函数输入节省约 12 至 14 毫秒。

它加入完整优化组合后，15 次完整编译中位数为：

| 实现 | 完整编译中位数 |
|---|---:|
| XGrammar，32 个编译线程 | 143.810 毫秒 |
| llguidance，一个用于受约束生成的外部参考库，使用 1 个线程 | 151.295 毫秒 |

组合结果中 XGrammar 快 7.485 毫秒，即 4.95%。该历史组合还包含 #781、#784、#785、#790、#791、#792 和 #793 对应的优化；它不是本请求单独或本请求只加 #793 的结果。历史候选中的相同缓存键任务分组后来没有显示明确收益，因此已从拆分请求中排除。

## 正确性

- 公开结构化标签转语法接口继续执行规范化，公开语法文本不变。
- 对应非可编辑安装运行语法编译和结构化标签测试：18 项通过，21 项因需要额外模型词表而未执行。
- 先前完整候选验证为 1350 项通过、9 项未执行，格式和静态检查全部通过。
