### PR TITLE
Avoid structural tag cache key serialization

### DIFF
--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -1758,7 +1758,7 @@ class StructuralTagGrammarConverter {
    * \return The rule id of the added rule. If the visit fails, the error is returned.
    * \note This method uses serialization to deduplicate identical formats.
    */
-  Result<int, ISTError> Visit(const Format& format);
+  Result<int, ISTError> Visit(const Format& format, bool deduplicate = true);
   Result<int, ISTError> VisitSub(const ConstStringFormat& format);
   Result<int, ISTError> VisitSub(const JSONSchemaFormat& format);
   Result<int, ISTError> VisitSub(const AnyTextFormat& format);
@@ -1804,7 +1804,7 @@ bool StructuralTagGrammarConverter::IsPrefix(
 Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(const StructuralTag& structural_tag
 ) {
   StructuralTagGrammarConverter converter;
-  auto result = converter.Visit(structural_tag.format);
+  auto result = converter.Visit(structural_tag.format, false);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }
@@ -1821,19 +1821,34 @@ Grammar StructuralTagGrammarConverter::AddRootRuleAndGetGrammar(int ref_rule_id)
   return grammar_builder_.Get(root_rule_id);
 }
 
-Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format) {
-  std::string fingerprint = FormatToJSONValue(format).serialize();
+Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format, bool deduplicate) {
+  std::string fingerprint;
+  if (deduplicate) {
+    if (const auto* json_schema = std::get_if<JSONSchemaFormat>(&format)) {
+      fingerprint.reserve(
+          json_schema->json_schema.size() + json_schema->style.size() + sizeof(int) + 16
+      );
+      fingerprint.append(JSONSchemaFormat::type);
+      fingerprint.push_back('\0');
+      fingerprint.append(json_schema->json_schema);
+      fingerprint.push_back('\0');
+      fingerprint.append(json_schema->style);
+      fingerprint.push_back('\0');
+      fingerprint.push_back(json_schema->any_order ? '\1' : '\0');
+      fingerprint.append(std::to_string(json_schema->max_whitespace_cnt.value_or(-1)));
+    } else {
+      fingerprint = FormatToJSONValue(format).serialize();
+    }
 
-  // Check if we've already processed an identical format
-  auto it = serialization_to_rule_id_.find(fingerprint);
-  if (it != serialization_to_rule_id_.end()) {
-    return ResultOk(it->second);
+    auto it = serialization_to_rule_id_.find(fingerprint);
+    if (it != serialization_to_rule_id_.end()) {
+      return ResultOk(it->second);
+    }
   }
 
-  // Process the format and cache the result
   auto result =
       std::visit([&](auto&& arg) -> Result<int, ISTError> { return VisitSub(arg); }, format);
-  if (result.IsOk()) {
+  if (result.IsOk() && deduplicate) {
     int rule_id = std::move(result).Unwrap();
     serialization_to_rule_id_[fingerprint] = rule_id;
     return ResultOk(rule_id);


### PR DESCRIPTION
## 改动

XGrammar 是本仓库的语法约束生成库。缓存键是查找可复用编译结果时使用的标识。本改动直接使用已经规范化的 JSON 结构描述作为缓存键，避免再次解析、排序和序列化同一结构。

改动只影响结构化标签内部缓存，不改变公开接口。

## 性能与限制

固定 400 函数的阶段计时中，结构化标签转换从 96.199 毫秒降至 76.790 毫秒，减少 20.2%。后续完整数据集对照中，大型和小型结构化标签编译只减少 1.0% 和 3.0%；大型 JSON 结构描述增加 5.3%，但该入口不直接使用目标结构化标签缓存。

目标阶段曾有明确收益，但最新端到端数据没有证明广泛收益。评审重点是确认实际缓存命中场景是否足以采用这项改动。

## 正确性

- 四类正式输入的优化前后接受结果差异为 0。
- 对应非可编辑安装运行结构化标签测试：7 项通过，12 项因需要额外模型词表而未执行。
