### PR TITLE
Build large structural tag choices with tries

### DIFF
--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1362,6 +1362,9 @@ class GrammarFSMBuilderImpl {
       bool loop_after_dispatch,
       const std::vector<std::string>& excluded_strings
   );
+  static std::optional<FSMWithStartEnd> BuildByteStringRuleRefByteStringChoices(
+      const GrammarExpr& expr, const Grammar& grammar
+  );
 
  private:
   static FSMWithStartEnd BuildRuleFSM(const Grammar& grammar, int rule_id);
@@ -1717,9 +1720,74 @@ FSMWithStartEnd GrammarFSMBuilderImpl::BuildRuleFSM(const Grammar& grammar, int 
   return BuildExpressionFSM(grammar->GetGrammarExpr(rule.body_expr_id), grammar, &rule.name);
 }
 
+std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildByteStringRuleRefByteStringChoices(
+    const GrammarExpr& expr, const Grammar& grammar
+) {
+  constexpr int kMinChoiceCount = 64;
+  if (expr.type != ExprType::kChoices || expr.size() < kMinChoiceCount) {
+    return std::nullopt;
+  }
+
+  std::vector<std::string> prefixes;
+  std::vector<int32_t> rule_ids;
+  std::vector<std::string> suffixes;
+  prefixes.reserve(expr.size());
+  rule_ids.reserve(expr.size());
+  suffixes.reserve(expr.size());
+  for (int32_t choice_id : expr) {
+    const auto& choice = grammar->GetGrammarExpr(choice_id);
+    if (choice.type != ExprType::kSequence || choice.size() != 3) {
+      return std::nullopt;
+    }
+    const auto& prefix = grammar->GetGrammarExpr(choice[0]);
+    const auto& rule_ref = grammar->GetGrammarExpr(choice[1]);
+    const auto& suffix = grammar->GetGrammarExpr(choice[2]);
+    if (prefix.type != ExprType::kByteString || rule_ref.type != ExprType::kRuleRef ||
+        rule_ref.size() != 1 || suffix.type != ExprType::kByteString) {
+      return std::nullopt;
+    }
+    prefixes.push_back(grammar->GetByteString(prefix));
+    rule_ids.push_back(rule_ref[0]);
+    suffixes.push_back(grammar->GetByteString(suffix));
+  }
+
+  std::vector<int32_t> prefix_end_states;
+  auto trie =
+      TrieFSMBuilder::Build(prefixes, std::vector<std::string>{}, &prefix_end_states, true, false);
+  XGRAMMAR_DCHECK(trie.has_value());
+  FSM fsm = std::move(trie->GetFsm());
+  const int start_state = trie->GetStart();
+  const int end_state = fsm.AddState();
+
+  std::map<std::string, int32_t> suffix_start_states;
+  std::set<std::tuple<int32_t, int32_t, int32_t>> added_rule_edges;
+  for (int i = 0; i < expr.size(); ++i) {
+    auto [it, inserted] = suffix_start_states.emplace(suffixes[i], end_state);
+    if (inserted) {
+      int32_t current_state = end_state;
+      for (auto byte = suffixes[i].rbegin(); byte != suffixes[i].rend(); ++byte) {
+        int32_t previous_state = fsm.AddState();
+        uint8_t value = static_cast<uint8_t>(*byte);
+        fsm.AddEdge(previous_state, current_state, value, value);
+        current_state = previous_state;
+      }
+      it->second = current_state;
+    }
+    auto edge = std::make_tuple(prefix_end_states[i], it->second, rule_ids[i]);
+    if (added_rule_edges.insert(edge).second) {
+      fsm.AddRuleEdge(prefix_end_states[i], it->second, rule_ids[i]);
+    }
+  }
+
+  return FSMWithStartEnd(fsm, start_state, {end_state});
+}
+
 FSMWithStartEnd GrammarFSMBuilderImpl::BuildExpressionFSM(
     const GrammarExpr& expr, const Grammar& grammar, const std::string* rule_name
 ) {
+  if (auto specialized = BuildByteStringRuleRefByteStringChoices(expr, grammar)) {
+    return std::move(*specialized);
+  }
   FSM result_fsm;
   int start_state = result_fsm.AddState();
   std::vector<int32_t> end_states;

--- a/tests/python/test_grammar_fsm_builder.py
+++ b/tests/python/test_grammar_fsm_builder.py
@@ -181,6 +181,22 @@ def test_recursive_rule_ref_in_sequence():
     assert not _matcher_accepts(matcher, "())")
 
 
+def test_large_byte_prefix_rule_ref_suffix_choices():
+    prefixes = ["a" * length for length in range(1, 65)]
+    alternatives = []
+    for index, prefix in enumerate(prefixes):
+        suffix = "!" if index % 2 == 0 else "?"
+        alternatives.append(f'"{prefix}" body "{suffix}"')
+    grammar = "root ::= " + " | ".join(alternatives) + "\nbody ::= [0-9]"
+    matcher = _make_string_matcher(grammar)
+
+    for index, prefix in enumerate(prefixes):
+        suffix = "!" if index % 2 == 0 else "?"
+        assert _matcher_accepts(matcher, prefix + "7" + suffix)
+        assert not _matcher_accepts(matcher, prefix + "7" + ("?" if suffix == "!" else "!"))
+        assert not _matcher_accepts(matcher, prefix + suffix)
+
+
 # --- Empty sequence ---
 
 


### PR DESCRIPTION
## 改动

XGrammar 是本仓库的语法约束生成库。前缀树是一种让多个字符串共享相同开头的数据结构。本改动识别大量“固定开头、引用一条规则、固定结尾”的选择分支，并直接构造共享前缀树，避免先展开大量重复状态再由优化器合并。

改动只涉及有限状态机构造器及对应回归测试，不改变公开接口。

## 性能

在 32 个物理处理器核心上，400 个函数组成的大型结构化标签编译时间从 361.300 毫秒降至 234.065 毫秒，减少 35.2%。小型结构化标签、大型 JSON 结构描述和小型 JSON 结构描述的编译变化分别为 +2.3%、+1.0% 和 +2.4%，均未达到 5% 的明确变化阈值。

大型输入只有一次正式计时，因此把 35.2% 视为目标场景的方向性证据；小型集合分别包含 3411 和 9019 个共同成功输入。

## 正确性

- 四类正式输入的优化前后接受结果差异为 0。
- 对应非可编辑安装运行 `tests/python/test_grammar_fsm_builder.py`：39 项通过。
- 新增大型共享前缀选择测试，覆盖生成结构和接受行为。

