### PR TITLE
Hash acyclic state continuations in linear time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,11 @@ list(FILTER XGRAMMAR_SOURCES_PATH EXCLUDE REGEX "${PROJECT_SOURCE_DIR}/cpp/tvm_f
 add_library(xgrammar STATIC ${XGRAMMAR_SOURCES_PATH})
 target_include_directories(xgrammar PUBLIC include)
 target_include_directories(xgrammar SYSTEM PUBLIC ${XGRAMMAR_INCLUDE_PATH})
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-fno-semantic-interposition" XGRAMMAR_HAS_NO_SEMANTIC_INTERPOSITION)
+if(XGRAMMAR_HAS_NO_SEMANTIC_INTERPOSITION)
+  target_compile_options(xgrammar PRIVATE -fno-semantic-interposition)
+endif()
 
 # link to cpptrace
 if(XGRAMMAR_ENABLE_CPPTRACE)

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -5,6 +5,8 @@
 
 #include <xgrammar/compiler.h>
 
+#include <algorithm>
+
 #include "compiled_grammar_impl.h"
 #include "support/json_serializer.h"
 #include "testing.h"
@@ -42,6 +44,28 @@ AdaptiveTokenMask::AdaptiveTokenMask(
   }
 
   this->uncertain_indices = uncertain_indices;
+  RebuildDerivedData(vocab_size, sorted_decoded_vocab);
+}
+
+AdaptiveTokenMask::AdaptiveTokenMask(
+    size_t vocab_size,
+    const std::vector<std::pair<int32_t, std::string>>& sorted_decoded_vocab,
+    std::vector<int32_t>&& accepted_indices,
+    std::vector<int32_t>&& uncertain_indices
+) {
+  const auto size_acc = accepted_indices.size();
+
+  store_type = size_acc >= USE_BITSET_THRESHOLD ? StoreType::kAcceptedBitset : StoreType::kAccepted;
+  if (store_type == StoreType::kAcceptedBitset) {
+    accepted_bitset = DynamicBitset(vocab_size);
+    for (auto idx : accepted_indices) {
+      accepted_bitset.Set(sorted_decoded_vocab[idx].first, true);
+    }
+  } else {
+    this->accepted_indices = std::move(accepted_indices);
+  }
+  this->uncertain_indices = std::move(uncertain_indices);
+  RebuildDerivedData(vocab_size, sorted_decoded_vocab);
 }
 
 AdaptiveTokenMask::AdaptiveTokenMask(
@@ -64,6 +88,39 @@ AdaptiveTokenMask::AdaptiveTokenMask(
     this->accepted_indices = accepted_indices;
   }
   this->uncertain_indices = uncertain_indices;
+  RebuildDerivedData(vocab_size, sorted_decoded_vocab);
+}
+
+void AdaptiveTokenMask::RebuildDerivedData(
+    size_t vocab_size, const std::vector<std::pair<int32_t, std::string>>& sorted_decoded_vocab
+) {
+  max_uncertain_token_length = 0;
+  if (uncertain_indices.size() < UNCERTAIN_BITSET_THRESHOLD) {
+    uncertain_bitset = DynamicBitset();
+    uncertain_lcp_with_previous.clear();
+    return;
+  }
+  uncertain_bitset = DynamicBitset(vocab_size);
+  uncertain_lcp_with_previous.resize(uncertain_indices.size());
+  const std::string* previous_token = nullptr;
+  for (size_t i = 0; i < uncertain_indices.size(); ++i) {
+    auto idx = uncertain_indices[i];
+    uncertain_bitset.Set(sorted_decoded_vocab[idx].first);
+    const auto& token = sorted_decoded_vocab[idx].second;
+    max_uncertain_token_length =
+        std::max(max_uncertain_token_length, static_cast<int32_t>(token.size()));
+    uncertain_lcp_with_previous[i] =
+        previous_token == nullptr
+            ? 0
+            : static_cast<int32_t>(
+                  std::mismatch(
+                      token.begin(), token.end(), previous_token->begin(), previous_token->end()
+                  )
+                      .first -
+                  token.begin()
+              );
+    previous_token = &token;
+  }
 }
 
 std::string AdaptiveTokenMask::Print(const TokenizerInfo& tokenizer_info) const {
@@ -168,7 +225,17 @@ picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl) {
   auto result = picojson::object{};
   result["grammar"] = AutoSerializeJSONValue(impl.grammar);
   result["tokenizer_metadata"] = impl.tokenizer_info->DumpMetadataValue();
-  result["adaptive_token_mask_cache"] = AutoSerializeJSONValue(impl.adaptive_token_mask_cache);
+  // Preserve the v14 wire format: serialized grammars store one mask value per ParserState even
+  // though the in-memory representation shares structurally identical masks.
+  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache>
+      serialized_adaptive_token_mask_cache;
+  serialized_adaptive_token_mask_cache.reserve(impl.adaptive_token_mask_ids.size());
+  for (const auto& [state, mask_id] : impl.adaptive_token_mask_ids) {
+    XGRAMMAR_DCHECK(mask_id < impl.adaptive_token_masks.size());
+    serialized_adaptive_token_mask_cache.emplace(state, impl.adaptive_token_masks[mask_id]);
+  }
+  result["adaptive_token_mask_cache"] =
+      AutoSerializeJSONValue(serialized_adaptive_token_mask_cache);
   return picojson::value(result);
 }
 
@@ -186,6 +253,7 @@ std::optional<SerializationError> DeserializeJSONValue(
     return ConstructDeserializeError("Expect a 'grammar' field", type_name);
   }
   AutoDeserializeJSONValue(&(impl->grammar), object["grammar"], type_name);
+  impl->earley_parser_metadata = EarleyParserGrammarMetadata(impl->grammar);
   if (object.find("tokenizer_metadata") == object.end()) {
     return ConstructDeserializeError("Expect a 'tokenizer_metadata' field", type_name);
   }
@@ -199,14 +267,29 @@ std::optional<SerializationError> DeserializeJSONValue(
   if (object.find("adaptive_token_mask_cache") == object.end()) {
     return ConstructDeserializeError("Expect a 'adaptive_token_mask_cache' field", type_name);
   }
-  AutoDeserializeJSONValue(&(impl->adaptive_token_mask_cache), object["adaptive_token_mask_cache"]);
+  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache>
+      serialized_adaptive_token_mask_cache;
+  AutoDeserializeJSONValue(
+      &serialized_adaptive_token_mask_cache, object["adaptive_token_mask_cache"]
+  );
+  const auto& sorted_decoded_vocab = tokenizer_info.GetSortedDecodedVocab();
+  const auto vocab_size = tokenizer_info.GetVocabSize();
+  impl->adaptive_token_masks.reserve(serialized_adaptive_token_mask_cache.size());
+  impl->adaptive_token_mask_ids.reserve(serialized_adaptive_token_mask_cache.size());
+  for (auto& [state, mask] : serialized_adaptive_token_mask_cache) {
+    mask.RebuildDerivedData(vocab_size, sorted_decoded_vocab);
+    const uint32_t mask_id = static_cast<uint32_t>(impl->adaptive_token_masks.size());
+    impl->adaptive_token_masks.push_back(std::move(mask));
+    impl->adaptive_token_mask_ids.emplace(state, mask_id);
+  }
   return std::nullopt;
 }
 
 /************** CompiledGrammar **************/
 
 std::size_t MemorySize(const CompiledGrammar::Impl& impl) {
-  return MemorySize(impl.grammar) + MemorySize(impl.adaptive_token_mask_cache);
+  return MemorySize(impl.grammar) + MemorySize(impl.earley_parser_metadata) +
+         MemorySize(impl.adaptive_token_masks) + MemorySize(impl.adaptive_token_mask_ids);
 }
 
 std::size_t CompiledGrammar::MemorySizeBytes() const { return MemorySize(*pimpl_); }

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -52,12 +52,17 @@ struct AdaptiveTokenMask {
   StoreType store_type;
 
   static constexpr int USE_BITSET_THRESHOLD = 1000;
+  static constexpr int UNCERTAIN_BITSET_THRESHOLD = 1024;
 
   std::vector<int32_t> accepted_indices;
   std::vector<int32_t> rejected_indices;
   DynamicBitset accepted_bitset;
 
   std::vector<int32_t> uncertain_indices;
+  // Derived, non-serialized data for batching large runtime uncertain-token operations.
+  DynamicBitset uncertain_bitset;
+  std::vector<int32_t> uncertain_lcp_with_previous;
+  int32_t max_uncertain_token_length = 0;
 
   /*! \brief Default constructor. Only for deserialization. */
   AdaptiveTokenMask() = default;
@@ -77,11 +82,23 @@ struct AdaptiveTokenMask {
       const std::vector<int32_t>& uncertain_indices
   );
 
+  AdaptiveTokenMask(
+      size_t vocab_size,
+      const std::vector<std::pair<int32_t, std::string>>& sorted_decoded_vocab,
+      std::vector<int32_t>&& accepted_indices,
+      std::vector<int32_t>&& uncertain_indices
+  );
+
+  void RebuildDerivedData(
+      size_t vocab_size, const std::vector<std::pair<int32_t, std::string>>& sorted_decoded_vocab
+  );
+
   std::string Print(const TokenizerInfo& tokenizer_info) const;
 
   friend std::size_t MemorySize(const AdaptiveTokenMask& mask) {
     return MemorySize(mask.uncertain_indices) + MemorySize(mask.accepted_indices) +
-           MemorySize(mask.rejected_indices) + MemorySize(mask.accepted_bitset);
+           MemorySize(mask.rejected_indices) + MemorySize(mask.accepted_bitset) +
+           MemorySize(mask.uncertain_bitset) + MemorySize(mask.uncertain_lcp_with_previous);
   }
 };
 
@@ -99,6 +116,32 @@ XGRAMMAR_MEMBER_TABLE(
     &AdaptiveTokenMask::uncertain_indices
 );
 
+#ifdef XGRAMMAR_PROFILE_COMPILE
+/*!
+ * \brief Profile-only cost of computing one structurally deduplicated adaptive-mask task.
+ *
+ * Several ParserStates can share one task result. Runtime coverage is therefore measured both by
+ * state (stored mask bytes) and by task group (compile work that a lazy compiler would execute).
+ */
+struct AdaptiveMaskCompileProfile {
+  ParserState representative_state;
+  uint64_t mask_cpu_us = 0;
+  uint64_t possible_tokens = 0;
+  uint64_t rule_cache_hits = 0;
+  uint64_t first_byte_cache_reused_tokens = 0;
+  uint64_t saturated_cache_reused_tokens = 0;
+  uint64_t token_edge_skipped_tokens = 0;
+  uint64_t speculative_accepted_tokens = 0;
+  uint64_t subtree_pruned_tokens = 0;
+  uint64_t parser_simulated_tokens = 0;
+  uint64_t parser_naive_token_bytes = 0;
+  uint64_t parser_advance_calls = 0;
+  uint64_t parser_failed_advance_calls = 0;
+  uint64_t mask_bytes = 0;
+  uint64_t state_count = 0;
+};
+#endif
+
 /*!
  * \brief All information that we need to match tokens in the tokenizer to the specified grammar.
  * It is the result of preprocessing.
@@ -112,12 +155,32 @@ class CompiledGrammar::Impl {
   /*! \brief The tokenizer information. */
   TokenizerInfo tokenizer_info{NullObj{}};
 
+  /*! \brief Grammar-only Earley metadata shared by compile-time tasks and runtime matchers. */
+  EarleyParserGrammarMetadata earley_parser_metadata;
+
   /*! \brief Default constructor. */
   Impl() = default;
 
-  /*! \brief Mapping from the parser state to the adaptive token mask. */
-  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache>
-      adaptive_token_mask_cache;
+  /*! \brief Structurally deduplicated adaptive token masks. */
+  std::vector<AdaptiveTokenMask> adaptive_token_masks;
+
+  /*! \brief Mapping from each parser state to an entry in adaptive_token_masks. */
+  std::unordered_map<ParserState, uint32_t, StateHashForCache, StateEqualForCache>
+      adaptive_token_mask_ids;
+
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  /*! \brief Per-task compile work, indexed by the structurally deduplicated task-group id. */
+  std::vector<AdaptiveMaskCompileProfile> adaptive_mask_compile_profiles;
+#endif
+
+  const AdaptiveTokenMask* FindAdaptiveTokenMask(const ParserState& state) const {
+    const auto mask_id_it = adaptive_token_mask_ids.find(state);
+    if (mask_id_it == adaptive_token_mask_ids.end()) {
+      return nullptr;
+    }
+    XGRAMMAR_DCHECK(mask_id_it->second < adaptive_token_masks.size());
+    return &adaptive_token_masks[mask_id_it->second];
+  }
 
   Grammar GetGrammar() const { return grammar; }
 
@@ -139,8 +202,10 @@ XGRAMMAR_MEMBER_TABLE(
     &CompiledGrammar::Impl::grammar,
     "tokenizer_info",
     &CompiledGrammar::Impl::tokenizer_info,
-    "adaptive_token_mask_cache",
-    &CompiledGrammar::Impl::adaptive_token_mask_cache
+    "adaptive_token_masks",
+    &CompiledGrammar::Impl::adaptive_token_masks,
+    "adaptive_token_mask_ids",
+    &CompiledGrammar::Impl::adaptive_token_mask_ids
 );
 
 }  // namespace xgrammar

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -31,7 +31,7 @@ void EarleyParser::PopLastStates(int32_t cnt) {
     XGRAMMAR_LOG(FATAL) << "The number of states to be popped is larger than the size of states.";
   }
   rule_id_to_completable_states_.PopBack(cnt);
-  is_completed_.erase(is_completed_.end() - cnt, is_completed_.end());
+  is_completed_.resize(is_completed_.size() - cnt);
   scanable_state_history_.PopBack(cnt);
 }
 
@@ -107,8 +107,7 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print) {
 
     // Check if the parent_state sits on a kRepeatRef edge
     bool handled_as_repeat = false;
-    const auto& parent_fsm = grammar_->per_rule_fsms[parent_state.rule_id].value();
-    for (const auto& edge : parent_fsm.GetFsm().GetFsm().GetEdges(parent_state.element_id)) {
+    for (const auto& edge : (*complete_fsm_edges_)[parent_state.element_id]) {
       // Because of invariance, a state with a kRepeatRef edge has exactly one outgoing edge.
       if (!edge.IsRepeatRef()) continue;
       auto info = grammar_->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
@@ -268,38 +267,170 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   }
 
   // execute Predict and Complete for all states in the queue until empty.
-  rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
+  rule_id_to_completable_states_.PushBackEmpty();
   while (!tmp_process_state_queue_.empty()) {
-    const auto state = std::move(tmp_process_state_queue_.front());
+    const ParserState& state = *tmp_process_state_queue_.front();
     tmp_process_state_queue_.pop();
     auto [scanable, completable] = Predict(state, debug_print);
     if (completable) {
       Complete(state, debug_print);
     }
     if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
+      tmp_states_to_be_added_.push_back(&state);
     }
   }
 
   // Check if the grammar is completed, and add the scannable states to the history.
   is_completed_.push_back(tmp_accept_stop_token_);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
   return true;
 }
 
-EarleyParser::EarleyParser(const Grammar& grammar, std::optional<ParserState> initial_state)
+EarleyParserGrammarMetadata::EarleyParserGrammarMetadata(const Grammar& grammar)
+    : fsm_state_flags(
+          grammar->complete_fsm.NumStates(), EarleyParserGrammarMetadata::kFsmStateInitialized
+      ),
+      rule_is_nullable(grammar->NumRules(), 0),
+      rule_has_atomic_token_edges(grammar->NumRules(), 0),
+      deterministic_byte_transition_ids(grammar->complete_fsm.NumStates(), -1) {
+  XGRAMMAR_CHECK(grammar->optimized)
+      << "Cannot build Earley parser metadata for an unoptimized grammar";
+
+  for (int32_t rule_id : grammar->allow_empty_rule_ids) {
+    rule_is_nullable[rule_id] = true;
+  }
+
+  std::vector<std::vector<int32_t>> referenced_rules(grammar->NumRules());
+  for (int32_t rule_id = 0; rule_id < grammar->NumRules(); ++rule_id) {
+    const auto& rule_fsm = grammar->per_rule_fsms[rule_id]->GetFsm();
+    std::unordered_set<int> reachable_states;
+    rule_fsm.GetReachableStates(&reachable_states);
+    for (int32_t state_id : reachable_states) {
+      for (const auto& edge : rule_fsm.GetFsm().GetEdges(state_id)) {
+        if (edge.IsToken() || edge.IsExcludeToken()) {
+          rule_has_atomic_token_edges[rule_id] = 1;
+        } else if (edge.IsRuleRef()) {
+          referenced_rules[rule_id].push_back(edge.GetRefRuleId());
+        } else if (edge.IsRepeatRef()) {
+          referenced_rules[rule_id].push_back(
+              grammar->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex()).RuleId()
+          );
+        }
+      }
+    }
+  }
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (int32_t rule_id = 0; rule_id < grammar->NumRules(); ++rule_id) {
+      if (rule_has_atomic_token_edges[rule_id]) {
+        continue;
+      }
+      for (int32_t referenced_rule_id : referenced_rules[rule_id]) {
+        if (rule_has_atomic_token_edges[referenced_rule_id]) {
+          rule_has_atomic_token_edges[rule_id] = 1;
+          changed = true;
+          break;
+        }
+      }
+    }
+  }
+
+  const auto& complete_fsm_edges = grammar->complete_fsm.GetEdges();
+  size_t dense_transition_candidate_count = 0;
+  for (int32_t state_id = 0; state_id < grammar->complete_fsm.NumStates(); ++state_id) {
+    dense_transition_candidate_count += complete_fsm_edges[state_id].size() >= 4;
+  }
+  deterministic_byte_transitions.reserve(dense_transition_candidate_count);
+
+  for (int32_t state_id = 0; state_id < grammar->complete_fsm.NumStates(); ++state_id) {
+    const auto edges = complete_fsm_edges[state_id];
+    uint8_t& flags = fsm_state_flags[state_id];
+    if (edges.size() != 0) {
+      flags |= EarleyParserGrammarMetadata::kFsmStateHasEdges;
+    }
+    for (const auto& edge : edges) {
+      if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken()) {
+        flags |= EarleyParserGrammarMetadata::kFsmStateScanable;
+      } else if (edge.IsRuleRef() || edge.IsEpsilon() || edge.IsRepeatRef()) {
+        flags |= EarleyParserGrammarMetadata::kFsmStateNonTerminal;
+      }
+    }
+
+    if (edges.size() < 4) {
+      continue;
+    }
+    std::array<int32_t, 256> targets;
+    targets.fill(-1);
+    bool deterministic = true;
+    for (const auto& edge : edges) {
+      if (!edge.IsCharRange()) {
+        continue;
+      }
+      const int32_t min = std::max<int32_t>(edge.min, 0);
+      const int32_t max = std::min<int32_t>(edge.max, 255);
+      for (int32_t ch = min; ch <= max; ++ch) {
+        int32_t& target = targets[ch];
+        if (target != -1 && target != edge.target) {
+          deterministic = false;
+          break;
+        }
+        target = edge.target;
+      }
+      if (!deterministic) {
+        break;
+      }
+    }
+    if (deterministic) {
+      deterministic_byte_transition_ids[state_id] =
+          static_cast<int32_t>(deterministic_byte_transitions.size());
+      deterministic_byte_transitions.push_back(std::move(targets));
+    }
+  }
+
+  // The complete FSM stores the disjoint automata of all rules but not their accepting-state
+  // bitmaps. Each per-rule view supplies that last grammar-only property.
+  for (const auto& optional_rule_fsm : grammar->per_rule_fsms) {
+    XGRAMMAR_DCHECK(optional_rule_fsm.has_value());
+    std::unordered_set<int> reachable_states;
+    optional_rule_fsm->GetFsm().GetReachableStates(&reachable_states);
+    for (int state_id : reachable_states) {
+      if (optional_rule_fsm->GetFsm().IsEndState(state_id)) {
+        fsm_state_flags[state_id] |= EarleyParserGrammarMetadata::kFsmStateEnd;
+      }
+    }
+  }
+}
+
+EarleyParser::EarleyParser(
+    const Grammar& grammar,
+    const EarleyParserGrammarMetadata& grammar_metadata,
+    std::optional<ParserState> initial_state,
+    bool need_expand
+)
     : grammar_(grammar),
-      fsm_state_flags_cache_(grammar->NumRules()),
-      rule_is_nullable_(grammar->NumRules(), 0) {
+      complete_fsm_edges_(&grammar_->complete_fsm.GetEdges()),
+      grammar_metadata_(&grammar_metadata) {
   if (!grammar->optimized) {
     XGRAMMAR_LOG(FATAL) << "The grammar is not optimized. Please optimize the grammar before using "
                            "the Earley parser.";
   }
+  XGRAMMAR_CHECK(
+      grammar_metadata_->fsm_state_flags.size() ==
+      static_cast<size_t>(grammar->complete_fsm.NumStates())
+  ) << "The Earley parser metadata does not match the grammar's FSM";
+  XGRAMMAR_CHECK(
+      grammar_metadata_->rule_is_nullable.size() == static_cast<size_t>(grammar->NumRules())
+  ) << "The Earley parser metadata does not match the grammar's rules";
 
-  for (int32_t rule_id : grammar_->allow_empty_rule_ids) {
-    rule_is_nullable_[rule_id] = true;
+  const ParserState init = initial_state.has_value() ? *initial_state : RootInitialState();
+  if (!need_expand) {
+    rule_id_to_completable_states_.PushBackEmpty();
+    is_completed_.push_back(false);
+    scanable_state_history_.PushBack({init});
+    return;
   }
-  PushStateAndExpand(initial_state.has_value() ? *initial_state : RootInitialState());
+  PushStateAndExpand(init);
 }
 
 ParserState EarleyParser::RootInitialState() const {
@@ -314,56 +445,25 @@ ParserState EarleyParser::RootInitialState() const {
   );
 }
 
-uint8_t EarleyParser::InitializeFsmStateFlags(int32_t rule_id, int32_t state_id) {
-  XGRAMMAR_DCHECK(grammar_->per_rule_fsms[rule_id].has_value());
-  const auto& fsm = grammar_->per_rule_fsms[rule_id]->GetFsm();
-  auto& flags_cache = fsm_state_flags_cache_[rule_id];
-  if (flags_cache.empty()) {
-    flags_cache.resize(fsm.NumStates());
-  }
-  XGRAMMAR_DCHECK(state_id >= 0 && state_id < static_cast<int32_t>(flags_cache.size()));
-  uint8_t& flags = flags_cache[state_id];
-  if (flags & kFsmStateInitialized) {
-    return flags;
-  }
-
-  flags = kFsmStateInitialized;
-  if (fsm.IsEndState(state_id)) {
-    flags |= kFsmStateEnd;
-  }
-  const auto& edges = fsm.GetFsm().GetEdges(state_id);
-  if (edges.size() != 0) {
-    flags |= kFsmStateHasEdges;
-  }
-  for (const auto& edge : edges) {
-    if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken()) {
-      flags |= kFsmStateScanable;
-    } else if (edge.IsRuleRef() || edge.IsEpsilon() || edge.IsRepeatRef()) {
-      flags |= kFsmStateNonTerminal;
-    }
-  }
-  return flags;
-}
-
 void EarleyParser::PushStateAndExpand(const ParserState& state) {
   tmp_states_visited_in_queue_.Clear();
   tmp_accept_stop_token_ = false;
   tmp_states_to_be_added_.clear();
   Enqueue(state);
-  rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
+  rule_id_to_completable_states_.PushBackEmpty();
   while (!tmp_process_state_queue_.empty()) {
-    const auto state = tmp_process_state_queue_.front();
+    const ParserState& state = *tmp_process_state_queue_.front();
     tmp_process_state_queue_.pop();
     auto [scanable, completable] = Predict(state);
     if (completable) {
       Complete(state);
     }
     if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
+      tmp_states_to_be_added_.push_back(&state);
     }
   }
   is_completed_.push_back(tmp_accept_stop_token_);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
 }
 
 void EarleyParser::Reset() {
@@ -456,13 +556,14 @@ void EarleyParser::ExpandNextRuleRefElement(
 
 void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool debug_print) {
   XGRAMMAR_DCHECK(state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value());
-  const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
-
   // Add the rule reference pairs, and enqueue the epsilon edges.
-  for (const auto& edge : fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
+  for (const auto& edge : (*complete_fsm_edges_)[state.element_id]) {
     if (edge.IsEpsilon()) {
       Enqueue(ParserState{state.rule_id, state.sequence_id, edge.target, state.rule_start_pos, 0});
       continue;
+    }
+    if (edge.IsCharRange()) {
+      break;
     }
 
     int target;
@@ -584,7 +685,7 @@ void EarleyParser::AdvanceByteString(
       Enqueue(new_state);
       // Assert: In a sequence, the bytestring can't be skipped. So the state can't be repeated.
     } else {
-      tmp_states_to_be_added_.push_back(new_state);
+      EnqueueWithoutProcessing(new_state);
     }
   }
   return;
@@ -659,7 +760,7 @@ void EarleyParser::AdvanceCharacterClass(
         // For positive classes: only continue if some range could match
         bool should_continue = is_negative ? true : could_match;
         if (should_continue) {
-          tmp_states_to_be_added_.push_back(new_state);
+          EnqueueWithoutProcessing(new_state);
         }
       }
     }
@@ -699,7 +800,7 @@ void EarleyParser::AdvanceCharacterClass(
       auto new_state = state;
       new_state.sub_element_id = num_bytes - 1;
       new_state.partial_codepoint = partial;
-      tmp_states_to_be_added_.push_back(new_state);
+      EnqueueWithoutProcessing(new_state);
     }
     return;
   }
@@ -792,7 +893,7 @@ void EarleyParser::AdvanceCharacterClassStar(
         // For positive classes: only continue if some range could match
         bool should_continue = is_negative ? true : could_match;
         if (should_continue) {
-          tmp_states_to_be_added_.push_back(new_state);
+          EnqueueWithoutProcessing(new_state);
         }
       }
     }
@@ -832,7 +933,7 @@ void EarleyParser::AdvanceCharacterClassStar(
       auto new_state = state;
       new_state.sub_element_id = num_bytes - 1;
       new_state.partial_codepoint = partial;
-      tmp_states_to_be_added_.push_back(new_state);
+      EnqueueWithoutProcessing(new_state);
     }
     return;
   }
@@ -854,18 +955,37 @@ void EarleyParser::AdvanceCharacterClassStar(
 
 void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
   XGRAMMAR_DCHECK(state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value());
-  const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
-  for (const auto& edge : current_fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
-    if ((!edge.IsCharRange()) || ch < edge.min || ch > edge.max) {
+  const auto edges = (*complete_fsm_edges_)[state.element_id];
+  const auto* targets =
+      edges.size() >= 4 ? GetDeterministicByteTransitions(state.element_id) : nullptr;
+  if (targets != nullptr) {
+    const int32_t target = (*targets)[ch];
+    if (target == -1) {
+      return;
+    }
+    const uint8_t flags = GetFsmStateFlags(state.rule_id, target);
+    if (!(flags & kFsmStateNonTerminal) && !(flags & kFsmStateEnd) && (flags & kFsmStateScanable)) {
+      EnqueueFsmTransitionWithoutProcessing(state, target);
+    } else {
+      EnqueueFsmTransition(state, target);
+    }
+    return;
+  }
+  for (const auto& edge : edges) {
+    if (!edge.IsCharRange()) {
       continue;
     }
-    auto new_state = state;
-    new_state.element_id = edge.target;
+    if (edge.min > ch) {
+      break;
+    }
+    if (ch > edge.max) {
+      continue;
+    }
     const uint8_t flags = GetFsmStateFlags(state.rule_id, edge.target);
     if (!(flags & kFsmStateNonTerminal) && !(flags & kFsmStateEnd) && (flags & kFsmStateScanable)) {
-      EnqueueWithoutProcessing(std::move(new_state));
+      EnqueueFsmTransitionWithoutProcessing(state, edge.target);
     } else {
-      Enqueue(std::move(new_state));
+      EnqueueFsmTransition(state, edge.target);
     }
   }
 }
@@ -874,7 +994,7 @@ void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
   if (state.rule_id == -1) return;
   XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
   const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
-  for (const auto& edge : current_fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
+  for (const auto& edge : (*complete_fsm_edges_)[state.element_id]) {
     bool matched = false;
     if (edge.IsToken()) {
       auto info = current_fsm.GetFsm().GetFsm().GetTokenEdgeInfo(edge.GetAuxIndex());
@@ -908,54 +1028,38 @@ bool EarleyParser::AdvanceAtomicToken(int32_t token_id, bool debug_print) {
   if (tmp_process_state_queue_.empty() && tmp_states_to_be_added_.empty()) {
     return false;
   }
-  rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
+  rule_id_to_completable_states_.PushBackEmpty();
   while (!tmp_process_state_queue_.empty()) {
-    const auto state = std::move(tmp_process_state_queue_.front());
+    const ParserState& state = *tmp_process_state_queue_.front();
     tmp_process_state_queue_.pop();
     auto [scanable, completable] = Predict(state, debug_print);
     if (completable) {
       Complete(state, debug_print);
     }
     if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
+      tmp_states_to_be_added_.push_back(&state);
     }
   }
   is_completed_.push_back(tmp_accept_stop_token_);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
   return true;
 }
 
-bool RepeatDetector::IsVisited(const ParserState& state) const {
-  // If the size is larger than the threshold, then we use the set to check.
-  if (size_ > transition_threshold_) {
-    return visited_set_.find(state) != visited_set_.end();
-  }
-  return std::find_if(
-             visited_vector_.begin(),
-             visited_vector_.begin() + size_,
-             [&state](const ParserState& s) { return StateEqualForParsing()(state, s); }
-         ) != visited_vector_.begin() + size_;
-}
-
-void RepeatDetector::Insert(const ParserState& state) {
-  if (size_ == transition_threshold_) {
-    for (const auto& s : visited_vector_) {
-      visited_set_.insert(s);
+const ParserState* RepeatDetector::InsertInSet(const ParserState& state) {
+  if (!using_set_) {
+    for (const auto& existing : visited_vector_) {
+      visited_set_.insert(existing);
     }
+    using_set_ = true;
   }
-  size_++;
-  if (size_ > transition_threshold_) {
-    visited_set_.insert(state);
-  } else {
-    visited_vector_[size_ - 1] = state;
+  const auto [it, inserted] = visited_set_.insert(state);
+  if (inserted) {
+    ++size_;
+    return &*it;
   }
+  return nullptr;
 }
 
-void RepeatDetector::Clear() {
-  if (size_ > transition_threshold_) {
-    visited_set_.clear();
-  }
-  size_ = 0;
-}
+void RepeatDetector::ClearSet() { visited_set_.clear(); }
 
 }  // namespace xgrammar

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -149,12 +149,11 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
   // Check if the rule has a corresponding FSM.
   if (state.rule_id != -1) {
     XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
-    // Try to expand the fsm.
-    ExpandNextRuleRefElementOnFSM(state, debug_print);
-    const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
-    return std::make_pair(
-        fsm.GetFsm().IsScanableState(state.element_id), fsm.GetFsm().IsEndState(state.element_id)
-    );
+    const uint8_t flags = GetFsmStateFlags(state.rule_id, state.element_id);
+    if (flags & kFsmStateNonTerminal) {
+      ExpandNextRuleRefElementOnFSM(state, debug_print);
+    }
+    return std::make_pair(flags & kFsmStateScanable, flags & kFsmStateEnd);
   }
   const GrammarExpr& grammar_expr = grammar_->GetGrammarExpr(state.sequence_id);
   XGRAMMAR_DCHECK(
@@ -289,10 +288,16 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
 }
 
 EarleyParser::EarleyParser(const Grammar& grammar, std::optional<ParserState> initial_state)
-    : grammar_(grammar) {
+    : grammar_(grammar),
+      fsm_state_flags_cache_(grammar->NumRules()),
+      rule_is_nullable_(grammar->NumRules(), 0) {
   if (!grammar->optimized) {
     XGRAMMAR_LOG(FATAL) << "The grammar is not optimized. Please optimize the grammar before using "
                            "the Earley parser.";
+  }
+
+  for (int32_t rule_id : grammar_->allow_empty_rule_ids) {
+    rule_is_nullable_[rule_id] = true;
   }
   PushStateAndExpand(initial_state.has_value() ? *initial_state : RootInitialState());
 }
@@ -307,6 +312,37 @@ ParserState EarleyParser::RootInitialState() const {
       ParserState::kNoPrevInputPos,
       0
   );
+}
+
+uint8_t EarleyParser::InitializeFsmStateFlags(int32_t rule_id, int32_t state_id) {
+  XGRAMMAR_DCHECK(grammar_->per_rule_fsms[rule_id].has_value());
+  const auto& fsm = grammar_->per_rule_fsms[rule_id]->GetFsm();
+  auto& flags_cache = fsm_state_flags_cache_[rule_id];
+  if (flags_cache.empty()) {
+    flags_cache.resize(fsm.NumStates());
+  }
+  XGRAMMAR_DCHECK(state_id >= 0 && state_id < static_cast<int32_t>(flags_cache.size()));
+  uint8_t& flags = flags_cache[state_id];
+  if (flags & kFsmStateInitialized) {
+    return flags;
+  }
+
+  flags = kFsmStateInitialized;
+  if (fsm.IsEndState(state_id)) {
+    flags |= kFsmStateEnd;
+  }
+  const auto& edges = fsm.GetFsm().GetEdges(state_id);
+  if (edges.size() != 0) {
+    flags |= kFsmStateHasEdges;
+  }
+  for (const auto& edge : edges) {
+    if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken()) {
+      flags |= kFsmStateScanable;
+    } else if (edge.IsRuleRef() || edge.IsEpsilon() || edge.IsRepeatRef()) {
+      flags |= kFsmStateNonTerminal;
+    }
+  }
+  return flags;
 }
 
 void EarleyParser::PushStateAndExpand(const ParserState& state) {
@@ -395,9 +431,7 @@ void EarleyParser::ExpandNextRuleRefElement(
     }
   }
 
-  if (std::find(
-          grammar_->allow_empty_rule_ids.begin(), grammar_->allow_empty_rule_ids.end(), ref_rule_id
-      ) != grammar_->allow_empty_rule_ids.end()) {
+  if (IsRuleNullable(ref_rule_id)) {
     XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kSequence);
     Enqueue(
         ParserState{state.rule_id, state.sequence_id, state.element_id + 1, state.rule_start_pos, 0}
@@ -460,8 +494,8 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
                          << grammar_->GetRule(state.rule_id).name << " predict the new rule "
                          << ref_rule_id << ": " << grammar_->GetRule(ref_rule_id).name << ".";
     }
-    if (!is_repeat && (fsm.GetFsm().GetFsm().GetEdges(target).size() == 0) &&
-        fsm.GetFsm().IsEndState(target) &&
+    const uint8_t target_flags = GetFsmStateFlags(state.rule_id, target);
+    if (!is_repeat && !(target_flags & kFsmStateHasEdges) && (target_flags & kFsmStateEnd) &&
         state.rule_start_pos != static_cast<int32_t>(rule_id_to_completable_states_.size() - 1)) {
       // It's a right recursion. We can optimize it.
       // If it's the right recursion, we need to add the ancestors of the parent state.
@@ -515,11 +549,7 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
     }
 
     // Check if the reference rule can be empty.
-    if (!is_repeat && std::binary_search(
-                          grammar_->allow_empty_rule_ids.begin(),
-                          grammar_->allow_empty_rule_ids.end(),
-                          ref_rule_id
-                      )) {
+    if (!is_repeat && IsRuleNullable(ref_rule_id)) {
       Enqueue(ParserState{state.rule_id, state.sequence_id, target, state.rule_start_pos, 0});
     }
 
@@ -831,9 +861,8 @@ void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
     }
     auto new_state = state;
     new_state.element_id = edge.target;
-    if ((!current_fsm.GetFsm().IsNonTerminalState(edge.target)) &&
-        (!current_fsm.GetFsm().IsEndState(edge.target) &&
-         current_fsm.GetFsm().IsScanableState(edge.target))) {
+    const uint8_t flags = GetFsmStateFlags(state.rule_id, edge.target);
+    if (!(flags & kFsmStateNonTerminal) && !(flags & kFsmStateEnd) && (flags & kFsmStateScanable)) {
       EnqueueWithoutProcessing(std::move(new_state));
     } else {
       Enqueue(std::move(new_state));
@@ -857,9 +886,8 @@ void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
     if (!matched) continue;
     auto new_state = state;
     new_state.element_id = edge.target;
-    if ((!current_fsm.GetFsm().IsNonTerminalState(edge.target)) &&
-        (!current_fsm.GetFsm().IsEndState(edge.target) &&
-         current_fsm.GetFsm().IsScanableState(edge.target))) {
+    const uint8_t flags = GetFsmStateFlags(state.rule_id, edge.target);
+    if (!(flags & kFsmStateNonTerminal) && !(flags & kFsmStateEnd) && (flags & kFsmStateScanable)) {
       EnqueueWithoutProcessing(std::move(new_state));
     } else {
       Enqueue(std::move(new_state));

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -6,7 +6,9 @@
 
 #ifndef XGRAMMAR_EARLEY_PARSER_H_
 #define XGRAMMAR_EARLEY_PARSER_H_
+#include <array>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <ostream>
 #include <queue>
@@ -193,6 +195,54 @@ class StateHashForParsing {
   }
 };
 
+/*!
+ * \brief Immutable Earley-parser metadata derived solely from an optimized grammar.
+ *
+ * A compiled grammar creates thousands of short-lived EarleyParser instances while building
+ * adaptive token masks. Keeping these tables in each parser repeats the same state classification,
+ * nullable-rule initialization, and deterministic byte-transition construction for every mask
+ * task. Build them once and share them between compile-time tasks and runtime matchers.
+ */
+struct EarleyParserGrammarMetadata {
+  enum FsmStateFlag : uint8_t {
+    kFsmStateInitialized = 1 << 0,
+    kFsmStateScanable = 1 << 1,
+    kFsmStateNonTerminal = 1 << 2,
+    kFsmStateEnd = 1 << 3,
+    kFsmStateHasEdges = 1 << 4,
+  };
+
+  /*! \brief Precomputed FSM state properties, indexed by complete-FSM state id. */
+  std::vector<uint8_t> fsm_state_flags;
+
+  /*! \brief Whether each rule can match the empty string. */
+  std::vector<uint8_t> rule_is_nullable;
+
+  /*!
+   * \brief Whether a rule or any transitively referenced rule can observe an atomic token ID.
+   */
+  std::vector<uint8_t> rule_has_atomic_token_edges;
+
+  /*!
+   * \brief State-to-table mapping for deterministic states with several character edges.
+   * A value of -1 means AdvanceFsm should scan the state's edges.
+   */
+  std::vector<int32_t> deterministic_byte_transition_ids;
+
+  /*! \brief Dense byte transitions selected by deterministic_byte_transition_ids. */
+  std::vector<std::array<int32_t, 256>> deterministic_byte_transitions;
+
+  EarleyParserGrammarMetadata() = default;
+  explicit EarleyParserGrammarMetadata(const Grammar& grammar);
+
+  friend std::size_t MemorySize(const EarleyParserGrammarMetadata& metadata) {
+    return MemorySize(metadata.fsm_state_flags) + MemorySize(metadata.rule_is_nullable) +
+           MemorySize(metadata.rule_has_atomic_token_edges) +
+           MemorySize(metadata.deterministic_byte_transition_ids) +
+           MemorySize(metadata.deterministic_byte_transitions);
+  }
+};
+
 /*! \brief This class is used to detect the repeated states. */
 class RepeatDetector {
  private:
@@ -203,6 +253,11 @@ class RepeatDetector {
   std::unordered_set<ParserState, StateHashForParsing, StateEqualForParsing> visited_set_;
 
   int size_ = 0;
+  bool using_set_ = false;
+
+  const ParserState* InsertInSet(const ParserState& state);
+
+  void ClearSet();
 
  public:
   RepeatDetector(const int transition_threshold = 50)
@@ -210,20 +265,54 @@ class RepeatDetector {
     visited_vector_.resize(transition_threshold_);
   }
 
-  /*!
-   * \brief Check if the element is visited.
-   * \return True if visited, false otherwise.
-   */
-  bool IsVisited(const ParserState& state) const;
+  /*! \brief Insert a state only if absent and return its stable address, or nullptr. */
+  const ParserState* InsertIfAbsent(const ParserState& state) {
+    if (!using_set_ && size_ < transition_threshold_) {
+      for (int i = 0; i < size_; ++i) {
+        if (StateEqualForParsing()(state, visited_vector_[i])) {
+          return nullptr;
+        }
+      }
+      visited_vector_[size_] = state;
+      return &visited_vector_[size_++];
+    }
+    return InsertInSet(state);
+  }
 
-  /*!
-   * \brief Add the state into the visited states.
-   * \param state The state to be added.
-   */
-  void Insert(const ParserState& state);
+  /*! \brief Insert a copy of an FSM state with a new element id. */
+  const ParserState* InsertFsmTransitionIfAbsent(
+      const ParserState& state, int32_t target_element_id
+  ) {
+    if (!using_set_ && size_ < transition_threshold_) {
+      for (int i = 0; i < size_; ++i) {
+        const ParserState& existing = visited_vector_[i];
+        if (existing.rule_id == state.rule_id && existing.sequence_id == state.sequence_id &&
+            existing.element_id == target_element_id &&
+            existing.rule_start_pos == state.rule_start_pos &&
+            existing.sub_element_id == state.sub_element_id &&
+            existing.repeat_count == state.repeat_count &&
+            existing.partial_codepoint == state.partial_codepoint) {
+          return nullptr;
+        }
+      }
+      ParserState* inserted = &visited_vector_[size_++];
+      *inserted = state;
+      inserted->element_id = target_element_id;
+      return inserted;
+    }
+    ParserState transitioned = state;
+    transitioned.element_id = target_element_id;
+    return InsertInSet(transitioned);
+  }
 
   /*! \brief Reset the detector. */
-  void Clear();
+  void Clear() {
+    if (using_set_) {
+      ClearSet();
+    }
+    size_ = 0;
+    using_set_ = false;
+  }
 };
 
 class EarleyParser {
@@ -245,11 +334,17 @@ class EarleyParser {
   /*! \brief The grammar to be parsed. */
   Grammar grammar_;
 
+  /*! \brief Direct access to the shared complete-FSM edge table. */
+  const Compact2DArray<FSMEdge>* complete_fsm_edges_;
+
+  /*! \brief Grammar-only metadata shared by all parsers for one compiled grammar. */
+  const EarleyParserGrammarMetadata* grammar_metadata_;
+
   /*! \brief In this round of advancing, check if the stop token can be accepted. */
   bool tmp_accept_stop_token_ = false;
 
   /*! \brief store when accepting i characters, if the stop token can be accepted. */
-  std::vector<bool> is_completed_;
+  std::vector<uint8_t> is_completed_;
 
   /*!
    * \brief rule_id_to_completable_states[i][j] is the i pos j rule_id states. Earley
@@ -267,10 +362,10 @@ class EarleyParser {
    * \brief A temporary vector only used in Advance, used to add states in the
    * scanable_state_history.
    */
-  std::vector<ParserState> tmp_states_to_be_added_;
+  std::vector<const ParserState*> tmp_states_to_be_added_;
 
-  /*! \brief It's the processing queue of the earley parser. */
-  std::queue<ParserState> tmp_process_state_queue_;
+  /*! \brief Stable pointers to visited states awaiting prediction/completion. */
+  std::queue<const ParserState*> tmp_process_state_queue_;
 
   /*! \brief The class is used to check if a state has been added into the queue. */
   RepeatDetector tmp_states_visited_in_queue_;
@@ -278,45 +373,46 @@ class EarleyParser {
   /*! \brief Check if the stop token is accepted. */
   bool stop_token_is_accepted_ = false;
 
-  enum FsmStateFlag : uint8_t {
-    kFsmStateInitialized = 1 << 0,
-    kFsmStateScanable = 1 << 1,
-    kFsmStateNonTerminal = 1 << 2,
-    kFsmStateEnd = 1 << 3,
-    kFsmStateHasEdges = 1 << 4,
+  using FsmStateFlag = EarleyParserGrammarMetadata::FsmStateFlag;
+  static constexpr uint8_t kFsmStateInitialized = EarleyParserGrammarMetadata::kFsmStateInitialized;
+  static constexpr uint8_t kFsmStateScanable = EarleyParserGrammarMetadata::kFsmStateScanable;
+  static constexpr uint8_t kFsmStateNonTerminal = EarleyParserGrammarMetadata::kFsmStateNonTerminal;
+  static constexpr uint8_t kFsmStateEnd = EarleyParserGrammarMetadata::kFsmStateEnd;
+  static constexpr uint8_t kFsmStateHasEdges = EarleyParserGrammarMetadata::kFsmStateHasEdges;
+
+  struct ByteTransitionCacheSlot {
+    int32_t state_id = -1;
+    const std::array<int32_t, 256>* targets = nullptr;
   };
 
-  /*! \brief Lazily-computed FSM state properties, indexed by rule id and state id. */
-  std::vector<std::vector<uint8_t>> fsm_state_flags_cache_;
+  /*! \brief Parser-local pointer front-end for the shared deterministic transition tables. */
+  std::array<ByteTransitionCacheSlot, 64> byte_transition_direct_cache_{};
 
-  /*! \brief Whether each rule can match the empty string. */
-  std::vector<uint8_t> rule_is_nullable_;
-
-  /*! \brief Compute and cache properties for a state in a per-rule FSM. */
-  uint8_t InitializeFsmStateFlags(int32_t rule_id, int32_t state_id);
-
-  /*! \brief Return cached properties for a state in a per-rule FSM. */
-  uint8_t GetFsmStateFlags(int32_t rule_id, int32_t state_id) {
-    XGRAMMAR_DCHECK(rule_id >= 0 && rule_id < static_cast<int32_t>(fsm_state_flags_cache_.size()));
-    auto& flags_cache = fsm_state_flags_cache_[rule_id];
-    if (!flags_cache.empty()) {
-      XGRAMMAR_DCHECK(state_id >= 0 && state_id < static_cast<int32_t>(flags_cache.size()));
-      if (flags_cache[state_id] != 0) {
-        return flags_cache[state_id];
-      }
+  const std::array<int32_t, 256>* GetDeterministicByteTransitions(int32_t state_id) {
+    auto& slot = byte_transition_direct_cache_
+        [static_cast<uint32_t>(state_id) % byte_transition_direct_cache_.size()];
+    if (slot.state_id == state_id) {
+      return slot.targets;
     }
-    return InitializeFsmStateFlags(rule_id, state_id);
+    const int32_t transition_id = grammar_metadata_->deterministic_byte_transition_ids[state_id];
+    const auto* targets = transition_id >= 0
+                              ? &grammar_metadata_->deterministic_byte_transitions[transition_id]
+                              : nullptr;
+    slot = {state_id, targets};
+    return targets;
   }
 
-  bool IsRuleNullable(int32_t rule_id) const { return rule_is_nullable_[rule_id] != 0; }
+  /*! \brief Return precomputed properties for a state in a per-rule FSM. */
+  uint8_t GetFsmStateFlags(int32_t rule_id, int32_t state_id) const {
+    XGRAMMAR_DCHECK(rule_id >= 0 && rule_id < grammar_->NumRules());
+    XGRAMMAR_DCHECK(
+        state_id >= 0 && state_id < static_cast<int32_t>(grammar_metadata_->fsm_state_flags.size())
+    );
+    return grammar_metadata_->fsm_state_flags[state_id];
+  }
 
-  /*!
-   * \brief Check if the state has been added into the queue.
-   * \param state The state to check.
-   * \return True if in the vector, false otherwise.
-   */
-  bool IsStateVisitedInQueue(const ParserState& state) const {
-    return tmp_states_visited_in_queue_.IsVisited(state);
+  bool IsRuleNullable(int32_t rule_id) const {
+    return grammar_metadata_->rule_is_nullable[rule_id] != 0;
   }
 
   /*!
@@ -434,9 +530,8 @@ class EarleyParser {
    * \details The state is enqueued if it is not visited in the queue.
    */
   void Enqueue(const ParserState& state) {
-    if (!IsStateVisitedInQueue(state)) {
-      tmp_process_state_queue_.push(state);
-      tmp_states_visited_in_queue_.Insert(state);
+    if (const ParserState* inserted = tmp_states_visited_in_queue_.InsertIfAbsent(state)) {
+      tmp_process_state_queue_.push(inserted);
     }
   }
 
@@ -445,9 +540,22 @@ class EarleyParser {
    * \param state The state to be enqueued.
    */
   void EnqueueWithoutProcessing(const ParserState& state) {
-    if (!IsStateVisitedInQueue(state)) {
-      tmp_states_visited_in_queue_.Insert(state);
-      tmp_states_to_be_added_.push_back(state);
+    if (const ParserState* inserted = tmp_states_visited_in_queue_.InsertIfAbsent(state)) {
+      tmp_states_to_be_added_.push_back(inserted);
+    }
+  }
+
+  void EnqueueFsmTransition(const ParserState& state, int32_t target_element_id) {
+    if (const ParserState* inserted =
+            tmp_states_visited_in_queue_.InsertFsmTransitionIfAbsent(state, target_element_id)) {
+      tmp_process_state_queue_.push(inserted);
+    }
+  }
+
+  void EnqueueFsmTransitionWithoutProcessing(const ParserState& state, int32_t target_element_id) {
+    if (const ParserState* inserted =
+            tmp_states_visited_in_queue_.InsertFsmTransitionIfAbsent(state, target_element_id)) {
+      tmp_states_to_be_added_.push_back(inserted);
     }
   }
 
@@ -458,8 +566,11 @@ class EarleyParser {
    * \param initial_state The state to start parsing from. If not provided, parsing starts
    * from the root rule of the grammar.
    */
-  explicit EarleyParser(
-      const Grammar& grammar, std::optional<ParserState> initial_state = std::nullopt
+  EarleyParser(
+      const Grammar& grammar,
+      const EarleyParserGrammarMetadata& grammar_metadata,
+      std::optional<ParserState> initial_state = std::nullopt,
+      bool need_expand = true
   );
 
   /*!
@@ -515,10 +626,22 @@ class EarleyParser {
    * \param state The state to be pushed.
    */
   void PushOneStateToCheck(const ParserState& state) {
-    rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
+    rule_id_to_completable_states_.PushBackEmpty();
     is_completed_.push_back(is_completed_.back());
     scanable_state_history_.PushBack(&state, 1);
     return;
+  }
+
+  /*! \brief Push several already-expanded states as one parser frontier. */
+  void PushStatesToCheck(const std::vector<ParserState>& states) {
+    XGRAMMAR_DCHECK(!states.empty());
+    rule_id_to_completable_states_.PushBackEmpty();
+    is_completed_.push_back(is_completed_.back());
+    scanable_state_history_.PushBack(states);
+  }
+
+  bool HasLatestScanableStates() const {
+    return scanable_state_history_[scanable_state_history_.size() - 1].size() != 0;
   }
 
   std::string PrintStates() const {

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -278,6 +278,38 @@ class EarleyParser {
   /*! \brief Check if the stop token is accepted. */
   bool stop_token_is_accepted_ = false;
 
+  enum FsmStateFlag : uint8_t {
+    kFsmStateInitialized = 1 << 0,
+    kFsmStateScanable = 1 << 1,
+    kFsmStateNonTerminal = 1 << 2,
+    kFsmStateEnd = 1 << 3,
+    kFsmStateHasEdges = 1 << 4,
+  };
+
+  /*! \brief Lazily-computed FSM state properties, indexed by rule id and state id. */
+  std::vector<std::vector<uint8_t>> fsm_state_flags_cache_;
+
+  /*! \brief Whether each rule can match the empty string. */
+  std::vector<uint8_t> rule_is_nullable_;
+
+  /*! \brief Compute and cache properties for a state in a per-rule FSM. */
+  uint8_t InitializeFsmStateFlags(int32_t rule_id, int32_t state_id);
+
+  /*! \brief Return cached properties for a state in a per-rule FSM. */
+  uint8_t GetFsmStateFlags(int32_t rule_id, int32_t state_id) {
+    XGRAMMAR_DCHECK(rule_id >= 0 && rule_id < static_cast<int32_t>(fsm_state_flags_cache_.size()));
+    auto& flags_cache = fsm_state_flags_cache_[rule_id];
+    if (!flags_cache.empty()) {
+      XGRAMMAR_DCHECK(state_id >= 0 && state_id < static_cast<int32_t>(flags_cache.size()));
+      if (flags_cache[state_id] != 0) {
+        return flags_cache[state_id];
+      }
+    }
+    return InitializeFsmStateFlags(rule_id, state_id);
+  }
+
+  bool IsRuleNullable(int32_t rule_id) const { return rule_is_nullable_[rule_id] != 0; }
+
   /*!
    * \brief Check if the state has been added into the queue.
    * \param state The state to check.

--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -28,7 +28,8 @@ std::size_t MemorySize(const Grammar::Impl& impl) {
   /// This should be improved in the future.
   return impl.rules_.size() * sizeof(std::string) + MemorySize(impl.grammar_expr_data_) +
          MemorySize(impl.grammar_expr_indptr_) + MemorySize(impl.complete_fsm) +
-         MemorySize(impl.per_rule_fsms) + MemorySize(impl.allow_empty_rule_ids);
+         MemorySize(impl.per_rule_fsms) + MemorySize(impl.per_rule_fsm_state_cache_keys) +
+         MemorySize(impl.allow_empty_rule_ids);
 }
 
 /******************* Grammar *******************/

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -6,10 +6,18 @@
 #include <xgrammar/compiler.h>
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <bitset>
 #include <cctype>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <exception>
+#include <future>
+#include <limits>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -23,6 +31,7 @@
 #include "grammar_functor.h"
 #include "grammar_impl.h"
 #include "support/dynamic_bitset.h"
+#include "support/encoding.h"
 #include "support/int_set.h"
 #include "support/logging.h"
 #include "support/thread_pool.h"
@@ -36,30 +45,495 @@ namespace xgrammar {
 
 /************** AdaptiveTokenMaskCache Generator **************/
 
+/*!
+ * \brief A compilation-local cache for one first-byte subtree of the tokenizer vocabulary.
+ *
+ * Two scanable FSM states can have different full reachable grammars while consuming a particular
+ * first byte into structurally identical continuations. In that case every token with this first
+ * byte has the same adaptive-mask classification. Caching that vocabulary bucket avoids replaying
+ * the common suffix language for every node of generated exclusion tries.
+ */
+class FirstByteTokenMaskCache {
+ public:
+  struct Key {
+    uint8_t first_byte;
+    bool collect_rejected;
+    std::vector<Grammar::Impl::FSMStateCacheKey> continuations;
+
+    bool operator==(const Key& other) const {
+      return first_byte == other.first_byte && collect_rejected == other.collect_rejected &&
+             continuations == other.continuations;
+    }
+  };
+
+  struct Result {
+    std::vector<int32_t> accepted_indices;
+    std::vector<int32_t> rejected_indices;
+    std::vector<int32_t> uncertain_indices;
+    size_t covered_max_suffix_bytes = std::numeric_limits<size_t>::max();
+  };
+
+  struct KeyHash {
+    size_t operator()(const Key& key) const {
+      uint64_t result = HashCombine(key.first_byte, key.collect_rejected);
+      for (const auto& continuation : key.continuations) {
+        HashCombineBinary(result, continuation.hash);
+        HashCombineBinary(result, continuation.state_count);
+        HashCombineBinary(result, continuation.edge_count);
+      }
+      return result;
+    }
+  };
+
+  explicit FirstByteTokenMaskCache(size_t max_memory_bytes) : max_memory_bytes_(max_memory_bytes) {}
+
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  ~FirstByteTokenMaskCache() {
+    XGRAMMAR_LOG(INFO) << "FirstByteTokenMaskCacheProfile(hits=" << profile_hits_
+                       << ", misses=" << profile_misses_
+                       << ", optional_chain_queries=" << profile_optional_chain_queries_
+                       << ", optional_chain_hits=" << profile_optional_chain_hits_
+                       << ", fixed_tail_queries=" << profile_fixed_tail_queries_
+                       << ", fixed_tail_hits=" << profile_fixed_tail_hits_
+                       << ", additions=" << profile_additions_
+                       << ", replacements=" << profile_replacements_
+                       << ", entries=" << cache_.size() << ", bytes=" << memory_bytes_ << ")";
+  }
+
+#endif
+
+  std::shared_ptr<const Result> Get(const Key& key) {
+    std::lock_guard<std::mutex> lock(mutex_);
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    const bool is_optional_chain =
+        !key.continuations.empty() && key.continuations[0].state_count == -1;
+    const bool is_fixed_tail = !key.continuations.empty() && key.continuations[0].state_count == -2;
+    profile_optional_chain_queries_ += is_optional_chain;
+    profile_fixed_tail_queries_ += is_fixed_tail;
+#endif
+    const auto it = cache_.find(key);
+    if (it == cache_.end()) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+      ++profile_misses_;
+#endif
+      return nullptr;
+    }
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    ++profile_hits_;
+    profile_optional_chain_hits_ += is_optional_chain;
+    profile_fixed_tail_hits_ += is_fixed_tail;
+#endif
+    return it->second;
+  }
+
+  void Add(Key key, Result result) {
+    const auto get_memory_bytes = [&](const Result& value) {
+      return sizeof(Key) + sizeof(Result) + value.accepted_indices.size() * sizeof(int32_t) +
+             value.rejected_indices.size() * sizeof(int32_t) +
+             value.uncertain_indices.size() * sizeof(int32_t) +
+             key.continuations.size() * sizeof(Grammar::Impl::FSMStateCacheKey);
+    };
+    const size_t new_memory_bytes = get_memory_bytes(result);
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto existing = cache_.find(key);
+    if (existing != cache_.end()) {
+      if (existing->second->covered_max_suffix_bytes >= result.covered_max_suffix_bytes) {
+        return;
+      }
+      const size_t existing_memory_bytes = get_memory_bytes(*existing->second);
+      const size_t memory_without_existing = memory_bytes_ - existing_memory_bytes;
+      if (new_memory_bytes > max_memory_bytes_ - memory_without_existing) {
+        return;
+      }
+      memory_bytes_ = memory_without_existing + new_memory_bytes;
+      existing->second = std::make_shared<const Result>(std::move(result));
+#ifdef XGRAMMAR_PROFILE_COMPILE
+      ++profile_replacements_;
+#endif
+      return;
+    }
+    if (new_memory_bytes > max_memory_bytes_ - memory_bytes_) {
+      return;
+    }
+    memory_bytes_ += new_memory_bytes;
+    cache_.emplace(std::move(key), std::make_shared<const Result>(std::move(result)));
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    ++profile_additions_;
+#endif
+  }
+
+ private:
+  std::mutex mutex_;
+  const size_t max_memory_bytes_;
+  size_t memory_bytes_ = 0;
+  std::unordered_map<Key, std::shared_ptr<const Result>, KeyHash> cache_;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  uint64_t profile_hits_ = 0;
+  uint64_t profile_misses_ = 0;
+  uint64_t profile_additions_ = 0;
+  uint64_t profile_replacements_ = 0;
+  uint64_t profile_optional_chain_queries_ = 0;
+  uint64_t profile_optional_chain_hits_ = 0;
+  uint64_t profile_fixed_tail_queries_ = 0;
+  uint64_t profile_fixed_tail_hits_ = 0;
+#endif
+};
+
+/*!
+ * \brief A compilation-local summary of how vocabulary tokens match one character class.
+ *
+ * Bounded repeats are lowered to one helper rule per remaining length. Without this cache, every
+ * helper rule decodes every vocabulary token again even though only the length limit changes.
+ * The first caller scans the vocabulary once; all remaining helper rules reuse the byte-decoding
+ * result and only compare the recorded character count with their own limit.
+ */
+class OptionalCharacterClassTokenSummaryCache {
+ public:
+  struct Key {
+    std::vector<int32_t> character_class;
+
+    bool operator==(const Key& other) const { return character_class == other.character_class; }
+  };
+
+  struct KeyHash {
+    size_t operator()(const Key& key) const {
+      uint64_t result = 0x4f50545f53554d4dULL;
+      for (int32_t value : key.character_class) {
+        HashCombineBinary(result, static_cast<uint64_t>(value));
+      }
+      return result;
+    }
+  };
+
+  struct TokenSummary {
+    int32_t sorted_vocab_index;
+    int32_t locally_consumed_characters;
+    bool consumed_whole_token;
+    bool has_completed_character_prefix;
+  };
+
+  using Result = std::vector<TokenSummary>;
+
+  template <typename Builder>
+  std::shared_ptr<const Result> GetOrCreate(const Key& key, Builder&& builder) {
+    using SharedResult = std::shared_ptr<const Result>;
+    std::shared_future<SharedResult> future;
+    std::promise<SharedResult> producer;
+    bool should_build = false;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      const auto it = cache_.find(key);
+      if (it != cache_.end()) {
+        future = it->second;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+        ++profile_hits_;
+#endif
+      } else {
+        future = producer.get_future().share();
+        cache_.emplace(key, future);
+        should_build = true;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+        ++profile_builds_;
+#endif
+      }
+    }
+    if (!should_build) {
+      return future.get();
+    }
+    try {
+      SharedResult result = std::make_shared<const Result>(builder());
+#ifdef XGRAMMAR_PROFILE_COMPILE
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        profile_candidate_tokens_ += result->size();
+      }
+#endif
+      producer.set_value(result);
+      return result;
+    } catch (...) {
+      producer.set_exception(std::current_exception());
+      throw;
+    }
+  }
+
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  ~OptionalCharacterClassTokenSummaryCache() {
+    XGRAMMAR_LOG(INFO) << "OptionalCharacterClassTokenSummaryProfile(builds=" << profile_builds_
+                       << ", hits=" << profile_hits_
+                       << ", candidate_tokens=" << profile_candidate_tokens_ << ")";
+  }
+#endif
+
+ private:
+  std::mutex mutex_;
+  std::unordered_map<Key, std::shared_future<std::shared_ptr<const Result>>, KeyHash> cache_;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  uint64_t profile_builds_ = 0;
+  uint64_t profile_hits_ = 0;
+  uint64_t profile_candidate_tokens_ = 0;
+#endif
+};
+
+struct OptionalCharacterClassChain {
+  uint64_t character_class_hash;
+  int32_t character_class_expr_id;
+  int32_t remaining_count;
+};
+
+/*!
+ * \brief Recognize the helper-rule chain emitted for a bounded optional character-class repeat.
+ *
+ * Each rule in the chain is `"" | character_class next_rule`, with the final rule omitting
+ * `next_rule`. The result records the common character class and the maximum number of characters
+ * that the current rule can still consume.
+ */
+std::optional<OptionalCharacterClassChain> RecognizeOptionalCharacterClassChain(
+    const Grammar& grammar, int32_t initial_rule_id
+) {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+
+  std::optional<uint64_t> character_class_hash;
+  std::optional<int32_t> character_class_expr_id;
+  int32_t remaining_count = 0;
+  int32_t rule_id = initial_rule_id;
+  std::unordered_set<int32_t> visited_rules;
+  while (visited_rules.insert(rule_id).second) {
+    const auto& body = grammar->GetGrammarExpr(grammar->GetRule(rule_id).body_expr_id);
+    if (body.type != GrammarExprType::kChoices || body.size() != 2) {
+      return std::nullopt;
+    }
+
+    std::optional<int32_t> non_empty_sequence_id;
+    bool has_empty_choice = false;
+    for (int32_t choice_id : body) {
+      const auto& choice = grammar->GetGrammarExpr(choice_id);
+      if (choice.type == GrammarExprType::kEmptyStr) {
+        has_empty_choice = true;
+      } else if (choice.type == GrammarExprType::kSequence) {
+        if (non_empty_sequence_id.has_value()) {
+          return std::nullopt;
+        }
+        non_empty_sequence_id = choice_id;
+      } else {
+        return std::nullopt;
+      }
+    }
+    if (!has_empty_choice || !non_empty_sequence_id.has_value()) {
+      return std::nullopt;
+    }
+
+    const auto& sequence = grammar->GetGrammarExpr(*non_empty_sequence_id);
+    if (sequence.size() < 1 || sequence.size() > 2) {
+      return std::nullopt;
+    }
+    const auto& repeated_element = grammar->GetGrammarExpr(sequence[0]);
+    if (repeated_element.type != GrammarExprType::kCharacterClass) {
+      return std::nullopt;
+    }
+    uint64_t current_character_class_hash =
+        HashCombine(uint64_t{0x4f50545f43484152ULL}, static_cast<int32_t>(repeated_element.type));
+    for (int32_t value : repeated_element) {
+      HashCombineBinary(current_character_class_hash, static_cast<uint64_t>(value));
+    }
+    if (character_class_hash.has_value() && *character_class_hash != current_character_class_hash) {
+      return std::nullopt;
+    }
+    character_class_hash = current_character_class_hash;
+    if (!character_class_expr_id.has_value()) {
+      character_class_expr_id = sequence[0];
+    }
+    ++remaining_count;
+
+    if (sequence.size() == 1) {
+      return OptionalCharacterClassChain{
+          *character_class_hash, *character_class_expr_id, remaining_count
+      };
+    }
+    const auto& next = grammar->GetGrammarExpr(sequence[1]);
+    if (next.type != GrammarExprType::kRuleRef || next.size() != 1) {
+      return std::nullopt;
+    }
+    rule_id = next[0];
+  }
+  return std::nullopt;
+}
+
+OptionalCharacterClassTokenSummaryCache::Result BuildOptionalCharacterClassTokenSummaries(
+    const Grammar::Impl::GrammarExpr& character_class,
+    const std::vector<std::pair<int32_t, std::string>>& sorted_vocab
+) {
+  XGRAMMAR_DCHECK(character_class.type == Grammar::Impl::GrammarExprType::kCharacterClass);
+  const bool is_negative = static_cast<bool>(character_class[0]);
+  const auto codepoint_is_in_ranges = [&](TCodepoint codepoint) {
+    for (int32_t range_index = 1; range_index < character_class.size(); range_index += 2) {
+      if (codepoint >= character_class[range_index] &&
+          codepoint <= character_class[range_index + 1]) {
+        return true;
+      }
+    }
+    return false;
+  };
+  const auto partial_codepoint_can_match =
+      [&](TCodepoint partial, int32_t remaining_bytes, int32_t total_bytes) {
+        if (is_negative) {
+          return true;
+        }
+        static constexpr std::array<TCodepoint, 5> kMinCodepointByUtf8Length = {
+            0, 0, 0x80, 0x800, 0x10000
+        };
+        const TCodepoint raw_min_codepoint = partial << (6 * remaining_bytes);
+        const TCodepoint min_codepoint =
+            std::max(raw_min_codepoint, kMinCodepointByUtf8Length[total_bytes]);
+        const TCodepoint max_codepoint = std::min<TCodepoint>(
+            raw_min_codepoint | ((TCodepoint{1} << (6 * remaining_bytes)) - 1), 0x10FFFF
+        );
+        if (min_codepoint > max_codepoint) {
+          return false;
+        }
+        for (int32_t range_index = 1; range_index < character_class.size(); range_index += 2) {
+          if (max_codepoint >= character_class[range_index] &&
+              min_codepoint <= character_class[range_index + 1]) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+  OptionalCharacterClassTokenSummaryCache::Result result;
+  result.reserve(sorted_vocab.size());
+  for (int32_t sorted_vocab_index = 0;
+       sorted_vocab_index < static_cast<int32_t>(sorted_vocab.size());
+       ++sorted_vocab_index) {
+    const auto& [token_id, token] = sorted_vocab[sorted_vocab_index];
+    static_cast<void>(token_id);
+    int32_t byte_offset = 0;
+    int32_t completed_characters = 0;
+    bool incomplete_character = false;
+    bool mismatch = false;
+    while (byte_offset < static_cast<int32_t>(token.size())) {
+      const uint8_t first_byte = static_cast<uint8_t>(token[byte_offset]);
+      auto [valid_first_byte, total_bytes, partial_codepoint] = HandleUTF8FirstByte(first_byte);
+      if (!valid_first_byte) {
+        mismatch = true;
+        break;
+      }
+      if (total_bytes == 1) {
+        const bool in_ranges = codepoint_is_in_ranges(partial_codepoint);
+        if (in_ranges == is_negative) {
+          mismatch = true;
+          break;
+        }
+        ++completed_characters;
+        ++byte_offset;
+      } else {
+        int32_t consumed_bytes = 1;
+        bool valid_continuations = true;
+        while (consumed_bytes < total_bytes &&
+               byte_offset + consumed_bytes < static_cast<int32_t>(token.size())) {
+          const uint8_t continuation = static_cast<uint8_t>(token[byte_offset + consumed_bytes]);
+          if ((continuation & 0xC0) != 0x80) {
+            valid_continuations = false;
+            break;
+          }
+          partial_codepoint = (partial_codepoint << 6) | (continuation & 0x3F);
+          ++consumed_bytes;
+        }
+        if (!valid_continuations) {
+          mismatch = true;
+          break;
+        }
+        if (consumed_bytes < total_bytes) {
+          incomplete_character = partial_codepoint_can_match(
+              partial_codepoint, total_bytes - consumed_bytes, total_bytes
+          );
+          mismatch = !incomplete_character;
+          byte_offset = token.size();
+          break;
+        }
+        static constexpr std::array<TCodepoint, 5> kMinCodepointByUtf8Length = {
+            0, 0, 0x80, 0x800, 0x10000
+        };
+        if (!is_negative && (partial_codepoint < kMinCodepointByUtf8Length[total_bytes] ||
+                             partial_codepoint > 0x10FFFF)) {
+          mismatch = true;
+          break;
+        }
+        const bool in_ranges = codepoint_is_in_ranges(partial_codepoint);
+        if (in_ranges == is_negative) {
+          mismatch = true;
+          break;
+        }
+        ++completed_characters;
+        byte_offset += total_bytes;
+      }
+    }
+    const bool consumed_whole_token =
+        byte_offset == static_cast<int32_t>(token.size()) && !mismatch;
+    const int32_t locally_consumed_characters =
+        completed_characters + static_cast<int32_t>(incomplete_character);
+    if (consumed_whole_token || completed_characters > 0) {
+      result.push_back(OptionalCharacterClassTokenSummaryCache::TokenSummary{
+          sorted_vocab_index,
+          locally_consumed_characters,
+          consumed_whole_token,
+          completed_characters > 0
+      });
+    }
+  }
+  return result;
+}
+
 /*! \brief The concrete implementation of GrammarMatcherNode. */
 class GrammarMatcherForTokenMaskCache : public EarleyParser {
  public:
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  struct ProfileCounters {
+    uint64_t possible_tokens = 0;
+    uint64_t rule_cache_hits = 0;
+    uint64_t first_byte_cache_reused_tokens = 0;
+    uint64_t saturated_cache_reused_tokens = 0;
+    uint64_t token_edge_skipped_tokens = 0;
+    uint64_t speculative_accepted_tokens = 0;
+    uint64_t subtree_pruned_tokens = 0;
+    uint64_t parser_simulated_tokens = 0;
+    uint64_t parser_naive_token_bytes = 0;
+    uint64_t parser_advance_calls = 0;
+    uint64_t parser_failed_advance_calls = 0;
+    bool used_optional_character_class_direct_mask = false;
+  };
+#endif
+
   GrammarMatcherForTokenMaskCache(
       const Grammar& grammar,
+      const EarleyParserGrammarMetadata& grammar_metadata,
       const ParserState& init_state,
       const std::unordered_map<int32_t, DynamicBitset>&
           tag_dispatch_rule_id_to_second_slicing_bitset,
       const TokenizerInfo& tokenizer_info,
-      std::optional<RuleLevelCache>& rule_level_cache
+      std::optional<RuleLevelCache>& rule_level_cache,
+      const std::shared_ptr<FirstByteTokenMaskCache>& first_byte_cache,
+      const std::shared_ptr<OptionalCharacterClassTokenSummaryCache>&
+          optional_character_class_token_summary_cache,
+      bool cache_direct_masks_across_grammars
   )
-      : EarleyParser(grammar, init_state),
+      : EarleyParser(grammar, grammar_metadata, init_state),
         init_rule_id_(init_state.rule_id),
         initial_state_(init_state),
         tag_dispatch_rule_id_to_second_slicing_bitset_(tag_dispatch_rule_id_to_second_slicing_bitset
         ),
         tokenizer_info_(tokenizer_info),
-        rule_level_cache_(rule_level_cache) {}
+        rule_level_cache_(rule_level_cache),
+        first_byte_cache_(first_byte_cache),
+        optional_character_class_token_summary_cache_(optional_character_class_token_summary_cache),
+        cache_direct_masks_across_grammars_(cache_direct_masks_across_grammars) {}
   /*!
    * \brief Get the adaptive token mask for the given ParserState.
    * \param is_root_rule Whether to consider the parent rule. If false, there will be
    * no uncertain tokens. Useful for the root rule.
    */
   AdaptiveTokenMask GetAdaptiveTokenMask(bool is_root_rule);
+
+  std::optional<AdaptiveTokenMask> GetOptionalCharacterClassDirectMask(bool is_root_rule) const;
 
   /*!
    * \brief Get the token mask for the given ParserState.
@@ -82,10 +556,33 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
    */
   void AdaptCacheWithLookahead(AdaptiveTokenMask* cache, bool is_root_rule);
 
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const ProfileCounters& GetProfileCounters() const { return profile_counters_; }
+#endif
+
  private:
+  /*!
+   * \brief Hash the sole direct character class repeated within the initial rule.
+   *
+   * Returns null when the rule contains fewer than two direct character-class elements or mixes
+   * distinct classes.
+   */
+  std::optional<uint64_t> GetHomogeneousCharacterClassHash() const;
+
+  /*!
+   * \brief Count consecutive copies of the current character class along an ASCII transition.
+   *
+   * This recognizes the fixed unzip tail emitted in one FSM sequence. A null result means the
+   * current state is not on such a homogeneous run.
+   */
+  std::optional<int32_t> GetRemainingAsciiCharacterClassRun(uint8_t first_byte) const;
+
+  /*! \brief Get the rule-local canonical id of an FSM state. */
+  std::optional<int32_t> GetCanonicalFsmStateId(int32_t state_id) const;
+
   /*! \brief Check if a token can pass the lookahead assertion. */
   std::pair</*acceptable*/ bool, /*can reach end*/ bool> IsTokenPassLookaheadAssertion(
-      const std::string& token, const std::vector<bool>& can_reach_end_stack
+      const std::string& token, const std::vector<uint8_t>& can_reach_end_stack
   );
 
   /*!
@@ -131,18 +628,185 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
 
   std::optional<RuleLevelCache> rule_level_cache_;
 
+  std::shared_ptr<FirstByteTokenMaskCache> first_byte_cache_;
+
+  std::shared_ptr<OptionalCharacterClassTokenSummaryCache>
+      optional_character_class_token_summary_cache_;
+
+  bool cache_direct_masks_across_grammars_;
+
   // Temporary data for GetAdaptiveTokenMask.
   std::vector<int32_t> tmp_accepted_indices_;
   std::vector<int32_t> tmp_rejected_indices_;
   std::vector<int32_t> tmp_uncertain_indices_;
   std::vector<int32_t> tmp_rejected_by_lookahead_indices_;
   std::vector<int32_t> tmp_accepted_by_lookahead_indices_;
-  std::vector<bool> tmp_can_reach_end_stack_;
-  std::vector<bool> tmp_can_reach_end_prefix_or_stack_;
+  std::vector<uint8_t> tmp_can_reach_end_stack_;
+  std::vector<uint8_t> tmp_can_reach_end_prefix_or_stack_;
   // Temporary data for GetTokenEdgeAcceptedIndices.
   std::vector<int32_t> tmp_token_edge_accepted_;
   std::vector<int32_t> tmp_token_edge_excluded_;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  ProfileCounters profile_counters_;
+#endif
 };
+
+std::optional<AdaptiveTokenMask>
+GrammarMatcherForTokenMaskCache::GetOptionalCharacterClassDirectMask(bool is_root_rule) const {
+  if (is_root_rule || initial_state_.sub_element_id != 0 ||
+      grammar_->GetRule(init_rule_id_).lookahead_assertion_id != -1 ||
+      initial_state_.element_id != grammar_->per_rule_fsms[init_rule_id_]->GetFsm().GetStart()) {
+    return std::nullopt;
+  }
+  const auto chain = RecognizeOptionalCharacterClassChain(grammar_, init_rule_id_);
+  if (!chain.has_value()) {
+    return std::nullopt;
+  }
+  const auto& character_class = grammar_->GetGrammarExpr(chain->character_class_expr_id);
+  XGRAMMAR_DCHECK(character_class.type == Grammar::Impl::GrammarExprType::kCharacterClass);
+  const auto& sorted_vocab = tokenizer_info_.GetSortedDecodedVocab();
+  const size_t vocab_size = tokenizer_info_.GetVocabSize();
+  OptionalCharacterClassTokenSummaryCache::Key summary_key;
+  summary_key.character_class.assign(character_class.begin(), character_class.end());
+  XGRAMMAR_DCHECK(optional_character_class_token_summary_cache_ != nullptr);
+  const auto token_summaries =
+      optional_character_class_token_summary_cache_->GetOrCreate(summary_key, [&]() {
+        return BuildOptionalCharacterClassTokenSummaries(character_class, sorted_vocab);
+      });
+
+  std::vector<int32_t> accepted_indices;
+  std::vector<int32_t> uncertain_indices;
+  accepted_indices.reserve(token_summaries->size());
+  uncertain_indices.reserve(token_summaries->size() / 4);
+  for (const auto& summary : *token_summaries) {
+    if (summary.consumed_whole_token &&
+        summary.locally_consumed_characters <= chain->remaining_count) {
+      accepted_indices.push_back(summary.sorted_vocab_index);
+    } else if (summary.has_completed_character_prefix) {
+      uncertain_indices.push_back(summary.sorted_vocab_index);
+    }
+  }
+  return AdaptiveTokenMask(
+      vocab_size, sorted_vocab, std::move(accepted_indices), std::move(uncertain_indices)
+  );
+}
+
+std::optional<uint64_t> GrammarMatcherForTokenMaskCache::GetHomogeneousCharacterClassHash() const {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+
+  const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(init_rule_id_).body_expr_id);
+  if (body.type != GrammarExprType::kChoices) {
+    return std::nullopt;
+  }
+  std::optional<uint64_t> character_class_hash;
+  int32_t character_class_count = 0;
+  for (int32_t choice_id : body) {
+    const auto& choice = grammar_->GetGrammarExpr(choice_id);
+    if (choice.type == GrammarExprType::kEmptyStr) {
+      continue;
+    }
+    if (choice.type != GrammarExprType::kSequence) {
+      return std::nullopt;
+    }
+    for (int32_t element_id : choice) {
+      const auto& element = grammar_->GetGrammarExpr(element_id);
+      if (element.type != GrammarExprType::kCharacterClass) {
+        continue;
+      }
+      uint64_t current_hash =
+          HashCombine(uint64_t{0x484f4d5f43484152ULL}, static_cast<int32_t>(element.type));
+      for (int32_t value : element) {
+        HashCombineBinary(current_hash, static_cast<uint64_t>(value));
+      }
+      if (character_class_hash.has_value() && *character_class_hash != current_hash) {
+        return std::nullopt;
+      }
+      character_class_hash = current_hash;
+      ++character_class_count;
+    }
+  }
+  return character_class_count >= 2 ? character_class_hash : std::nullopt;
+}
+
+std::optional<int32_t> GrammarMatcherForTokenMaskCache::GetRemainingAsciiCharacterClassRun(
+    uint8_t first_byte
+) const {
+  const auto& fsm = grammar_->per_rule_fsms[init_rule_id_]->GetFsm();
+  auto get_char_edge_signature = [&](int32_t state_id) -> std::optional<uint64_t> {
+    uint64_t signature = uint64_t{0x434841525f454447ULL};
+    int32_t char_edge_count = 0;
+    for (const auto& edge : fsm.GetFsm().GetEdges(state_id)) {
+      if (!edge.IsCharRange()) {
+        return std::nullopt;
+      }
+      signature = HashCombine(signature, edge.min, edge.max);
+      ++char_edge_count;
+    }
+    return char_edge_count == 0 ? std::nullopt : std::optional<uint64_t>(signature);
+  };
+
+  const auto initial_signature = get_char_edge_signature(initial_state_.element_id);
+  if (!initial_signature.has_value()) {
+    return std::nullopt;
+  }
+  // A non-ASCII first byte enters the UTF-8 sub-FSM before completing the current character
+  // class. Count the number of repeated class elements with an accepted ASCII probe instead. The
+  // resulting byte-length saturation bound remains conservative for the original multi-byte
+  // token, while allowing its bucket to share the same homogeneous-tail cache.
+  uint8_t traversal_byte = first_byte;
+  if (traversal_byte >= 0x80) {
+    bool found_ascii_probe = false;
+    for (const auto& edge : fsm.GetFsm().GetEdges(initial_state_.element_id)) {
+      if (!edge.IsCharRange()) {
+        return std::nullopt;
+      }
+      const int32_t probe_min = std::max<int32_t>(edge.min, 0);
+      const int32_t probe_max = std::min<int32_t>(edge.max, 0x7f);
+      if (probe_min <= probe_max) {
+        traversal_byte = static_cast<uint8_t>(probe_min);
+        found_ascii_probe = true;
+        break;
+      }
+    }
+    if (!found_ascii_probe) {
+      return std::nullopt;
+    }
+  }
+  int32_t state_id = initial_state_.element_id;
+  int32_t run_length = 0;
+  std::unordered_set<int32_t> visited_states;
+  while (visited_states.insert(state_id).second) {
+    const auto signature = get_char_edge_signature(state_id);
+    if (!signature.has_value() || *signature != *initial_signature) {
+      break;
+    }
+    std::optional<int32_t> next_state;
+    for (const auto& edge : fsm.GetFsm().GetEdges(state_id)) {
+      if (traversal_byte < edge.min || traversal_byte > edge.max) {
+        continue;
+      }
+      if (next_state.has_value() && *next_state != edge.target) {
+        return std::nullopt;
+      }
+      next_state = edge.target;
+    }
+    if (!next_state.has_value()) {
+      break;
+    }
+    ++run_length;
+    state_id = *next_state;
+  }
+  return run_length >= 2 ? std::optional<int32_t>(run_length) : std::nullopt;
+}
+
+std::optional<int32_t> GrammarMatcherForTokenMaskCache::GetCanonicalFsmStateId(int32_t state_id
+) const {
+  const auto& state_ids = grammar_->per_rule_fsm_new_state_ids[init_rule_id_];
+  const auto it = std::find_if(state_ids.begin(), state_ids.end(), [&](const auto& item) {
+    return item.first == state_id;
+  });
+  return it == state_ids.end() ? std::nullopt : std::optional<int32_t>(it->second);
+}
 
 void GrammarMatcherForTokenMaskCache::AdaptCacheWithLookahead(
     AdaptiveTokenMask* cache_ptr, bool is_root_rule
@@ -188,13 +852,11 @@ void GrammarMatcherForTokenMaskCache::AdaptCacheWithLookahead(
           // Case 2. The common prefix is shorter than the previous matched size. Rollback
           // the non-common part.
           PopLastStates(prev_matched_size - lcp_len);
-          tmp_can_reach_end_stack_.erase(
-              tmp_can_reach_end_stack_.end() - (prev_matched_size - lcp_len),
-              tmp_can_reach_end_stack_.end()
+          tmp_can_reach_end_stack_.resize(
+              tmp_can_reach_end_stack_.size() - (prev_matched_size - lcp_len)
           );
-          tmp_can_reach_end_prefix_or_stack_.erase(
-              tmp_can_reach_end_prefix_or_stack_.end() - (prev_matched_size - lcp_len),
-              tmp_can_reach_end_prefix_or_stack_.end()
+          tmp_can_reach_end_prefix_or_stack_.resize(
+              tmp_can_reach_end_prefix_or_stack_.size() - (prev_matched_size - lcp_len)
           );
         }
         prev_matched_size = std::min(prev_matched_size, lcp_len);
@@ -306,10 +968,11 @@ void GrammarMatcherForTokenMaskCache::AdaptCacheWithLookahead(
       break;
     }
   }
+  cache.RebuildDerivedData(tokenizer_info_.GetVocabSize(), sorted_decoded_vocab);
 }
 
 std::pair<bool, bool> GrammarMatcherForTokenMaskCache::IsTokenPassLookaheadAssertion(
-    const std::string& token, const std::vector<bool>& can_reach_end_stack
+    const std::string& token, const std::vector<uint8_t>& can_reach_end_stack
 ) {
   bool accepted = true;
   bool can_reach_end = true;
@@ -500,6 +1163,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
   std::vector<std::pair<int32_t, int32_t>> possible_intervals;
   int possible_token_num =
       GetPossibleTokenIntervals(sorted_decoded_vocab, first_char_mask, possible_intervals);
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  profile_counters_.possible_tokens += possible_token_num;
+#endif
 
   // Check if the type of the mask can be rejected.
   tmp_accepted_indices_.reserve(possible_token_num);
@@ -530,138 +1196,451 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
     definite_accepted_bitset = &tag_dispatch_rule_id_to_second_slicing_bitset_.at(init_rule_id_);
   }
 
+  const bool can_use_first_byte_cache =
+      first_byte_cache_ != nullptr && token_edge_accepted.empty() && !speculative_calculation &&
+      !is_root_rule && grammar_->GetRule(init_rule_id_).lookahead_assertion_id == -1 &&
+      initial_state_.sub_element_id == 0 && !is_tag_dispatch_rule &&
+      !grammar_->per_rule_fsm_state_cache_keys[init_rule_id_].empty();
+  const auto optional_character_class_chain =
+      can_use_first_byte_cache ? RecognizeOptionalCharacterClassChain(grammar_, init_rule_id_)
+                               : std::nullopt;
+  const auto homogeneous_character_class_hash =
+      can_use_first_byte_cache ? GetHomogeneousCharacterClassHash() : std::nullopt;
+  const auto get_repeat_saturation_limit = [&](uint8_t first_byte) -> std::optional<size_t> {
+    if (homogeneous_character_class_hash.has_value()) {
+      const auto remaining_run = GetRemainingAsciiCharacterClassRun(first_byte);
+      if (remaining_run.has_value()) {
+        return static_cast<size_t>(*remaining_run - 1);
+      }
+    }
+    if (optional_character_class_chain.has_value()) {
+      return static_cast<size_t>(optional_character_class_chain->remaining_count - 1);
+    }
+    return std::nullopt;
+  };
+  const auto get_first_byte_cache_key =
+      [&](uint8_t first_byte, bool collect_rejected, size_t max_suffix_bytes
+      ) -> std::optional<FirstByteTokenMaskCache::Key> {
+    if (!can_use_first_byte_cache) {
+      return std::nullopt;
+    }
+    FirstByteTokenMaskCache::Key key{first_byte, collect_rejected, {}};
+    const auto& fsm = grammar_->per_rule_fsms[init_rule_id_]->GetFsm();
+
+    // The large-range expansion also emits one rule containing a fixed tail of 128 identical
+    // character classes. If a token bucket is shorter than the remaining tail, it cannot observe
+    // the exact position in that tail. Canonicalize those positions without changing the runtime
+    // grammar or its precomputed masks.
+    if (homogeneous_character_class_hash.has_value()) {
+      const auto saturation_limit = get_repeat_saturation_limit(first_byte);
+      if (saturation_limit.has_value() && max_suffix_bytes <= *saturation_limit) {
+        key.continuations.push_back(Grammar::Impl::FSMStateCacheKey{
+            HashCombine(uint64_t{0x5341545f46495844ULL}, *homogeneous_character_class_hash), -2, -2
+        });
+        return key;
+      }
+    }
+
+    // A token whose suffix is shorter than the remaining optional character-class chain cannot
+    // observe the chain's exact upper bound. For that vocabulary bucket, every longer chain has
+    // identical behavior. Use a saturated, rule-local continuation key so the 128 helper states
+    // emitted by a bounded string length share their already-computed bucket result. The byte
+    // length is conservative for multi-byte codepoints: it can reduce sharing, never cross a
+    // reachable repetition boundary.
+    if (optional_character_class_chain.has_value() &&
+        max_suffix_bytes <= *get_repeat_saturation_limit(first_byte)) {
+      for (const auto& edge : fsm.GetFsm().GetEdges(initial_state_.element_id)) {
+        if (!edge.IsCharRange() || first_byte < edge.min || first_byte > edge.max) {
+          continue;
+        }
+        const auto canonical_target_id = GetCanonicalFsmStateId(edge.target);
+        if (!canonical_target_id.has_value()) {
+          key.continuations.clear();
+          break;
+        }
+        key.continuations.push_back(Grammar::Impl::FSMStateCacheKey{
+            HashCombine(
+                uint64_t{0x5341545f4f505443ULL},
+                optional_character_class_chain->character_class_hash,
+                *canonical_target_id
+            ),
+            -1,
+            -1
+        });
+      }
+      if (!key.continuations.empty()) {
+        std::sort(key.continuations.begin(), key.continuations.end());
+        key.continuations.erase(
+            std::unique(key.continuations.begin(), key.continuations.end()), key.continuations.end()
+        );
+        return key;
+      }
+    }
+
+    const auto& state_cache_keys = grammar_->per_rule_fsm_state_cache_keys[init_rule_id_];
+    for (const auto& edge : fsm.GetFsm().GetEdges(initial_state_.element_id)) {
+      if (!edge.IsCharRange() || first_byte < edge.min || first_byte > edge.max) {
+        continue;
+      }
+      const auto state_cache_key =
+          std::find_if(state_cache_keys.begin(), state_cache_keys.end(), [&](const auto& item) {
+            return item.first == edge.target;
+          });
+      if (state_cache_key == state_cache_keys.end()) {
+        return std::nullopt;
+      }
+      key.continuations.push_back(state_cache_key->second);
+    }
+    if (key.continuations.empty()) {
+      return std::nullopt;
+    }
+    std::sort(key.continuations.begin(), key.continuations.end());
+    key.continuations.erase(
+        std::unique(key.continuations.begin(), key.continuations.end()), key.continuations.end()
+    );
+    return key;
+  };
+
   const std::string* prev_token = nullptr;
   int32_t skip_ptr = 0;
   const int32_t skip_size = static_cast<int32_t>(token_edge_accepted.size());
   for (size_t interval_idx = 0; interval_idx < possible_intervals.size(); ++interval_idx) {
     const auto& interval = possible_intervals[interval_idx];
-    for (int i = interval.first; i < interval.second; ++i) {
-      // Skip tokens already accepted by token edges (avoid expensive Earley simulation).
-      while (skip_ptr < skip_size && token_edge_accepted[skip_ptr] < i) ++skip_ptr;
-      if (skip_ptr < skip_size && token_edge_accepted[skip_ptr] == i) continue;
+    int group_begin = interval.first;
+    while (group_begin < interval.second) {
+      XGRAMMAR_DCHECK(!sorted_decoded_vocab[group_begin].second.empty());
+      const uint8_t first_byte = static_cast<uint8_t>(sorted_decoded_vocab[group_begin].second[0]);
+      size_t first_byte_group_max_suffix_bytes =
+          sorted_decoded_vocab[group_begin].second.size() - 1;
+      int first_byte_group_end = group_begin + 1;
+      while (first_byte_group_end < interval.second &&
+             !sorted_decoded_vocab[first_byte_group_end].second.empty() &&
+             static_cast<uint8_t>(sorted_decoded_vocab[first_byte_group_end].second[0]) ==
+                 first_byte) {
+        first_byte_group_max_suffix_bytes = std::max(
+            first_byte_group_max_suffix_bytes,
+            sorted_decoded_vocab[first_byte_group_end].second.size() - 1
+        );
+        ++first_byte_group_end;
+      }
 
-      // Check if the current token is in the rejected range. i.e. check if the current token
-      // is on the subtree of the rejected token.
-      if (i < last_rejected_range) {
-        if (fill_reject_indices) {
+      int group_end = first_byte_group_end;
+      size_t group_max_suffix_bytes = first_byte_group_max_suffix_bytes;
+
+      const bool collect_rejected = fill_reject_indices;
+      auto first_byte_cache_key =
+          get_first_byte_cache_key(first_byte, collect_rejected, group_max_suffix_bytes);
+      std::shared_ptr<const FirstByteTokenMaskCache::Result> saturated_subset_cache;
+      if (first_byte_cache_key.has_value()) {
+        auto cached = first_byte_cache_->Get(*first_byte_cache_key);
+        if (cached != nullptr && cached->covered_max_suffix_bytes >= group_max_suffix_bytes) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+          profile_counters_.first_byte_cache_reused_tokens += group_end - group_begin;
+#endif
+          tmp_accepted_indices_.insert(
+              tmp_accepted_indices_.end(),
+              cached->accepted_indices.begin(),
+              cached->accepted_indices.end()
+          );
+          tmp_uncertain_indices_.insert(
+              tmp_uncertain_indices_.end(),
+              cached->uncertain_indices.begin(),
+              cached->uncertain_indices.end()
+          );
+          if (collect_rejected) {
+            tmp_rejected_indices_.insert(
+                tmp_rejected_indices_.end(),
+                cached->rejected_indices.begin(),
+                cached->rejected_indices.end()
+            );
+            if (tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD) {
+              fill_reject_indices = false;
+            }
+          }
+          group_begin = group_end;
+          continue;
+        }
+        saturated_subset_cache = std::move(cached);
+      }
+
+      // A long token in this first-byte bucket can observe the exact remaining repeat bound and
+      // therefore prevents caching the whole bucket under the saturated key. The shorter tokens
+      // are still indistinguishable from the same bucket at a longer repeat tail. Reuse their
+      // classifications from that already-computed saturated bucket and simulate only the tokens
+      // that can actually cross the current boundary.
+      const auto repeat_saturation_limit = get_repeat_saturation_limit(first_byte);
+      if (repeat_saturation_limit.has_value() &&
+          group_max_suffix_bytes > *repeat_saturation_limit) {
+        auto saturated_key =
+            get_first_byte_cache_key(first_byte, collect_rejected, /*max_suffix_bytes=*/0);
+        if (saturated_key.has_value() && saturated_subset_cache == nullptr) {
+          saturated_subset_cache = first_byte_cache_->Get(*saturated_key);
+        }
+      }
+
+      const size_t accepted_begin = tmp_accepted_indices_.size();
+      const size_t rejected_begin = tmp_rejected_indices_.size();
+      const size_t uncertain_begin = tmp_uncertain_indices_.size();
+      size_t cached_accepted_pos = 0;
+      size_t cached_rejected_pos = 0;
+      size_t cached_uncertain_pos = 0;
+      for (int i = group_begin; i < group_end; ++i) {
+        if (saturated_subset_cache != nullptr && repeat_saturation_limit.has_value() &&
+            sorted_decoded_vocab[i].second.size() - 1 <=
+                std::min(
+                    *repeat_saturation_limit, saturated_subset_cache->covered_max_suffix_bytes
+                )) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+          ++profile_counters_.saturated_cache_reused_tokens;
+#endif
+          const auto advance_to_index = [&](const std::vector<int32_t>& indices, size_t* position) {
+            while (*position < indices.size() && indices[*position] < i) {
+              ++*position;
+            }
+            return *position < indices.size() && indices[*position] == i;
+          };
+          const bool is_accepted =
+              advance_to_index(saturated_subset_cache->accepted_indices, &cached_accepted_pos);
+          const bool is_rejected =
+              collect_rejected &&
+              advance_to_index(saturated_subset_cache->rejected_indices, &cached_rejected_pos);
+          const bool is_uncertain =
+              advance_to_index(saturated_subset_cache->uncertain_indices, &cached_uncertain_pos);
+          const int cached_classification_count = static_cast<int>(is_accepted) +
+                                                  static_cast<int>(is_rejected) +
+                                                  static_cast<int>(is_uncertain);
+          XGRAMMAR_DCHECK(
+              cached_classification_count <= 1 &&
+              (!collect_rejected || cached_classification_count == 1)
+          );
+          if (is_accepted) {
+            tmp_accepted_indices_.push_back(i);
+          } else if (is_uncertain) {
+            tmp_uncertain_indices_.push_back(i);
+          } else if (collect_rejected) {
+            tmp_rejected_indices_.push_back(i);
+            if (tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD) {
+              fill_reject_indices = false;
+            }
+          }
+          continue;
+        }
+
+        // Skip tokens already accepted by token edges (avoid expensive Earley simulation).
+        while (skip_ptr < skip_size && token_edge_accepted[skip_ptr] < i) ++skip_ptr;
+        if (skip_ptr < skip_size && token_edge_accepted[skip_ptr] == i) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+          ++profile_counters_.token_edge_skipped_tokens;
+#endif
+          continue;
+        }
+
+        // Check if the current token is in the rejected range. i.e. check if the current token
+        // is on the subtree of the rejected token.
+        if (i < last_rejected_range) {
+          if (fill_reject_indices) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+            ++profile_counters_.subtree_pruned_tokens;
+#endif
+            tmp_rejected_indices_.push_back(i);
+            fill_reject_indices =
+                tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
+                    ? false
+                    : fill_reject_indices;
+          } else {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+            profile_counters_.subtree_pruned_tokens += last_rejected_range - i;
+#endif
+            i = last_rejected_range - 1;
+          }
+          continue;
+        }
+        const auto& token = sorted_decoded_vocab[i].second;
+        // This optimization is useful for simple self-recursive rules, like string content.
+        if (speculative_calculation) {
+          // Optimization for tag dispatch rules.
+          if (definite_accepted_bitset.has_value()) {
+            // If the token is empty, it must be accepted.
+            if (token.empty()) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+              ++profile_counters_.speculative_accepted_tokens;
+#endif
+              tmp_accepted_indices_.push_back(i);
+              continue;
+            }
+            // If the token doesn't contain tags or stop strings since the second character, and it
+            // will transit to the start state after consuming the first character, it must be
+            // accepted.
+            if (speculative_mask[static_cast<uint8_t>(token[0])] &&
+                (*definite_accepted_bitset.value())[i]) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+              ++profile_counters_.speculative_accepted_tokens;
+#endif
+              tmp_accepted_indices_.push_back(i);
+              continue;
+            }
+          } else {
+            bool all_accepted = true;
+            for (char ch : token) {
+              // If the first character is not the ascii character or can't be accepted by the
+              // first character mask, we need to check them in the parser.
+              if (isascii(ch) == 0 || !speculative_mask[static_cast<uint8_t>(ch)]) {
+                all_accepted = false;
+                break;
+              }
+            }
+            if (all_accepted) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+              ++profile_counters_.speculative_accepted_tokens;
+#endif
+              tmp_accepted_indices_.push_back(i);
+              continue;
+            }
+          }
+        }
+        // Many tokens may contain the same prefix, so we will avoid unnecessary matching
+        // by finding the longest common prefix with the previous token.
+#ifdef XGRAMMAR_PROFILE_COMPILE
+        ++profile_counters_.parser_simulated_tokens;
+        profile_counters_.parser_naive_token_bytes += token.size();
+#endif
+        bool accepted = true;
+        if (prev_token != nullptr) {
+          int lcp_len =
+              std::mismatch(token.begin(), token.end(), prev_token->begin(), prev_token->end())
+                  .first -
+              token.begin();
+          if (lcp_len > prev_matched_size) {
+            // Case 1. The common prefix is rejected by the matcher in the last token. Reject
+            // directly.
+            accepted = false;
+          } else if (lcp_len < prev_matched_size) {
+            // Case 2. The common prefix is shorter than the previous matched size. Rollback
+            // the non-common part.
+            PopLastStates(prev_matched_size - lcp_len);
+            tmp_can_reach_end_stack_.resize(
+                tmp_can_reach_end_stack_.size() - (prev_matched_size - lcp_len)
+            );
+            tmp_can_reach_end_prefix_or_stack_.resize(
+                tmp_can_reach_end_prefix_or_stack_.size() - (prev_matched_size - lcp_len)
+            );
+          }
+          prev_matched_size = std::min(prev_matched_size, lcp_len);
+        }
+
+        prev_token = &token;
+
+        if (accepted) {
+          // Accept the rest chars one by one.
+          for (int j = prev_matched_size; j < static_cast<int>(token.size()); ++j) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+            ++profile_counters_.parser_advance_calls;
+#endif
+            if (!Advance(token[j])) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+              ++profile_counters_.parser_failed_advance_calls;
+#endif
+              accepted = false;
+              break;
+            }
+            tmp_can_reach_end_stack_.push_back(IsCompleted());
+            tmp_can_reach_end_prefix_or_stack_.push_back(
+                tmp_can_reach_end_stack_.back() || tmp_can_reach_end_prefix_or_stack_.back()
+            );
+            prev_matched_size = j + 1;
+          }
+        }
+
+        bool can_reach_end = tmp_can_reach_end_prefix_or_stack_.back();
+
+        if (accepted) {
+          tmp_accepted_indices_.push_back(i);
+        } else if (can_reach_end && prev_matched_size > 0) {
+          auto [lookahead_accepted, lookahead_completed] =
+              IsTokenPassLookaheadAssertion(token, tmp_can_reach_end_stack_);
+          if ((!is_root_rule) && lookahead_accepted) {
+            if (lookahead_completed || !is_exact_lookahead) {
+              tmp_uncertain_indices_.push_back(i);
+            } else {
+              tmp_accepted_indices_.push_back(i);
+              tmp_accepted_by_lookahead_indices_.push_back(i);
+            }
+          } else {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+            profile_counters_.subtree_pruned_tokens += subtree_nodes_range[i] - i - 1;
+#endif
+            for (int j = i; j < subtree_nodes_range[i]; j++) {
+              tmp_rejected_indices_.push_back(j);
+              tmp_rejected_by_lookahead_indices_.push_back(j);
+            }
+            i = subtree_nodes_range[i] - 1;  // Skip the subtree nodes.
+          }
+        } else {
           tmp_rejected_indices_.push_back(i);
+          last_rejected_range = subtree_nodes_range[i];
           fill_reject_indices =
               tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
                   ? false
                   : fill_reject_indices;
-        } else {
-          i = last_rejected_range - 1;
         }
-        continue;
       }
-      const auto& token = sorted_decoded_vocab[i].second;
-      // This optimization is useful for simple self-recursive rules, like string content.
-      if (speculative_calculation) {
-        // Optimization for tag dispatch rules.
-        if (definite_accepted_bitset.has_value()) {
-          // If the token is empty, it must be accepted.
-          if (token.empty()) {
-            tmp_accepted_indices_.push_back(i);
-            continue;
-          }
-          // If the token doesn't contain tags or stop strings since the second character, and it
-          // will transit to the start state after consuming the first character, it must be
-          // accepted.
-          if (speculative_mask[static_cast<uint8_t>(token[0])] &&
-              (*definite_accepted_bitset.value())[i]) {
-            tmp_accepted_indices_.push_back(i);
-            continue;
-          }
-        } else {
-          bool all_accepted = true;
-          for (char ch : token) {
-            // If the first character is not the ascii character or can't be accepted by the
-            // first character mask, we need to check them in the parser.
-            if (isascii(ch) == 0 || !speculative_mask[static_cast<uint8_t>(ch)]) {
-              all_accepted = false;
-              break;
+
+      PopLastStates(prev_matched_size);
+      tmp_can_reach_end_stack_.resize(tmp_can_reach_end_stack_.size() - prev_matched_size);
+      tmp_can_reach_end_prefix_or_stack_.resize(
+          tmp_can_reach_end_prefix_or_stack_.size() - prev_matched_size
+      );
+      prev_matched_size = 0;
+      prev_token = nullptr;
+      last_rejected_range = 0;
+
+      if (first_byte_cache_key.has_value() && (!collect_rejected || fill_reject_indices)) {
+        if (repeat_saturation_limit.has_value() &&
+            group_max_suffix_bytes > *repeat_saturation_limit &&
+            (saturated_subset_cache == nullptr ||
+             saturated_subset_cache->covered_max_suffix_bytes < *repeat_saturation_limit)) {
+          const auto filter_saturated_indices = [&](auto begin, auto end) {
+            std::vector<int32_t> result;
+            result.reserve(static_cast<size_t>(end - begin));
+            for (auto it = begin; it != end; ++it) {
+              if (sorted_decoded_vocab[*it].second.size() - 1 <= *repeat_saturation_limit) {
+                result.push_back(*it);
+              }
             }
-          }
-          if (all_accepted) {
-            tmp_accepted_indices_.push_back(i);
-            continue;
+            return result;
+          };
+          auto saturated_key =
+              get_first_byte_cache_key(first_byte, collect_rejected, /*max_suffix_bytes=*/0);
+          if (saturated_key.has_value()) {
+            first_byte_cache_->Add(
+                std::move(*saturated_key),
+                FirstByteTokenMaskCache::Result{
+                    filter_saturated_indices(
+                        tmp_accepted_indices_.begin() + accepted_begin, tmp_accepted_indices_.end()
+                    ),
+                    filter_saturated_indices(
+                        tmp_rejected_indices_.begin() + rejected_begin, tmp_rejected_indices_.end()
+                    ),
+                    filter_saturated_indices(
+                        tmp_uncertain_indices_.begin() + uncertain_begin,
+                        tmp_uncertain_indices_.end()
+                    ),
+                    *repeat_saturation_limit
+                }
+            );
           }
         }
+        first_byte_cache_->Add(
+            std::move(*first_byte_cache_key),
+            FirstByteTokenMaskCache::Result{
+                {tmp_accepted_indices_.begin() + accepted_begin, tmp_accepted_indices_.end()},
+                {tmp_rejected_indices_.begin() + rejected_begin, tmp_rejected_indices_.end()},
+                {tmp_uncertain_indices_.begin() + uncertain_begin, tmp_uncertain_indices_.end()},
+                group_max_suffix_bytes
+            }
+        );
       }
-      // Many tokens may contain the same prefix, so we will avoid unnecessary matching
-      // by finding the longest common prefix with the previous token.
-      bool accepted = true;
-      if (prev_token != nullptr) {
-        int lcp_len =
-            std::mismatch(token.begin(), token.end(), prev_token->begin(), prev_token->end())
-                .first -
-            token.begin();
-        if (lcp_len > prev_matched_size) {
-          // Case 1. The common prefix is rejected by the matcher in the last token. Reject
-          // directly.
-          accepted = false;
-        } else if (lcp_len < prev_matched_size) {
-          // Case 2. The common prefix is shorter than the previous matched size. Rollback
-          // the non-common part.
-          PopLastStates(prev_matched_size - lcp_len);
-          tmp_can_reach_end_stack_.erase(
-              tmp_can_reach_end_stack_.end() - (prev_matched_size - lcp_len),
-              tmp_can_reach_end_stack_.end()
-          );
-          tmp_can_reach_end_prefix_or_stack_.erase(
-              tmp_can_reach_end_prefix_or_stack_.end() - (prev_matched_size - lcp_len),
-              tmp_can_reach_end_prefix_or_stack_.end()
-          );
-        }
-        prev_matched_size = std::min(prev_matched_size, lcp_len);
-      }
-
-      prev_token = &token;
-
-      if (accepted) {
-        // Accept the rest chars one by one.
-        for (int j = prev_matched_size; j < static_cast<int>(token.size()); ++j) {
-          if (!Advance(token[j])) {
-            accepted = false;
-            break;
-          }
-          tmp_can_reach_end_stack_.push_back(IsCompleted());
-          tmp_can_reach_end_prefix_or_stack_.push_back(
-              tmp_can_reach_end_stack_.back() || tmp_can_reach_end_prefix_or_stack_.back()
-          );
-          prev_matched_size = j + 1;
-        }
-      }
-
-      bool can_reach_end = tmp_can_reach_end_prefix_or_stack_.back();
-
-      if (accepted) {
-        tmp_accepted_indices_.push_back(i);
-      } else if (can_reach_end && prev_matched_size > 0) {
-        auto [lookahead_accepted, lookahead_completed] =
-            IsTokenPassLookaheadAssertion(token, tmp_can_reach_end_stack_);
-        if ((!is_root_rule) && lookahead_accepted) {
-          if (lookahead_completed || !is_exact_lookahead) {
-            tmp_uncertain_indices_.push_back(i);
-          } else {
-            tmp_accepted_indices_.push_back(i);
-            tmp_accepted_by_lookahead_indices_.push_back(i);
-          }
-        } else {
-          for (int j = i; j < subtree_nodes_range[i]; j++) {
-            tmp_rejected_indices_.push_back(j);
-            tmp_rejected_by_lookahead_indices_.push_back(j);
-          }
-          i = subtree_nodes_range[i] - 1;  // Skip the subtree nodes.
-        }
-      } else {
-        tmp_rejected_indices_.push_back(i);
-        last_rejected_range = subtree_nodes_range[i];
-        fill_reject_indices =
-            tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
-                ? false
-                : fill_reject_indices;
-      }
+      group_begin = group_end;
     }
     if (interval_idx != possible_intervals.size() - 1 && fill_reject_indices) {
       const auto& next_interval = possible_intervals[interval_idx + 1];
@@ -674,8 +1653,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
     }
   }
 
-  // Rollback the last matched part.
-  PopLastStates(prev_matched_size);
+  XGRAMMAR_DCHECK(prev_matched_size == 0);
 
   if (possible_intervals.back().second != static_cast<int>(sorted_decoded_vocab.size()) &&
       fill_reject_indices) {
@@ -790,46 +1768,89 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   tmp_can_reach_end_prefix_or_stack_.push_back(false);
 
   // Try to get the crossing cache.
-  bool rule_level_cache_is_available =
-      rule_level_cache_.has_value() && grammar_->per_rule_fsm_hashes[init_rule_id_].has_value();
+  bool rule_level_cache_is_available = rule_level_cache_.has_value();
   std::optional<uint64_t> fsm_hash = std::nullopt;
   int32_t new_state_id = -1;
+  int32_t cache_state_count = -1;
+  int32_t cache_edge_count = -1;
   std::optional<AdaptiveTokenMask> crossing_cache = std::nullopt;
   int lookahead_id = grammar_->GetRule(initial_state_.rule_id).lookahead_assertion_id;
   bool is_exact_lookahead = grammar_->GetRule(initial_state_.rule_id).is_exact_lookahead;
   std::optional<uint64_t> lookahead_hash = std::nullopt;
   if (rule_level_cache_is_available) {
-    lookahead_hash = GrammarFSMHasher::HashSequence(grammar_, lookahead_id);
-    const auto& original_to_new_id = grammar_->per_rule_fsm_new_state_ids[init_rule_id_];
-    fsm_hash = grammar_->per_rule_fsm_hashes[init_rule_id_].value();
-    for (const auto& original_new_pair : original_to_new_id) {
-      if (original_new_pair.first == initial_state_.element_id) {
-        new_state_id = original_new_pair.second;
-        break;
+    const auto& state_cache_keys = grammar_->per_rule_fsm_state_cache_keys[init_rule_id_];
+    const auto state_cache_key =
+        std::find_if(state_cache_keys.begin(), state_cache_keys.end(), [&](const auto& item) {
+          return item.first == initial_state_.element_id;
+        });
+    if (state_cache_key != state_cache_keys.end()) {
+      // This domain-separated key describes the complete continuation reachable from the current
+      // state. It permits exact reuse across larger FSMs that differ only in unreachable prefixes.
+      fsm_hash = state_cache_key->second.hash;
+      new_state_id = 0;
+      cache_state_count = state_cache_key->second.state_count;
+      cache_edge_count = state_cache_key->second.edge_count;
+    } else if (grammar_->per_rule_fsm_hashes[init_rule_id_].has_value()) {
+      const auto& original_to_new_id = grammar_->per_rule_fsm_new_state_ids[init_rule_id_];
+      fsm_hash = grammar_->per_rule_fsm_hashes[init_rule_id_].value();
+      const auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
+      cache_state_count = fsm.GetNodeNum();
+      cache_edge_count = fsm.GetEdgeNum();
+      for (const auto& original_new_pair : original_to_new_id) {
+        if (original_new_pair.first == initial_state_.element_id) {
+          new_state_id = original_new_pair.second;
+          break;
+        }
       }
+      XGRAMMAR_DCHECK(new_state_id != -1);
+    } else {
+      rule_level_cache_is_available = false;
     }
-    XGRAMMAR_DCHECK(new_state_id != -1);
-    const auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
+  }
+  if (rule_level_cache_is_available) {
+    lookahead_hash = GrammarFSMHasher::HashSequence(grammar_, lookahead_id);
     if (lookahead_hash.has_value()) {
       crossing_cache = rule_level_cache_->GetCache(
           HashCombine(fsm_hash.value(), lookahead_hash.value(), is_exact_lookahead),
           new_state_id,
-          fsm.GetNodeNum(),
-          fsm.GetEdgeNum()
+          cache_state_count,
+          cache_edge_count
       );
       if (crossing_cache.has_value()) {
         // A perfect match.
+#ifdef XGRAMMAR_PROFILE_COMPILE
+        ++profile_counters_.rule_cache_hits;
+#endif
         return crossing_cache.value();
       }
     }
     crossing_cache = rule_level_cache_->GetCache(
-        fsm_hash.value(), new_state_id, fsm.GetNodeNum(), fsm.GetEdgeNum()
+        fsm_hash.value(), new_state_id, cache_state_count, cache_edge_count
     );
     // If the rule doesn't have a lookahead, then it is exactly the same fsm.
     if (crossing_cache.has_value()) {
       AdaptCacheWithLookahead(&crossing_cache.value(), is_root_rule);
+#ifdef XGRAMMAR_PROFILE_COMPILE
+      ++profile_counters_.rule_cache_hits;
+#endif
       return std::move(crossing_cache.value());
     }
+  }
+
+  if (auto direct_optional_chain_mask = GetOptionalCharacterClassDirectMask(is_root_rule)) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    profile_counters_.used_optional_character_class_direct_mask = true;
+#endif
+    if (rule_level_cache_is_available && cache_direct_masks_across_grammars_) {
+      rule_level_cache_->AddCache(
+          fsm_hash.value(),
+          new_state_id,
+          cache_state_count,
+          cache_edge_count,
+          *direct_optional_chain_mask
+      );
+    }
+    return std::move(*direct_optional_chain_mask);
   }
 
   std::bitset<256> first_character_mask;
@@ -868,9 +1889,8 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     if (rule_level_cache_is_available) {
       if (lookahead_id == -1 && !is_root_rule) {
         // If the rule doesn't have a lookahead, then it is exactly the same fsm.
-        auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
         rule_level_cache_->AddCache(
-            fsm_hash.value(), new_state_id, fsm.GetNodeNum(), fsm.GetEdgeNum(), return_value
+            fsm_hash.value(), new_state_id, cache_state_count, cache_edge_count, return_value
         );
         return return_value;
       }
@@ -901,12 +1921,11 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
           tmp_accepted_by_lookahead_indices_.end(),
           std::back_inserter(accepted_indices_without_lookahead)
       );
-      auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
       rule_level_cache_->AddCache(
           fsm_hash.value(),
           new_state_id,
-          fsm.GetNodeNum(),
-          fsm.GetEdgeNum(),
+          cache_state_count,
+          cache_edge_count,
           AdaptiveTokenMask(
               tokenizer_info_.GetVocabSize(),
               tokenizer_info_.GetSortedDecodedVocab(),
@@ -916,12 +1935,11 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
           )
       );
       if (lookahead_hash.has_value()) {
-        auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
         rule_level_cache_->AddCache(
             HashCombine(fsm_hash.value(), lookahead_hash.value(), is_exact_lookahead),
             new_state_id,
-            fsm.GetNodeNum(),
-            fsm.GetEdgeNum(),
+            cache_state_count,
+            cache_edge_count,
             return_value
         );
       }
@@ -937,11 +1955,10 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
 
     if (rule_level_cache_is_available) {
       // Prepare for cache.
-      auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
       if (lookahead_id == -1 && !is_root_rule) {
         // If the rule doesn't have a lookahead, then it is exactly the same fsm.
         rule_level_cache_->AddCache(
-            fsm_hash.value(), new_state_id, fsm.GetNodeNum(), fsm.GetEdgeNum(), return_value
+            fsm_hash.value(), new_state_id, cache_state_count, cache_edge_count, return_value
         );
         return return_value;
       }
@@ -963,8 +1980,8 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
       rule_level_cache_->AddCache(
           fsm_hash.value(),
           new_state_id,
-          fsm.GetNodeNum(),
-          fsm.GetEdgeNum(),
+          cache_state_count,
+          cache_edge_count,
           AdaptiveTokenMask(
               tokenizer_info_.GetVocabSize(),
               tokenizer_info_.GetSortedDecodedVocab(),
@@ -977,8 +1994,8 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
         rule_level_cache_->AddCache(
             HashCombine(fsm_hash.value(), lookahead_hash.value(), is_exact_lookahead),
             new_state_id,
-            fsm.GetNodeNum(),
-            fsm.GetEdgeNum(),
+            cache_state_count,
+            cache_edge_count,
             return_value
         );
       }
@@ -1001,6 +2018,7 @@ class GrammarCompilerSub {
   )
       : tokenizer_info_(tokenizer_info),
         max_threads_(max_threads),
+        thread_pool_(max_threads > 1 ? std::make_unique<ThreadPool>(max_threads) : nullptr),
         rule_level_cache_(rule_level_cache) {}
 
   CompiledGrammar CompileBuiltinJSONGrammar();
@@ -1040,76 +2058,273 @@ class GrammarCompilerSub {
   const TokenizerInfo tokenizer_info_;
   /*! \brief The maximum number of threads to use. */
   const int max_threads_;
+  /*! \brief Reused workers so each compile avoids thread startup and teardown. */
+  std::unique_ptr<ThreadPool> thread_pool_;
 
   /*! \brief The manager of the rule level cache.*/
   std::optional<RuleLevelCache> rule_level_cache_;
 };
 
+struct AdaptiveMaskTaskKey {
+  uint64_t exact_fsm_hash;
+  int32_t canonical_state_id;
+  int32_t state_count;
+  int32_t edge_count;
+
+  bool operator==(const AdaptiveMaskTaskKey& other) const {
+    return exact_fsm_hash == other.exact_fsm_hash &&
+           canonical_state_id == other.canonical_state_id && state_count == other.state_count &&
+           edge_count == other.edge_count;
+  }
+};
+
+struct AdaptiveMaskTaskKeyHash {
+  size_t operator()(const AdaptiveMaskTaskKey& key) const {
+    return HashCombine(key.exact_fsm_hash, key.canonical_state_id, key.state_count, key.edge_count);
+  }
+};
+
+struct AdaptiveMaskTaskGroup {
+  std::vector<ParserState> states;
+  bool is_root_rule;
+};
+
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const auto compile_started_at = std::chrono::steady_clock::now();
+  const auto optimizer_started_at = compile_started_at;
+#endif
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
   compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const auto optimizer_finished_at = std::chrono::steady_clock::now();
+  const auto optimizer_elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                        optimizer_finished_at - optimizer_started_at
+  )
+                                        .count();
+  const auto earley_metadata_started_at = std::chrono::steady_clock::now();
+#endif
+  compiled_grammar_impl->earley_parser_metadata =
+      EarleyParserGrammarMetadata(compiled_grammar_impl->grammar);
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const auto earley_metadata_elapsed_us =
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now() - earley_metadata_started_at
+      )
+          .count();
+#endif
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
   }
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const auto tag_dispatch_started_at = std::chrono::steady_clock::now();
+#endif
   std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
   TagDispatchOptimization(compiled_grammar_impl, &tag_dispatch_rule_id_to_second_slicing_bitset);
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const auto tag_dispatch_finished_at = std::chrono::steady_clock::now();
+  const auto tag_dispatch_elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                           tag_dispatch_finished_at - tag_dispatch_started_at
+  )
+                                           .count();
+#endif
 
-  // If the compiler is cache-enabled, then we hash the grammars for crossing-grammar caching.
-  if (rule_level_cache_.has_value()) {
-    GrammarFSMHasher().Apply(&compiled_grammar_impl->grammar);
+  // Reuse structurally identical rule FSMs within one compilation even when the persistent
+  // cross-grammar cache is disabled. Large schemas contain many generated JSON rules with the
+  // same automata; recomputing a full-vocabulary Earley mask for every copy dominates cold compile
+  // latency. The local cache is discarded with this call and is bounded independently.
+  constexpr size_t kLocalRuleCacheMaxBytes = 256 * 1024 * 1024;
+  std::optional<RuleLevelCache> active_rule_level_cache = rule_level_cache_;
+  const bool cache_direct_masks_across_grammars = rule_level_cache_.has_value();
+  if (!active_rule_level_cache.has_value()) {
+    active_rule_level_cache.emplace(kLocalRuleCacheMaxBytes);
   }
+  constexpr size_t kFirstByteCacheMaxBytes = 64 * 1024 * 1024;
+  auto first_byte_cache = std::make_shared<FirstByteTokenMaskCache>(kFirstByteCacheMaxBytes);
+  auto optional_character_class_token_summary_cache =
+      std::make_shared<OptionalCharacterClassTokenSummaryCache>();
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const auto fsm_hash_started_at = std::chrono::steady_clock::now();
+#endif
+  GrammarFSMHasher().Apply(&compiled_grammar_impl->grammar);
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const auto fsm_hash_finished_at = std::chrono::steady_clock::now();
+  const auto fsm_hash_elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                       fsm_hash_finished_at - fsm_hash_started_at
+  )
+                                       .count();
+#endif
   // Step 3. Compute the adaptive token mask cache
   // The token mask cache is computed for these positions in the grammar:
   // 1. All character class or character class star (with last_utf8_bytes=0, 1, 2, 3)
   // 2. All byte strings (with element_in_string=0, 1, 2, ...)
   // since other positions will be expanded to the above positions
 
-  // TODO(Charlie): Figure out how to support ThreadPool and std::mutex in WebAssembly.
-  // Only declare ThreadPool and mutex if max_threads > 1, so when max_threads = 1, we do
-  // not need ThreadPool or std::mutex, which throws error in runtime in WebAssembly.
-  std::optional<ThreadPool> thread_pool;
-  std::optional<std::mutex> adaptive_token_mask_cache_mutex;
-  if (max_threads_ > 1) {
-    thread_pool.emplace(max_threads_);
-    adaptive_token_mask_cache_mutex.emplace();
-  }
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  struct AggregateMaskComputeProfile {
+    std::atomic<uint64_t> mask_cpu_us{0};
+    std::atomic<uint64_t> possible_tokens{0};
+    std::atomic<uint64_t> rule_cache_hits{0};
+    std::atomic<uint64_t> first_byte_cache_reused_tokens{0};
+    std::atomic<uint64_t> saturated_cache_reused_tokens{0};
+    std::atomic<uint64_t> token_edge_skipped_tokens{0};
+    std::atomic<uint64_t> speculative_accepted_tokens{0};
+    std::atomic<uint64_t> subtree_pruned_tokens{0};
+    std::atomic<uint64_t> parser_simulated_tokens{0};
+    std::atomic<uint64_t> parser_naive_token_bytes{0};
+    std::atomic<uint64_t> parser_advance_calls{0};
+    std::atomic<uint64_t> parser_failed_advance_calls{0};
+    std::atomic<uint64_t> optional_character_class_direct_tasks{0};
+    std::atomic<uint64_t> optional_character_class_direct_cpu_us{0};
+  } aggregate_mask_compute_profile;
+#endif
 
-  auto add_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
+  std::mutex adaptive_token_mask_ids_mutex;
+  auto add_adaptive_token_mask = [&](const AdaptiveMaskTaskGroup& task_group,
+                                     size_t task_group_id) {
+    XGRAMMAR_DCHECK(!task_group.states.empty());
+    const ParserState& state = task_group.states.front();
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    const auto mask_started_at = std::chrono::steady_clock::now();
+#endif
     auto grammar_matcher = GrammarMatcherForTokenMaskCache(
         compiled_grammar_impl->grammar,
+        compiled_grammar_impl->earley_parser_metadata,
         state,
         tag_dispatch_rule_id_to_second_slicing_bitset,
         tokenizer_info_,
-        rule_level_cache_
+        active_rule_level_cache,
+        first_byte_cache,
+        optional_character_class_token_summary_cache,
+        cache_direct_masks_across_grammars
     );
-    auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask(is_root_rule);
-    if (max_threads_ > 1) {
-      std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex.value());
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
-    } else {
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
+    auto cur_adaptive_token_mask_cache =
+        grammar_matcher.GetAdaptiveTokenMask(task_group.is_root_rule);
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    const auto mask_elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                     std::chrono::steady_clock::now() - mask_started_at
+    )
+                                     .count();
+    aggregate_mask_compute_profile.mask_cpu_us.fetch_add(
+        mask_elapsed_us, std::memory_order_relaxed
+    );
+    const auto& task_profile = grammar_matcher.GetProfileCounters();
+    aggregate_mask_compute_profile.possible_tokens.fetch_add(
+        task_profile.possible_tokens, std::memory_order_relaxed
+    );
+    aggregate_mask_compute_profile.rule_cache_hits.fetch_add(
+        task_profile.rule_cache_hits, std::memory_order_relaxed
+    );
+    aggregate_mask_compute_profile.first_byte_cache_reused_tokens.fetch_add(
+        task_profile.first_byte_cache_reused_tokens, std::memory_order_relaxed
+    );
+    aggregate_mask_compute_profile.saturated_cache_reused_tokens.fetch_add(
+        task_profile.saturated_cache_reused_tokens, std::memory_order_relaxed
+    );
+    aggregate_mask_compute_profile.token_edge_skipped_tokens.fetch_add(
+        task_profile.token_edge_skipped_tokens, std::memory_order_relaxed
+    );
+    aggregate_mask_compute_profile.speculative_accepted_tokens.fetch_add(
+        task_profile.speculative_accepted_tokens, std::memory_order_relaxed
+    );
+    aggregate_mask_compute_profile.subtree_pruned_tokens.fetch_add(
+        task_profile.subtree_pruned_tokens, std::memory_order_relaxed
+    );
+    aggregate_mask_compute_profile.parser_simulated_tokens.fetch_add(
+        task_profile.parser_simulated_tokens, std::memory_order_relaxed
+    );
+    aggregate_mask_compute_profile.parser_naive_token_bytes.fetch_add(
+        task_profile.parser_naive_token_bytes, std::memory_order_relaxed
+    );
+    aggregate_mask_compute_profile.parser_advance_calls.fetch_add(
+        task_profile.parser_advance_calls, std::memory_order_relaxed
+    );
+    aggregate_mask_compute_profile.parser_failed_advance_calls.fetch_add(
+        task_profile.parser_failed_advance_calls, std::memory_order_relaxed
+    );
+    if (task_profile.used_optional_character_class_direct_mask) {
+      aggregate_mask_compute_profile.optional_character_class_direct_tasks.fetch_add(
+          1, std::memory_order_relaxed
+      );
+      aggregate_mask_compute_profile.optional_character_class_direct_cpu_us.fetch_add(
+          mask_elapsed_us, std::memory_order_relaxed
+      );
+    }
+    AdaptiveMaskCompileProfile compile_profile;
+    compile_profile.representative_state = state;
+    compile_profile.mask_cpu_us = mask_elapsed_us;
+    compile_profile.possible_tokens = task_profile.possible_tokens;
+    compile_profile.rule_cache_hits = task_profile.rule_cache_hits;
+    compile_profile.first_byte_cache_reused_tokens = task_profile.first_byte_cache_reused_tokens;
+    compile_profile.saturated_cache_reused_tokens = task_profile.saturated_cache_reused_tokens;
+    compile_profile.token_edge_skipped_tokens = task_profile.token_edge_skipped_tokens;
+    compile_profile.speculative_accepted_tokens = task_profile.speculative_accepted_tokens;
+    compile_profile.subtree_pruned_tokens = task_profile.subtree_pruned_tokens;
+    compile_profile.parser_simulated_tokens = task_profile.parser_simulated_tokens;
+    compile_profile.parser_naive_token_bytes = task_profile.parser_naive_token_bytes;
+    compile_profile.parser_advance_calls = task_profile.parser_advance_calls;
+    compile_profile.parser_failed_advance_calls = task_profile.parser_failed_advance_calls;
+    compile_profile.mask_bytes = MemorySize(cur_adaptive_token_mask_cache);
+    compile_profile.state_count = task_group.states.size();
+    compiled_grammar_impl->adaptive_mask_compile_profiles[task_group_id] = compile_profile;
+    if (mask_elapsed_us >= 2000) {
+      uint64_t uncertain_hash = 0;
+      for (int32_t index : cur_adaptive_token_mask_cache.uncertain_indices) {
+        HashCombineBinary(uncertain_hash, static_cast<uint64_t>(index));
+      }
+      XGRAMMAR_LOG(INFO) << "SlowAdaptiveTokenMask(rule_id=" << state.rule_id << ", rule_name="
+                         << compiled_grammar_impl->grammar->GetRule(state.rule_id).name
+                         << ", state_id=" << state.element_id << ", elapsed_us=" << mask_elapsed_us
+                         << ", accepted=" << cur_adaptive_token_mask_cache.accepted_indices.size()
+                         << ", rejected=" << cur_adaptive_token_mask_cache.rejected_indices.size()
+                         << ", uncertain=" << cur_adaptive_token_mask_cache.uncertain_indices.size()
+                         << ", uncertain_hash=" << uncertain_hash << ")";
+    }
+#endif
+    compiled_grammar_impl->adaptive_token_masks[task_group_id] =
+        std::move(cur_adaptive_token_mask_cache);
+    {
+      std::lock_guard<std::mutex> lock(adaptive_token_mask_ids_mutex);
+      for (const ParserState& grouped_state : task_group.states) {
+        compiled_grammar_impl->adaptive_token_mask_ids.emplace(
+            grouped_state, static_cast<uint32_t>(task_group_id)
+        );
+      }
     }
   };
 
-  auto add_task_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
+  auto add_task_adaptive_token_mask = [&](const AdaptiveMaskTaskGroup& task_group,
+                                          size_t task_group_id) {
     // Execute depending on whether we use thread_pool
     if (max_threads_ > 1) {
-      thread_pool->Execute([add_adaptive_token_mask, state, is_root_rule]() {
-        add_adaptive_token_mask(state, is_root_rule);
+      thread_pool_->Execute([add_adaptive_token_mask, task_group, task_group_id]() {
+        add_adaptive_token_mask(task_group, task_group_id);
       });
     } else {
-      add_adaptive_token_mask(state, is_root_rule);
+      add_adaptive_token_mask(task_group, task_group_id);
     }
   };
 
   auto root_rule_id = compiled_grammar_impl->grammar->GetRootRuleId();
+  std::vector<AdaptiveMaskTaskGroup> task_groups;
+  std::unordered_map<AdaptiveMaskTaskKey, size_t, AdaptiveMaskTaskKeyHash> exact_task_group_indices;
+  size_t scanable_state_count = 0;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const auto task_discovery_started_at = std::chrono::steady_clock::now();
+#endif
 
   for (int32_t rule_id = 0; rule_id < static_cast<int>(compiled_grammar_impl->grammar->NumRules());
        ++rule_id) {
     auto rule = compiled_grammar_impl->grammar->GetRule(rule_id);
     const auto& rule_fsm = compiled_grammar_impl->grammar->per_rule_fsms[rule_id];
     XGRAMMAR_DCHECK(rule_fsm.has_value());
+    std::optional<uint64_t> lookahead_hash;
+    const auto& fsm_hash = compiled_grammar_impl->grammar->per_rule_fsm_hashes[rule_id];
+    const int32_t lookahead_id = rule.lookahead_assertion_id;
+    if (lookahead_id != -1) {
+      lookahead_hash = GrammarFSMHasher::HashSequence(compiled_grammar_impl->grammar, lookahead_id);
+    }
     auto cur_stack_element =
         ParserState(rule_id, rule.body_expr_id, 0, ParserState::kNoPrevInputPos, 0);
     std::unordered_set<int> reachable_states;
@@ -1119,13 +2334,142 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
       if (!rule_fsm->GetFsm().IsScanableState(i)) {
         continue;
       }
-      add_task_adaptive_token_mask(cur_stack_element, rule_id == root_rule_id);
+      ++scanable_state_count;
+      std::optional<AdaptiveMaskTaskKey> exact_task_key;
+      if (rule_id != root_rule_id && (lookahead_id == -1 || lookahead_hash.has_value())) {
+        const auto& state_cache_keys =
+            compiled_grammar_impl->grammar->per_rule_fsm_state_cache_keys[rule_id];
+        const auto state_cache_key =
+            std::find_if(state_cache_keys.begin(), state_cache_keys.end(), [i](const auto& item) {
+              return item.first == i;
+            });
+        if (state_cache_key != state_cache_keys.end()) {
+          const uint64_t exact_hash =
+              lookahead_id == -1
+                  ? state_cache_key->second.hash
+                  : HashCombine(
+                        state_cache_key->second.hash, *lookahead_hash, rule.is_exact_lookahead
+                    );
+          exact_task_key = AdaptiveMaskTaskKey{
+              exact_hash, 0, state_cache_key->second.state_count, state_cache_key->second.edge_count
+          };
+        } else if (fsm_hash.has_value()) {
+          const auto& original_to_new_id =
+              compiled_grammar_impl->grammar->per_rule_fsm_new_state_ids[rule_id];
+          const auto canonical_state = std::find_if(
+              original_to_new_id.begin(),
+              original_to_new_id.end(),
+              [i](const auto& item) { return item.first == i; }
+          );
+          XGRAMMAR_DCHECK(canonical_state != original_to_new_id.end());
+          const uint64_t exact_hash =
+              lookahead_id == -1 ? *fsm_hash
+                                 : HashCombine(*fsm_hash, *lookahead_hash, rule.is_exact_lookahead);
+          exact_task_key = AdaptiveMaskTaskKey{
+              exact_hash, canonical_state->second, rule_fsm->GetNodeNum(), rule_fsm->GetEdgeNum()
+          };
+        }
+      }
+      if (exact_task_key.has_value()) {
+        const auto [group_it, inserted] =
+            exact_task_group_indices.emplace(*exact_task_key, task_groups.size());
+        if (inserted) {
+          task_groups.push_back(AdaptiveMaskTaskGroup{{cur_stack_element}, /*is_root_rule=*/false});
+        } else {
+          task_groups[group_it->second].states.push_back(cur_stack_element);
+        }
+      } else {
+        task_groups.push_back(AdaptiveMaskTaskGroup{{cur_stack_element}, rule_id == root_rule_id});
+      }
     }
   }
 
-  if (max_threads_ > 1) {
-    thread_pool->Join();
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const auto task_discovery_finished_at = std::chrono::steady_clock::now();
+  const auto task_discovery_elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                             task_discovery_finished_at - task_discovery_started_at
+  )
+                                             .count();
+#endif
+
+  compiled_grammar_impl->adaptive_token_masks.resize(task_groups.size());
+  compiled_grammar_impl->adaptive_token_mask_ids.reserve(scanable_state_count);
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  compiled_grammar_impl->adaptive_mask_compile_profiles.resize(task_groups.size());
+  const auto mask_wall_started_at = std::chrono::steady_clock::now();
+#endif
+  for (size_t task_group_id = 0; task_group_id < task_groups.size(); ++task_group_id) {
+    add_task_adaptive_token_mask(task_groups[task_group_id], task_group_id);
   }
+
+  if (max_threads_ > 1) {
+    thread_pool_->Wait();
+  }
+
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const auto mask_wall_finished_at = std::chrono::steady_clock::now();
+  const auto mask_wall_elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                        mask_wall_finished_at - mask_wall_started_at
+  )
+                                        .count();
+  const auto compile_elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                      mask_wall_finished_at - compile_started_at
+  )
+                                      .count();
+  size_t hashable_rule_count = 0;
+  size_t profiled_scanable_state_count = 0;
+  for (int32_t rule_id = 0;
+       rule_id < static_cast<int32_t>(compiled_grammar_impl->grammar->NumRules());
+       ++rule_id) {
+    hashable_rule_count += compiled_grammar_impl->grammar->per_rule_fsm_hashes[rule_id].has_value();
+    std::unordered_set<int> reachable_states;
+    compiled_grammar_impl->grammar->per_rule_fsms[rule_id]->GetFsm().GetReachableStates(
+        &reachable_states
+    );
+    for (int state_id : reachable_states) {
+      profiled_scanable_state_count +=
+          compiled_grammar_impl->grammar->per_rule_fsms[rule_id]->GetFsm().IsScanableState(state_id
+          );
+    }
+  }
+  XGRAMMAR_LOG(INFO
+  ) << "GrammarCompileProfile(rules="
+    << compiled_grammar_impl->grammar->NumRules() << ", hashable_rules=" << hashable_rule_count
+    << ", scanable_states=" << profiled_scanable_state_count
+    << ", mask_task_groups=" << task_groups.size()
+    << ", masks=" << compiled_grammar_impl->adaptive_token_mask_ids.size()
+    << ", optimizer_us=" << optimizer_elapsed_us
+    << ", earley_metadata_us=" << earley_metadata_elapsed_us
+    << ", tag_dispatch_us=" << tag_dispatch_elapsed_us << ", fsm_hash_us=" << fsm_hash_elapsed_us
+    << ", task_discovery_us=" << task_discovery_elapsed_us
+    << ", mask_wall_us=" << mask_wall_elapsed_us << ", total_us=" << compile_elapsed_us
+    << ", deterministic_byte_tables="
+    << compiled_grammar_impl->earley_parser_metadata.deterministic_byte_transitions.size()
+    << ", earley_metadata_bytes=" << MemorySize(compiled_grammar_impl->earley_parser_metadata)
+    << ", mask_cpu_us=" << aggregate_mask_compute_profile.mask_cpu_us.load()
+    << ", possible_tokens=" << aggregate_mask_compute_profile.possible_tokens.load()
+    << ", rule_cache_hits=" << aggregate_mask_compute_profile.rule_cache_hits.load()
+    << ", first_byte_cache_reused_tokens="
+    << aggregate_mask_compute_profile.first_byte_cache_reused_tokens.load()
+    << ", saturated_cache_reused_tokens="
+    << aggregate_mask_compute_profile.saturated_cache_reused_tokens.load()
+    << ", token_edge_skipped_tokens="
+    << aggregate_mask_compute_profile.token_edge_skipped_tokens.load()
+    << ", speculative_accepted_tokens="
+    << aggregate_mask_compute_profile.speculative_accepted_tokens.load()
+    << ", subtree_pruned_tokens=" << aggregate_mask_compute_profile.subtree_pruned_tokens.load()
+    << ", parser_simulated_tokens=" << aggregate_mask_compute_profile.parser_simulated_tokens.load()
+    << ", parser_naive_token_bytes="
+    << aggregate_mask_compute_profile.parser_naive_token_bytes.load()
+    << ", parser_advance_calls=" << aggregate_mask_compute_profile.parser_advance_calls.load()
+    << ", parser_failed_advance_calls="
+    << aggregate_mask_compute_profile.parser_failed_advance_calls.load()
+    << ", optional_character_class_direct_tasks="
+    << aggregate_mask_compute_profile.optional_character_class_direct_tasks.load()
+    << ", optional_character_class_direct_cpu_us="
+    << aggregate_mask_compute_profile.optional_character_class_direct_cpu_us.load()
+    << ", compiled_bytes=" << MemorySize(*compiled_grammar_impl) << ")";
+#endif
 
   return CompiledGrammar(compiled_grammar_impl);
 }
@@ -1143,7 +2487,10 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
     std::optional<int> max_whitespace_cnt,
     bool any_order
 ) {
-  return MultiThreadCompileGrammar(Grammar::FromJSONSchema(
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const auto frontend_started_at = std::chrono::steady_clock::now();
+#endif
+  auto grammar = Grammar::FromJSONSchema(
       schema,
       any_whitespace,
       indent,
@@ -1152,7 +2499,16 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
       max_whitespace_cnt,
       /*print_converted_ebnf=*/false,
       any_order
-  ));
+  );
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  XGRAMMAR_LOG(INFO) << "JSONSchemaFrontendProfile(elapsed_us="
+                     << std::chrono::duration_cast<std::chrono::microseconds>(
+                            std::chrono::steady_clock::now() - frontend_started_at
+                        )
+                            .count()
+                     << ")";
+#endif
+  return MultiThreadCompileGrammar(std::move(grammar));
 }
 
 CompiledGrammar GrammarCompilerSub::CompileStructuralTag(const std::string& structural_tag_json) {

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -2147,7 +2147,7 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
 #ifdef XGRAMMAR_PROFILE_COMPILE
   const auto fsm_hash_started_at = std::chrono::steady_clock::now();
 #endif
-  GrammarFSMHasher().Apply(&compiled_grammar_impl->grammar);
+  GrammarFSMHasher::Apply(&compiled_grammar_impl->grammar, max_threads_, thread_pool_.get());
 #ifdef XGRAMMAR_PROFILE_COMPILE
   const auto fsm_hash_finished_at = std::chrono::steady_clock::now();
   const auto fsm_hash_elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1790,6 +1790,8 @@ class RepetitionRangeExpanderImpl : public GrammarMutator {
 
 /****************** Repetition range helpers ******************/
 
+constexpr int64_t kRepetitionUnzipThreshold = 128;
+
 int32_t RepetitionRangeExpanderImpl::LegacyHandleRepetitionRange(
     const std::string& cur_rule_name, int32_t grammar_expr_id, int64_t lower, int64_t upper
 ) {
@@ -1869,7 +1871,8 @@ int32_t RepetitionRangeExpanderImpl::HandleRepetitionRange(
       ref_rule_body.size() == 1) {
     const auto& ref_choice = base_grammar_->GetGrammarExpr(ref_rule_body[0]);
     if (ref_choice.size() == 1) {
-      grammar_expr_id = builder_->AddGrammarExpr(base_grammar_->GetGrammarExpr(ref_choice[0]));
+      const auto& repeated_element = base_grammar_->GetGrammarExpr(ref_choice[0]);
+      grammar_expr_id = builder_->AddGrammarExpr(repeated_element);
     }
   }
 
@@ -1895,13 +1898,13 @@ int32_t RepetitionRangeExpanderImpl::HandleRepetitionRange(
 int32_t RepetitionRangeExpanderImpl::ExpandRepetitionRange(
     const std::string& cur_rule_name, int32_t grammar_expr_id, int64_t lower, int64_t upper
 ) {
-  static const int64_t kUnzipThreshold = 128;
   XGRAMMAR_DCHECK(lower >= 0);
   XGRAMMAR_DCHECK(upper == -1 || upper >= lower);
 
   // Case 1.1 small upper (<=threshold), unzip the repetition.
   // Case 1.2 unbounded upper, and lower is also small (<=threshold), unzip the lower part.
-  if ((upper != -1 && upper <= kUnzipThreshold) || (upper == -1 && lower <= kUnzipThreshold)) {
+  if ((upper != -1 && upper <= kRepetitionUnzipThreshold) ||
+      (upper == -1 && lower <= kRepetitionUnzipThreshold)) {
     return LegacyHandleRepetitionRange(cur_rule_name, grammar_expr_id, lower, upper);
   }
 
@@ -1911,11 +1914,11 @@ int32_t RepetitionRangeExpanderImpl::ExpandRepetitionRange(
   // Case 2.1.1. lower is smaller than threshold, and upper is large. Transform {lower, upper} into:
   // {threshold, upper} | {lower, threshold}
   std::vector<int32_t> choices;
-  if (lower < kUnzipThreshold) {
-    choices.push_back(builder_->AddSequence(
-        {LegacyHandleRepetitionRange(cur_rule_name, grammar_expr_id, lower, kUnzipThreshold - 1)}
-    ));
-    lower = kUnzipThreshold;
+  if (lower < kRepetitionUnzipThreshold) {
+    choices.push_back(builder_->AddSequence({LegacyHandleRepetitionRange(
+        cur_rule_name, grammar_expr_id, lower, kRepetitionUnzipThreshold - 1
+    )}));
+    lower = kRepetitionUnzipThreshold;
   }
 
   std::optional<int32_t> infinite_repetition_id = std::nullopt;
@@ -1945,7 +1948,7 @@ int32_t RepetitionRangeExpanderImpl::ExpandRepetitionRange(
 
   // Handle the {lower, upper} part, where threshold <= lower <= upper.
   const auto repeat_name = cur_rule_name + "_repeat_1";
-  XGRAMMAR_DCHECK(lower >= kUnzipThreshold && upper >= lower);
+  XGRAMMAR_DCHECK(lower >= kRepetitionUnzipThreshold && upper >= lower);
 
   // If we have infinite repetition part, add it to the sequence.
   if (infinite_repetition_id.has_value()) {
@@ -1953,22 +1956,23 @@ int32_t RepetitionRangeExpanderImpl::ExpandRepetitionRange(
   }
 
   // The repetition body.
-  if (upper != kUnzipThreshold) {
-    XGRAMMAR_DCHECK(upper > kUnzipThreshold);
+  if (upper != kRepetitionUnzipThreshold) {
+    XGRAMMAR_DCHECK(upper > kRepetitionUnzipThreshold);
     auto new_grammar_expr_id = builder_->AddChoices({builder_->AddSequence({grammar_expr_id})});
     auto new_rule_id = builder_->AddRuleWithHint(repeat_name, new_grammar_expr_id);
-    auto new_repeated_ref_rule_expr = builder_->AddChoices({builder_->AddSequence(
-        {builder_->AddRepeat(new_rule_id, lower - kUnzipThreshold, upper - kUnzipThreshold)}
-    )});
+    auto new_repeated_ref_rule_expr =
+        builder_->AddChoices({builder_->AddSequence({builder_->AddRepeat(
+            new_rule_id, lower - kRepetitionUnzipThreshold, upper - kRepetitionUnzipThreshold
+        )})});
     auto new_repeated_rule_id =
         builder_->AddRuleWithHint(repeat_name + "_inner", new_repeated_ref_rule_expr);
     repeated_sequence.push_back(builder_->AddRuleRef(new_repeated_rule_id));
-    std::vector<int32_t> repetition_lookahead(kUnzipThreshold, grammar_expr_id);
+    std::vector<int32_t> repetition_lookahead(kRepetitionUnzipThreshold, grammar_expr_id);
     builder_->UpdateLookaheadAssertion(new_rule_id, builder_->AddSequence(repetition_lookahead));
   }
 
   // Add the last threshold grammar_expr_id to the sequence.
-  for (int i = 0; i < kUnzipThreshold; ++i) {
+  for (int i = 0; i < kRepetitionUnzipThreshold; ++i) {
     repeated_sequence.push_back(grammar_expr_id);
   }
 
@@ -2119,6 +2123,11 @@ class GrammarFSMHasherImpl {
    * \brief Get the hash value of a fsm, with a given grammar.
    */
   uint64_t HashFsm(int fsm_index);
+
+  /*!
+   * \brief Get a structural cache key for the continuation reachable from one FSM state.
+   */
+  std::optional<Grammar::Impl::FSMStateCacheKey> HashFsmState(int fsm_index, int32_t start_state);
 
   /*!
    * \brief Find a simple cycle in the reference graph, And hash the
@@ -2340,6 +2349,25 @@ void GrammarFSMHasherImpl::Apply(Grammar* grammar) {
   for (const auto& [rule_id, hash_value] : partial_hashed_list) {
     grammar->ImplPtr()->per_rule_fsm_hashes[rule_id] = hash_value;
   }
+
+  grammar->ImplPtr()->per_rule_fsm_state_cache_keys.resize((*grammar)->NumRules());
+  for (int32_t rule_id = 0; rule_id < (*grammar)->NumRules(); ++rule_id) {
+    if (!grammar_->ImplPtr()->per_rule_fsm_hashes[rule_id].has_value() ||
+        !grammar_->ImplPtr()->per_rule_fsms[rule_id].has_value()) {
+      continue;
+    }
+    const auto& fsm = grammar_->ImplPtr()->per_rule_fsms[rule_id]->GetFsm();
+    std::unordered_set<int> reachable_states;
+    fsm.GetReachableStates(&reachable_states);
+    auto& state_cache_keys = grammar_->ImplPtr()->per_rule_fsm_state_cache_keys[rule_id];
+    state_cache_keys.reserve(reachable_states.size());
+    for (int32_t state_id : reachable_states) {
+      auto cache_key = HashFsmState(rule_id, state_id);
+      if (cache_key.has_value()) {
+        state_cache_keys.emplace_back(state_id, *cache_key);
+      }
+    }
+  }
 }
 
 std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index) {
@@ -2559,6 +2587,94 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
   return hash_result;
 }
 
+std::optional<Grammar::Impl::FSMStateCacheKey> GrammarFSMHasherImpl::HashFsmState(
+    int fsm_index, int32_t start_state
+) {
+  XGRAMMAR_DCHECK(
+      fsm_index >= 0 && fsm_index < (*grammar_)->NumRules() &&
+      grammar_->ImplPtr()->per_rule_fsms[fsm_index].has_value() &&
+      grammar_->ImplPtr()->per_rule_fsm_hashes[fsm_index].has_value()
+  );
+  const auto& fsm = grammar_->ImplPtr()->per_rule_fsms[fsm_index]->GetFsm();
+  const auto& complete_fsm = grammar_->ImplPtr()->complete_fsm;
+
+  // Domain-separate state-continuation keys from whole-FSM hashes because both use the same
+  // RuleLevelCache.
+  uint64_t hash_result = 0x53544154455f4653ULL;
+  std::map<int32_t, int32_t> original_state_id_to_new_id;
+  original_state_id_to_new_id[start_state] = 0;
+  std::queue<int32_t> bfs_queue;
+  bfs_queue.push(start_state);
+  int32_t edge_count = 0;
+
+  while (!bfs_queue.empty()) {
+    const int32_t current_old_state_id = bfs_queue.front();
+    bfs_queue.pop();
+    const int32_t current_new_state_id = original_state_id_to_new_id[current_old_state_id];
+    hash_result = HashCombine(
+        hash_result,
+        current_new_state_id,
+        fsm.IsEndState(current_old_state_id) ? kEndStateFlag : kNotEndStateFlag
+    );
+
+    std::vector<std::pair<uint64_t, int32_t>> labeled_targets;
+    labeled_targets.reserve(sorted_edges_[current_old_state_id].size());
+    for (const auto& edge : sorted_edges_[current_old_state_id]) {
+      uint64_t label_hash = HashCombine(uint64_t{0}, edge.min);
+      if (edge.IsRuleRef()) {
+        const int32_t ref_rule_id = edge.GetRefRuleId();
+        if (!grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].has_value()) {
+          return std::nullopt;
+        }
+        label_hash =
+            HashCombine(label_hash, grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].value());
+      } else if (edge.IsRepeatRef()) {
+        const auto info = complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
+        if (!grammar_->ImplPtr()->per_rule_fsm_hashes[info.RuleId()].has_value()) {
+          return std::nullopt;
+        }
+        label_hash = HashCombine(
+            label_hash,
+            grammar_->ImplPtr()->per_rule_fsm_hashes[info.RuleId()].value(),
+            info.Lower(),
+            info.Upper()
+        );
+      } else if (edge.IsToken()) {
+        const auto info = complete_fsm.GetTokenEdgeInfo(edge.GetAuxIndex());
+        label_hash = HashCombine(label_hash, info.Count());
+        for (int32_t i = 0; i < info.Count(); ++i) {
+          label_hash = HashCombine(label_hash, info.TokenIds()[i]);
+        }
+      } else if (edge.IsExcludeToken()) {
+        const auto info = complete_fsm.GetExcludeTokenEdgeInfo(edge.GetAuxIndex());
+        label_hash = HashCombine(label_hash, info.Count());
+        for (int32_t i = 0; i < info.Count(); ++i) {
+          label_hash = HashCombine(label_hash, info.TokenIds()[i]);
+        }
+      } else {
+        label_hash = HashCombine(label_hash, edge.max);
+      }
+      labeled_targets.emplace_back(label_hash, edge.target);
+    }
+    std::sort(labeled_targets.begin(), labeled_targets.end());
+
+    for (const auto& [label_hash, target] : labeled_targets) {
+      auto [target_it, inserted] = original_state_id_to_new_id.emplace(
+          target, static_cast<int32_t>(original_state_id_to_new_id.size())
+      );
+      if (inserted) {
+        bfs_queue.push(target);
+      }
+      hash_result = HashCombine(hash_result, current_new_state_id, label_hash, target_it->second);
+      ++edge_count;
+    }
+  }
+
+  return Grammar::Impl::FSMStateCacheKey{
+      hash_result, static_cast<int32_t>(original_state_id_to_new_id.size()), edge_count
+  };
+}
+
 std::optional<uint64_t> GrammarFSMHasherImpl::HashSequence(
     const Grammar& grammar, int32_t sequence_id
 ) {
@@ -2639,6 +2755,10 @@ class RuleLevelCache::Impl {
 
   explicit Impl(size_t max_cache_memory_size) : max_cache_memory_size_(max_cache_memory_size) {}
 
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  ~Impl();
+#endif
+
   std::optional<AdaptiveTokenMask> GetCache(
       const uint64_t& fsm_hash,
       int32_t fsm_new_node_id,
@@ -2688,6 +2808,12 @@ class RuleLevelCache::Impl {
     // The cache map: (fsm_hash, node_id, ...) -> index in cache_list
     List<NodeType> cache_list;
     std::unordered_map<NodeKey, int> cache;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    uint64_t profile_hits = 0;
+    uint64_t profile_misses = 0;
+    uint64_t profile_additions = 0;
+    uint64_t profile_duplicate_additions = 0;
+#endif
   };
 
   Shard& GetShard(const NodeKey& key) {
@@ -2703,6 +2829,29 @@ class RuleLevelCache::Impl {
   const size_t max_cache_memory_size_;
   std::array<Shard, kNumShards> shards_;
 };
+
+#ifdef XGRAMMAR_PROFILE_COMPILE
+RuleLevelCache::Impl::~Impl() {
+  uint64_t profile_hits = 0;
+  uint64_t profile_misses = 0;
+  uint64_t profile_additions = 0;
+  uint64_t profile_duplicate_additions = 0;
+  size_t entries = 0;
+  int64_t bytes = 0;
+  for (const auto& shard : shards_) {
+    profile_hits += shard.profile_hits;
+    profile_misses += shard.profile_misses;
+    profile_additions += shard.profile_additions;
+    profile_duplicate_additions += shard.profile_duplicate_additions;
+    entries += shard.cache.size();
+    bytes += shard.current_cache_memory_size;
+  }
+  XGRAMMAR_LOG(INFO) << "RuleLevelCacheProfile(hits=" << profile_hits
+                     << ", misses=" << profile_misses << ", additions=" << profile_additions
+                     << ", duplicate_additions=" << profile_duplicate_additions
+                     << ", entries=" << entries << ", bytes=" << bytes << ")";
+}
+#endif
 
 std::optional<AdaptiveTokenMask> RuleLevelCache::GetCache(
     const uint64_t& fsm_hash,
@@ -2749,9 +2898,15 @@ std::optional<AdaptiveTokenMask> RuleLevelCache::Impl::GetCache(
   std::lock_guard<std::mutex> lock(shard.mutex);
   auto it = shard.cache.find(key);
   if (it == shard.cache.end()) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    ++shard.profile_misses;
+#endif
     return std::nullopt;
   }
 
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  ++shard.profile_hits;
+#endif
   // Move the node to the back of the list.
   shard.cache_list.MoveBack(it->second);
   return List<NodeType>::iterator(it->second, shard.cache_list)->second;
@@ -2784,6 +2939,9 @@ bool RuleLevelCache::Impl::AddCache(
     return false;
   }
   if (shard.cache.find(key) != shard.cache.end()) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    ++shard.profile_duplicate_additions;
+#endif
     // Already exists.
     return false;
   }
@@ -2809,6 +2967,9 @@ bool RuleLevelCache::Impl::AddCache(
   auto new_it = shard.cache_list.PushBack(NodeType(key, std::move(token_mask)));
   shard.current_cache_memory_size += MemorySize(new_it->second);
   shard.cache[key] = new_it.Index();
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  ++shard.profile_additions;
+#endif
   return true;
 }
 

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -2640,23 +2640,35 @@ std::optional<Grammar::Impl::FSMStateCacheKey> GrammarFSMHasherImpl::HashFsmStat
   // Domain-separate state-continuation keys from whole-FSM hashes because both use the same
   // RuleLevelCache.
   uint64_t hash_result = 0x53544154455f4653ULL;
-  std::map<int32_t, int32_t> original_state_id_to_new_id;
-  original_state_id_to_new_id[start_state] = 0;
-  std::queue<int32_t> bfs_queue;
-  bfs_queue.push(start_state);
+  const int32_t state_offset = fsm_state_offsets_[fsm_index];
+  std::vector<int32_t> original_state_id_to_new_id(
+      grammar_->ImplPtr()->per_rule_fsms[fsm_index]->GetNodeNum(), -1
+  );
+  auto mapped_id = [&](int32_t state_id) -> int32_t& {
+    XGRAMMAR_DCHECK(
+        state_id >= state_offset &&
+        state_id < state_offset + static_cast<int32_t>(original_state_id_to_new_id.size())
+    );
+    return original_state_id_to_new_id[state_id - state_offset];
+  };
+  mapped_id(start_state) = 0;
+  int32_t next_new_state_id = 1;
+  std::vector<int32_t> bfs_queue;
+  bfs_queue.reserve(original_state_id_to_new_id.size());
+  bfs_queue.push_back(start_state);
+  std::vector<std::pair<uint64_t, int32_t>> labeled_targets;
   int32_t edge_count = 0;
 
-  while (!bfs_queue.empty()) {
-    const int32_t current_old_state_id = bfs_queue.front();
-    bfs_queue.pop();
-    const int32_t current_new_state_id = original_state_id_to_new_id[current_old_state_id];
+  for (size_t queue_index = 0; queue_index < bfs_queue.size(); ++queue_index) {
+    const int32_t current_old_state_id = bfs_queue[queue_index];
+    const int32_t current_new_state_id = mapped_id(current_old_state_id);
     hash_result = HashCombine(
         hash_result,
         current_new_state_id,
         fsm.IsEndState(current_old_state_id) ? kEndStateFlag : kNotEndStateFlag
     );
 
-    std::vector<std::pair<uint64_t, int32_t>> labeled_targets;
+    labeled_targets.clear();
     labeled_targets.reserve(sorted_edges_[current_old_state_id].size());
     for (const auto& edge : sorted_edges_[current_old_state_id]) {
       uint64_t label_hash = HashCombine(uint64_t{0}, edge.min);
@@ -2698,20 +2710,17 @@ std::optional<Grammar::Impl::FSMStateCacheKey> GrammarFSMHasherImpl::HashFsmStat
     std::sort(labeled_targets.begin(), labeled_targets.end());
 
     for (const auto& [label_hash, target] : labeled_targets) {
-      auto [target_it, inserted] = original_state_id_to_new_id.emplace(
-          target, static_cast<int32_t>(original_state_id_to_new_id.size())
-      );
-      if (inserted) {
-        bfs_queue.push(target);
+      int32_t& target_new_state_id = mapped_id(target);
+      if (target_new_state_id == -1) {
+        target_new_state_id = next_new_state_id++;
+        bfs_queue.push_back(target);
       }
-      hash_result = HashCombine(hash_result, current_new_state_id, label_hash, target_it->second);
+      hash_result = HashCombine(hash_result, current_new_state_id, label_hash, target_new_state_id);
       ++edge_count;
     }
   }
 
-  return Grammar::Impl::FSMStateCacheKey{
-      hash_result, static_cast<int32_t>(original_state_id_to_new_id.size()), edge_count
-  };
+  return Grammar::Impl::FSMStateCacheKey{hash_result, next_new_state_id, edge_count};
 }
 
 std::optional<uint64_t> GrammarFSMHasherImpl::HashSequence(

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <bitset>
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -2132,6 +2133,13 @@ class GrammarFSMHasherImpl {
    */
   std::optional<Grammar::Impl::FSMStateCacheKey> HashFsmState(int fsm_index, int32_t start_state);
 
+  /*! \brief Hash all state continuations of an acyclic FSM in linear time. */
+  std::optional<std::vector<std::pair<int32_t, Grammar::Impl::FSMStateCacheKey>>>
+  HashAcyclicFsmStates(int fsm_index);
+
+  /*! \brief Get the structural label hash of one FSM edge. */
+  std::optional<uint64_t> HashFsmEdgeLabel(const FSMEdge& edge);
+
   /*!
    * \brief Find a simple cycle in the reference graph, And hash the
    * fsms in the simple cycle.
@@ -2377,6 +2385,10 @@ void GrammarFSMHasherImpl::Apply(Grammar* grammar, int max_threads, ThreadPool* 
       continue;
     }
     const auto& fsm = grammar_->ImplPtr()->per_rule_fsms[rule_id]->GetFsm();
+    if (auto acyclic_state_keys = HashAcyclicFsmStates(rule_id)) {
+      grammar_->ImplPtr()->per_rule_fsm_state_cache_keys[rule_id] = std::move(*acyclic_state_keys);
+      continue;
+    }
     std::unordered_set<int> reachable_states;
     fsm.GetReachableStates(&reachable_states);
     std::vector<int32_t> sorted_reachable_states(reachable_states.begin(), reachable_states.end());
@@ -2666,6 +2678,139 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
   return hash_result;
 }
 
+std::optional<uint64_t> GrammarFSMHasherImpl::HashFsmEdgeLabel(const FSMEdge& edge) {
+  const auto& complete_fsm = grammar_->ImplPtr()->complete_fsm;
+  uint64_t label_hash = HashCombine(uint64_t{0}, edge.min);
+  if (edge.IsRuleRef()) {
+    const int32_t ref_rule_id = edge.GetRefRuleId();
+    if (!grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].has_value()) {
+      return std::nullopt;
+    }
+    label_hash =
+        HashCombine(label_hash, grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].value());
+  } else if (edge.IsRepeatRef()) {
+    const auto info = complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
+    if (!grammar_->ImplPtr()->per_rule_fsm_hashes[info.RuleId()].has_value()) {
+      return std::nullopt;
+    }
+    label_hash = HashCombine(
+        label_hash,
+        grammar_->ImplPtr()->per_rule_fsm_hashes[info.RuleId()].value(),
+        info.Lower(),
+        info.Upper()
+    );
+  } else if (edge.IsToken()) {
+    const auto info = complete_fsm.GetTokenEdgeInfo(edge.GetAuxIndex());
+    label_hash = HashCombine(label_hash, info.Count());
+    for (int32_t i = 0; i < info.Count(); ++i) {
+      label_hash = HashCombine(label_hash, info.TokenIds()[i]);
+    }
+  } else if (edge.IsExcludeToken()) {
+    const auto info = complete_fsm.GetExcludeTokenEdgeInfo(edge.GetAuxIndex());
+    label_hash = HashCombine(label_hash, info.Count());
+    for (int32_t i = 0; i < info.Count(); ++i) {
+      label_hash = HashCombine(label_hash, info.TokenIds()[i]);
+    }
+  } else {
+    label_hash = HashCombine(label_hash, edge.max);
+  }
+  return label_hash;
+}
+
+std::optional<std::vector<std::pair<int32_t, Grammar::Impl::FSMStateCacheKey>>>
+GrammarFSMHasherImpl::HashAcyclicFsmStates(int fsm_index) {
+  XGRAMMAR_DCHECK(
+      fsm_index >= 0 && fsm_index < (*grammar_)->NumRules() &&
+      grammar_->ImplPtr()->per_rule_fsms[fsm_index].has_value() &&
+      grammar_->ImplPtr()->per_rule_fsm_hashes[fsm_index].has_value()
+  );
+  const auto& sized_fsm = grammar_->ImplPtr()->per_rule_fsms[fsm_index].value();
+  const auto& fsm = sized_fsm.GetFsm();
+  const int32_t state_offset = fsm_state_offsets_[fsm_index];
+  const int32_t node_count = sized_fsm.GetNodeNum();
+  auto local_id = [&](int32_t state_id) {
+    XGRAMMAR_DCHECK(state_id >= state_offset && state_id < state_offset + node_count);
+    return state_id - state_offset;
+  };
+
+  std::unordered_set<int> reachable_state_set;
+  fsm.GetReachableStates(&reachable_state_set);
+  std::vector<int32_t> reachable_states(reachable_state_set.begin(), reachable_state_set.end());
+  std::sort(reachable_states.begin(), reachable_states.end());
+
+  std::vector<int32_t> indegree(node_count, 0);
+  for (int32_t state_id : reachable_states) {
+    for (const auto& edge : sorted_edges_[state_id]) {
+      ++indegree[local_id(edge.target)];
+    }
+  }
+  std::vector<int32_t> topological_order;
+  topological_order.reserve(reachable_states.size());
+  for (int32_t state_id : reachable_states) {
+    if (indegree[local_id(state_id)] == 0) {
+      topological_order.push_back(state_id);
+    }
+  }
+  for (size_t order_index = 0; order_index < topological_order.size(); ++order_index) {
+    for (const auto& edge : sorted_edges_[topological_order[order_index]]) {
+      int32_t& target_indegree = indegree[local_id(edge.target)];
+      if (--target_indegree == 0) {
+        topological_order.push_back(edge.target);
+      }
+    }
+  }
+  if (topological_order.size() != reachable_states.size()) {
+    return std::nullopt;
+  }
+
+  std::vector<std::optional<Grammar::Impl::FSMStateCacheKey>> state_keys(node_count);
+  using LabeledKey = std::pair<uint64_t, Grammar::Impl::FSMStateCacheKey>;
+  std::vector<LabeledKey> labeled_targets;
+  for (auto state_it = topological_order.rbegin(); state_it != topological_order.rend();
+       ++state_it) {
+    const int32_t state_id = *state_it;
+    labeled_targets.clear();
+    labeled_targets.reserve(sorted_edges_[state_id].size());
+    for (const auto& edge : sorted_edges_[state_id]) {
+      auto label_hash = HashFsmEdgeLabel(edge);
+      const auto& target_key = state_keys[local_id(edge.target)];
+      if (!label_hash.has_value() || !target_key.has_value()) {
+        return std::nullopt;
+      }
+      labeled_targets.emplace_back(*label_hash, *target_key);
+    }
+    std::sort(labeled_targets.begin(), labeled_targets.end());
+
+    uint64_t hash_result = HashCombine(
+        uint64_t{0x4441475f53544154ULL},
+        fsm.IsEndState(state_id) ? kEndStateFlag : kNotEndStateFlag,
+        static_cast<int32_t>(labeled_targets.size())
+    );
+    int64_t state_count = 1;
+    int64_t edge_count = static_cast<int64_t>(labeled_targets.size());
+    for (const auto& [label_hash, target_key] : labeled_targets) {
+      hash_result = HashCombine(
+          hash_result, label_hash, target_key.hash, target_key.state_count, target_key.edge_count
+      );
+      state_count += target_key.state_count;
+      edge_count += target_key.edge_count;
+    }
+    state_keys[local_id(state_id)] = Grammar::Impl::FSMStateCacheKey{
+        hash_result,
+        static_cast<int32_t>(std::min<int64_t>(state_count, std::numeric_limits<int32_t>::max())),
+        static_cast<int32_t>(std::min<int64_t>(edge_count, std::numeric_limits<int32_t>::max()))
+    };
+  }
+
+  std::vector<std::pair<int32_t, Grammar::Impl::FSMStateCacheKey>> result;
+  result.reserve(reachable_states.size());
+  for (int32_t state_id : reachable_states) {
+    XGRAMMAR_DCHECK(state_keys[local_id(state_id)].has_value());
+    result.emplace_back(state_id, *state_keys[local_id(state_id)]);
+  }
+  return result;
+}
+
 std::optional<Grammar::Impl::FSMStateCacheKey> GrammarFSMHasherImpl::HashFsmState(
     int fsm_index, int32_t start_state
 ) {
@@ -2675,7 +2820,6 @@ std::optional<Grammar::Impl::FSMStateCacheKey> GrammarFSMHasherImpl::HashFsmStat
       grammar_->ImplPtr()->per_rule_fsm_hashes[fsm_index].has_value()
   );
   const auto& fsm = grammar_->ImplPtr()->per_rule_fsms[fsm_index]->GetFsm();
-  const auto& complete_fsm = grammar_->ImplPtr()->complete_fsm;
 
   // Domain-separate state-continuation keys from whole-FSM hashes because both use the same
   // RuleLevelCache.
@@ -2711,41 +2855,11 @@ std::optional<Grammar::Impl::FSMStateCacheKey> GrammarFSMHasherImpl::HashFsmStat
     labeled_targets.clear();
     labeled_targets.reserve(sorted_edges_[current_old_state_id].size());
     for (const auto& edge : sorted_edges_[current_old_state_id]) {
-      uint64_t label_hash = HashCombine(uint64_t{0}, edge.min);
-      if (edge.IsRuleRef()) {
-        const int32_t ref_rule_id = edge.GetRefRuleId();
-        if (!grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].has_value()) {
-          return std::nullopt;
-        }
-        label_hash =
-            HashCombine(label_hash, grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].value());
-      } else if (edge.IsRepeatRef()) {
-        const auto info = complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
-        if (!grammar_->ImplPtr()->per_rule_fsm_hashes[info.RuleId()].has_value()) {
-          return std::nullopt;
-        }
-        label_hash = HashCombine(
-            label_hash,
-            grammar_->ImplPtr()->per_rule_fsm_hashes[info.RuleId()].value(),
-            info.Lower(),
-            info.Upper()
-        );
-      } else if (edge.IsToken()) {
-        const auto info = complete_fsm.GetTokenEdgeInfo(edge.GetAuxIndex());
-        label_hash = HashCombine(label_hash, info.Count());
-        for (int32_t i = 0; i < info.Count(); ++i) {
-          label_hash = HashCombine(label_hash, info.TokenIds()[i]);
-        }
-      } else if (edge.IsExcludeToken()) {
-        const auto info = complete_fsm.GetExcludeTokenEdgeInfo(edge.GetAuxIndex());
-        label_hash = HashCombine(label_hash, info.Count());
-        for (int32_t i = 0; i < info.Count(); ++i) {
-          label_hash = HashCombine(label_hash, info.TokenIds()[i]);
-        }
-      } else {
-        label_hash = HashCombine(label_hash, edge.max);
+      auto label_hash = HashFsmEdgeLabel(edge);
+      if (!label_hash.has_value()) {
+        return std::nullopt;
       }
-      labeled_targets.emplace_back(label_hash, edge.target);
+      labeled_targets.emplace_back(*label_hash, edge.target);
     }
     std::sort(labeled_targets.begin(), labeled_targets.end());
 

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -2111,6 +2111,7 @@ class GrammarFSMHasherImpl {
   std::vector<std::vector<int32_t>> ref_graph_from_referee_to_referrer_;
   std::vector<std::vector<FSMEdge>> sorted_edges_;
   std::vector<bool> has_inward_edges_;
+  std::vector<int32_t> fsm_state_offsets_;
 
   /*!
    * \brief The worklist of fsms that are ready to be hashed: fsms whose references are all
@@ -2267,6 +2268,16 @@ void GrammarFSMHasherImpl::Apply(Grammar* grammar) {
     }
   }
 
+  fsm_state_offsets_.resize((*grammar)->NumRules());
+  int32_t state_offset = 0;
+  for (int32_t rule_id = 0; rule_id < (*grammar)->NumRules(); ++rule_id) {
+    fsm_state_offsets_[rule_id] = state_offset;
+    if (grammar->ImplPtr()->per_rule_fsms[rule_id].has_value()) {
+      state_offset += grammar->ImplPtr()->per_rule_fsms[rule_id]->GetNodeNum();
+    }
+  }
+  XGRAMMAR_DCHECK(state_offset == grammar->ImplPtr()->complete_fsm.NumStates());
+
   // Get the reference graph.
   ref_graph_from_referee_to_referrer_ = RuleRefGraphFinder().Apply(*grammar);
   ref_graph_from_referrer_to_referee_ = std::vector<std::vector<int32_t>>((*grammar)->NumRules());
@@ -2375,18 +2386,28 @@ std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index)
   XGRAMMAR_DCHECK(fsm_index >= 0 && fsm_index < (*grammar_)->NumRules())
       << "Invalid fsm index: " << fsm_index << " num_rules: " << (*grammar_)->NumRules();
   XGRAMMAR_DCHECK(grammar_->ImplPtr()->per_rule_fsms[fsm_index].has_value());
-  const auto& fsm = grammar_->ImplPtr()->per_rule_fsms[fsm_index].value().GetFsm();
-  std::map<int32_t, int32_t> original_state_id_to_new_id;
-  original_state_id_to_new_id[fsm.GetStart()] = 0;
-  std::queue<int32_t> bfs_queue;
+  const auto& sized_fsm = grammar_->ImplPtr()->per_rule_fsms[fsm_index].value();
+  const auto& fsm = sized_fsm.GetFsm();
+  const int32_t state_offset = fsm_state_offsets_[fsm_index];
+  std::vector<int32_t> original_state_id_to_new_id(sized_fsm.GetNodeNum(), -1);
+  auto mapped_id = [&](int32_t state_id) -> int32_t& {
+    XGRAMMAR_DCHECK(
+        state_id >= state_offset &&
+        state_id < state_offset + static_cast<int32_t>(original_state_id_to_new_id.size())
+    );
+    return original_state_id_to_new_id[state_id - state_offset];
+  };
+  mapped_id(fsm.GetStart()) = 0;
+  int32_t next_new_state_id = 1;
+  std::vector<int32_t> bfs_queue;
+  bfs_queue.reserve(sized_fsm.GetNodeNum());
   std::set<std::pair<uint64_t, int32_t>> hash_and_target;
-  bfs_queue.push(fsm.GetStart());
+  bfs_queue.push_back(fsm.GetStart());
   // Perform a bfs to hash all the edges.
-  while (!bfs_queue.empty()) {
-    int current_old_state_id = bfs_queue.front();
+  for (size_t queue_index = 0; queue_index < bfs_queue.size(); ++queue_index) {
+    int current_old_state_id = bfs_queue[queue_index];
     bool is_start = current_old_state_id == fsm.GetStart();
-    int current_new_state_id = original_state_id_to_new_id[current_old_state_id];
-    bfs_queue.pop();
+    int current_new_state_id = mapped_id(current_old_state_id);
 
     // Check if the current state is an end state.
     if (fsm.IsEndState(current_old_state_id)) {
@@ -2445,23 +2466,21 @@ std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index)
 
     // Hash them.
     for (const auto& [hash, target] : hash_and_target) {
-      if (original_state_id_to_new_id.find(target) == original_state_id_to_new_id.end()) {
-        original_state_id_to_new_id[target] =
-            static_cast<int32_t>(original_state_id_to_new_id.size());
-        bfs_queue.push(target);
+      if (mapped_id(target) == -1) {
+        mapped_id(target) = next_new_state_id++;
+        bfs_queue.push_back(target);
       }
-      int32_t target_new_id = original_state_id_to_new_id[target];
+      int32_t target_new_id = mapped_id(target);
       hash_result = HashCombine(hash_result, current_new_state_id, hash, target_new_id);
     }
 
     // Then, check the edges which are not rule/repeat references.
     for (const auto& edge : sorted_edges_[current_old_state_id]) {
-      if (original_state_id_to_new_id.find(edge.target) == original_state_id_to_new_id.end()) {
-        original_state_id_to_new_id[edge.target] =
-            static_cast<int32_t>(original_state_id_to_new_id.size());
-        bfs_queue.push(edge.target);
+      if (mapped_id(edge.target) == -1) {
+        mapped_id(edge.target) = next_new_state_id++;
+        bfs_queue.push_back(edge.target);
       }
-      int32_t target_new_id = original_state_id_to_new_id[edge.target];
+      int32_t target_new_id = mapped_id(edge.target);
       if (edge.IsRuleRef() || edge.IsRepeatRef()) {
         continue;
       }
@@ -2475,9 +2494,15 @@ std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index)
     }
   }
   std::vector<std::pair<int32_t, int32_t>> new_id_mapping;
-  new_id_mapping.reserve(original_state_id_to_new_id.size());
-  for (const auto& [original_state_id, new_state_id] : original_state_id_to_new_id) {
-    new_id_mapping.emplace_back(original_state_id, new_state_id);
+  new_id_mapping.reserve(next_new_state_id);
+  for (int32_t local_state_id = 0;
+       local_state_id < static_cast<int32_t>(original_state_id_to_new_id.size());
+       ++local_state_id) {
+    if (original_state_id_to_new_id[local_state_id] != -1) {
+      new_id_mapping.emplace_back(
+          local_state_id + state_offset, original_state_id_to_new_id[local_state_id]
+      );
+    }
   }
   grammar_->ImplPtr()->per_rule_fsm_new_state_ids[fsm_index] = new_id_mapping;
   return {true, hash_result};
@@ -2488,18 +2513,28 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
   XGRAMMAR_DCHECK(fsm_index >= 0 && fsm_index < (*grammar_)->NumRules())
       << "Invalid fsm index: " << fsm_index << " num_rules: " << (*grammar_)->NumRules();
   XGRAMMAR_DCHECK(grammar_->ImplPtr()->per_rule_fsms[fsm_index].has_value());
-  const auto& fsm = grammar_->ImplPtr()->per_rule_fsms[fsm_index].value().GetFsm();
-  std::map<int32_t, int32_t> original_state_id_to_new_id;
-  original_state_id_to_new_id[fsm.GetStart()] = 0;
-  std::queue<int32_t> bfs_queue;
+  const auto& sized_fsm = grammar_->ImplPtr()->per_rule_fsms[fsm_index].value();
+  const auto& fsm = sized_fsm.GetFsm();
+  const int32_t state_offset = fsm_state_offsets_[fsm_index];
+  std::vector<int32_t> original_state_id_to_new_id(sized_fsm.GetNodeNum(), -1);
+  auto mapped_id = [&](int32_t state_id) -> int32_t& {
+    XGRAMMAR_DCHECK(
+        state_id >= state_offset &&
+        state_id < state_offset + static_cast<int32_t>(original_state_id_to_new_id.size())
+    );
+    return original_state_id_to_new_id[state_id - state_offset];
+  };
+  mapped_id(fsm.GetStart()) = 0;
+  int32_t next_new_state_id = 1;
+  std::vector<int32_t> bfs_queue;
+  bfs_queue.reserve(sized_fsm.GetNodeNum());
   std::set<std::pair<int32_t, int32_t>> hash_and_target;
-  bfs_queue.push(fsm.GetStart());
+  bfs_queue.push_back(fsm.GetStart());
 
   // Perform a bfs to hash all the edges.
-  while (!bfs_queue.empty()) {
-    int current_old_state_id = bfs_queue.front();
-    int current_new_state_id = original_state_id_to_new_id[current_old_state_id];
-    bfs_queue.pop();
+  for (size_t queue_index = 0; queue_index < bfs_queue.size(); ++queue_index) {
+    int current_old_state_id = bfs_queue[queue_index];
+    int current_new_state_id = mapped_id(current_old_state_id);
 
     // Check if the current state is an end state.
     if (fsm.IsEndState(current_old_state_id)) {
@@ -2549,23 +2584,21 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
 
     // Hash them.
     for (const auto& [hash, target] : hash_and_target) {
-      if (original_state_id_to_new_id.find(target) == original_state_id_to_new_id.end()) {
-        original_state_id_to_new_id[target] =
-            static_cast<int32_t>(original_state_id_to_new_id.size());
-        bfs_queue.push(target);
+      if (mapped_id(target) == -1) {
+        mapped_id(target) = next_new_state_id++;
+        bfs_queue.push_back(target);
       }
-      int32_t target_new_id = original_state_id_to_new_id[target];
+      int32_t target_new_id = mapped_id(target);
       hash_result = HashCombine(hash_result, current_new_state_id, hash, target_new_id);
     }
 
     // Then, check the edges which are not rule/repeat references.
     for (const auto& edge : sorted_edges_[current_old_state_id]) {
-      if (original_state_id_to_new_id.find(edge.target) == original_state_id_to_new_id.end()) {
-        original_state_id_to_new_id[edge.target] =
-            static_cast<int32_t>(original_state_id_to_new_id.size());
-        bfs_queue.push(edge.target);
+      if (mapped_id(edge.target) == -1) {
+        mapped_id(edge.target) = next_new_state_id++;
+        bfs_queue.push_back(edge.target);
       }
-      int32_t target_new_id = original_state_id_to_new_id[edge.target];
+      int32_t target_new_id = mapped_id(edge.target);
       if (edge.IsRuleRef() || edge.IsRepeatRef()) {
         continue;
       }
@@ -2579,9 +2612,15 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
     }
   }
   std::vector<std::pair<int32_t, int32_t>> new_id_mapping;
-  new_id_mapping.reserve(original_state_id_to_new_id.size());
-  for (const auto& [original_state_id, new_state_id] : original_state_id_to_new_id) {
-    new_id_mapping.emplace_back(original_state_id, new_state_id);
+  new_id_mapping.reserve(next_new_state_id);
+  for (int32_t local_state_id = 0;
+       local_state_id < static_cast<int32_t>(original_state_id_to_new_id.size());
+       ++local_state_id) {
+    if (original_state_id_to_new_id[local_state_id] != -1) {
+      new_id_mapping.emplace_back(
+          local_state_id + state_offset, original_state_id_to_new_id[local_state_id]
+      );
+    }
   }
   grammar_->ImplPtr()->per_rule_fsm_new_state_ids[fsm_index] = new_id_mapping;
   return hash_result;

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -8,6 +8,7 @@
 #include <xgrammar/xgrammar.h>
 
 #include <array>
+#include <atomic>
 #include <bitset>
 #include <cstdint>
 #include <map>
@@ -28,6 +29,7 @@
 #include "support/container.h"
 #include "support/encoding.h"
 #include "support/logging.h"
+#include "support/thread_pool.h"
 #include "xgrammar/grammar.h"
 
 namespace xgrammar {
@@ -2095,7 +2097,7 @@ class RootRuleRenamerImpl {
 
 class GrammarFSMHasherImpl {
  public:
-  void Apply(Grammar* grammar);
+  void Apply(Grammar* grammar, int max_threads, ThreadPool* thread_pool);
   static std::optional<uint64_t> HashSequence(const Grammar& grammar, int32_t sequence_id);
 
   static constexpr int16_t kNotEndStateFlag = -0x100;
@@ -2252,7 +2254,7 @@ void GrammarFSMHasherImpl::RemoveHashedFsmFromRefGraph(int32_t fsm_index) {
   }
 }
 
-void GrammarFSMHasherImpl::Apply(Grammar* grammar) {
+void GrammarFSMHasherImpl::Apply(Grammar* grammar, int max_threads, ThreadPool* thread_pool) {
   grammar_ = grammar;
   grammar->ImplPtr()->per_rule_fsm_hashes =
       std::vector<std::optional<uint64_t>>((*grammar)->NumRules());
@@ -2361,7 +2363,14 @@ void GrammarFSMHasherImpl::Apply(Grammar* grammar) {
     grammar->ImplPtr()->per_rule_fsm_hashes[rule_id] = hash_value;
   }
 
+  struct StateHashTask {
+    int32_t rule_id;
+    int32_t state_id;
+    std::optional<Grammar::Impl::FSMStateCacheKey> cache_key;
+  };
+
   grammar->ImplPtr()->per_rule_fsm_state_cache_keys.resize((*grammar)->NumRules());
+  std::vector<StateHashTask> state_hash_tasks;
   for (int32_t rule_id = 0; rule_id < (*grammar)->NumRules(); ++rule_id) {
     if (!grammar_->ImplPtr()->per_rule_fsm_hashes[rule_id].has_value() ||
         !grammar_->ImplPtr()->per_rule_fsms[rule_id].has_value()) {
@@ -2370,13 +2379,44 @@ void GrammarFSMHasherImpl::Apply(Grammar* grammar) {
     const auto& fsm = grammar_->ImplPtr()->per_rule_fsms[rule_id]->GetFsm();
     std::unordered_set<int> reachable_states;
     fsm.GetReachableStates(&reachable_states);
-    auto& state_cache_keys = grammar_->ImplPtr()->per_rule_fsm_state_cache_keys[rule_id];
-    state_cache_keys.reserve(reachable_states.size());
-    for (int32_t state_id : reachable_states) {
-      auto cache_key = HashFsmState(rule_id, state_id);
-      if (cache_key.has_value()) {
-        state_cache_keys.emplace_back(state_id, *cache_key);
-      }
+    std::vector<int32_t> sorted_reachable_states(reachable_states.begin(), reachable_states.end());
+    std::sort(sorted_reachable_states.begin(), sorted_reachable_states.end());
+    for (int32_t state_id : sorted_reachable_states) {
+      state_hash_tasks.push_back(StateHashTask{rule_id, state_id, std::nullopt});
+    }
+  }
+
+  auto compute_state_hash = [&](size_t task_id) {
+    auto& task = state_hash_tasks[task_id];
+    task.cache_key = HashFsmState(task.rule_id, task.state_id);
+  };
+  const int num_workers =
+      std::min<int>(std::max(max_threads, 1), static_cast<int>(state_hash_tasks.size()));
+  constexpr size_t kMinParallelStateHashTasks = 256;
+  if (thread_pool != nullptr && num_workers > 1 &&
+      state_hash_tasks.size() >= kMinParallelStateHashTasks) {
+    std::atomic<size_t> next_task_id{0};
+    for (int worker_id = 0; worker_id < num_workers; ++worker_id) {
+      thread_pool->Execute([&]() {
+        size_t task_id;
+        while ((task_id = next_task_id.fetch_add(1, std::memory_order_relaxed)) <
+               state_hash_tasks.size()) {
+          compute_state_hash(task_id);
+        }
+      });
+    }
+    thread_pool->Wait();
+  } else {
+    for (size_t task_id = 0; task_id < state_hash_tasks.size(); ++task_id) {
+      compute_state_hash(task_id);
+    }
+  }
+
+  for (const auto& task : state_hash_tasks) {
+    if (task.cache_key.has_value()) {
+      grammar_->ImplPtr()->per_rule_fsm_state_cache_keys[task.rule_id].emplace_back(
+          task.state_id, *task.cache_key
+      );
     }
   }
 }
@@ -3065,7 +3105,9 @@ void GrammarFSMBuilder::Apply(Grammar* grammar) { GrammarFSMBuilderImpl().Apply(
 
 void RepetitionNormalizer::Apply(Grammar* grammar) { RepetitionNormalizerImpl().Apply(grammar); }
 
-void GrammarFSMHasher::Apply(Grammar* grammar) { GrammarFSMHasherImpl().Apply(grammar); }
+void GrammarFSMHasher::Apply(Grammar* grammar, int max_threads, ThreadPool* thread_pool) {
+  GrammarFSMHasherImpl().Apply(grammar, max_threads, thread_pool);
+}
 
 std::optional<uint64_t> GrammarFSMHasher::HashSequence(
     const Grammar& grammar, int32_t sequence_id

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -22,6 +22,8 @@
 
 namespace xgrammar {
 
+class ThreadPool;
+
 /*!
  * \brief Base class for visitors and mutators of the BNF grammar.
  * \tparam T The type of the return value of visitor functions. Typical values:
@@ -442,7 +444,7 @@ class RootRuleRenamer {
  */
 class GrammarFSMHasher {
  public:
-  static void Apply(Grammar* grammar);
+  static void Apply(Grammar* grammar, int max_threads = 1, ThreadPool* thread_pool = nullptr);
   static std::optional<uint64_t> HashSequence(const Grammar& grammar, int32_t sequence_id);
 };
 

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -335,6 +335,31 @@ class Grammar::Impl {
    */
   std::vector<std::vector<std::pair<int32_t, int32_t>>> per_rule_fsm_new_state_ids;
 
+  struct FSMStateCacheKey {
+    uint64_t hash;
+    int32_t state_count;
+    int32_t edge_count;
+
+    bool operator==(const FSMStateCacheKey& other) const {
+      return hash == other.hash && state_count == other.state_count &&
+             edge_count == other.edge_count;
+    }
+
+    bool operator<(const FSMStateCacheKey& other) const {
+      if (hash != other.hash) return hash < other.hash;
+      if (state_count != other.state_count) return state_count < other.state_count;
+      return edge_count < other.edge_count;
+    }
+  };
+
+  /*!
+   * \brief A structural cache key for the behavior reachable from each FSM state.
+   * \details Unlike per_rule_fsm_hashes, this excludes states that can only occur before the
+   * selected state. The compiler uses target-state keys to share token-prefix work whose
+   * post-byte continuations are structurally identical.
+   */
+  std::vector<std::vector<std::pair<int32_t, FSMStateCacheKey>>> per_rule_fsm_state_cache_keys;
+
   /*! \brief The ids of the rules that are allowed to be empty. */
   std::vector<int32_t> allow_empty_rule_ids;
 

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -10,10 +10,16 @@
 #include <xgrammar/matcher.h>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstdint>
+#include <limits>
+#include <memory>
 #include <optional>
+#include <string_view>
 #include <thread>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -26,7 +32,9 @@
 #include "support/int_set.h"
 #include "support/logging.h"
 #include "support/thread_pool.h"
+#include "support/utils.h"
 #include "testing.h"
+#include "tokenizer_info_impl.h"
 
 namespace xgrammar {
 
@@ -453,15 +461,495 @@ class GrammarMatcher::Impl : public EarleyParser {
       // max_rollback_tokens_ is deprecated and not used.
       int max_rollback_tokens = -1
   )
-      : EarleyParser(compiled_grammar->grammar),
+      : EarleyParser(compiled_grammar->grammar, compiled_grammar->earley_parser_metadata),
         compiled_grammar_(compiled_grammar),
         tokenizer_info_(compiled_grammar->tokenizer_info),
         stop_token_ids_(override_stop_tokens.value_or(tokenizer_info_.GetStopTokenIds())),
         terminate_without_stop_token_(terminate_without_stop_token),
-        tmp_accepted_bitset_(tokenizer_info_.GetVocabSize()) {
+        resolved_uncertain_mask_cache_(this),
+        tmp_accepted_bitset_(tokenizer_info_.GetVocabSize()),
+        tmp_deferred_uncertain_accepted_bitset_(tokenizer_info_.GetVocabSize()),
+        tmp_unresolved_uncertain_bitset_(tokenizer_info_.GetVocabSize()),
+        tmp_suffix_accepted_bitset_(tokenizer_info_.GetVocabSize())
+#ifdef XGRAMMAR_PROFILE_COMPILE
+        ,
+        profile_uncertain_union_bitset_(tokenizer_info_.GetVocabSize()),
+        profile_local_explicit_accepted_bitset_(tokenizer_info_.GetVocabSize()),
+        profile_whitespace_slice_bitset_(tokenizer_info_.GetVocabSize()),
+        profile_string_safe_10_slice_bitset_(tokenizer_info_.GetVocabSize()),
+        profile_string_safe_30_slice_bitset_(tokenizer_info_.GetVocabSize()),
+        profile_string_safe_slice_bitset_(tokenizer_info_.GetVocabSize()),
+        profile_ascii_safe_10_slice_bitset_(tokenizer_info_.GetVocabSize()),
+        profile_ascii_safe_30_slice_bitset_(tokenizer_info_.GetVocabSize()),
+        profile_ascii_safe_slice_bitset_(tokenizer_info_.GetVocabSize()),
+        profile_suffix_accepted_union_bitset_(tokenizer_info_.GetVocabSize()),
+        profile_full_configuration_candidate_bitset_(tokenizer_info_.GetSortedDecodedVocab().size()
+        ),
+        profile_full_configuration_expected_accepted_bitset_(
+            tokenizer_info_.GetSortedDecodedVocab().size()
+        ),
+        profile_candidate_slice_filtered_bitset_(tokenizer_info_.GetSortedDecodedVocab().size())
+#endif
+  {
     XGRAMMAR_CHECK(!override_stop_tokens.has_value() || !override_stop_tokens->empty())
         << "The override_stop_tokens should not be empty";
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    // Mirror LLGuidance v1.3.0's general tokenizer slices. These are profile-only oracle masks
+    // used to measure how much exact regex/FSM subsumption could remove from the counterfactual
+    // traversal; they do not participate in mask generation.
+    for (const auto& [token_id, token] : tokenizer_info_.GetSortedDecodedVocab()) {
+      const bool is_whitespace =
+          !token.empty() && std::all_of(token.begin(), token.end(), [](uint8_t byte) {
+            return byte == 0x20 || byte == 0x0A || byte == 0x0D || byte == 0x09;
+          });
+      const bool is_string_safe =
+          !token.empty() && std::all_of(token.begin(), token.end(), [](uint8_t byte) {
+            return byte != '"' && byte != '\\' && byte >= 0x20 && byte != 0x7F;
+          });
+      const bool is_ascii_safe =
+          !token.empty() && std::all_of(token.begin(), token.end(), [](uint8_t byte) {
+            return byte != '"' && byte != '\\' && byte >= 0x20 && byte < 0x7F;
+          });
+      if (is_whitespace) {
+        profile_whitespace_slice_bitset_.Set(token_id);
+      }
+      if (is_string_safe) {
+        profile_string_safe_slice_bitset_.Set(token_id);
+        if (token.size() <= 30) {
+          profile_string_safe_30_slice_bitset_.Set(token_id);
+        }
+        if (token.size() <= 10) {
+          profile_string_safe_10_slice_bitset_.Set(token_id);
+        }
+      }
+      if (is_ascii_safe) {
+        profile_ascii_safe_slice_bitset_.Set(token_id);
+        if (token.size() <= 30) {
+          profile_ascii_safe_30_slice_bitset_.Set(token_id);
+        }
+        if (token.size() <= 10) {
+          profile_ascii_safe_10_slice_bitset_.Set(token_id);
+        }
+      }
+    }
+
+    // Prove that a grammar state can consume every string over the safe ASCII alphabet. Besides
+    // direct character edges, follow epsilon edges and rule-entry edges. This covers the common
+    // grammar shape "consume one character, then enter the recursive string-content rule" without
+    // consulting runtime parent rows. Rule completion and bounded repeat edges are deliberately
+    // excluded, so the result remains a sufficient proof.
+    const auto& complete_fsm = grammar_->complete_fsm;
+    const auto& complete_fsm_edges = complete_fsm.GetEdges();
+    const int32_t fsm_state_count = complete_fsm.NumStates();
+    std::vector<std::vector<int32_t>> entry_predecessors(fsm_state_count);
+    for (int32_t state_id = 0; state_id < fsm_state_count; ++state_id) {
+      for (const auto& edge : complete_fsm_edges[state_id]) {
+        if (edge.IsEpsilon()) {
+          entry_predecessors[edge.target].push_back(state_id);
+        } else if (edge.IsRuleRef()) {
+          const int32_t ref_rule_id = edge.GetRefRuleId();
+          const int32_t ref_start = grammar_->per_rule_fsms[ref_rule_id]->GetFsm().GetStart();
+          entry_predecessors[ref_start].push_back(state_id);
+          if (compiled_grammar_->earley_parser_metadata.rule_is_nullable[ref_rule_id]) {
+            entry_predecessors[edge.target].push_back(state_id);
+          }
+        }
+      }
+    }
+
+    constexpr uint64_t kSafeAsciiLowMask = ~((uint64_t{1} << 32) - 1) & ~(uint64_t{1} << '"');
+    constexpr uint64_t kSafeAsciiHighMask =
+        ((uint64_t{1} << 63) - 1) & ~(uint64_t{1} << ('\\' - 64));
+    struct ByteCoverage {
+      uint64_t low = 0;
+      uint64_t high = 0;
+    };
+    auto add_range = [](ByteCoverage* coverage, int32_t min_byte, int32_t max_byte) {
+      min_byte = std::max(min_byte, 0x20);
+      max_byte = std::min(max_byte, 0x7E);
+      for (int32_t byte = min_byte; byte <= max_byte; ++byte) {
+        if (byte == '"' || byte == '\\') {
+          continue;
+        }
+        if (byte < 64) {
+          coverage->low |= uint64_t{1} << byte;
+        } else {
+          coverage->high |= uint64_t{1} << (byte - 64);
+        }
+      }
+    };
+    auto compute_universal_predecessors = [&](const std::vector<uint8_t>& accepted_targets) {
+      std::vector<ByteCoverage> coverage(fsm_state_count);
+      std::vector<int32_t> worklist;
+      std::vector<uint8_t> in_worklist(fsm_state_count, 0);
+      worklist.reserve(fsm_state_count);
+      for (int32_t state_id = 0; state_id < fsm_state_count; ++state_id) {
+        auto& state_coverage = coverage[state_id];
+        for (const auto& edge : complete_fsm_edges[state_id]) {
+          if (edge.IsCharRange() && accepted_targets[edge.target]) {
+            add_range(&state_coverage, edge.min, edge.max);
+          }
+        }
+        if (state_coverage.low != 0 || state_coverage.high != 0) {
+          worklist.push_back(state_id);
+          in_worklist[state_id] = 1;
+        }
+      }
+      for (size_t worklist_index = 0; worklist_index < worklist.size(); ++worklist_index) {
+        const int32_t target = worklist[worklist_index];
+        in_worklist[target] = 0;
+        for (int32_t predecessor : entry_predecessors[target]) {
+          auto& predecessor_coverage = coverage[predecessor];
+          const uint64_t old_low = predecessor_coverage.low;
+          const uint64_t old_high = predecessor_coverage.high;
+          predecessor_coverage.low |= coverage[target].low;
+          predecessor_coverage.high |= coverage[target].high;
+          if ((predecessor_coverage.low != old_low || predecessor_coverage.high != old_high) &&
+              !in_worklist[predecessor]) {
+            worklist.push_back(predecessor);
+            in_worklist[predecessor] = 1;
+          }
+        }
+      }
+      std::vector<uint8_t> result(fsm_state_count, 0);
+      for (int32_t state_id = 0; state_id < fsm_state_count; ++state_id) {
+        result[state_id] = (coverage[state_id].low & kSafeAsciiLowMask) == kSafeAsciiLowMask &&
+                           (coverage[state_id].high & kSafeAsciiHighMask) == kSafeAsciiHighMask;
+      }
+      return result;
+    };
+
+    std::vector<uint8_t> bounded_states(fsm_state_count, 1);
+    for (int32_t depth = 1; depth <= 30; ++depth) {
+      bounded_states = compute_universal_predecessors(bounded_states);
+      if (depth == 10) {
+        profile_ascii_safe_10_fsm_states_ = bounded_states;
+      } else if (depth == 30) {
+        profile_ascii_safe_30_fsm_states_ = bounded_states;
+      }
+    }
+
+    profile_ascii_safe_closed_fsm_states_.assign(fsm_state_count, 1);
+    while (true) {
+      auto next_closed_states =
+          compute_universal_predecessors(profile_ascii_safe_closed_fsm_states_);
+      if (next_closed_states == profile_ascii_safe_closed_fsm_states_) {
+        break;
+      }
+      profile_ascii_safe_closed_fsm_states_ = std::move(next_closed_states);
+    }
+    const size_t ascii_safe_10_state_count = std::count(
+        profile_ascii_safe_10_fsm_states_.begin(),
+        profile_ascii_safe_10_fsm_states_.end(),
+        uint8_t{1}
+    );
+    const size_t ascii_safe_30_state_count = std::count(
+        profile_ascii_safe_30_fsm_states_.begin(),
+        profile_ascii_safe_30_fsm_states_.end(),
+        uint8_t{1}
+    );
+    const size_t ascii_safe_closed_state_count = std::count(
+        profile_ascii_safe_closed_fsm_states_.begin(),
+        profile_ascii_safe_closed_fsm_states_.end(),
+        uint8_t{1}
+    );
+    XGRAMMAR_LOG(INFO) << "TokenizerSliceFSMProfile(ascii_safe_10_states="
+                       << ascii_safe_10_state_count
+                       << ", ascii_safe_30_states=" << ascii_safe_30_state_count
+                       << ", ascii_safe_closed_states=" << ascii_safe_closed_state_count
+                       << ", fsm_states=" << fsm_state_count << ")";
+#endif
   }
+
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  ~Impl() {
+    if (profile_fill_calls_ != 0) {
+      const auto& compile_profiles = compiled_grammar_->adaptive_mask_compile_profiles;
+      const auto& state_to_task_group = compiled_grammar_->adaptive_token_mask_ids;
+      if (!compile_profiles.empty() && !state_to_task_group.empty()) {
+        struct CoverageTotals {
+          uint64_t mask_cpu_us = 0;
+          uint64_t possible_tokens = 0;
+          uint64_t first_byte_cache_reused_tokens = 0;
+          uint64_t saturated_cache_reused_tokens = 0;
+          uint64_t token_edge_skipped_tokens = 0;
+          uint64_t speculative_accepted_tokens = 0;
+          uint64_t subtree_pruned_tokens = 0;
+          uint64_t parser_simulated_tokens = 0;
+          uint64_t parser_naive_token_bytes = 0;
+          uint64_t parser_advance_calls = 0;
+          uint64_t parser_failed_advance_calls = 0;
+          uint64_t task_mask_bytes = 0;
+        };
+        auto add_profile = [](CoverageTotals* totals, const AdaptiveMaskCompileProfile& profile) {
+          totals->mask_cpu_us += profile.mask_cpu_us;
+          totals->possible_tokens += profile.possible_tokens;
+          totals->first_byte_cache_reused_tokens += profile.first_byte_cache_reused_tokens;
+          totals->saturated_cache_reused_tokens += profile.saturated_cache_reused_tokens;
+          totals->token_edge_skipped_tokens += profile.token_edge_skipped_tokens;
+          totals->speculative_accepted_tokens += profile.speculative_accepted_tokens;
+          totals->subtree_pruned_tokens += profile.subtree_pruned_tokens;
+          totals->parser_simulated_tokens += profile.parser_simulated_tokens;
+          totals->parser_naive_token_bytes += profile.parser_naive_token_bytes;
+          totals->parser_advance_calls += profile.parser_advance_calls;
+          totals->parser_failed_advance_calls += profile.parser_failed_advance_calls;
+          totals->task_mask_bytes += profile.mask_bytes;
+        };
+
+        CoverageTotals total;
+        for (const auto& profile : compile_profiles) {
+          add_profile(&total, profile);
+        }
+
+        std::unordered_set<size_t> visited_task_groups;
+        visited_task_groups.reserve(profile_visited_adaptive_mask_states_.size());
+        uint64_t visited_state_mask_bytes = 0;
+        for (const auto& state : profile_visited_adaptive_mask_states_) {
+          const auto task_group_it = state_to_task_group.find(state);
+          XGRAMMAR_DCHECK(task_group_it != state_to_task_group.end());
+          visited_task_groups.insert(task_group_it->second);
+          const auto mask_it = compiled_grammar_->adaptive_token_mask_ids.find(state);
+          XGRAMMAR_DCHECK(mask_it != compiled_grammar_->adaptive_token_mask_ids.end());
+          XGRAMMAR_DCHECK(mask_it->second < compiled_grammar_->adaptive_token_masks.size());
+          visited_state_mask_bytes +=
+              MemorySize(compiled_grammar_->adaptive_token_masks[mask_it->second]);
+        }
+
+        CoverageTotals visited;
+        for (size_t task_group_id : visited_task_groups) {
+          XGRAMMAR_DCHECK(task_group_id < compile_profiles.size());
+          add_profile(&visited, compile_profiles[task_group_id]);
+        }
+
+        uint64_t total_state_mask_bytes = 0;
+        for (const auto& [state, mask_id] : compiled_grammar_->adaptive_token_mask_ids) {
+          XGRAMMAR_DCHECK(mask_id < compiled_grammar_->adaptive_token_masks.size());
+          total_state_mask_bytes += MemorySize(compiled_grammar_->adaptive_token_masks[mask_id]);
+        }
+
+        XGRAMMAR_LOG(INFO
+        ) << "AdaptiveMaskCoverageProfile(compiled_states="
+          << compiled_grammar_->adaptive_token_mask_ids.size()
+          << ", visited_states=" << profile_visited_adaptive_mask_states_.size()
+          << ", task_groups=" << compile_profiles.size()
+          << ", visited_task_groups=" << visited_task_groups.size()
+          << ", task_mask_cpu_us=" << total.mask_cpu_us
+          << ", visited_task_mask_cpu_us=" << visited.mask_cpu_us
+          << ", task_possible_tokens=" << total.possible_tokens
+          << ", visited_task_possible_tokens=" << visited.possible_tokens
+          << ", task_first_byte_cache_reused_tokens=" << total.first_byte_cache_reused_tokens
+          << ", visited_task_first_byte_cache_reused_tokens="
+          << visited.first_byte_cache_reused_tokens
+          << ", task_saturated_cache_reused_tokens=" << total.saturated_cache_reused_tokens
+          << ", visited_task_saturated_cache_reused_tokens="
+          << visited.saturated_cache_reused_tokens
+          << ", task_token_edge_skipped_tokens=" << total.token_edge_skipped_tokens
+          << ", visited_task_token_edge_skipped_tokens=" << visited.token_edge_skipped_tokens
+          << ", task_speculative_accepted_tokens=" << total.speculative_accepted_tokens
+          << ", visited_task_speculative_accepted_tokens=" << visited.speculative_accepted_tokens
+          << ", task_subtree_pruned_tokens=" << total.subtree_pruned_tokens
+          << ", visited_task_subtree_pruned_tokens=" << visited.subtree_pruned_tokens
+          << ", task_parser_simulated_tokens=" << total.parser_simulated_tokens
+          << ", visited_task_parser_simulated_tokens=" << visited.parser_simulated_tokens
+          << ", task_parser_naive_token_bytes=" << total.parser_naive_token_bytes
+          << ", visited_task_parser_naive_token_bytes=" << visited.parser_naive_token_bytes
+          << ", task_parser_advance_calls=" << total.parser_advance_calls
+          << ", visited_task_parser_advance_calls=" << visited.parser_advance_calls
+          << ", task_parser_failed_advance_calls=" << total.parser_failed_advance_calls
+          << ", visited_task_parser_failed_advance_calls=" << visited.parser_failed_advance_calls
+          << ", task_mask_bytes=" << total.task_mask_bytes
+          << ", visited_task_mask_bytes=" << visited.task_mask_bytes
+          << ", state_mask_bytes=" << total_state_mask_bytes
+          << ", visited_state_mask_bytes=" << visited_state_mask_bytes << ")";
+
+        constexpr std::array<uint64_t, 8> kCompileCostBinUpperBoundsUs{
+            10, 25, 50, 100, 250, 500, 1000, std::numeric_limits<uint64_t>::max()
+        };
+        std::array<uint64_t, kCompileCostBinUpperBoundsUs.size()> total_tasks_by_cost{};
+        std::array<uint64_t, kCompileCostBinUpperBoundsUs.size()> visited_tasks_by_cost{};
+        std::array<uint64_t, kCompileCostBinUpperBoundsUs.size()> total_cpu_us_by_cost{};
+        std::array<uint64_t, kCompileCostBinUpperBoundsUs.size()> visited_cpu_us_by_cost{};
+        for (size_t task_group_id = 0; task_group_id < compile_profiles.size(); ++task_group_id) {
+          const auto& profile = compile_profiles[task_group_id];
+          const size_t bin = std::lower_bound(
+                                 kCompileCostBinUpperBoundsUs.begin(),
+                                 kCompileCostBinUpperBoundsUs.end(),
+                                 profile.mask_cpu_us
+                             ) -
+                             kCompileCostBinUpperBoundsUs.begin();
+          ++total_tasks_by_cost[bin];
+          total_cpu_us_by_cost[bin] += profile.mask_cpu_us;
+          if (visited_task_groups.count(task_group_id)) {
+            ++visited_tasks_by_cost[bin];
+            visited_cpu_us_by_cost[bin] += profile.mask_cpu_us;
+          }
+        }
+        for (size_t bin = 0; bin < kCompileCostBinUpperBoundsUs.size(); ++bin) {
+          XGRAMMAR_LOG(INFO) << "AdaptiveMaskCostBinProfile(upper_us="
+                             << kCompileCostBinUpperBoundsUs[bin]
+                             << ", total_tasks=" << total_tasks_by_cost[bin]
+                             << ", visited_tasks=" << visited_tasks_by_cost[bin]
+                             << ", total_cpu_us=" << total_cpu_us_by_cost[bin]
+                             << ", visited_cpu_us=" << visited_cpu_us_by_cost[bin] << ")";
+        }
+        for (size_t task_group_id : visited_task_groups) {
+          const auto& profile = compile_profiles[task_group_id];
+          if (profile.mask_cpu_us < 1000) {
+            continue;
+          }
+          const auto& representative = profile.representative_state;
+          XGRAMMAR_LOG(INFO) << "VisitedExpensiveAdaptiveMaskProfile(rule_id="
+                             << representative.rule_id
+                             << ", rule_name=" << grammar_->GetRule(representative.rule_id).name
+                             << ", state_id=" << representative.element_id
+                             << ", mask_cpu_us=" << profile.mask_cpu_us
+                             << ", possible_tokens=" << profile.possible_tokens
+                             << ", parser_advance_calls=" << profile.parser_advance_calls
+                             << ", state_count=" << profile.state_count << ")";
+        }
+      }
+      XGRAMMAR_LOG(INFO
+      ) << "RuntimeMaskComputeProfile(fill_calls="
+        << profile_fill_calls_ << ", leaf_masks=" << profile_leaf_masks_
+        << ", full_mask_cache_hits=" << profile_full_mask_cache_hits_
+        << ", uncertain_tokens_seen=" << profile_uncertain_tokens_seen_
+        << ", union_uncertain_tokens=" << profile_union_uncertain_tokens_
+        << ", unresolved_union_uncertain_tokens=" << profile_unresolved_union_uncertain_tokens_
+        << ", uncertain_loop_tokens=" << profile_uncertain_loop_tokens_
+        << ", uncertain_parser_tokens=" << profile_uncertain_parser_tokens_
+        << ", uncertain_advance_calls=" << profile_uncertain_advance_calls_
+        << ", transition_cache_queries=" << profile_transition_cache_queries_
+        << ", transition_cache_hits=" << profile_transition_cache_hits_
+        << ", full_configuration_calls=" << profile_full_configuration_calls_
+        << ", full_configuration_candidate_tokens=" << profile_full_configuration_candidate_tokens_
+        << ", full_configuration_loop_tokens=" << profile_full_configuration_loop_tokens_
+        << ", full_configuration_subtree_pruned_tokens="
+        << profile_full_configuration_subtree_pruned_tokens_
+        << ", full_configuration_parser_tokens=" << profile_full_configuration_parser_tokens_
+        << ", full_configuration_advance_calls=" << profile_full_configuration_advance_calls_
+        << ", full_configuration_transition_cache_queries="
+        << profile_full_configuration_transition_cache_queries_
+        << ", full_configuration_transition_cache_hits="
+        << profile_full_configuration_transition_cache_hits_
+        << ", full_configuration_expected_accepted_tokens="
+        << profile_full_configuration_expected_accepted_tokens_
+        << ", full_configuration_mismatches=" << profile_full_configuration_mismatches_
+        << ", full_configuration_traversal_ns=" << profile_full_configuration_traversal_ns_
+        << ", slice_whitespace_candidates=" << profile_slice_candidate_tokens_[0]
+        << ", slice_whitespace_subsumed_calls=" << profile_slice_subsumed_calls_[0]
+        << ", slice_whitespace_covered_candidates=" << profile_slice_covered_candidate_tokens_[0]
+        << ", slice_string_safe_10_candidates=" << profile_slice_candidate_tokens_[1]
+        << ", slice_string_safe_10_subsumed_calls=" << profile_slice_subsumed_calls_[1]
+        << ", slice_string_safe_10_covered_candidates="
+        << profile_slice_covered_candidate_tokens_[1]
+        << ", slice_string_safe_30_candidates=" << profile_slice_candidate_tokens_[2]
+        << ", slice_string_safe_30_subsumed_calls=" << profile_slice_subsumed_calls_[2]
+        << ", slice_string_safe_30_covered_candidates="
+        << profile_slice_covered_candidate_tokens_[2]
+        << ", slice_string_safe_candidates=" << profile_slice_candidate_tokens_[3]
+        << ", slice_string_safe_subsumed_calls=" << profile_slice_subsumed_calls_[3]
+        << ", slice_string_safe_covered_candidates=" << profile_slice_covered_candidate_tokens_[3]
+        << ", slice_any_covered_candidates=" << profile_slice_any_covered_candidate_tokens_
+        << ", candidate_slice_whitespace_subsumed_calls="
+        << profile_candidate_slice_subsumed_calls_[0]
+        << ", candidate_slice_whitespace_covered_candidates="
+        << profile_candidate_slice_covered_tokens_[0]
+        << ", candidate_slice_string_safe_10_subsumed_calls="
+        << profile_candidate_slice_subsumed_calls_[1]
+        << ", candidate_slice_string_safe_10_covered_candidates="
+        << profile_candidate_slice_covered_tokens_[1]
+        << ", candidate_slice_string_safe_30_subsumed_calls="
+        << profile_candidate_slice_subsumed_calls_[2]
+        << ", candidate_slice_string_safe_30_covered_candidates="
+        << profile_candidate_slice_covered_tokens_[2]
+        << ", candidate_slice_string_safe_subsumed_calls="
+        << profile_candidate_slice_subsumed_calls_[3]
+        << ", candidate_slice_string_safe_covered_candidates="
+        << profile_candidate_slice_covered_tokens_[3] << ", candidate_slice_any_covered_candidates="
+        << profile_candidate_slice_any_covered_tokens_
+        << ", candidate_ascii_safe_candidates=" << profile_candidate_ascii_safe_tokens_
+        << ", candidate_ascii_safe_subsumed_calls=" << profile_candidate_ascii_safe_subsumed_calls_
+        << ", candidate_ascii_safe_covered_candidates="
+        << profile_candidate_ascii_safe_covered_tokens_
+        << ", fsm_ascii_safe_subsumed_calls=" << profile_fsm_ascii_safe_subsumed_calls_
+        << ", fsm_ascii_safe_candidate_tokens=" << profile_fsm_ascii_safe_candidate_tokens_
+        << ", fsm_ascii_safe_rejected_candidates="
+        << profile_fsm_ascii_safe_rejected_candidate_tokens_
+        << ", fsm_ascii_safe_covered_candidates="
+        << profile_fsm_ascii_safe_covered_candidate_tokens_
+        << ", fsm_ascii_safe_10_subsumed_calls=" << profile_fsm_ascii_safe_10_subsumed_calls_
+        << ", fsm_ascii_safe_30_subsumed_calls=" << profile_fsm_ascii_safe_30_subsumed_calls_
+        << ", fsm_ascii_safe_bounded_candidate_tokens="
+        << profile_fsm_ascii_safe_bounded_candidate_tokens_
+        << ", fsm_ascii_safe_bounded_rejected_candidates="
+        << profile_fsm_ascii_safe_bounded_rejected_candidate_tokens_
+        << ", fsm_ascii_safe_bounded_covered_candidates="
+        << profile_fsm_ascii_safe_bounded_covered_candidate_tokens_
+        << ", runtime_ascii_closure_queries=" << profile_runtime_ascii_closure_queries_
+        << ", runtime_ascii_closure_hits=" << profile_runtime_ascii_closure_hits_
+        << ", runtime_ascii_closure_configurations="
+        << profile_runtime_ascii_closure_configurations_
+        << ", runtime_ascii_closure_transitions=" << profile_runtime_ascii_closure_transitions_
+        << ", runtime_ascii_closure_covered_candidates="
+        << profile_runtime_ascii_closure_covered_candidates_
+        << ", runtime_ascii_closure_mismatches=" << profile_runtime_ascii_closure_mismatches_
+        << ", runtime_ascii_closure_ns=" << profile_runtime_ascii_closure_ns_
+        << ", local_continuation_structure_queries="
+        << profile_local_continuation_structure_queries_
+        << ", local_continuation_structure_hits=" << profile_local_continuation_structure_hits_
+        << ", local_continuation_structures=" << profile_local_continuation_structures_.size()
+        << ", whitespace_continuation_batch_queries="
+        << profile_whitespace_continuation_batch_queries_
+        << ", whitespace_continuation_batch_hits=" << profile_whitespace_continuation_batch_hits_
+        << ", whitespace_continuation_batch_builds="
+        << profile_whitespace_continuation_batch_builds_
+        << ", whitespace_continuation_batch_tokens="
+        << profile_whitespace_continuation_batch_tokens_
+        << ", candidate_slice_filtered_candidate_tokens="
+        << profile_candidate_slice_filtered_candidate_tokens_
+        << ", candidate_slice_filtered_loop_tokens="
+        << profile_candidate_slice_filtered_loop_tokens_
+        << ", candidate_slice_filtered_subtree_pruned_tokens="
+        << profile_candidate_slice_filtered_subtree_pruned_tokens_
+        << ", candidate_slice_filtered_parser_tokens="
+        << profile_candidate_slice_filtered_parser_tokens_
+        << ", candidate_slice_filtered_advance_calls="
+        << profile_candidate_slice_filtered_advance_calls_
+        << ", candidate_slice_filtered_transition_cache_queries="
+        << profile_candidate_slice_filtered_transition_cache_queries_
+        << ", candidate_slice_filtered_transition_cache_hits="
+        << profile_candidate_slice_filtered_transition_cache_hits_
+        << ", candidate_slice_filtered_mismatches=" << profile_candidate_slice_filtered_mismatches_
+        << ", candidate_slice_filtered_traversal_ns="
+        << profile_candidate_slice_filtered_traversal_ns_
+        << ", suffix_certificate_queries=" << profile_suffix_certificate_queries_
+        << ", suffix_certificate_hits=" << profile_suffix_certificate_hits_
+        << ", suffix_certificate_union_builds=" << profile_suffix_certificate_union_builds_
+        << ", suffix_certificate_mask_queries=" << profile_suffix_certificate_mask_queries_
+        << ", suffix_certificate_canonical_union_builds="
+        << profile_suffix_certificate_canonical_union_builds_
+        << ", suffix_certificate_run_checks=" << profile_suffix_certificate_run_checks_
+        << ", suffix_certificate_run_skipped_tokens="
+        << profile_suffix_certificate_run_skipped_tokens_
+        << ", suffix_certificate_skipped_bytes=" << profile_suffix_certificate_skipped_bytes_
+        << ", suffix_certificate_loop_tokens=" << profile_suffix_certificate_loop_tokens_
+        << ", suffix_certificate_subtree_pruned_tokens="
+        << profile_suffix_certificate_subtree_pruned_tokens_
+        << ", suffix_certificate_parser_tokens=" << profile_suffix_certificate_parser_tokens_
+        << ", suffix_certificate_advance_calls=" << profile_suffix_certificate_advance_calls_
+        << ", suffix_certificate_transition_cache_queries="
+        << profile_suffix_certificate_transition_cache_queries_
+        << ", suffix_certificate_transition_cache_hits="
+        << profile_suffix_certificate_transition_cache_hits_
+        << ", suffix_certificate_mismatches=" << profile_suffix_certificate_mismatches_
+        << ", suffix_certificate_traversal_ns=" << profile_suffix_certificate_traversal_ns_
+        << ", resolved_cache_queries=" << resolved_uncertain_mask_cache_.Queries()
+        << ", resolved_cache_hits=" << resolved_uncertain_mask_cache_.Hits()
+        << ", full_mask_cache_queries=" << resolved_uncertain_mask_cache_.FullMaskQueries()
+        << ", full_mask_cache_result_hits=" << resolved_uncertain_mask_cache_.FullMaskHits() << ")";
+    }
+  }
+#endif
 
   bool AcceptToken(int32_t token_id, bool debug_print = false);
 
@@ -481,10 +969,2597 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   const std::vector<int>& GetStopTokenIds() const { return stop_token_ids_; }
 
+  void RebindAfterFork() { resolved_uncertain_mask_cache_.RebindMatcher(this); }
+
   std::string _DebugPrintInternalState() const { return PrintStates(); }
 
  private:
   using StoreType = AdaptiveTokenMask::StoreType;
+
+  struct WhitespaceContinuationBatchCacheEntry {
+    ParserState source_state;
+    std::vector<ParserState> continuation_states;
+    std::shared_ptr<DynamicBitset> batched_tokens;
+  };
+
+  static bool ParserStateLessIgnoringPosition(const ParserState& lhs, const ParserState& rhs) {
+    if (lhs.rule_id != rhs.rule_id) return lhs.rule_id < rhs.rule_id;
+    if (lhs.sequence_id != rhs.sequence_id) return lhs.sequence_id < rhs.sequence_id;
+    if (lhs.element_id != rhs.element_id) return lhs.element_id < rhs.element_id;
+    if (lhs.sub_element_id != rhs.sub_element_id) {
+      return lhs.sub_element_id < rhs.sub_element_id;
+    }
+    if (lhs.repeat_count != rhs.repeat_count) return lhs.repeat_count < rhs.repeat_count;
+    return lhs.partial_codepoint < rhs.partial_codepoint;
+  }
+
+  static bool ParserStateEqualIgnoringPosition(const ParserState& lhs, const ParserState& rhs) {
+    return lhs.rule_id == rhs.rule_id && lhs.sequence_id == rhs.sequence_id &&
+           lhs.element_id == rhs.element_id && lhs.sub_element_id == rhs.sub_element_id &&
+           lhs.repeat_count == rhs.repeat_count && lhs.partial_codepoint == rhs.partial_codepoint;
+  }
+
+  std::unique_ptr<DynamicBitset> BuildWhitespaceContinuationBatch(
+      const ParserState& source_state,
+      const std::vector<ParserState>& continuation_states,
+      const AdaptiveTokenMask& source_mask
+  ) {
+    const auto& sorted_vocab = tokenizer_info_.GetSortedDecodedVocab();
+    const auto& suffix_sorted_indices = tokenizer_info_->GetMixedWhitespaceSuffixSortedIndices();
+    const auto& suffix_offsets = tokenizer_info_->GetMixedWhitespaceSuffixOffsets();
+    const auto& suffix_lcps = tokenizer_info_->GetMixedWhitespaceSuffixLcpWithPrevious();
+    const int32_t suffix_count = static_cast<int32_t>(suffix_sorted_indices.size());
+    if (continuation_states.empty() || suffix_count == 0) {
+      return nullptr;
+    }
+    XGRAMMAR_DCHECK(
+        suffix_offsets.size() == suffix_sorted_indices.size() &&
+        suffix_lcps.size() == suffix_sorted_indices.size()
+    );
+
+    std::vector<uint8_t> source_candidates(suffix_count, 0);
+    std::vector<uint8_t> locally_accepted(suffix_count, 0);
+    std::unordered_map<std::string, bool> prefix_proofs;
+    prefix_proofs.reserve(32);
+    uint64_t source_candidate_count = 0;
+
+    const bool has_uncertain_bitset = source_mask.uncertain_bitset.Size() != 0;
+    for (int32_t suffix_index = 0; suffix_index < suffix_count; ++suffix_index) {
+      const int32_t sorted_vocab_index = suffix_sorted_indices[suffix_index];
+      const auto& [token_id, token] = sorted_vocab[sorted_vocab_index];
+      const bool is_uncertain = has_uncertain_bitset ? source_mask.uncertain_bitset[token_id]
+                                                     : std::binary_search(
+                                                           source_mask.uncertain_indices.begin(),
+                                                           source_mask.uncertain_indices.end(),
+                                                           sorted_vocab_index
+                                                       );
+      if (!is_uncertain) {
+        continue;
+      }
+
+      const int32_t suffix_offset = suffix_offsets[suffix_index];
+      const std::string prefix = token.substr(0, suffix_offset);
+      auto proof_it = prefix_proofs.find(prefix);
+      if (proof_it == prefix_proofs.end()) {
+        EarleyParser source_parser(
+            grammar_, compiled_grammar_->earley_parser_metadata, source_state, false
+        );
+        bool prefix_accepted = true;
+        for (uint8_t byte : prefix) {
+          if (!source_parser.Advance(byte)) {
+            prefix_accepted = false;
+            break;
+          }
+        }
+        bool returned_to_source_state = false;
+        if (prefix_accepted) {
+          for (const auto& reached_state : source_parser.GetLatestScanableStates()) {
+            if (ParserStateEqualIgnoringPosition(reached_state, source_state)) {
+              returned_to_source_state = true;
+              break;
+            }
+          }
+        }
+        proof_it = prefix_proofs.emplace(prefix, returned_to_source_state).first;
+      }
+      if (proof_it->second) {
+        source_candidates[suffix_index] = 1;
+        ++source_candidate_count;
+      }
+    }
+    constexpr uint64_t kMinSourceCandidates = 1024;
+    if (source_candidate_count < kMinSourceCandidates) {
+      return nullptr;
+    }
+
+    EarleyParser continuation_parser(
+        grammar_, compiled_grammar_->earley_parser_metadata, continuation_states.front(), false
+    );
+    continuation_parser.PushStatesToCheck(continuation_states);
+    int32_t previous_matched_size = 0;
+    for (int32_t suffix_index = 0; suffix_index < suffix_count; ++suffix_index) {
+      const int32_t sorted_vocab_index = suffix_sorted_indices[suffix_index];
+      const auto& token = sorted_vocab[sorted_vocab_index].second;
+      const int32_t suffix_offset = suffix_offsets[suffix_index];
+      const std::string_view suffix(token.data() + suffix_offset, token.size() - suffix_offset);
+      const int32_t lcp_length = suffix_lcps[suffix_index];
+      bool byte_path_accepted = true;
+      if (suffix_index != 0 && lcp_length > previous_matched_size) {
+        byte_path_accepted = false;
+      } else if (lcp_length < previous_matched_size) {
+        continuation_parser.PopLastStates(previous_matched_size - lcp_length);
+        previous_matched_size = lcp_length;
+      }
+      if (byte_path_accepted) {
+        for (int32_t byte_index = previous_matched_size;
+             byte_index < static_cast<int32_t>(suffix.size());
+             ++byte_index) {
+          if (!continuation_parser.Advance(static_cast<uint8_t>(suffix[byte_index]))) {
+            byte_path_accepted = false;
+            break;
+          }
+          previous_matched_size = byte_index + 1;
+        }
+      }
+      // A surviving scanable state proves that the suffix has not depended on returning through
+      // the discarded absolute parent rows. Root completion alone is intentionally excluded.
+      locally_accepted[suffix_index] = source_candidates[suffix_index] && byte_path_accepted &&
+                                       continuation_parser.HasLatestScanableStates();
+    }
+    if (previous_matched_size != 0) {
+      continuation_parser.PopLastStates(previous_matched_size);
+    }
+
+    std::vector<int32_t> source_prefix_counts(suffix_count + 1, 0);
+    std::vector<int32_t> accepted_prefix_counts(suffix_count + 1, 0);
+    for (int32_t suffix_index = 0; suffix_index < suffix_count; ++suffix_index) {
+      source_prefix_counts[suffix_index + 1] =
+          source_prefix_counts[suffix_index] + source_candidates[suffix_index];
+      accepted_prefix_counts[suffix_index + 1] =
+          accepted_prefix_counts[suffix_index] + locally_accepted[suffix_index];
+    }
+
+    auto batched_tokens = std::make_unique<DynamicBitset>(tokenizer_info_.GetVocabSize());
+    int32_t covered_until = -1;
+    for (int32_t suffix_index = 0; suffix_index < suffix_count; ++suffix_index) {
+      if (suffix_index < covered_until || !locally_accepted[suffix_index]) {
+        continue;
+      }
+      const int32_t sorted_vocab_index = suffix_sorted_indices[suffix_index];
+      const auto& token = sorted_vocab[sorted_vocab_index].second;
+      const int32_t suffix_offset = suffix_offsets[suffix_index];
+      const std::string_view suffix(token.data() + suffix_offset, token.size() - suffix_offset);
+      int32_t complete_subtree_end = -1;
+      for (int32_t prefix_length = 1; prefix_length <= static_cast<int32_t>(suffix.size());
+           ++prefix_length) {
+        if (suffix_index != 0 && suffix_lcps[suffix_index] >= prefix_length) {
+          continue;
+        }
+        int32_t low = suffix_index + 1;
+        int32_t high = suffix_count;
+        while (low < high) {
+          const int32_t mid = low + (high - low) / 2;
+          const int32_t mid_sorted_vocab_index = suffix_sorted_indices[mid];
+          const auto& mid_token = sorted_vocab[mid_sorted_vocab_index].second;
+          const int32_t mid_suffix_offset = suffix_offsets[mid];
+          const std::string_view mid_suffix(
+              mid_token.data() + mid_suffix_offset, mid_token.size() - mid_suffix_offset
+          );
+          const bool shares_prefix =
+              mid_suffix.size() >= static_cast<size_t>(prefix_length) &&
+              mid_suffix.substr(0, prefix_length) == suffix.substr(0, prefix_length);
+          if (shares_prefix) {
+            low = mid + 1;
+          } else {
+            high = mid;
+          }
+        }
+        const int32_t source_count = source_prefix_counts[low] - source_prefix_counts[suffix_index];
+        const int32_t accepted_count =
+            accepted_prefix_counts[low] - accepted_prefix_counts[suffix_index];
+        if (source_count >= 2 && source_count == accepted_count) {
+          complete_subtree_end = low;
+          break;
+        }
+      }
+      if (complete_subtree_end == -1) {
+        continue;
+      }
+      for (int32_t covered_index = suffix_index; covered_index < complete_subtree_end;
+           ++covered_index) {
+        if (source_candidates[covered_index]) {
+          const int32_t covered_sorted_vocab_index = suffix_sorted_indices[covered_index];
+          batched_tokens->Set(sorted_vocab[covered_sorted_vocab_index].first);
+        }
+      }
+      covered_until = complete_subtree_end;
+    }
+    if (static_cast<uint64_t>(batched_tokens->Count()) < kMinSourceCandidates) {
+      return nullptr;
+    }
+    return batched_tokens;
+  }
+
+  const DynamicBitset* FindOrBuildWhitespaceContinuationBatch(
+      const ParserState& state, const AdaptiveTokenMask& source_mask
+  ) {
+    constexpr size_t kMinUncertainTokens = 8192;
+    constexpr size_t kMaxCacheEntries = 32;
+    if (state.rule_id < 0 || source_mask.uncertain_indices.size() < kMinUncertainTokens) {
+      return nullptr;
+    }
+    const uint8_t state_flags = GetFsmStateFlags(state.rule_id, state.element_id);
+    if (!(state_flags & EarleyParserGrammarMetadata::kFsmStateScanable)) {
+      return nullptr;
+    }
+
+    XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
+    const bool saved_accept_stop_token = tmp_accept_stop_token_;
+    const auto saved_states_to_be_added = tmp_states_to_be_added_;
+    tmp_states_visited_in_queue_.Clear();
+    tmp_states_to_be_added_.clear();
+    tmp_accept_stop_token_ = false;
+    rule_id_to_completable_states_.PushBackEmpty();
+    Complete(state);
+    while (!tmp_process_state_queue_.empty()) {
+      const ParserState& continuation_state = *tmp_process_state_queue_.front();
+      tmp_process_state_queue_.pop();
+      auto [scanable, completable] = Predict(continuation_state);
+      if (completable) {
+        Complete(continuation_state);
+      }
+      if (scanable) {
+        tmp_states_to_be_added_.push_back(&continuation_state);
+      }
+    }
+    std::vector<ParserState> continuation_states;
+    continuation_states.reserve(tmp_states_to_be_added_.size());
+    for (const ParserState* continuation_state : tmp_states_to_be_added_) {
+      ParserState normalized = *continuation_state;
+      normalized.rule_start_pos = ParserState::kNoPrevInputPos;
+      continuation_states.push_back(normalized);
+    }
+    std::sort(
+        continuation_states.begin(), continuation_states.end(), ParserStateLessIgnoringPosition
+    );
+    continuation_states.erase(
+        std::unique(
+            continuation_states.begin(), continuation_states.end(), ParserStateEqualIgnoringPosition
+        ),
+        continuation_states.end()
+    );
+    rule_id_to_completable_states_.PopBack(1);
+    tmp_states_visited_in_queue_.Clear();
+    tmp_states_to_be_added_ = saved_states_to_be_added;
+    tmp_accept_stop_token_ = saved_accept_stop_token;
+    if (continuation_states.empty()) {
+      return nullptr;
+    }
+
+    ParserState normalized_source = state;
+    normalized_source.rule_start_pos = ParserState::kNoPrevInputPos;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    ++profile_whitespace_continuation_batch_queries_;
+#endif
+    for (const auto& entry : whitespace_continuation_batch_cache_) {
+      if (!ParserStateEqualIgnoringPosition(entry.source_state, normalized_source) ||
+          entry.continuation_states.size() != continuation_states.size() ||
+          !std::equal(
+              entry.continuation_states.begin(),
+              entry.continuation_states.end(),
+              continuation_states.begin(),
+              ParserStateEqualIgnoringPosition
+          )) {
+        continue;
+      }
+#ifdef XGRAMMAR_PROFILE_COMPILE
+      ++profile_whitespace_continuation_batch_hits_;
+#endif
+      return entry.batched_tokens.get();
+    }
+    if (whitespace_continuation_batch_cache_.size() >= kMaxCacheEntries) {
+      return nullptr;
+    }
+    std::shared_ptr<DynamicBitset> batched_tokens =
+        BuildWhitespaceContinuationBatch(normalized_source, continuation_states, source_mask);
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    ++profile_whitespace_continuation_batch_builds_;
+    if (batched_tokens) {
+      profile_whitespace_continuation_batch_tokens_ += batched_tokens->Count();
+    }
+#endif
+    whitespace_continuation_batch_cache_.push_back(WhitespaceContinuationBatchCacheEntry{
+        normalized_source, std::move(continuation_states), std::move(batched_tokens)
+    });
+    return whitespace_continuation_batch_cache_.back().batched_tokens.get();
+  }
+
+  enum class CachedRowRefKind : uint8_t { kNone, kExternal, kCanonical, kCurrent };
+
+  struct CachedParserState {
+    int32_t rule_id;
+    int32_t sequence_id;
+    int32_t element_id;
+    CachedRowRefKind row_ref_kind;
+    int32_t row_ref_id;
+    int32_t sub_element_id;
+    int32_t repeat_count;
+    int32_t partial_codepoint;
+
+    bool operator==(const CachedParserState& other) const {
+      return rule_id == other.rule_id && sequence_id == other.sequence_id &&
+             element_id == other.element_id && row_ref_kind == other.row_ref_kind &&
+             row_ref_id == other.row_ref_id && sub_element_id == other.sub_element_id &&
+             repeat_count == other.repeat_count && partial_codepoint == other.partial_codepoint;
+    }
+  };
+
+  struct CanonicalCompletableRow {
+    std::vector<std::pair<int32_t, CachedParserState>> entries;
+
+    bool operator==(const CanonicalCompletableRow& other) const { return entries == other.entries; }
+  };
+
+  struct CanonicalConfiguration {
+    int32_t current_row_id;
+    bool is_completed;
+    std::vector<CachedParserState> scanable_states;
+
+    bool operator==(const CanonicalConfiguration& other) const {
+      return current_row_id == other.current_row_id && is_completed == other.is_completed &&
+             scanable_states == other.scanable_states;
+    }
+  };
+
+  // Cache the exact "all uncertain tokens accepted" result across mask calls. Earley row numbers
+  // are input positions, so equivalent recursive continuations at different positions would not
+  // compare equal directly. This interner recursively replaces every previous-row reference with
+  // an exact canonical row ID while preserving self references and every ParserState field.
+  class ResolvedUncertainMaskCache {
+   public:
+    explicit ResolvedUncertainMaskCache(Impl* matcher) : matcher_(matcher) {}
+
+    void RebindMatcher(Impl* matcher) { matcher_ = matcher; }
+
+    void BeginFill() {
+      const size_t row_count = matcher_->rule_id_to_completable_states_.size();
+      if (row_count > kMaxAbsoluteRowsPerFill ||
+          (row_count + 1) * sizeof(int32_t) > kMaxBytes - memory_bytes_) {
+        std::vector<int32_t>().swap(absolute_row_ids_);
+        usable_this_fill_ = false;
+        return;
+      }
+      absolute_row_ids_.assign(row_count + 1, -1);
+      if (TotalAccountedBytes() > kMaxBytes) {
+        std::vector<int32_t>().swap(absolute_row_ids_);
+        usable_this_fill_ = false;
+        return;
+      }
+      usable_this_fill_ = true;
+    }
+
+    std::optional<int32_t> InternCurrentConfiguration() {
+      if (!usable_this_fill_) {
+        return std::nullopt;
+      }
+      const int32_t current_row = matcher_->rule_id_to_completable_states_.size() - 1;
+      if (current_row < 0) {
+        return std::nullopt;
+      }
+      if (absolute_row_ids_.size() <= static_cast<size_t>(current_row)) {
+        absolute_row_ids_.resize(current_row + 1, -1);
+      }
+      absolute_row_ids_[current_row] = -1;
+      const auto current_row_id = InternAbsoluteRow(current_row);
+      if (!current_row_id.has_value()) {
+        return std::nullopt;
+      }
+
+      const auto scanable_states = matcher_->scanable_state_history_[current_row];
+      const auto additional_bytes = AccountedElementBytes(
+          sizeof(CanonicalConfiguration), scanable_states.size(), sizeof(CachedParserState)
+      );
+      if (!additional_bytes.has_value()) {
+        return std::nullopt;
+      }
+      CanonicalConfiguration normalized{*current_row_id, matcher_->is_completed_.back() != 0, {}};
+      normalized.scanable_states.reserve(scanable_states.size());
+      for (const auto& state : scanable_states) {
+        const auto normalized_state = NormalizeState(state, current_row);
+        if (!normalized_state.has_value()) {
+          return std::nullopt;
+        }
+        normalized.scanable_states.push_back(*normalized_state);
+      }
+      for (int32_t i = 0; i < static_cast<int32_t>(configurations_.size()); ++i) {
+        if (configurations_[i] == normalized) {
+          return i;
+        }
+      }
+      if (configurations_.size() >= kMaxConfigurations || !TryAccountBytes(*additional_bytes)) {
+        return std::nullopt;
+      }
+      configurations_.push_back(std::move(normalized));
+      return configurations_.size() - 1;
+    }
+
+    bool IsAllAccepted(const AdaptiveTokenMask* mask, int32_t configuration_id) {
+      ++queries_;
+      for (const auto& result : all_accepted_results_) {
+        if (result.mask == mask && result.configuration_id == configuration_id) {
+          ++hits_;
+          return true;
+        }
+      }
+      return false;
+    }
+
+    void InsertAllAccepted(const AdaptiveTokenMask* mask, int32_t configuration_id) {
+      for (const auto& result : all_accepted_results_) {
+        if (result.mask == mask && result.configuration_id == configuration_id) {
+          return;
+        }
+      }
+      if (all_accepted_results_.size() >= kMaxResults ||
+          !TryAccountBytes(sizeof(AllAcceptedResult))) {
+        return;
+      }
+      all_accepted_results_.push_back(AllAcceptedResult{mask, configuration_id});
+    }
+
+    bool MayHaveFullMask(uint64_t raw_state_hash) const {
+      for (const auto& result : full_mask_results_) {
+        if (result.raw_state_hash == raw_state_hash) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    const DynamicBitset* FindFullMask(uint64_t raw_state_hash, int32_t configuration_id) {
+      ++full_mask_queries_;
+      for (const auto& result : full_mask_results_) {
+        if (result.raw_state_hash == raw_state_hash &&
+            result.configuration_id == configuration_id) {
+          ++full_mask_hits_;
+          return &result.mask;
+        }
+      }
+      return nullptr;
+    }
+
+    void InsertFullMask(
+        uint64_t raw_state_hash, int32_t configuration_id, const DynamicBitset& mask
+    ) {
+      for (const auto& result : full_mask_results_) {
+        if (result.raw_state_hash == raw_state_hash &&
+            result.configuration_id == configuration_id) {
+          return;
+        }
+      }
+      const size_t additional_bytes = sizeof(FullMaskResult) + MemorySize(mask);
+      if (full_mask_results_.size() >= kMaxFullMaskResults || !TryAccountBytes(additional_bytes)) {
+        return;
+      }
+      DynamicBitset owned_mask(mask.Size());
+      owned_mask = mask;
+      full_mask_results_.push_back(
+          FullMaskResult{raw_state_hash, configuration_id, std::move(owned_mask)}
+      );
+    }
+
+    uint64_t Queries() const { return queries_; }
+    uint64_t Hits() const { return hits_; }
+    size_t NumRows() const { return rows_.size(); }
+    size_t NumConfigurations() const { return configurations_.size(); }
+    size_t NumResults() const { return all_accepted_results_.size(); }
+    size_t NumFullMaskResults() const { return full_mask_results_.size(); }
+    size_t Bytes() const { return TotalAccountedBytes(); }
+    uint64_t FullMaskQueries() const { return full_mask_queries_; }
+    uint64_t FullMaskHits() const { return full_mask_hits_; }
+
+   private:
+    static constexpr size_t kMaxBytes = 8 * 1024 * 1024;
+    static constexpr size_t kMaxAbsoluteRowsPerFill = 1 << 20;
+    static constexpr size_t kMaxRows = 4096;
+    static constexpr size_t kMaxConfigurations = 1024;
+    static constexpr size_t kMaxResults = 256;
+    static constexpr size_t kMaxFullMaskResults = 256;
+    struct AllAcceptedResult {
+      const AdaptiveTokenMask* mask;
+      int32_t configuration_id;
+    };
+
+    struct FullMaskResult {
+      uint64_t raw_state_hash;
+      int32_t configuration_id;
+      DynamicBitset mask;
+    };
+
+    std::optional<CachedParserState> NormalizeState(const ParserState& state, int32_t current_row) {
+      CachedRowRefKind row_ref_kind = CachedRowRefKind::kNone;
+      int32_t row_ref_id = -1;
+      if (state.rule_start_pos != ParserState::kNoPrevInputPos) {
+        if (state.rule_start_pos == current_row) {
+          row_ref_kind = CachedRowRefKind::kCurrent;
+        } else {
+          if (state.rule_start_pos < 0 || state.rule_start_pos >= current_row) {
+            return std::nullopt;
+          }
+          const auto canonical_row_id = InternAbsoluteRow(state.rule_start_pos);
+          if (!canonical_row_id.has_value()) {
+            return std::nullopt;
+          }
+          row_ref_kind = CachedRowRefKind::kCanonical;
+          row_ref_id = *canonical_row_id;
+        }
+      }
+      return CachedParserState{
+          state.rule_id,
+          state.sequence_id,
+          state.element_id,
+          row_ref_kind,
+          row_ref_id,
+          state.sub_element_id,
+          state.repeat_count,
+          state.partial_codepoint
+      };
+    }
+
+    std::optional<int32_t> InternAbsoluteRow(int32_t absolute_row) {
+      if (absolute_row < 0 || absolute_row >= static_cast<int32_t>(absolute_row_ids_.size())) {
+        return std::nullopt;
+      }
+      if (absolute_row_ids_[absolute_row] >= 0) {
+        return absolute_row_ids_[absolute_row];
+      }
+      const auto row = matcher_->rule_id_to_completable_states_[absolute_row];
+      const auto additional_bytes = AccountedElementBytes(
+          sizeof(CanonicalCompletableRow), row.size(), sizeof(std::pair<int32_t, CachedParserState>)
+      );
+      if (!additional_bytes.has_value()) {
+        return std::nullopt;
+      }
+      CanonicalCompletableRow normalized;
+      normalized.entries.reserve(row.size());
+      for (const auto& [ref_rule_id, parent_state] : row) {
+        const auto normalized_state = NormalizeState(parent_state, absolute_row);
+        if (!normalized_state.has_value()) {
+          return std::nullopt;
+        }
+        normalized.entries.emplace_back(ref_rule_id, *normalized_state);
+      }
+      for (int32_t i = 0; i < static_cast<int32_t>(rows_.size()); ++i) {
+        if (rows_[i] == normalized) {
+          absolute_row_ids_[absolute_row] = i;
+          return i;
+        }
+      }
+      if (rows_.size() >= kMaxRows || !TryAccountBytes(*additional_bytes)) {
+        return std::nullopt;
+      }
+      rows_.push_back(std::move(normalized));
+      const int32_t row_id = rows_.size() - 1;
+      absolute_row_ids_[absolute_row] = row_id;
+      return row_id;
+    }
+
+    std::optional<size_t> AccountedElementBytes(
+        size_t base_bytes, size_t element_count, size_t element_bytes
+    ) const {
+      const size_t total_bytes = TotalAccountedBytes();
+      if (base_bytes > kMaxBytes - total_bytes) {
+        return std::nullopt;
+      }
+      const size_t available_element_bytes = kMaxBytes - total_bytes - base_bytes;
+      if (element_count > available_element_bytes / element_bytes) {
+        return std::nullopt;
+      }
+      return base_bytes + element_count * element_bytes;
+    }
+
+    bool TryAccountBytes(size_t additional_bytes) {
+      if (additional_bytes > kMaxBytes - TotalAccountedBytes()) {
+        return false;
+      }
+      memory_bytes_ += additional_bytes;
+      return true;
+    }
+
+    size_t TotalAccountedBytes() const { return memory_bytes_ + MemorySize(absolute_row_ids_); }
+
+    Impl* matcher_;
+    bool usable_this_fill_ = true;
+    size_t memory_bytes_ = 0;
+    uint64_t queries_ = 0;
+    uint64_t hits_ = 0;
+    uint64_t full_mask_queries_ = 0;
+    uint64_t full_mask_hits_ = 0;
+    std::vector<int32_t> absolute_row_ids_;
+    std::vector<CanonicalCompletableRow> rows_;
+    std::vector<CanonicalConfiguration> configurations_;
+    std::vector<AllAcceptedResult> all_accepted_results_;
+    std::vector<FullMaskResult> full_mask_results_;
+  };
+
+  // During token-mask generation, trie traversal repeatedly reaches structurally identical Earley
+  // continuations at different temporary input positions. Rows retain absolute references to the
+  // matcher history, while temporary-row references are canonicalized by exact row contents and
+  // self references remain explicit. This makes (configuration, byte) an exact transition key.
+  // Cache hits stay virtual; an unseen transition or any resource limit first materializes the
+  // virtual prefix, then falls back to EarleyParser. The cache is destroyed after one ParserState.
+  class ContinuationTransitionCache {
+   public:
+    ContinuationTransitionCache(Impl* matcher, int32_t external_row_count)
+        : matcher_(matcher),
+          external_row_count_(external_row_count),
+          memory_bytes_(
+              kAdmissionQueries * sizeof(TransitionSlot) + kMaxVirtualDepth * sizeof(Transition)
+          ),
+          peak_bytes_(memory_bytes_) {
+      warmup_transitions_.reserve(kAdmissionQueries);
+      XGRAMMAR_DCHECK(matcher_->rule_id_to_completable_states_.size() == external_row_count_ + 1);
+      const auto initial_row_id = InternCurrentCompletableRow();
+      if (!initial_row_id.has_value()) {
+        Disable();
+        return;
+      }
+      const auto initial_configuration_id = InternCurrentConfiguration(*initial_row_id);
+      if (!initial_configuration_id.has_value()) {
+        Disable();
+        return;
+      }
+      PushVirtualRow(
+          Transition{TransitionStatus::kAccepted, *initial_row_id, *initial_configuration_id}
+      );
+      RecordMaterializedRow(*initial_row_id);
+      materialized_depth_ = 1;
+      if (!Admit()) {
+        Disable();
+        return;
+      }
+      fast_queries_remaining_ = kPostAdmissionReuseCheckQueries;
+    }
+
+    // The admitted-cache hit path runs once per vocabulary-trie byte and dominates the remaining
+    // mask tail. Keep it small enough to inline into FillNextTokenBitmask; admission checks,
+    // misses, and fallbacks stay out of line.
+#ifdef _MSC_VER
+    __forceinline bool Advance(uint8_t ch) {
+#else
+    __attribute__((always_inline)) inline bool Advance(uint8_t ch) {
+#endif
+      if (steady_fast_path_) {
+        const Transition cached = current_transition_row_[ch];
+        const TransitionStatus status = cached.Status();
+        if (status == TransitionStatus::kAccepted) {
+          PushVirtualRow(cached);
+          return true;
+        }
+        if (status == TransitionStatus::kRejected) {
+          return false;
+        }
+        return AdvanceSlow(ch);
+      }
+      if (enabled_ && admitted_ && fast_queries_remaining_ != 0) {
+        const Transition cached = current_transition_row_[ch];
+        const TransitionStatus status = cached.Status();
+        if (status == TransitionStatus::kAccepted) {
+          --fast_queries_remaining_;
+          PushVirtualRow(cached);
+          return true;
+        }
+        if (status == TransitionStatus::kRejected) {
+          --fast_queries_remaining_;
+          return false;
+        }
+      }
+      return AdvanceSlow(ch);
+    }
+
+    bool AdvanceSlow(uint8_t ch) {
+      if (!enabled_) {
+        return matcher_->EarleyParser::Advance(ch);
+      }
+      if (transition_depth_ >= kMaxVirtualDepth) {
+        DisableAndMaterialize();
+        return matcher_->EarleyParser::Advance(ch);
+      }
+      FlushFastQueries();
+      const uint64_t reuse_window_queries = queries_ - reuse_window_start_queries_;
+      const uint64_t reuse_window_misses = misses_ - reuse_window_start_misses_;
+      const uint64_t reuse_window_hits = reuse_window_queries - reuse_window_misses;
+      const uint64_t reuse_check_queries =
+          admitted_ ? kPostAdmissionReuseCheckQueries : kAdmissionQueries;
+      if (reuse_window_queries >= reuse_check_queries) {
+        const uint64_t min_reuse_hit_rate_denominator =
+            admitted_ ? kPostAdmissionMinReuseHitRateDenominator
+                      : kAdmissionMinReuseHitRateDenominator;
+        if (reuse_window_hits * min_reuse_hit_rate_denominator < reuse_window_queries) {
+          disabled_for_low_reuse_ = true;
+          DisableAndMaterialize();
+          return matcher_->EarleyParser::Advance(ch);
+        }
+        if (!admitted_ && !Admit()) {
+          DisableAndMaterialize();
+          return matcher_->EarleyParser::Advance(ch);
+        }
+        if (admitted_) {
+          steady_fast_path_ = true;
+        }
+        reuse_window_start_queries_ = queries_;
+        reuse_window_start_misses_ = misses_;
+        if (admitted_ && !steady_fast_path_) {
+          fast_queries_remaining_ = kPostAdmissionReuseCheckQueries;
+        }
+      }
+
+      const uint64_t transition_key =
+          (static_cast<uint64_t>(transition_history_[transition_depth_ - 1].OutputConfigurationId())
+           << 8) |
+          ch;
+      ++queries_;
+      if (const Transition* cached = FindTransition(transition_key)) {
+        if (cached->Status() == TransitionStatus::kRejected) {
+          return false;
+        }
+        PushVirtualRow(*cached);
+        return true;
+      }
+      ++misses_;
+
+      if (num_transitions_ >= kMaxEntries) {
+        DisableAndMaterialize();
+        return matcher_->EarleyParser::Advance(ch);
+      }
+
+      MaterializeVirtualPrefix();
+      const bool accepted = matcher_->EarleyParser::Advance(ch);
+      if (!accepted) {
+        InsertTransition(transition_key, Transition{TransitionStatus::kRejected, -1, -1});
+        return false;
+      }
+
+      const auto output_row_id = InternCurrentCompletableRow();
+      if (!output_row_id.has_value()) {
+        Disable();
+        return true;
+      }
+      const auto output_configuration_id = InternCurrentConfiguration(*output_row_id);
+      if (!output_configuration_id.has_value()) {
+        Disable();
+        return true;
+      }
+      const Transition output_transition{
+          TransitionStatus::kAccepted, *output_row_id, *output_configuration_id
+      };
+      InsertTransition(transition_key, output_transition);
+      PushVirtualRow(output_transition);
+      RecordMaterializedRow(*output_row_id);
+      ++materialized_depth_;
+      return true;
+    }
+
+    void PopLastStates(int32_t count) {
+      if (!enabled_) {
+        matcher_->EarleyParser::PopLastStates(count);
+        return;
+      }
+      XGRAMMAR_DCHECK(count >= 0 && count <= static_cast<int32_t>(transition_depth_));
+      const size_t target_depth = transition_depth_ - count;
+      if (materialized_depth_ > target_depth) {
+        matcher_->EarleyParser::PopLastStates(materialized_depth_ - target_depth);
+      }
+      while (materialized_depth_ > target_depth) {
+        const int32_t canonical_row_id = transition_history_[materialized_depth_ - 1].OutputRowId();
+        XGRAMMAR_DCHECK(!absolute_rows_by_canonical_id_[canonical_row_id].empty());
+        absolute_rows_by_canonical_id_[canonical_row_id].pop_back();
+        --materialized_depth_;
+      }
+      transition_depth_ = target_depth;
+      if (admitted_ && transition_depth_ != 0) {
+        current_configuration_id_ =
+            transition_history_[transition_depth_ - 1].OutputConfigurationId();
+        current_transition_row_ = transition_table_.data() + current_configuration_id_ * 256;
+      }
+    }
+
+    uint64_t Queries() const { return queries_ + PendingFastQueries(); }
+    uint64_t Hits() const { return Queries() - misses_; }
+    size_t NumTransitions() const { return num_transitions_; }
+    size_t PeakCanonicalRows() const { return peak_canonical_rows_; }
+    size_t PeakCanonicalConfigurations() const { return peak_canonical_configurations_; }
+    size_t PeakBytes() const { return peak_bytes_; }
+    bool IsEnabled() const { return enabled_; }
+    bool IsAdmitted() const { return admitted_; }
+    bool DisabledForLowReuse() const { return disabled_for_low_reuse_; }
+    static constexpr size_t MaxVirtualDepth() { return kMaxVirtualDepth; }
+
+    bool PrepareCurrentConfigurationSuffixCertificateMasks() {
+      if (!enabled_ || current_configuration_id_ < 0) {
+        return false;
+      }
+      XGRAMMAR_DCHECK(current_configuration_id_ < static_cast<int32_t>(configurations_.size()));
+      if (suffix_certificate_masks_ready_[current_configuration_id_]) {
+        return true;
+      }
+      auto& cached_masks = suffix_certificate_masks_[current_configuration_id_];
+      const auto& configuration = configurations_[current_configuration_id_];
+      cached_masks.reserve(configuration.scanable_states.size());
+      for (const auto& state : configuration.scanable_states) {
+        if (state.rule_id < 0 || matcher_->compiled_grammar_->earley_parser_metadata
+                                     .rule_has_atomic_token_edges[state.rule_id]) {
+          continue;
+        }
+        const ParserState lookup_state{
+            state.rule_id,
+            state.sequence_id,
+            state.element_id,
+            ParserState::kNoPrevInputPos,
+            state.sub_element_id,
+            state.repeat_count,
+            state.partial_codepoint
+        };
+        const AdaptiveTokenMask* mask =
+            matcher_->compiled_grammar_->FindAdaptiveTokenMask(lookup_state);
+        XGRAMMAR_DCHECK(mask != nullptr);
+        cached_masks.push_back(mask);
+      }
+      std::stable_sort(
+          cached_masks.begin(),
+          cached_masks.end(),
+          [](const AdaptiveTokenMask* lhs, const AdaptiveTokenMask* rhs) {
+            const auto rank = [](StoreType store_type) {
+              if (store_type == StoreType::kRejected) {
+                return 0;
+              }
+              if (store_type == StoreType::kAcceptedBitset) {
+                return 1;
+              }
+              return 2;
+            };
+            return rank(lhs->store_type) < rank(rhs->store_type);
+          }
+      );
+      cached_masks.erase(std::unique(cached_masks.begin(), cached_masks.end()), cached_masks.end());
+      suffix_certificate_masks_ready_[current_configuration_id_] = 1;
+      return true;
+    }
+
+    std::optional<bool> CurrentConfigurationDefinitelyAccepts(
+        int32_t sorted_vocab_index, int32_t token_id
+    ) {
+      if (!PrepareCurrentConfigurationSuffixCertificateMasks()) {
+        return std::nullopt;
+      }
+      auto& cached_masks = suffix_certificate_masks_[current_configuration_id_];
+      constexpr uint32_t kQueriesBeforeSuffixAcceptedUnion = 64;
+      auto& accepted_union = suffix_certificate_accepted_unions_[current_configuration_id_];
+      if (accepted_union != nullptr) {
+        return (*accepted_union)[token_id];
+      }
+      uint32_t& configuration_queries = suffix_certificate_queries_[current_configuration_id_];
+      ++configuration_queries;
+      if (configuration_queries == kQueriesBeforeSuffixAcceptedUnion && !cached_masks.empty()) {
+        auto new_union = std::make_unique<DynamicBitset>(matcher_->tokenizer_info_.GetVocabSize());
+        for (const AdaptiveTokenMask* mask : cached_masks) {
+          if (mask->store_type == StoreType::kAcceptedBitset) {
+            *new_union |= mask->accepted_bitset;
+          } else if (mask->store_type == StoreType::kAccepted) {
+            for (int32_t accepted_index : mask->accepted_indices) {
+              new_union->Set(matcher_->tokenizer_info_.GetSortedDecodedVocab()[accepted_index].first
+              );
+            }
+          } else {
+            matcher_->tmp_suffix_accepted_bitset_.Set();
+            for (int32_t rejected_index : mask->rejected_indices) {
+              matcher_->tmp_suffix_accepted_bitset_.Reset(
+                  matcher_->tokenizer_info_.GetSortedDecodedVocab()[rejected_index].first
+              );
+            }
+            for (int32_t uncertain_index : mask->uncertain_indices) {
+              matcher_->tmp_suffix_accepted_bitset_.Reset(
+                  matcher_->tokenizer_info_.GetSortedDecodedVocab()[uncertain_index].first
+              );
+            }
+            *new_union |= matcher_->tmp_suffix_accepted_bitset_;
+          }
+        }
+        if (TryAccountBytes(MemorySize(*new_union))) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+          ++matcher_->profile_suffix_certificate_canonical_union_builds_;
+#endif
+          accepted_union = std::move(new_union);
+          return (*accepted_union)[token_id];
+        }
+      }
+      for (const AdaptiveTokenMask* mask : cached_masks) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+        ++matcher_->profile_suffix_certificate_mask_queries_;
+#endif
+        if (mask->store_type == StoreType::kAcceptedBitset) {
+          if (mask->accepted_bitset[token_id]) {
+            return true;
+          }
+        } else if (mask->store_type == StoreType::kAccepted) {
+          if (std::binary_search(
+                  mask->accepted_indices.begin(), mask->accepted_indices.end(), sorted_vocab_index
+              )) {
+            return true;
+          }
+        } else if (!std::binary_search(
+                       mask->rejected_indices.begin(),
+                       mask->rejected_indices.end(),
+                       sorted_vocab_index
+                   ) &&
+                   !std::binary_search(
+                       mask->uncertain_indices.begin(),
+                       mask->uncertain_indices.end(),
+                       sorted_vocab_index
+                   )) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    const DynamicBitset* CurrentConfigurationAcceptedUnion() {
+      if (!PrepareCurrentConfigurationSuffixCertificateMasks()) {
+        return nullptr;
+      }
+      auto& accepted_union = suffix_certificate_accepted_unions_[current_configuration_id_];
+      if (accepted_union != nullptr) {
+        return accepted_union.get();
+      }
+      const auto& cached_masks = suffix_certificate_masks_[current_configuration_id_];
+      if (cached_masks.empty()) {
+        return nullptr;
+      }
+      auto new_union = std::make_unique<DynamicBitset>(matcher_->tokenizer_info_.GetVocabSize());
+      for (const AdaptiveTokenMask* mask : cached_masks) {
+        if (mask->store_type == StoreType::kAcceptedBitset) {
+          *new_union |= mask->accepted_bitset;
+        } else if (mask->store_type == StoreType::kAccepted) {
+          for (int32_t accepted_index : mask->accepted_indices) {
+            new_union->Set(matcher_->tokenizer_info_.GetSortedDecodedVocab()[accepted_index].first);
+          }
+        } else {
+          matcher_->tmp_suffix_accepted_bitset_.Set();
+          for (int32_t rejected_index : mask->rejected_indices) {
+            matcher_->tmp_suffix_accepted_bitset_.Reset(
+                matcher_->tokenizer_info_.GetSortedDecodedVocab()[rejected_index].first
+            );
+          }
+          for (int32_t uncertain_index : mask->uncertain_indices) {
+            matcher_->tmp_suffix_accepted_bitset_.Reset(
+                matcher_->tokenizer_info_.GetSortedDecodedVocab()[uncertain_index].first
+            );
+          }
+          *new_union |= matcher_->tmp_suffix_accepted_bitset_;
+        }
+      }
+      if (!TryAccountBytes(MemorySize(*new_union))) {
+        return nullptr;
+      }
+#ifdef XGRAMMAR_PROFILE_COMPILE
+      ++matcher_->profile_suffix_certificate_canonical_union_builds_;
+#endif
+      accepted_union = std::move(new_union);
+      return accepted_union.get();
+    }
+
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    // Prove that every byte string over the ordinary printable ASCII alphabet can advance from
+    // the current complete Earley configuration. The proof explores the exact reachable
+    // configuration graph. A repeated canonical configuration closes a cycle; any rejected edge
+    // or resource limit makes the proof fail conservatively.
+    bool CurrentConfigurationHasAsciiSafeClosure(
+        uint64_t* explored_configurations, uint64_t* explored_transitions
+    ) {
+      if (!enabled_ || current_configuration_id_ < 0) {
+        return false;
+      }
+      std::array<uint8_t, kMaxCanonicalConfigurations> seen{};
+      constexpr size_t kMaxExploredConfigurations = 16;
+      return ExploreAsciiSafeClosure(
+          &seen, kMaxExploredConfigurations, explored_configurations, explored_transitions
+      );
+    }
+#endif
+
+   private:
+    static constexpr size_t kMaxEntries = 4096;
+    static constexpr size_t kMaxVirtualDepth = 1024;
+    static constexpr size_t kMaxBytes = 8 * 1024 * 1024;
+    static constexpr size_t kMaxCanonicalRows = 128;
+    static constexpr size_t kMaxCanonicalConfigurations = 128;
+    static constexpr uint64_t kAdmissionQueries = 16;
+    static constexpr uint64_t kPostAdmissionReuseCheckQueries = 4096;
+    static constexpr uint64_t kAdmissionMinReuseHitRateDenominator = 4;
+    static constexpr uint64_t kPostAdmissionMinReuseHitRateDenominator = 8;
+    static constexpr size_t kDenseTransitionCount = kMaxCanonicalConfigurations * 256;
+
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    bool ExploreAsciiSafeClosure(
+        std::array<uint8_t, kMaxCanonicalConfigurations>* seen,
+        size_t max_explored_configurations,
+        uint64_t* explored_configurations,
+        uint64_t* explored_transitions
+    ) {
+      if (!enabled_ || current_configuration_id_ < 0 ||
+          current_configuration_id_ >= static_cast<int32_t>(kMaxCanonicalConfigurations)) {
+        return false;
+      }
+      const int32_t source_configuration_id = current_configuration_id_;
+      if ((*seen)[source_configuration_id]) {
+        return true;
+      }
+      if (*explored_configurations >= max_explored_configurations) {
+        return false;
+      }
+      (*seen)[source_configuration_id] = 1;
+      ++*explored_configurations;
+      for (int32_t byte = 0x20; byte < 0x7F; ++byte) {
+        if (byte == '"' || byte == '\\') {
+          continue;
+        }
+        ++*explored_transitions;
+        if (!Advance(static_cast<uint8_t>(byte))) {
+          return false;
+        }
+        if (!enabled_ || current_configuration_id_ < 0) {
+          PopLastStates(1);
+          return false;
+        }
+        const bool target_is_closed = ExploreAsciiSafeClosure(
+            seen, max_explored_configurations, explored_configurations, explored_transitions
+        );
+        PopLastStates(1);
+        if (!target_is_closed) {
+          return false;
+        }
+      }
+      return true;
+    }
+#endif
+
+    enum class TransitionStatus : uint8_t { kEmpty, kRejected, kAccepted };
+
+    struct Transition {
+      Transition() = default;
+
+      Transition(TransitionStatus status, int32_t output_row_id, int32_t output_configuration_id) {
+        if (status == TransitionStatus::kEmpty) {
+          encoded_ = kEmpty;
+        } else if (status == TransitionStatus::kRejected) {
+          encoded_ = kRejected;
+        } else {
+          XGRAMMAR_DCHECK(
+              output_row_id >= 0 && output_row_id < static_cast<int32_t>(kMaxCanonicalRows) &&
+              output_configuration_id >= 0 &&
+              output_configuration_id < static_cast<int32_t>(kMaxCanonicalConfigurations)
+          );
+          encoded_ = static_cast<uint16_t>(
+              kAccepted | (output_row_id << kRowShift) |
+              (output_configuration_id << kConfigurationShift)
+          );
+        }
+      }
+
+      TransitionStatus Status() const {
+        switch (encoded_ & kStatusMask) {
+          case kRejected:
+            return TransitionStatus::kRejected;
+          case kAccepted:
+            return TransitionStatus::kAccepted;
+          default:
+            return TransitionStatus::kEmpty;
+        }
+      }
+
+      int32_t OutputRowId() const {
+        XGRAMMAR_DCHECK(Status() == TransitionStatus::kAccepted);
+        return (encoded_ >> kRowShift) & kIdMask;
+      }
+
+      int32_t OutputConfigurationId() const {
+        XGRAMMAR_DCHECK(Status() == TransitionStatus::kAccepted);
+        return (encoded_ >> kConfigurationShift) & kIdMask;
+      }
+
+     private:
+      static constexpr uint16_t kEmpty = 0;
+      static constexpr uint16_t kRejected = 1;
+      static constexpr uint16_t kAccepted = 2;
+      static constexpr uint16_t kStatusMask = 3;
+      static constexpr uint16_t kRowShift = 2;
+      static constexpr uint16_t kConfigurationShift = 9;
+      static constexpr uint16_t kIdMask = 127;
+      uint16_t encoded_ = kEmpty;
+    };
+    static_assert(sizeof(Transition) == sizeof(uint16_t));
+
+    struct TransitionSlot {
+      static constexpr uint64_t kEmptyKey = ~uint64_t{0};
+
+      uint64_t key = kEmptyKey;
+      Transition transition;
+    };
+
+    const Transition* FindTransition(uint64_t key) const {
+      if (!admitted_) {
+        for (const auto& slot : warmup_transitions_) {
+          if (slot.key == key) {
+            return &slot.transition;
+          }
+        }
+        return nullptr;
+      }
+      XGRAMMAR_DCHECK(key < transition_table_.size());
+      const auto& transition = transition_table_[key];
+      return transition.Status() == TransitionStatus::kEmpty ? nullptr : &transition;
+    }
+
+    void InsertTransitionIntoTable(uint64_t key, const Transition& transition) {
+      XGRAMMAR_DCHECK(
+          key < transition_table_.size() &&
+          transition_table_[key].Status() == TransitionStatus::kEmpty
+      );
+      transition_table_[key] = transition;
+    }
+
+    void InsertTransition(uint64_t key, const Transition& transition) {
+      if (admitted_) {
+        InsertTransitionIntoTable(key, transition);
+      } else {
+        XGRAMMAR_DCHECK(warmup_transitions_.size() < kAdmissionQueries);
+        warmup_transitions_.push_back(TransitionSlot{key, transition});
+      }
+      ++num_transitions_;
+    }
+
+    bool Admit() {
+      XGRAMMAR_DCHECK(!admitted_);
+      if (!TryAccountBytes(kDenseTransitionCount * sizeof(Transition))) {
+        return false;
+      }
+      transition_table_.resize(kDenseTransitionCount);
+      admitted_ = true;
+      for (const auto& slot : warmup_transitions_) {
+        InsertTransitionIntoTable(slot.key, slot.transition);
+      }
+      std::vector<TransitionSlot>().swap(warmup_transitions_);
+      current_configuration_id_ =
+          transition_history_[transition_depth_ - 1].OutputConfigurationId();
+      current_transition_row_ = transition_table_.data() + current_configuration_id_ * 256;
+      return true;
+    }
+
+    CachedParserState NormalizeState(const ParserState& state, int32_t current_row) const {
+      CachedRowRefKind row_ref_kind = CachedRowRefKind::kNone;
+      int32_t row_ref_id = -1;
+      if (state.rule_start_pos != ParserState::kNoPrevInputPos) {
+        if (state.rule_start_pos < external_row_count_) {
+          row_ref_kind = CachedRowRefKind::kExternal;
+          row_ref_id = state.rule_start_pos;
+        } else if (state.rule_start_pos == current_row) {
+          row_ref_kind = CachedRowRefKind::kCurrent;
+        } else {
+          const int32_t local_index = state.rule_start_pos - external_row_count_;
+          XGRAMMAR_DCHECK(
+              local_index >= 0 && local_index < static_cast<int32_t>(transition_depth_)
+          );
+          row_ref_kind = CachedRowRefKind::kCanonical;
+          row_ref_id = transition_history_[local_index].OutputRowId();
+        }
+      }
+      return CachedParserState{
+          state.rule_id,
+          state.sequence_id,
+          state.element_id,
+          row_ref_kind,
+          row_ref_id,
+          state.sub_element_id,
+          state.repeat_count,
+          state.partial_codepoint
+      };
+    }
+
+    ParserState MaterializeState(const CachedParserState& state, int32_t current_row) const {
+      int32_t rule_start_pos = ParserState::kNoPrevInputPos;
+      switch (state.row_ref_kind) {
+        case CachedRowRefKind::kNone:
+          break;
+        case CachedRowRefKind::kExternal:
+          rule_start_pos = state.row_ref_id;
+          break;
+        case CachedRowRefKind::kCanonical:
+          rule_start_pos = FindAbsoluteRow(state.row_ref_id);
+          break;
+        case CachedRowRefKind::kCurrent:
+          rule_start_pos = current_row;
+          break;
+      }
+      return ParserState{
+          state.rule_id,
+          state.sequence_id,
+          state.element_id,
+          rule_start_pos,
+          state.sub_element_id,
+          state.repeat_count,
+          state.partial_codepoint
+      };
+    }
+
+    std::optional<int32_t> InternCurrentCompletableRow() {
+      const int32_t current_row = matcher_->rule_id_to_completable_states_.size() - 1;
+      const auto row = matcher_->rule_id_to_completable_states_[current_row];
+      const auto additional_bytes = AccountedElementBytes(
+          sizeof(CanonicalCompletableRow) + sizeof(std::vector<int32_t>),
+          row.size(),
+          sizeof(std::pair<int32_t, CachedParserState>)
+      );
+      if (!additional_bytes.has_value()) {
+        return std::nullopt;
+      }
+      CanonicalCompletableRow normalized;
+      normalized.entries.reserve(row.size());
+      for (const auto& [ref_rule_id, parent_state] : row) {
+        normalized.entries.emplace_back(ref_rule_id, NormalizeState(parent_state, current_row));
+      }
+      for (int32_t i = 0; i < static_cast<int32_t>(rows_.size()); ++i) {
+        if (rows_[i] == normalized) {
+          return i;
+        }
+      }
+      if (rows_.size() >= kMaxCanonicalRows || !TryAccountBytes(*additional_bytes)) {
+        return std::nullopt;
+      }
+      rows_.push_back(std::move(normalized));
+      absolute_rows_by_canonical_id_.emplace_back();
+      peak_canonical_rows_ = std::max(peak_canonical_rows_, rows_.size());
+      return rows_.size() - 1;
+    }
+
+    std::optional<int32_t> InternCurrentConfiguration(int32_t current_row_id) {
+      const int32_t current_row = matcher_->rule_id_to_completable_states_.size() - 1;
+      const auto scanable_states = matcher_->scanable_state_history_[current_row];
+      const auto additional_bytes = AccountedElementBytes(
+          sizeof(CanonicalConfiguration), scanable_states.size(), sizeof(CachedParserState)
+      );
+      if (!additional_bytes.has_value()) {
+        return std::nullopt;
+      }
+      CanonicalConfiguration normalized{current_row_id, matcher_->is_completed_.back() != 0, {}};
+      normalized.scanable_states.reserve(scanable_states.size());
+      for (const auto& state : scanable_states) {
+        normalized.scanable_states.push_back(NormalizeState(state, current_row));
+      }
+      for (int32_t i = 0; i < static_cast<int32_t>(configurations_.size()); ++i) {
+        if (configurations_[i] == normalized) {
+          return i;
+        }
+      }
+      if (configurations_.size() >= kMaxCanonicalConfigurations ||
+          !TryAccountBytes(*additional_bytes)) {
+        return std::nullopt;
+      }
+      configurations_.push_back(std::move(normalized));
+      peak_canonical_configurations_ =
+          std::max(peak_canonical_configurations_, configurations_.size());
+      return configurations_.size() - 1;
+    }
+
+    int32_t FindAbsoluteRow(int32_t canonical_row_id) const {
+      XGRAMMAR_DCHECK(
+          canonical_row_id >= 0 &&
+          canonical_row_id < static_cast<int32_t>(absolute_rows_by_canonical_id_.size()) &&
+          !absolute_rows_by_canonical_id_[canonical_row_id].empty()
+      );
+      return absolute_rows_by_canonical_id_[canonical_row_id].back();
+    }
+
+    void RecordMaterializedRow(int32_t canonical_row_id) {
+      const int32_t absolute_row = external_row_count_ + materialized_depth_;
+      absolute_rows_by_canonical_id_[canonical_row_id].push_back(absolute_row);
+    }
+
+    void PushVirtualRow(const Transition& transition) {
+      XGRAMMAR_DCHECK(transition_depth_ < kMaxVirtualDepth);
+      transition_history_[transition_depth_++] = transition;
+      if (admitted_) {
+        const int32_t output_configuration_id = transition.OutputConfigurationId();
+        if (output_configuration_id != current_configuration_id_) {
+          current_configuration_id_ = output_configuration_id;
+          current_transition_row_ = transition_table_.data() + output_configuration_id * 256;
+        }
+      }
+    }
+
+    uint64_t PendingFastQueries() const {
+      return admitted_ && !steady_fast_path_
+                 ? kPostAdmissionReuseCheckQueries - fast_queries_remaining_
+                 : 0;
+    }
+
+    void FlushFastQueries() {
+      if (!admitted_ || steady_fast_path_) {
+        return;
+      }
+      queries_ += PendingFastQueries();
+      fast_queries_remaining_ = kPostAdmissionReuseCheckQueries;
+    }
+
+    void MaterializeTransition(const Transition& transition) {
+      const int32_t current_row = matcher_->rule_id_to_completable_states_.size();
+      const auto& cached_row = rows_[transition.OutputRowId()];
+      tmp_completable_states_.clear();
+      tmp_completable_states_.reserve(cached_row.entries.size());
+      for (const auto& [ref_rule_id, parent_state] : cached_row.entries) {
+        tmp_completable_states_.emplace_back(
+            ref_rule_id, MaterializeState(parent_state, current_row)
+        );
+      }
+
+      const auto& cached_configuration = configurations_[transition.OutputConfigurationId()];
+      XGRAMMAR_DCHECK(cached_configuration.current_row_id == transition.OutputRowId());
+      tmp_scanable_states_.clear();
+      tmp_scanable_states_.reserve(cached_configuration.scanable_states.size());
+      for (const auto& state : cached_configuration.scanable_states) {
+        tmp_scanable_states_.push_back(MaterializeState(state, current_row));
+      }
+
+      matcher_->rule_id_to_completable_states_.PushBack(tmp_completable_states_);
+      matcher_->is_completed_.push_back(cached_configuration.is_completed);
+      matcher_->scanable_state_history_.PushBack(tmp_scanable_states_);
+      matcher_->tmp_accept_stop_token_ = cached_configuration.is_completed;
+      matcher_->tmp_states_to_be_added_.clear();
+    }
+
+    void MaterializeVirtualPrefix() {
+      while (materialized_depth_ < transition_depth_) {
+        const Transition& transition = transition_history_[materialized_depth_];
+        MaterializeTransition(transition);
+        RecordMaterializedRow(transition.OutputRowId());
+        ++materialized_depth_;
+      }
+    }
+
+    std::optional<size_t> AccountedElementBytes(
+        size_t base_bytes, size_t element_count, size_t element_bytes
+    ) const {
+      if (base_bytes > kMaxBytes - memory_bytes_) {
+        return std::nullopt;
+      }
+      const size_t available_element_bytes = kMaxBytes - memory_bytes_ - base_bytes;
+      if (element_count > available_element_bytes / element_bytes) {
+        return std::nullopt;
+      }
+      return base_bytes + element_count * element_bytes;
+    }
+
+    bool TryAccountBytes(size_t additional_bytes) {
+      if (additional_bytes > kMaxBytes - memory_bytes_) {
+        return false;
+      }
+      memory_bytes_ += additional_bytes;
+      peak_bytes_ = std::max(peak_bytes_, memory_bytes_);
+      return true;
+    }
+
+    void Disable() {
+      enabled_ = false;
+      admitted_ = false;
+      steady_fast_path_ = false;
+      fast_queries_remaining_ = 0;
+      std::vector<TransitionSlot>().swap(warmup_transitions_);
+      std::vector<Transition>().swap(transition_table_);
+      std::vector<CanonicalCompletableRow>().swap(rows_);
+      std::vector<CanonicalConfiguration>().swap(configurations_);
+      std::vector<std::vector<int32_t>>().swap(absolute_rows_by_canonical_id_);
+      std::vector<std::pair<int32_t, ParserState>>().swap(tmp_completable_states_);
+      std::vector<ParserState>().swap(tmp_scanable_states_);
+      transition_depth_ = 0;
+      current_transition_row_ = nullptr;
+      current_configuration_id_ = -1;
+      materialized_depth_ = 0;
+      memory_bytes_ = 0;
+    }
+
+    void DisableAndMaterialize() {
+      MaterializeVirtualPrefix();
+      Disable();
+    }
+
+    Impl* matcher_;
+    int32_t external_row_count_;
+    bool enabled_ = true;
+    bool admitted_ = false;
+    bool steady_fast_path_ = false;
+    bool disabled_for_low_reuse_ = false;
+    uint64_t queries_ = 0;
+    uint64_t misses_ = 0;
+    uint64_t reuse_window_start_queries_ = 0;
+    uint64_t reuse_window_start_misses_ = 0;
+    uint64_t fast_queries_remaining_ = 0;
+    size_t memory_bytes_ = 0;
+    size_t peak_bytes_ = 0;
+    size_t peak_canonical_rows_ = 0;
+    size_t peak_canonical_configurations_ = 0;
+    size_t num_transitions_ = 0;
+    std::vector<TransitionSlot> warmup_transitions_;
+    std::vector<Transition> transition_table_;
+    std::vector<CanonicalCompletableRow> rows_;
+    std::vector<CanonicalConfiguration> configurations_;
+    std::vector<std::vector<int32_t>> absolute_rows_by_canonical_id_;
+    std::array<Transition, kMaxVirtualDepth> transition_history_;
+    size_t transition_depth_ = 0;
+    const Transition* current_transition_row_ = nullptr;
+    int32_t current_configuration_id_ = -1;
+    size_t materialized_depth_ = 0;
+    std::vector<std::pair<int32_t, ParserState>> tmp_completable_states_;
+    std::vector<ParserState> tmp_scanable_states_;
+    std::array<std::vector<const AdaptiveTokenMask*>, kMaxCanonicalConfigurations>
+        suffix_certificate_masks_;
+    std::array<uint8_t, kMaxCanonicalConfigurations> suffix_certificate_masks_ready_{};
+    std::array<uint32_t, kMaxCanonicalConfigurations> suffix_certificate_queries_{};
+    std::array<std::unique_ptr<DynamicBitset>, kMaxCanonicalConfigurations>
+        suffix_certificate_accepted_unions_;
+  };
+
+#ifdef _MSC_VER
+  __declspec(noinline)
+#else
+  __attribute__((noinline))
+#endif
+  int32_t
+  EvaluateDisjointUncertainTokens(
+      const AdaptiveTokenMask& adaptive_token_mask,
+      ContinuationTransitionCache* transition_cache,
+      bool* has_rejection
+  ) {
+    const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
+    const auto& subtree_range = tokenizer_info_.GetTrieSubtreeNodesRange();
+    const int32_t* uncertain_indices = adaptive_token_mask.uncertain_indices.data();
+    const int32_t* uncertain_lcps = adaptive_token_mask.uncertain_lcp_with_previous.data();
+    const size_t uncertain_count = adaptive_token_mask.uncertain_indices.size();
+    int32_t prev_matched_size = 0;
+    int32_t last_rejected_uncertain_range = 0;
+    int32_t lcp_with_last_evaluated_token = std::numeric_limits<int32_t>::max();
+
+    for (size_t position = 0; position < uncertain_count; ++position) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+      ++profile_uncertain_loop_tokens_;
+#endif
+      const int32_t cur_token_idx = uncertain_indices[position];
+      if (position != 0) {
+        lcp_with_last_evaluated_token =
+            std::min(lcp_with_last_evaluated_token, uncertain_lcps[position]);
+      }
+      if (cur_token_idx < last_rejected_uncertain_range) {
+        if (!*has_rejection) {
+          tmp_deferred_uncertain_accepted_bitset_ = adaptive_token_mask.uncertain_bitset;
+          *has_rejection = true;
+        }
+        tmp_deferred_uncertain_accepted_bitset_.Reset(sorted_decoded_vocab[cur_token_idx].first);
+        continue;
+      }
+
+      const auto& cur_token = sorted_decoded_vocab[cur_token_idx].second;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+      ++profile_uncertain_parser_tokens_;
+#endif
+      bool accepted = true;
+      if (position != 0) {
+        const int32_t lcp_len = lcp_with_last_evaluated_token;
+        if (lcp_len > prev_matched_size) {
+          last_rejected_uncertain_range = subtree_range[cur_token_idx];
+          accepted = false;
+        } else if (lcp_len < prev_matched_size) {
+          transition_cache->PopLastStates(prev_matched_size - lcp_len);
+        }
+        prev_matched_size = std::min(prev_matched_size, lcp_len);
+      }
+
+      if (accepted) {
+        for (int32_t j = prev_matched_size; j < static_cast<int32_t>(cur_token.size()); ++j) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+          ++profile_uncertain_advance_calls_;
+#endif
+          if (!transition_cache->Advance(cur_token[j])) {
+            last_rejected_uncertain_range = subtree_range[cur_token_idx];
+            accepted = false;
+            break;
+          }
+          prev_matched_size = j + 1;
+        }
+      }
+
+      if (!accepted) {
+        if (!*has_rejection) {
+          tmp_deferred_uncertain_accepted_bitset_ = adaptive_token_mask.uncertain_bitset;
+          *has_rejection = true;
+        }
+        tmp_deferred_uncertain_accepted_bitset_.Reset(sorted_decoded_vocab[cur_token_idx].first);
+      }
+      lcp_with_last_evaluated_token = std::numeric_limits<int32_t>::max();
+    }
+    return prev_matched_size;
+  }
+
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  // Evaluate the unresolved union once from the complete Earley configuration. This is a
+  // profile-only counterfactual for the LLGuidance-style runtime design: it does not affect the
+  // returned mask, and every result is checked against the current per-leaf exact path.
+  void ProfileFullConfigurationTraversal(const DynamicBitset& exact_output_mask) {
+    const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
+    const auto& subtree_range = tokenizer_info_.GetTrieSubtreeNodesRange();
+    const auto& suffix_lookup_indptr = tokenizer_info_->GetSuffixLookupIndptr();
+    const auto& suffix_lookup_sorted_indices = tokenizer_info_->GetSuffixLookupSortedIndices();
+    const auto& suffix_lookup_token_ids = tokenizer_info_->GetSuffixLookupTokenIds();
+    const auto& suffix_prefix_range_ends = tokenizer_info_->GetSuffixPrefixRangeEnds();
+    const bool saved_tmp_accept_stop_token = tmp_accept_stop_token_;
+    const auto saved_tmp_states_to_be_added = tmp_states_to_be_added_;
+    const uint64_t candidate_count = profile_full_configuration_candidate_bitset_.Count();
+    ++profile_full_configuration_calls_;
+    profile_full_configuration_candidate_tokens_ += candidate_count;
+    if (candidate_count == 0) {
+      return;
+    }
+
+    profile_full_configuration_expected_accepted_bitset_.Reset();
+    const std::array<const DynamicBitset*, 4> tokenizer_slices{
+        &profile_whitespace_slice_bitset_,
+        &profile_string_safe_10_slice_bitset_,
+        &profile_string_safe_30_slice_bitset_,
+        &profile_string_safe_slice_bitset_
+    };
+    std::array<bool, 4> slice_is_subsumed{};
+    for (size_t slice_index = 0; slice_index < tokenizer_slices.size(); ++slice_index) {
+      slice_is_subsumed[slice_index] = tokenizer_slices[slice_index]->IsSubsetOf(exact_output_mask);
+      if (slice_is_subsumed[slice_index]) {
+        ++profile_slice_subsumed_calls_[slice_index];
+      }
+    }
+    bool fsm_ascii_safe_is_subsumed = false;
+    bool fsm_ascii_safe_10_is_subsumed = false;
+    bool fsm_ascii_safe_30_is_subsumed = false;
+    for (const auto& state : scanable_state_history_[scanable_state_history_.size() - 1]) {
+      if (state.rule_id < 0 || state.element_id < 0 ||
+          state.element_id >= static_cast<int32_t>(profile_ascii_safe_closed_fsm_states_.size())) {
+        continue;
+      }
+      fsm_ascii_safe_is_subsumed |= profile_ascii_safe_closed_fsm_states_[state.element_id];
+      fsm_ascii_safe_10_is_subsumed |= profile_ascii_safe_10_fsm_states_[state.element_id];
+      fsm_ascii_safe_30_is_subsumed |= profile_ascii_safe_30_fsm_states_[state.element_id];
+    }
+    std::array<uint64_t, 4> candidate_tokens_in_slice{};
+    std::array<uint64_t, 4> rejected_candidate_tokens_in_slice{};
+    uint64_t candidate_ascii_safe_tokens = 0;
+    uint64_t rejected_candidate_ascii_safe_tokens = 0;
+    uint64_t candidate_ascii_safe_10_tokens = 0;
+    uint64_t rejected_candidate_ascii_safe_10_tokens = 0;
+    uint64_t candidate_ascii_safe_30_tokens = 0;
+    uint64_t rejected_candidate_ascii_safe_30_tokens = 0;
+    for (int32_t sorted_vocab_index = profile_full_configuration_candidate_bitset_.FindFirstOne();
+         sorted_vocab_index != -1;
+         sorted_vocab_index =
+             profile_full_configuration_candidate_bitset_.FindNextOne(sorted_vocab_index)) {
+      const auto& [token_id, token] = sorted_decoded_vocab[sorted_vocab_index];
+      const bool expected_accepted = exact_output_mask[token_id];
+      if (profile_ascii_safe_slice_bitset_[token_id]) {
+        ++candidate_ascii_safe_tokens;
+        rejected_candidate_ascii_safe_tokens += !expected_accepted;
+      }
+      if (profile_ascii_safe_10_slice_bitset_[token_id]) {
+        ++candidate_ascii_safe_10_tokens;
+        rejected_candidate_ascii_safe_10_tokens += !expected_accepted;
+      }
+      if (profile_ascii_safe_30_slice_bitset_[token_id]) {
+        ++candidate_ascii_safe_30_tokens;
+        rejected_candidate_ascii_safe_30_tokens += !expected_accepted;
+      }
+      bool covered_by_subsumed_slice = false;
+      for (size_t slice_index = 0; slice_index < tokenizer_slices.size(); ++slice_index) {
+        if ((*tokenizer_slices[slice_index])[token_id]) {
+          ++profile_slice_candidate_tokens_[slice_index];
+          ++candidate_tokens_in_slice[slice_index];
+          rejected_candidate_tokens_in_slice[slice_index] += !expected_accepted;
+          if (slice_is_subsumed[slice_index]) {
+            ++profile_slice_covered_candidate_tokens_[slice_index];
+            covered_by_subsumed_slice = true;
+          }
+        }
+      }
+      profile_slice_any_covered_candidate_tokens_ += covered_by_subsumed_slice;
+      if (expected_accepted) {
+        profile_full_configuration_expected_accepted_bitset_.Set(sorted_vocab_index);
+        ++profile_full_configuration_expected_accepted_tokens_;
+      }
+    }
+    profile_candidate_ascii_safe_tokens_ += candidate_ascii_safe_tokens;
+    if (candidate_ascii_safe_tokens != 0 && rejected_candidate_ascii_safe_tokens == 0) {
+      ++profile_candidate_ascii_safe_subsumed_calls_;
+      profile_candidate_ascii_safe_covered_tokens_ += candidate_ascii_safe_tokens;
+      for (const auto& state : scanable_state_history_[scanable_state_history_.size() - 1]) {
+        const AdaptiveTokenMask* mask = compiled_grammar_->FindAdaptiveTokenMask(state);
+        XGRAMMAR_DCHECK(mask != nullptr);
+        bool has_relevant_uncertain_token = false;
+        for (int32_t sorted_vocab_index : mask->uncertain_indices) {
+          const int32_t token_id = sorted_decoded_vocab[sorted_vocab_index].first;
+          if (profile_full_configuration_candidate_bitset_[sorted_vocab_index] &&
+              profile_ascii_safe_slice_bitset_[token_id]) {
+            has_relevant_uncertain_token = true;
+            break;
+          }
+        }
+        if (!has_relevant_uncertain_token) {
+          continue;
+        }
+
+        XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
+        const bool saved_accept_stop_token = tmp_accept_stop_token_;
+        const auto saved_states_to_be_added = tmp_states_to_be_added_;
+        tmp_states_visited_in_queue_.Clear();
+        tmp_states_to_be_added_.clear();
+        tmp_accept_stop_token_ = false;
+        rule_id_to_completable_states_.PushBackEmpty();
+        Complete(state);
+        while (!tmp_process_state_queue_.empty()) {
+          const ParserState& continuation_state = *tmp_process_state_queue_.front();
+          tmp_process_state_queue_.pop();
+          auto [scanable, completable] = Predict(continuation_state);
+          if (completable) {
+            Complete(continuation_state);
+          }
+          if (scanable) {
+            tmp_states_to_be_added_.push_back(&continuation_state);
+          }
+        }
+        std::vector<ParserState> normalized_continuation_states;
+        normalized_continuation_states.reserve(tmp_states_to_be_added_.size());
+        for (const ParserState* continuation_state : tmp_states_to_be_added_) {
+          ParserState normalized = *continuation_state;
+          normalized.rule_start_pos = ParserState::kNoPrevInputPos;
+          normalized_continuation_states.push_back(normalized);
+        }
+        auto state_less = [](const ParserState& lhs, const ParserState& rhs) {
+          if (lhs.rule_id != rhs.rule_id) return lhs.rule_id < rhs.rule_id;
+          if (lhs.sequence_id != rhs.sequence_id) return lhs.sequence_id < rhs.sequence_id;
+          if (lhs.element_id != rhs.element_id) return lhs.element_id < rhs.element_id;
+          if (lhs.sub_element_id != rhs.sub_element_id) {
+            return lhs.sub_element_id < rhs.sub_element_id;
+          }
+          if (lhs.repeat_count != rhs.repeat_count) return lhs.repeat_count < rhs.repeat_count;
+          return lhs.partial_codepoint < rhs.partial_codepoint;
+        };
+        std::sort(
+            normalized_continuation_states.begin(), normalized_continuation_states.end(), state_less
+        );
+        StateEqualForParsing state_equal;
+        normalized_continuation_states.erase(
+            std::unique(
+                normalized_continuation_states.begin(),
+                normalized_continuation_states.end(),
+                [&](const ParserState& lhs, const ParserState& rhs) {
+                  return state_equal(lhs, rhs);
+                }
+            ),
+            normalized_continuation_states.end()
+        );
+
+        ++profile_local_continuation_structure_queries_;
+        const auto existing_structure = std::find_if(
+            profile_local_continuation_structures_.begin(),
+            profile_local_continuation_structures_.end(),
+            [&](const std::vector<ParserState>& candidate) {
+              return candidate.size() == normalized_continuation_states.size() &&
+                     std::equal(
+                         candidate.begin(),
+                         candidate.end(),
+                         normalized_continuation_states.begin(),
+                         [&](const ParserState& lhs, const ParserState& rhs) {
+                           return state_equal(lhs, rhs);
+                         }
+                     );
+            }
+        );
+        if (existing_structure != profile_local_continuation_structures_.end()) {
+          ++profile_local_continuation_structure_hits_;
+        } else {
+          profile_local_continuation_structures_.push_back(std::move(normalized_continuation_states)
+          );
+        }
+        rule_id_to_completable_states_.PopBack(1);
+        tmp_states_visited_in_queue_.Clear();
+        tmp_states_to_be_added_ = saved_states_to_be_added;
+        tmp_accept_stop_token_ = saved_accept_stop_token;
+      }
+      if (!profile_logged_first_candidate_ascii_safe_subsumption_) {
+        profile_logged_first_candidate_ascii_safe_subsumption_ = true;
+        XGRAMMAR_LOG(INFO) << "CandidateAsciiSafeSubsumptionProfile(candidate_tokens="
+                           << candidate_ascii_safe_tokens << ", latest_states="
+                           << scanable_state_history_[scanable_state_history_.size() - 1].size()
+                           << ")";
+        for (const auto& state : scanable_state_history_[scanable_state_history_.size() - 1]) {
+          const AdaptiveTokenMask* mask = compiled_grammar_->FindAdaptiveTokenMask(state);
+          XGRAMMAR_DCHECK(mask != nullptr);
+          uint64_t uncertain_candidate_tokens = 0;
+          if (mask->uncertain_bitset.Size() != 0) {
+            for (int32_t sorted_vocab_index =
+                     profile_full_configuration_candidate_bitset_.FindFirstOne();
+                 sorted_vocab_index != -1;
+                 sorted_vocab_index =
+                     profile_full_configuration_candidate_bitset_.FindNextOne(sorted_vocab_index)) {
+              const int32_t token_id = sorted_decoded_vocab[sorted_vocab_index].first;
+              uncertain_candidate_tokens +=
+                  profile_ascii_safe_slice_bitset_[token_id] && mask->uncertain_bitset[token_id];
+            }
+          } else {
+            for (int32_t sorted_vocab_index : mask->uncertain_indices) {
+              const int32_t token_id = sorted_decoded_vocab[sorted_vocab_index].first;
+              uncertain_candidate_tokens +=
+                  profile_full_configuration_candidate_bitset_[sorted_vocab_index] &&
+                  profile_ascii_safe_slice_bitset_[token_id];
+            }
+          }
+          if (uncertain_candidate_tokens == 0) {
+            continue;
+          }
+          std::ostringstream edge_summary;
+          if (state.rule_id >= 0) {
+            for (const auto& edge : (*complete_fsm_edges_)[state.element_id]) {
+              if (edge.IsCharRange()) {
+                edge_summary << " char[" << edge.min << "," << edge.max << "]->" << edge.target;
+              } else if (edge.IsRuleRef()) {
+                edge_summary << " rule(" << edge.GetRefRuleId() << ")->" << edge.target;
+              } else if (edge.IsRepeatRef()) {
+                const auto repeat = grammar_->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
+                edge_summary << " repeat(rule=" << repeat.RuleId() << ",lower=" << repeat.Lower()
+                             << ",upper=" << repeat.Upper() << ")->" << edge.target;
+              } else if (edge.IsEpsilon()) {
+                edge_summary << " epsilon->" << edge.target;
+              } else {
+                edge_summary << " special(" << edge.min << ")->" << edge.target;
+              }
+            }
+          }
+          XGRAMMAR_LOG(INFO) << "CandidateAsciiSafeSource(state=" << state << ", rule_name="
+                             << (state.rule_id >= 0 ? grammar_->GetRule(state.rule_id).name
+                                                    : std::string("<legacy-sequence>"))
+                             << ", uncertain_candidate_tokens=" << uncertain_candidate_tokens
+                             << ", uncertain_tokens=" << mask->uncertain_indices.size()
+                             << ", edges=\"" << edge_summary.str() << "\")";
+          if (state.rule_id >= 0) {
+            std::vector<int32_t> logged_targets;
+            for (const auto& source_edge : (*complete_fsm_edges_)[state.element_id]) {
+              if (!source_edge.IsCharRange() ||
+                  std::find(logged_targets.begin(), logged_targets.end(), source_edge.target) !=
+                      logged_targets.end()) {
+                continue;
+              }
+              logged_targets.push_back(source_edge.target);
+              std::ostringstream target_edge_summary;
+              for (const auto& target_edge : (*complete_fsm_edges_)[source_edge.target]) {
+                target_edge_summary << " edge(" << target_edge.min << "," << target_edge.max
+                                    << ")->" << target_edge.target;
+              }
+              XGRAMMAR_LOG(INFO
+              ) << "CandidateAsciiSafeSourceTarget(state_id="
+                << source_edge.target << ", flags="
+                << static_cast<int>(GetFsmStateFlags(state.rule_id, source_edge.target))
+                << ", edges=\"" << target_edge_summary.str() << "\")";
+            }
+          }
+          if (state.rule_start_pos >= 0 &&
+              state.rule_start_pos < static_cast<int32_t>(rule_id_to_completable_states_.size())) {
+            for (const auto& [completed_rule_id, parent_state] :
+                 rule_id_to_completable_states_[state.rule_start_pos]) {
+              if (completed_rule_id != state.rule_id) {
+                continue;
+              }
+              std::ostringstream parent_edge_summary;
+              if (parent_state.rule_id >= 0) {
+                for (const auto& edge : (*complete_fsm_edges_)[parent_state.element_id]) {
+                  if (edge.IsCharRange()) {
+                    parent_edge_summary << " char[" << edge.min << "," << edge.max << "]->"
+                                        << edge.target;
+                  } else if (edge.IsRuleRef()) {
+                    parent_edge_summary << " rule(" << edge.GetRefRuleId() << ")->" << edge.target;
+                  } else if (edge.IsRepeatRef()) {
+                    const auto repeat =
+                        grammar_->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
+                    parent_edge_summary << " repeat(rule=" << repeat.RuleId()
+                                        << ",lower=" << repeat.Lower()
+                                        << ",upper=" << repeat.Upper() << ")->" << edge.target;
+                  } else if (edge.IsEpsilon()) {
+                    parent_edge_summary << " epsilon->" << edge.target;
+                  } else {
+                    parent_edge_summary << " special(" << edge.min << ")->" << edge.target;
+                  }
+                }
+              }
+              XGRAMMAR_LOG(INFO
+              ) << "CandidateAsciiSafeParent(completed_rule_id="
+                << completed_rule_id << ", state=" << parent_state << ", rule_name="
+                << (parent_state.rule_id >= 0 ? grammar_->GetRule(parent_state.rule_id).name
+                                              : std::string("<legacy-sequence>"))
+                << ", ascii_safe_10="
+                << (parent_state.element_id >= 0 &&
+                    parent_state.element_id <
+                        static_cast<int32_t>(profile_ascii_safe_10_fsm_states_.size()) &&
+                    profile_ascii_safe_10_fsm_states_[parent_state.element_id])
+                << ", ascii_safe_30="
+                << (parent_state.element_id >= 0 &&
+                    parent_state.element_id <
+                        static_cast<int32_t>(profile_ascii_safe_30_fsm_states_.size()) &&
+                    profile_ascii_safe_30_fsm_states_[parent_state.element_id])
+                << ", ascii_safe_closed="
+                << (parent_state.element_id >= 0 &&
+                    parent_state.element_id <
+                        static_cast<int32_t>(profile_ascii_safe_closed_fsm_states_.size()) &&
+                    profile_ascii_safe_closed_fsm_states_[parent_state.element_id])
+                << ", edges=\"" << parent_edge_summary.str() << "\")";
+            }
+          }
+          XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
+          const bool saved_accept_stop_token = tmp_accept_stop_token_;
+          const auto saved_states_to_be_added = tmp_states_to_be_added_;
+          tmp_states_visited_in_queue_.Clear();
+          tmp_states_to_be_added_.clear();
+          tmp_accept_stop_token_ = false;
+          rule_id_to_completable_states_.PushBackEmpty();
+          Complete(state);
+          while (!tmp_process_state_queue_.empty()) {
+            const ParserState& continuation_state = *tmp_process_state_queue_.front();
+            tmp_process_state_queue_.pop();
+            auto [scanable, completable] = Predict(continuation_state);
+            if (completable) {
+              Complete(continuation_state);
+            }
+            if (scanable) {
+              tmp_states_to_be_added_.push_back(&continuation_state);
+            }
+          }
+          std::vector<ParserState> normalized_continuation_states;
+          normalized_continuation_states.reserve(tmp_states_to_be_added_.size());
+          for (const ParserState* continuation_state : tmp_states_to_be_added_) {
+            ParserState normalized = *continuation_state;
+            normalized.rule_start_pos = ParserState::kNoPrevInputPos;
+            normalized_continuation_states.push_back(normalized);
+          }
+          for (const ParserState* continuation_state : tmp_states_to_be_added_) {
+            const int32_t element_id = continuation_state->element_id;
+            XGRAMMAR_LOG(INFO
+            ) << "CandidateAsciiSafeCompletionState(state="
+              << *continuation_state << ", rule_name="
+              << (continuation_state->rule_id >= 0
+                      ? grammar_->GetRule(continuation_state->rule_id).name
+                      : std::string("<legacy-sequence>"))
+              << ", ascii_safe_10="
+              << (element_id >= 0 &&
+                  element_id < static_cast<int32_t>(profile_ascii_safe_10_fsm_states_.size()) &&
+                  profile_ascii_safe_10_fsm_states_[element_id])
+              << ", ascii_safe_30="
+              << (element_id >= 0 &&
+                  element_id < static_cast<int32_t>(profile_ascii_safe_30_fsm_states_.size()) &&
+                  profile_ascii_safe_30_fsm_states_[element_id])
+              << ", ascii_safe_closed="
+              << (element_id >= 0 &&
+                  element_id < static_cast<int32_t>(profile_ascii_safe_closed_fsm_states_.size()) &&
+                  profile_ascii_safe_closed_fsm_states_[element_id])
+              << ")";
+          }
+          profile_suffix_accepted_union_bitset_.Reset();
+          for (const ParserState* continuation_state : tmp_states_to_be_added_) {
+            if (continuation_state->rule_id < 0 ||
+                compiled_grammar_->earley_parser_metadata
+                    .rule_has_atomic_token_edges[continuation_state->rule_id]) {
+              continue;
+            }
+            const AdaptiveTokenMask* continuation_mask =
+                compiled_grammar_->FindAdaptiveTokenMask(*continuation_state);
+            XGRAMMAR_DCHECK(continuation_mask != nullptr);
+            if (continuation_mask->store_type == StoreType::kAcceptedBitset) {
+              profile_suffix_accepted_union_bitset_ |= continuation_mask->accepted_bitset;
+            } else if (continuation_mask->store_type == StoreType::kAccepted) {
+              for (int32_t accepted_index : continuation_mask->accepted_indices) {
+                profile_suffix_accepted_union_bitset_.Set(sorted_decoded_vocab[accepted_index].first
+                );
+              }
+            } else {
+              tmp_suffix_accepted_bitset_.Set();
+              for (int32_t rejected_index : continuation_mask->rejected_indices) {
+                tmp_suffix_accepted_bitset_.Reset(sorted_decoded_vocab[rejected_index].first);
+              }
+              for (int32_t uncertain_index : continuation_mask->uncertain_indices) {
+                tmp_suffix_accepted_bitset_.Reset(sorted_decoded_vocab[uncertain_index].first);
+              }
+              profile_suffix_accepted_union_bitset_ |= tmp_suffix_accepted_bitset_;
+            }
+          }
+          scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
+          is_completed_.push_back(tmp_accept_stop_token_);
+          uint64_t parent_ascii_closure_configurations = 0;
+          uint64_t parent_ascii_closure_transitions = 0;
+          const auto parent_ascii_closure_started_at = details::Clock::now();
+          const int32_t parent_external_row_count =
+              static_cast<int32_t>(rule_id_to_completable_states_.size()) - 1;
+          ContinuationTransitionCache parent_closure_cache(this, parent_external_row_count);
+          const bool parent_has_ascii_closure =
+              parent_closure_cache.CurrentConfigurationHasAsciiSafeClosure(
+                  &parent_ascii_closure_configurations, &parent_ascii_closure_transitions
+              );
+          ++profile_parent_ascii_closure_queries_;
+          profile_parent_ascii_closure_hits_ += parent_has_ascii_closure;
+          profile_parent_ascii_closure_configurations_ += parent_ascii_closure_configurations;
+          profile_parent_ascii_closure_transitions_ += parent_ascii_closure_transitions;
+          profile_parent_ascii_closure_ns_ +=
+              std::chrono::duration_cast<std::chrono::nanoseconds>(
+                  details::Clock::now() - parent_ascii_closure_started_at
+              )
+                  .count();
+          uint64_t whitespace_prefix_certified_tokens = 0;
+          uint64_t whitespace_prefix_rejected_certificates = 0;
+          uint64_t whitespace_prefix_missing_suffix_tokens = 0;
+          DynamicBitset whitespace_prefix_source_candidates(sorted_decoded_vocab.size());
+          DynamicBitset whitespace_prefix_certified_candidates(sorted_decoded_vocab.size());
+          DynamicBitset whitespace_prefix_oracle_ascii_candidates(sorted_decoded_vocab.size());
+          for (int32_t sorted_vocab_index =
+                   profile_full_configuration_candidate_bitset_.FindFirstOne();
+               sorted_vocab_index != -1;
+               sorted_vocab_index =
+                   profile_full_configuration_candidate_bitset_.FindNextOne(sorted_vocab_index)) {
+            const auto& [token_id, token] = sorted_decoded_vocab[sorted_vocab_index];
+            const bool source_is_uncertain = mask->uncertain_bitset.Size() != 0
+                                                 ? mask->uncertain_bitset[token_id]
+                                                 : std::binary_search(
+                                                       mask->uncertain_indices.begin(),
+                                                       mask->uncertain_indices.end(),
+                                                       sorted_vocab_index
+                                                   );
+            if (!source_is_uncertain) {
+              continue;
+            }
+            int32_t suffix_offset = 0;
+            while (suffix_offset < static_cast<int32_t>(token.size())) {
+              const uint8_t byte = token[suffix_offset];
+              if (byte != 0x09 && byte != 0x0A && byte != 0x0B && byte != 0x0C && byte != 0x0D &&
+                  byte != 0x20) {
+                break;
+              }
+              ++suffix_offset;
+            }
+            if (suffix_offset == 0 || suffix_offset == static_cast<int32_t>(token.size())) {
+              continue;
+            }
+            whitespace_prefix_source_candidates.Set(sorted_vocab_index);
+            if (!profile_ascii_safe_slice_bitset_[token_id]) {
+              continue;
+            }
+            if (exact_output_mask[token_id]) {
+              whitespace_prefix_oracle_ascii_candidates.Set(sorted_vocab_index);
+            }
+            const int32_t lookup_index = suffix_lookup_indptr[sorted_vocab_index] + suffix_offset;
+            const int32_t suffix_token_id = suffix_lookup_token_ids[lookup_index];
+            if (suffix_token_id < 0) {
+              ++whitespace_prefix_missing_suffix_tokens;
+              continue;
+            }
+            if (profile_suffix_accepted_union_bitset_[suffix_token_id]) {
+              ++whitespace_prefix_certified_tokens;
+              whitespace_prefix_certified_candidates.Set(sorted_vocab_index);
+              whitespace_prefix_rejected_certificates += !exact_output_mask[token_id];
+            }
+          }
+          struct CompleteCandidateSubtreeStats {
+            uint64_t subtree_count = 0;
+            uint64_t subtree_tokens = 0;
+            uint64_t residual_singletons = 0;
+          };
+          auto count_complete_candidate_subtrees = [&](const DynamicBitset& certified_candidates) {
+            CompleteCandidateSubtreeStats result;
+            const int32_t vocab_count = static_cast<int32_t>(sorted_decoded_vocab.size());
+            std::vector<int32_t> source_prefix_counts(vocab_count + 1, 0);
+            std::vector<int32_t> certified_prefix_counts(vocab_count + 1, 0);
+            for (int32_t index = 0; index < vocab_count; ++index) {
+              source_prefix_counts[index + 1] =
+                  source_prefix_counts[index] + whitespace_prefix_source_candidates[index];
+              certified_prefix_counts[index + 1] =
+                  certified_prefix_counts[index] + certified_candidates[index];
+            }
+            int32_t covered_until = -1;
+            for (int32_t sorted_vocab_index = certified_candidates.FindFirstOne();
+                 sorted_vocab_index != -1;
+                 sorted_vocab_index = certified_candidates.FindNextOne(sorted_vocab_index)) {
+              if (sorted_vocab_index < covered_until) {
+                continue;
+              }
+              const auto& token = sorted_decoded_vocab[sorted_vocab_index].second;
+              int32_t complete_subtree_end = -1;
+              int32_t complete_subtree_tokens = 0;
+              for (int32_t prefix_length = 1; prefix_length <= static_cast<int32_t>(token.size());
+                   ++prefix_length) {
+                const std::string prefix = token.substr(0, prefix_length);
+                const auto prefix_begin = std::lower_bound(
+                    sorted_decoded_vocab.begin(),
+                    sorted_decoded_vocab.end(),
+                    prefix,
+                    [](const auto& item, const std::string& value) { return item.second < value; }
+                );
+                const int32_t prefix_start =
+                    static_cast<int32_t>(prefix_begin - sorted_decoded_vocab.begin());
+                const int32_t prefix_end = suffix_prefix_range_ends
+                    [suffix_lookup_indptr[sorted_vocab_index] + prefix_length - 1];
+                const int32_t source_count =
+                    source_prefix_counts[prefix_end] - source_prefix_counts[prefix_start];
+                const int32_t certified_count =
+                    certified_prefix_counts[prefix_end] - certified_prefix_counts[prefix_start];
+                if (source_count >= 2 && source_count == certified_count) {
+                  complete_subtree_end = prefix_end;
+                  complete_subtree_tokens = source_count;
+                  break;
+                }
+              }
+              if (complete_subtree_end >= 0) {
+                ++result.subtree_count;
+                result.subtree_tokens += complete_subtree_tokens;
+                covered_until = complete_subtree_end;
+              } else {
+                ++result.residual_singletons;
+              }
+            }
+            return result;
+          };
+          DynamicBitset local_continuation_accepted_candidates(sorted_decoded_vocab.size());
+          uint64_t local_continuation_unique_suffixes = 0;
+          uint64_t local_continuation_naive_bytes = 0;
+          uint64_t local_continuation_advance_calls = 0;
+          uint64_t local_continuation_false_positives = 0;
+          uint64_t local_continuation_false_negatives = 0;
+          uint64_t local_continuation_ns = 0;
+          if (!normalized_continuation_states.empty()) {
+            std::vector<std::pair<std::string_view, int32_t>> suffix_candidates;
+            suffix_candidates.reserve(whitespace_prefix_source_candidates.Count());
+            for (int32_t sorted_vocab_index = whitespace_prefix_source_candidates.FindFirstOne();
+                 sorted_vocab_index != -1;
+                 sorted_vocab_index =
+                     whitespace_prefix_source_candidates.FindNextOne(sorted_vocab_index)) {
+              const auto& token = sorted_decoded_vocab[sorted_vocab_index].second;
+              int32_t suffix_offset = 0;
+              while (suffix_offset < static_cast<int32_t>(token.size())) {
+                const uint8_t byte = token[suffix_offset];
+                if (byte != 0x09 && byte != 0x0A && byte != 0x0B && byte != 0x0C && byte != 0x0D &&
+                    byte != 0x20) {
+                  break;
+                }
+                ++suffix_offset;
+              }
+              XGRAMMAR_DCHECK(
+                  suffix_offset > 0 && suffix_offset < static_cast<int32_t>(token.size())
+              );
+              const std::string_view suffix(
+                  token.data() + suffix_offset, token.size() - suffix_offset
+              );
+              suffix_candidates.emplace_back(suffix, sorted_vocab_index);
+              local_continuation_naive_bytes += suffix.size();
+            }
+            std::sort(
+                suffix_candidates.begin(),
+                suffix_candidates.end(),
+                [](const auto& lhs, const auto& rhs) {
+                  if (lhs.first != rhs.first) {
+                    return lhs.first < rhs.first;
+                  }
+                  return lhs.second < rhs.second;
+                }
+            );
+
+            const auto local_started_at = details::Clock::now();
+            EarleyParser local_parser(
+                grammar_,
+                normalized_continuation_states.front(),
+                compiled_grammar_->earley_parser_metadata,
+                false
+            );
+            local_parser.PushStatesToCheck(normalized_continuation_states);
+            std::string_view previous_suffix;
+            bool has_previous_suffix = false;
+            int32_t previous_matched_size = 0;
+            for (const auto& [suffix, sorted_vocab_index] : suffix_candidates) {
+              int32_t common_prefix_size = 0;
+              if (has_previous_suffix) {
+                const int32_t common_limit =
+                    std::min<int32_t>(suffix.size(), previous_suffix.size());
+                while (common_prefix_size < common_limit &&
+                       suffix[common_prefix_size] == previous_suffix[common_prefix_size]) {
+                  ++common_prefix_size;
+                }
+              }
+              if (!has_previous_suffix || suffix != previous_suffix) {
+                ++local_continuation_unique_suffixes;
+              }
+              bool accepted = true;
+              if (has_previous_suffix && common_prefix_size > previous_matched_size) {
+                // The previous suffix failed immediately after the retained
+                // prefix, so every lexicographically adjacent suffix sharing
+                // that failed byte is rejected as well.
+                accepted = false;
+              } else if (common_prefix_size < previous_matched_size) {
+                local_parser.PopLastStates(previous_matched_size - common_prefix_size);
+                previous_matched_size = common_prefix_size;
+              }
+              if (accepted) {
+                for (int32_t byte_index = previous_matched_size;
+                     byte_index < static_cast<int32_t>(suffix.size());
+                     ++byte_index) {
+                  ++local_continuation_advance_calls;
+                  if (!local_parser.Advance(static_cast<uint8_t>(suffix[byte_index]))) {
+                    accepted = false;
+                    break;
+                  }
+                  previous_matched_size = byte_index + 1;
+                }
+              }
+              if (accepted) {
+                local_continuation_accepted_candidates.Set(sorted_vocab_index);
+              }
+              const int32_t token_id = sorted_decoded_vocab[sorted_vocab_index].first;
+              const bool expected = exact_output_mask[token_id];
+              local_continuation_false_positives += accepted && !expected;
+              local_continuation_false_negatives += !accepted && expected;
+              previous_suffix = suffix;
+              has_previous_suffix = true;
+            }
+            local_parser.PopLastStates(previous_matched_size);
+            local_continuation_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                        details::Clock::now() - local_started_at
+            )
+                                        .count();
+          }
+          const auto certified_subtrees =
+              count_complete_candidate_subtrees(whitespace_prefix_certified_candidates);
+          const auto oracle_ascii_subtrees =
+              count_complete_candidate_subtrees(whitespace_prefix_oracle_ascii_candidates);
+          const auto local_continuation_subtrees =
+              count_complete_candidate_subtrees(local_continuation_accepted_candidates);
+          XGRAMMAR_LOG(INFO
+          ) << "CandidateWhitespacePrefixCertificate(source_state="
+            << state << ", certified_tokens=" << whitespace_prefix_certified_tokens
+            << ", rejected_certificates=" << whitespace_prefix_rejected_certificates
+            << ", missing_suffix_tokens=" << whitespace_prefix_missing_suffix_tokens
+            << ", parent_ascii_closure=" << parent_has_ascii_closure
+            << ", parent_ascii_closure_configurations=" << parent_ascii_closure_configurations
+            << ", parent_ascii_closure_transitions=" << parent_ascii_closure_transitions
+            << ", source_candidates=" << whitespace_prefix_source_candidates.Count()
+            << ", certified_subtrees=" << certified_subtrees.subtree_count
+            << ", certified_subtree_tokens=" << certified_subtrees.subtree_tokens
+            << ", certified_residual_singletons=" << certified_subtrees.residual_singletons
+            << ", oracle_ascii_tokens=" << whitespace_prefix_oracle_ascii_candidates.Count()
+            << ", oracle_ascii_subtrees=" << oracle_ascii_subtrees.subtree_count
+            << ", oracle_ascii_subtree_tokens=" << oracle_ascii_subtrees.subtree_tokens
+            << ", oracle_ascii_residual_singletons=" << oracle_ascii_subtrees.residual_singletons
+            << ", local_continuation_states=" << normalized_continuation_states.size()
+            << ", local_continuation_unique_suffixes=" << local_continuation_unique_suffixes
+            << ", local_continuation_naive_bytes=" << local_continuation_naive_bytes
+            << ", local_continuation_advance_calls=" << local_continuation_advance_calls
+            << ", local_continuation_accepted_tokens="
+            << local_continuation_accepted_candidates.Count()
+            << ", local_continuation_false_positives=" << local_continuation_false_positives
+            << ", local_continuation_false_negatives=" << local_continuation_false_negatives
+            << ", local_continuation_subtrees=" << local_continuation_subtrees.subtree_count
+            << ", local_continuation_subtree_tokens=" << local_continuation_subtrees.subtree_tokens
+            << ", local_continuation_residual_singletons="
+            << local_continuation_subtrees.residual_singletons
+            << ", local_continuation_ns=" << local_continuation_ns << ")";
+          rule_id_to_completable_states_.PopBack(1);
+          scanable_state_history_.PopBack(1);
+          is_completed_.pop_back();
+          tmp_states_visited_in_queue_.Clear();
+          tmp_states_to_be_added_ = saved_states_to_be_added;
+          tmp_accept_stop_token_ = saved_accept_stop_token;
+        }
+      }
+    }
+    if (candidate_ascii_safe_tokens != 0) {
+      ++profile_runtime_ascii_closure_queries_;
+      uint64_t explored_configurations = 0;
+      uint64_t explored_transitions = 0;
+      const auto closure_started_at = details::Clock::now();
+      const int32_t external_row_count =
+          static_cast<int32_t>(rule_id_to_completable_states_.size()) - 1;
+      ContinuationTransitionCache closure_cache(this, external_row_count);
+      const bool has_ascii_safe_closure = closure_cache.CurrentConfigurationHasAsciiSafeClosure(
+          &explored_configurations, &explored_transitions
+      );
+      profile_runtime_ascii_closure_ns_ += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                               details::Clock::now() - closure_started_at
+      )
+                                               .count();
+      profile_runtime_ascii_closure_configurations_ += explored_configurations;
+      profile_runtime_ascii_closure_transitions_ += explored_transitions;
+      if (has_ascii_safe_closure) {
+        ++profile_runtime_ascii_closure_hits_;
+        profile_runtime_ascii_closure_covered_candidates_ += candidate_ascii_safe_tokens;
+        profile_runtime_ascii_closure_mismatches_ += rejected_candidate_ascii_safe_tokens;
+      }
+    }
+    if (fsm_ascii_safe_is_subsumed && candidate_ascii_safe_tokens != 0) {
+      ++profile_fsm_ascii_safe_subsumed_calls_;
+      profile_fsm_ascii_safe_candidate_tokens_ += candidate_ascii_safe_tokens;
+      profile_fsm_ascii_safe_rejected_candidate_tokens_ += rejected_candidate_ascii_safe_tokens;
+      if (rejected_candidate_ascii_safe_tokens == 0) {
+        profile_fsm_ascii_safe_covered_candidate_tokens_ += candidate_ascii_safe_tokens;
+      }
+    }
+    if (fsm_ascii_safe_10_is_subsumed && candidate_ascii_safe_10_tokens != 0) {
+      ++profile_fsm_ascii_safe_10_subsumed_calls_;
+    }
+    if (fsm_ascii_safe_30_is_subsumed && candidate_ascii_safe_30_tokens != 0) {
+      ++profile_fsm_ascii_safe_30_subsumed_calls_;
+    }
+    const uint64_t bounded_candidate_tokens =
+        fsm_ascii_safe_30_is_subsumed
+            ? candidate_ascii_safe_30_tokens
+            : (fsm_ascii_safe_10_is_subsumed ? candidate_ascii_safe_10_tokens : 0);
+    const uint64_t bounded_rejected_candidate_tokens =
+        fsm_ascii_safe_30_is_subsumed
+            ? rejected_candidate_ascii_safe_30_tokens
+            : (fsm_ascii_safe_10_is_subsumed ? rejected_candidate_ascii_safe_10_tokens : 0);
+    profile_fsm_ascii_safe_bounded_candidate_tokens_ += bounded_candidate_tokens;
+    profile_fsm_ascii_safe_bounded_rejected_candidate_tokens_ += bounded_rejected_candidate_tokens;
+    if (bounded_rejected_candidate_tokens == 0) {
+      profile_fsm_ascii_safe_bounded_covered_candidate_tokens_ += bounded_candidate_tokens;
+    }
+    std::array<bool, 4> candidate_slice_is_subsumed{};
+    for (size_t slice_index = 0; slice_index < tokenizer_slices.size(); ++slice_index) {
+      candidate_slice_is_subsumed[slice_index] =
+          candidate_tokens_in_slice[slice_index] != 0 &&
+          rejected_candidate_tokens_in_slice[slice_index] == 0;
+      if (candidate_slice_is_subsumed[slice_index]) {
+        ++profile_candidate_slice_subsumed_calls_[slice_index];
+        profile_candidate_slice_covered_tokens_[slice_index] +=
+            candidate_tokens_in_slice[slice_index];
+      }
+    }
+    profile_candidate_slice_filtered_bitset_ = profile_full_configuration_candidate_bitset_;
+    for (int32_t sorted_vocab_index = profile_full_configuration_candidate_bitset_.FindFirstOne();
+         sorted_vocab_index != -1;
+         sorted_vocab_index =
+             profile_full_configuration_candidate_bitset_.FindNextOne(sorted_vocab_index)) {
+      const int32_t token_id = sorted_decoded_vocab[sorted_vocab_index].first;
+      bool covered = false;
+      for (size_t slice_index = 0; slice_index < tokenizer_slices.size(); ++slice_index) {
+        covered |=
+            candidate_slice_is_subsumed[slice_index] && (*tokenizer_slices[slice_index])[token_id];
+      }
+      profile_candidate_slice_any_covered_tokens_ += covered;
+      if (covered) {
+        profile_candidate_slice_filtered_bitset_.Reset(sorted_vocab_index);
+      }
+    }
+    profile_candidate_slice_filtered_candidate_tokens_ +=
+        profile_candidate_slice_filtered_bitset_.Count();
+
+    uint64_t suffix_configuration_generation = 0;
+    uint64_t cached_suffix_configuration_generation = std::numeric_limits<uint64_t>::max();
+    uint64_t suffix_queries_in_current_configuration = 0;
+    bool suffix_accepted_union_is_ready = false;
+    std::vector<const AdaptiveTokenMask*> suffix_configuration_masks;
+    auto suffix_is_definitely_accepted = [&](int32_t sorted_vocab_index,
+                                             const std::string& token,
+                                             int32_t suffix_offset,
+                                             ContinuationTransitionCache* transition_cache) {
+      ++profile_suffix_certificate_queries_;
+      const int32_t lookup_index = suffix_lookup_indptr[sorted_vocab_index] + suffix_offset;
+      const int32_t suffix_sorted_vocab_index = suffix_lookup_sorted_indices[lookup_index];
+      if (suffix_sorted_vocab_index == -1) {
+        return false;
+      }
+      const int32_t suffix_token_id = suffix_lookup_token_ids[lookup_index];
+      if (transition_cache != nullptr) {
+        const auto cached_result = transition_cache->CurrentConfigurationDefinitelyAccepts(
+            suffix_sorted_vocab_index, suffix_token_id
+        );
+        if (cached_result.has_value()) {
+          if (*cached_result) {
+            ++profile_suffix_certificate_hits_;
+            profile_suffix_certificate_skipped_bytes_ += token.size() - suffix_offset;
+          }
+          return *cached_result;
+        }
+      }
+      if (cached_suffix_configuration_generation != suffix_configuration_generation) {
+        cached_suffix_configuration_generation = suffix_configuration_generation;
+        suffix_queries_in_current_configuration = 0;
+        suffix_accepted_union_is_ready = false;
+        suffix_configuration_masks.clear();
+        for (const auto& state : scanable_state_history_[scanable_state_history_.size() - 1]) {
+          if (state.rule_id < 0 || compiled_grammar_->earley_parser_metadata
+                                       .rule_has_atomic_token_edges[state.rule_id]) {
+            continue;
+          }
+          const AdaptiveTokenMask* mask = compiled_grammar_->FindAdaptiveTokenMask(state);
+          XGRAMMAR_DCHECK(mask != nullptr);
+          suffix_configuration_masks.push_back(mask);
+        }
+      }
+      ++suffix_queries_in_current_configuration;
+      constexpr uint64_t kSuffixQueriesBeforeAcceptedUnion = 1ULL << 30;
+      if (!suffix_accepted_union_is_ready &&
+          suffix_queries_in_current_configuration >= kSuffixQueriesBeforeAcceptedUnion) {
+        ++profile_suffix_certificate_union_builds_;
+        profile_suffix_accepted_union_bitset_.Reset();
+        for (const AdaptiveTokenMask* mask : suffix_configuration_masks) {
+          if (mask->store_type == StoreType::kAcceptedBitset) {
+            profile_suffix_accepted_union_bitset_ |= mask->accepted_bitset;
+          } else if (mask->store_type == StoreType::kAccepted) {
+            for (int32_t accepted_index : mask->accepted_indices) {
+              profile_suffix_accepted_union_bitset_.Set(sorted_decoded_vocab[accepted_index].first);
+            }
+          } else {
+            tmp_suffix_accepted_bitset_.Set();
+            for (int32_t rejected_index : mask->rejected_indices) {
+              tmp_suffix_accepted_bitset_.Reset(sorted_decoded_vocab[rejected_index].first);
+            }
+            for (int32_t uncertain_index : mask->uncertain_indices) {
+              tmp_suffix_accepted_bitset_.Reset(sorted_decoded_vocab[uncertain_index].first);
+            }
+            profile_suffix_accepted_union_bitset_ |= tmp_suffix_accepted_bitset_;
+          }
+        }
+        suffix_accepted_union_is_ready = true;
+      }
+      if (suffix_accepted_union_is_ready) {
+        if (profile_suffix_accepted_union_bitset_[suffix_token_id]) {
+          ++profile_suffix_certificate_hits_;
+          profile_suffix_certificate_skipped_bytes_ += token.size() - suffix_offset;
+          return true;
+        }
+        return false;
+      }
+      for (const AdaptiveTokenMask* mask_ptr : suffix_configuration_masks) {
+        const auto& mask = *mask_ptr;
+        bool definitely_accepted = false;
+        if (mask.store_type == StoreType::kAcceptedBitset) {
+          definitely_accepted = mask.accepted_bitset[suffix_token_id];
+        } else if (mask.store_type == StoreType::kAccepted) {
+          definitely_accepted = std::binary_search(
+              mask.accepted_indices.begin(), mask.accepted_indices.end(), suffix_sorted_vocab_index
+          );
+        } else {
+          definitely_accepted = !std::binary_search(
+                                    mask.rejected_indices.begin(),
+                                    mask.rejected_indices.end(),
+                                    suffix_sorted_vocab_index
+                                ) &&
+                                !std::binary_search(
+                                    mask.uncertain_indices.begin(),
+                                    mask.uncertain_indices.end(),
+                                    suffix_sorted_vocab_index
+                                );
+        }
+        if (definitely_accepted) {
+          ++profile_suffix_certificate_hits_;
+          profile_suffix_certificate_skipped_bytes_ += token.size() - suffix_offset;
+          return true;
+        }
+      }
+      return false;
+    };
+
+    auto traverse_candidates = [&](const DynamicBitset& candidates,
+                                   bool use_suffix_certificates,
+                                   uint64_t& loop_tokens,
+                                   uint64_t& subtree_pruned_tokens,
+                                   uint64_t& parser_tokens,
+                                   uint64_t& advance_calls,
+                                   uint64_t& transition_cache_queries,
+                                   uint64_t& transition_cache_hits,
+                                   uint64_t& mismatches,
+                                   uint64_t& traversal_ns) {
+      int32_t sorted_vocab_index = candidates.FindFirstOne();
+      if (sorted_vocab_index == -1) {
+        return;
+      }
+
+      int32_t max_candidate_token_length = 0;
+      for (int32_t candidate_index = sorted_vocab_index; candidate_index != -1;
+           candidate_index = candidates.FindNextOne(candidate_index)) {
+        max_candidate_token_length = std::max(
+            max_candidate_token_length,
+            static_cast<int32_t>(sorted_decoded_vocab[candidate_index].second.size())
+        );
+      }
+
+      const auto traversal_started_at = details::Clock::now();
+      const bool use_transition_cache =
+          max_candidate_token_length <
+          static_cast<int32_t>(ContinuationTransitionCache::MaxVirtualDepth());
+      std::unique_ptr<ContinuationTransitionCache> transition_cache;
+      if (use_transition_cache) {
+        // Unlike the per-leaf path, no temporary state row is pushed here. The current full
+        // configuration is itself the cache's initial row, so all preceding rows are external.
+        const int32_t external_row_count =
+            static_cast<int32_t>(rule_id_to_completable_states_.size()) - 1;
+        transition_cache = std::make_unique<ContinuationTransitionCache>(this, external_row_count);
+      }
+      const std::string* previous_token = nullptr;
+      int32_t previous_matched_size = 0;
+      while (sorted_vocab_index != -1) {
+        ++loop_tokens;
+        ++parser_tokens;
+        const auto& current_token = sorted_decoded_vocab[sorted_vocab_index].second;
+        bool accepted = true;
+        bool suffix_certificate_hit = false;
+
+        if (previous_token != nullptr) {
+          const int32_t lcp_length = static_cast<int32_t>(
+              std::mismatch(
+                  current_token.begin(),
+                  current_token.end(),
+                  previous_token->begin(),
+                  previous_token->end()
+              )
+                  .first -
+              current_token.begin()
+          );
+          if (lcp_length > previous_matched_size && !use_suffix_certificates) {
+            // This can only occur for a token under a previously rejected prefix. The subtree
+            // jump below should normally make the branch unreachable, but retaining it makes
+            // the counterfactual traversal independently exact.
+            accepted = false;
+          } else if (lcp_length < previous_matched_size) {
+            if (transition_cache) {
+              transition_cache->PopLastStates(previous_matched_size - lcp_length);
+            } else {
+              PopLastStates(previous_matched_size - lcp_length);
+            }
+            if (use_suffix_certificates) {
+              ++suffix_configuration_generation;
+            }
+          }
+          previous_matched_size = std::min(previous_matched_size, lcp_length);
+        }
+
+        if (accepted) {
+          for (int32_t byte_index = previous_matched_size;
+               byte_index < static_cast<int32_t>(current_token.size());) {
+            if (use_suffix_certificates && previous_matched_size > 0 &&
+                suffix_is_definitely_accepted(
+                    sorted_vocab_index, current_token, previous_matched_size, transition_cache.get()
+                )) {
+              suffix_certificate_hit = true;
+              break;
+            }
+            ++advance_calls;
+            const bool byte_accepted = transition_cache
+                                           ? transition_cache->Advance(current_token[byte_index])
+                                           : EarleyParser::Advance(current_token[byte_index]);
+            if (!byte_accepted) {
+              accepted = false;
+              break;
+            }
+            previous_matched_size = byte_index + 1;
+            if (use_suffix_certificates) {
+              ++suffix_configuration_generation;
+            }
+            ++byte_index;
+          }
+        }
+
+        const bool expected_accepted =
+            profile_full_configuration_expected_accepted_bitset_[sorted_vocab_index];
+        if (accepted != expected_accepted) {
+          ++mismatches;
+        }
+        previous_token = &current_token;
+        int32_t suffix_certified_run_next_index = -1;
+        bool suffix_certified_run_skipped = false;
+        if (accepted && suffix_certificate_hit && transition_cache != nullptr) {
+          if (const DynamicBitset* accepted_union =
+                  transition_cache->CurrentConfigurationAcceptedUnion()) {
+            const int32_t first_run_index = candidates.FindNextOne(sorted_vocab_index);
+            const int32_t prefix_range_end = suffix_prefix_range_ends
+                [suffix_lookup_indptr[sorted_vocab_index] + previous_matched_size - 1];
+            int32_t run_index = first_run_index;
+            while (run_index != -1 && run_index < prefix_range_end) {
+              const auto& [run_token_id, run_token] = sorted_decoded_vocab[run_index];
+              static_cast<void>(run_token_id);
+              XGRAMMAR_DCHECK(run_token.size() > static_cast<size_t>(previous_matched_size));
+              ++profile_suffix_certificate_run_checks_;
+              const int32_t lookup_index = suffix_lookup_indptr[run_index] + previous_matched_size;
+              const int32_t suffix_token_id = suffix_lookup_token_ids[lookup_index];
+              if (suffix_token_id == -1 || !(*accepted_union)[suffix_token_id]) {
+                break;
+              }
+              ++profile_suffix_certificate_hits_;
+              ++profile_suffix_certificate_run_skipped_tokens_;
+              profile_suffix_certificate_skipped_bytes_ += run_token.size() - previous_matched_size;
+              if (!profile_full_configuration_expected_accepted_bitset_[run_index]) {
+                ++mismatches;
+              }
+              run_index = candidates.FindNextOne(run_index);
+            }
+            if (run_index != first_run_index) {
+              suffix_certified_run_skipped = true;
+              suffix_certified_run_next_index = run_index;
+            }
+          }
+        }
+
+        if (!accepted) {
+          const int32_t rejected_subtree_end = subtree_range[sorted_vocab_index];
+          int32_t skipped_index = candidates.FindNextOne(sorted_vocab_index);
+          while (skipped_index != -1 && skipped_index < rejected_subtree_end) {
+            ++subtree_pruned_tokens;
+            if (profile_full_configuration_expected_accepted_bitset_[skipped_index]) {
+              ++mismatches;
+            }
+            skipped_index = candidates.FindNextOne(skipped_index);
+          }
+          sorted_vocab_index = skipped_index;
+        } else if (suffix_certified_run_skipped) {
+          // A null next index means the certified run reached the end of the candidate set.
+          sorted_vocab_index = suffix_certified_run_next_index;
+        } else {
+          sorted_vocab_index = candidates.FindNextOne(sorted_vocab_index);
+        }
+      }
+
+      if (transition_cache) {
+        transition_cache->PopLastStates(previous_matched_size);
+        transition_cache_queries += transition_cache->Queries();
+        transition_cache_hits += transition_cache->Hits();
+      } else {
+        PopLastStates(previous_matched_size);
+      }
+      tmp_accept_stop_token_ = saved_tmp_accept_stop_token;
+      tmp_states_to_be_added_ = saved_tmp_states_to_be_added;
+      traversal_ns += std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          details::Clock::now() - traversal_started_at
+      )
+                          .count();
+    };
+
+    traverse_candidates(
+        profile_full_configuration_candidate_bitset_,
+        false,
+        profile_full_configuration_loop_tokens_,
+        profile_full_configuration_subtree_pruned_tokens_,
+        profile_full_configuration_parser_tokens_,
+        profile_full_configuration_advance_calls_,
+        profile_full_configuration_transition_cache_queries_,
+        profile_full_configuration_transition_cache_hits_,
+        profile_full_configuration_mismatches_,
+        profile_full_configuration_traversal_ns_
+    );
+    traverse_candidates(
+        profile_candidate_slice_filtered_bitset_,
+        false,
+        profile_candidate_slice_filtered_loop_tokens_,
+        profile_candidate_slice_filtered_subtree_pruned_tokens_,
+        profile_candidate_slice_filtered_parser_tokens_,
+        profile_candidate_slice_filtered_advance_calls_,
+        profile_candidate_slice_filtered_transition_cache_queries_,
+        profile_candidate_slice_filtered_transition_cache_hits_,
+        profile_candidate_slice_filtered_mismatches_,
+        profile_candidate_slice_filtered_traversal_ns_
+    );
+    traverse_candidates(
+        profile_full_configuration_candidate_bitset_,
+        true,
+        profile_suffix_certificate_loop_tokens_,
+        profile_suffix_certificate_subtree_pruned_tokens_,
+        profile_suffix_certificate_parser_tokens_,
+        profile_suffix_certificate_advance_calls_,
+        profile_suffix_certificate_transition_cache_queries_,
+        profile_suffix_certificate_transition_cache_hits_,
+        profile_suffix_certificate_mismatches_,
+        profile_suffix_certificate_traversal_ns_
+    );
+  }
+#endif
 
   /*!
    * \brief If is_uncertain_saved is true, find the next token in uncertain_indices. Otherwise,
@@ -528,10 +3603,127 @@ class GrammarMatcher::Impl : public EarleyParser {
   bool terminate_without_stop_token_;
   std::deque<int> token_length_history;
 
+  ResolvedUncertainMaskCache resolved_uncertain_mask_cache_;
+
   // Temporary data for FillNextTokenBitmask. They are stored here to avoid repeated allocation.
   DynamicBitset tmp_accepted_bitset_;
+  DynamicBitset tmp_deferred_uncertain_accepted_bitset_;
+  DynamicBitset tmp_unresolved_uncertain_bitset_;
+  DynamicBitset tmp_suffix_accepted_bitset_;
+  std::vector<int32_t> tmp_unresolved_uncertain_indices_;
   std::vector<int32_t> tmp_rejected_indices_;
   std::vector<int32_t> tmp_rejected_indices_delta_;
+  std::vector<WhitespaceContinuationBatchCacheEntry> whitespace_continuation_batch_cache_;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  std::unordered_set<ParserState, StateHashForCache, StateEqualForCache>
+      profile_visited_adaptive_mask_states_;
+  uint64_t profile_fill_calls_ = 0;
+  uint64_t profile_leaf_masks_ = 0;
+  uint64_t profile_full_mask_cache_hits_ = 0;
+  uint64_t profile_uncertain_tokens_seen_ = 0;
+  uint64_t profile_union_uncertain_tokens_ = 0;
+  uint64_t profile_unresolved_union_uncertain_tokens_ = 0;
+  uint64_t profile_uncertain_loop_tokens_ = 0;
+  uint64_t profile_uncertain_parser_tokens_ = 0;
+  uint64_t profile_uncertain_advance_calls_ = 0;
+  uint64_t profile_transition_cache_queries_ = 0;
+  uint64_t profile_transition_cache_hits_ = 0;
+  uint64_t profile_full_configuration_calls_ = 0;
+  uint64_t profile_full_configuration_candidate_tokens_ = 0;
+  uint64_t profile_full_configuration_loop_tokens_ = 0;
+  uint64_t profile_full_configuration_subtree_pruned_tokens_ = 0;
+  uint64_t profile_full_configuration_parser_tokens_ = 0;
+  uint64_t profile_full_configuration_advance_calls_ = 0;
+  uint64_t profile_full_configuration_transition_cache_queries_ = 0;
+  uint64_t profile_full_configuration_transition_cache_hits_ = 0;
+  uint64_t profile_full_configuration_expected_accepted_tokens_ = 0;
+  uint64_t profile_full_configuration_mismatches_ = 0;
+  uint64_t profile_full_configuration_traversal_ns_ = 0;
+  DynamicBitset profile_uncertain_union_bitset_;
+  DynamicBitset profile_local_explicit_accepted_bitset_;
+  DynamicBitset profile_whitespace_slice_bitset_;
+  DynamicBitset profile_string_safe_10_slice_bitset_;
+  DynamicBitset profile_string_safe_30_slice_bitset_;
+  DynamicBitset profile_string_safe_slice_bitset_;
+  DynamicBitset profile_ascii_safe_10_slice_bitset_;
+  DynamicBitset profile_ascii_safe_30_slice_bitset_;
+  DynamicBitset profile_ascii_safe_slice_bitset_;
+  std::vector<uint8_t> profile_ascii_safe_10_fsm_states_;
+  std::vector<uint8_t> profile_ascii_safe_30_fsm_states_;
+  std::vector<uint8_t> profile_ascii_safe_closed_fsm_states_;
+  DynamicBitset profile_suffix_accepted_union_bitset_;
+  std::array<uint64_t, 4> profile_slice_candidate_tokens_{};
+  std::array<uint64_t, 4> profile_slice_subsumed_calls_{};
+  std::array<uint64_t, 4> profile_slice_covered_candidate_tokens_{};
+  uint64_t profile_slice_any_covered_candidate_tokens_ = 0;
+  std::array<uint64_t, 4> profile_candidate_slice_subsumed_calls_{};
+  std::array<uint64_t, 4> profile_candidate_slice_covered_tokens_{};
+  uint64_t profile_candidate_slice_any_covered_tokens_ = 0;
+  uint64_t profile_candidate_ascii_safe_tokens_ = 0;
+  uint64_t profile_candidate_ascii_safe_subsumed_calls_ = 0;
+  uint64_t profile_candidate_ascii_safe_covered_tokens_ = 0;
+  bool profile_logged_first_candidate_ascii_safe_subsumption_ = false;
+  uint64_t profile_fsm_ascii_safe_subsumed_calls_ = 0;
+  uint64_t profile_fsm_ascii_safe_candidate_tokens_ = 0;
+  uint64_t profile_fsm_ascii_safe_rejected_candidate_tokens_ = 0;
+  uint64_t profile_fsm_ascii_safe_covered_candidate_tokens_ = 0;
+  uint64_t profile_fsm_ascii_safe_10_subsumed_calls_ = 0;
+  uint64_t profile_fsm_ascii_safe_30_subsumed_calls_ = 0;
+  uint64_t profile_fsm_ascii_safe_bounded_candidate_tokens_ = 0;
+  uint64_t profile_fsm_ascii_safe_bounded_rejected_candidate_tokens_ = 0;
+  uint64_t profile_fsm_ascii_safe_bounded_covered_candidate_tokens_ = 0;
+  uint64_t profile_runtime_ascii_closure_queries_ = 0;
+  uint64_t profile_runtime_ascii_closure_hits_ = 0;
+  uint64_t profile_runtime_ascii_closure_configurations_ = 0;
+  uint64_t profile_runtime_ascii_closure_transitions_ = 0;
+  uint64_t profile_runtime_ascii_closure_covered_candidates_ = 0;
+  uint64_t profile_runtime_ascii_closure_mismatches_ = 0;
+  uint64_t profile_runtime_ascii_closure_ns_ = 0;
+  uint64_t profile_local_continuation_structure_queries_ = 0;
+  uint64_t profile_local_continuation_structure_hits_ = 0;
+  std::vector<std::vector<ParserState>> profile_local_continuation_structures_;
+  uint64_t profile_whitespace_continuation_batch_queries_ = 0;
+  uint64_t profile_whitespace_continuation_batch_hits_ = 0;
+  uint64_t profile_whitespace_continuation_batch_builds_ = 0;
+  uint64_t profile_whitespace_continuation_batch_tokens_ = 0;
+  uint64_t profile_parent_ascii_closure_queries_ = 0;
+  uint64_t profile_parent_ascii_closure_hits_ = 0;
+  uint64_t profile_parent_ascii_closure_configurations_ = 0;
+  uint64_t profile_parent_ascii_closure_transitions_ = 0;
+  uint64_t profile_parent_ascii_closure_ns_ = 0;
+  uint64_t profile_candidate_slice_filtered_candidate_tokens_ = 0;
+  uint64_t profile_candidate_slice_filtered_loop_tokens_ = 0;
+  uint64_t profile_candidate_slice_filtered_subtree_pruned_tokens_ = 0;
+  uint64_t profile_candidate_slice_filtered_parser_tokens_ = 0;
+  uint64_t profile_candidate_slice_filtered_advance_calls_ = 0;
+  uint64_t profile_candidate_slice_filtered_transition_cache_queries_ = 0;
+  uint64_t profile_candidate_slice_filtered_transition_cache_hits_ = 0;
+  uint64_t profile_candidate_slice_filtered_mismatches_ = 0;
+  uint64_t profile_candidate_slice_filtered_traversal_ns_ = 0;
+  uint64_t profile_suffix_certificate_queries_ = 0;
+  uint64_t profile_suffix_certificate_hits_ = 0;
+  uint64_t profile_suffix_certificate_union_builds_ = 0;
+  uint64_t profile_suffix_certificate_mask_queries_ = 0;
+  uint64_t profile_suffix_certificate_canonical_union_builds_ = 0;
+  uint64_t profile_suffix_certificate_run_checks_ = 0;
+  uint64_t profile_suffix_certificate_run_skipped_tokens_ = 0;
+  uint64_t profile_suffix_certificate_skipped_bytes_ = 0;
+  uint64_t profile_suffix_certificate_loop_tokens_ = 0;
+  uint64_t profile_suffix_certificate_subtree_pruned_tokens_ = 0;
+  uint64_t profile_suffix_certificate_parser_tokens_ = 0;
+  uint64_t profile_suffix_certificate_advance_calls_ = 0;
+  uint64_t profile_suffix_certificate_transition_cache_queries_ = 0;
+  uint64_t profile_suffix_certificate_transition_cache_hits_ = 0;
+  uint64_t profile_suffix_certificate_mismatches_ = 0;
+  uint64_t profile_suffix_certificate_traversal_ns_ = 0;
+  // Indexed by sorted-vocabulary position, unlike all runtime output bitsets (which use token ID).
+  DynamicBitset profile_full_configuration_candidate_bitset_;
+  DynamicBitset profile_full_configuration_expected_accepted_bitset_;
+  DynamicBitset profile_candidate_slice_filtered_bitset_;
+  bool profile_has_rejected_storage_mask_ = false;
+  std::vector<int32_t> profile_rejected_storage_nonaccepted_intersection_;
+  std::vector<int32_t> profile_tmp_rejected_storage_nonaccepted_;
+#endif
 };
 
 class BatchGrammarMatcher::Impl {
@@ -809,6 +4001,10 @@ bool GrammarMatcher::Impl::IsTokenBitmaskAllTrue(int32_t* bitmask_data_ptr) {
 bool GrammarMatcher::Impl::FillNextTokenBitmask(
     DLTensor* next_token_bitmask, int index, bool debug_print
 ) {
+  const auto fill_started_at = details::Clock::now();
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  ++profile_fill_calls_;
+#endif
   XGRAMMAR_CHECK(!IsStopTokenAccepted())
       << "GrammarMatcher has terminated after accepting the stop token, but is trying to "
          "find the next token mask";
@@ -816,10 +4012,39 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
       CheckAndGetBitmaskPtr(*next_token_bitmask, tokenizer_info_.GetVocabSize(), index);
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
   const auto& subtree_range = tokenizer_info_.GetTrieSubtreeNodesRange();
-  const auto& adaptive_token_mask_cache = compiled_grammar_->adaptive_token_mask_cache;
   // We need to have a copy, because scanable_state_history_ will be modified during the
   // FillNextTokenBitmask process, which can lead to undefined behavior.
   auto latest_states = GetLatestScanableStates();
+  uint64_t raw_state_hash = latest_states.size();
+  for (const auto& state : latest_states) {
+    HashCombineBinary(raw_state_hash, static_cast<uint32_t>(state.rule_id));
+    HashCombineBinary(raw_state_hash, static_cast<uint32_t>(state.sequence_id));
+    HashCombineBinary(raw_state_hash, static_cast<uint32_t>(state.element_id));
+    HashCombineBinary(raw_state_hash, static_cast<uint32_t>(state.sub_element_id));
+    HashCombineBinary(raw_state_hash, static_cast<uint32_t>(state.repeat_count));
+    HashCombineBinary(raw_state_hash, static_cast<uint32_t>(state.partial_codepoint));
+  }
+  bool resolved_mask_cache_started = false;
+  std::optional<int32_t> full_mask_configuration;
+  if (resolved_uncertain_mask_cache_.MayHaveFullMask(raw_state_hash)) {
+    resolved_uncertain_mask_cache_.BeginFill();
+    resolved_mask_cache_started = true;
+    full_mask_configuration = resolved_uncertain_mask_cache_.InternCurrentConfiguration();
+    if (full_mask_configuration.has_value()) {
+      if (const auto* cached_mask = resolved_uncertain_mask_cache_.FindFullMask(
+              raw_state_hash, *full_mask_configuration
+          )) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+        ++profile_full_mask_cache_hits_;
+#endif
+        DynamicBitset output_mask(
+            tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr)
+        );
+        output_mask = *cached_mask;
+        return !output_mask.All();
+      }
+    }
+  }
 
   // We check all the latest states of the earley parser, and check all the masks of the leaf
   // states. The final accepted token set is the union of the accepted token sets of all leaf
@@ -828,6 +4053,10 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
 
   // Note these indices store the indices in sorted_decoded_vocab, instead of the token ids.
   tmp_accepted_bitset_.Reset();
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  profile_uncertain_union_bitset_.Reset();
+  profile_full_configuration_candidate_bitset_.Reset();
+#endif
   // {-1} means the universal set, i.e. all tokens initially
   tmp_rejected_indices_.assign({-1});
 
@@ -836,118 +4065,367 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
                        << ", num of states=" << latest_states.size();
   }
 
-  std::vector<std::pair<ParserState, decltype(adaptive_token_mask_cache.cbegin())>>
-      latest_states_with_masks;
+  std::vector<std::pair<ParserState, const AdaptiveTokenMask*>> latest_states_with_masks;
 
   for (const auto& state : latest_states) {
-    auto adaptive_token_mask_it = adaptive_token_mask_cache.find(state);
-    XGRAMMAR_CHECK(adaptive_token_mask_it != adaptive_token_mask_cache.end()) << state;
-    const auto& adaptive_token_mask = adaptive_token_mask_it->second;
-    latest_states_with_masks.push_back(std::make_pair(state, adaptive_token_mask_it));
-    if (adaptive_token_mask.store_type == StoreType::kAcceptedBitset) {
-      tmp_accepted_bitset_ |= adaptive_token_mask.accepted_bitset;
-    } else if (adaptive_token_mask.store_type == StoreType::kAccepted) {
-      for (auto idx : adaptive_token_mask.accepted_indices) {
+    const AdaptiveTokenMask* adaptive_token_mask = compiled_grammar_->FindAdaptiveTokenMask(state);
+    XGRAMMAR_CHECK(adaptive_token_mask != nullptr) << state;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    profile_visited_adaptive_mask_states_.insert(state);
+#endif
+    latest_states_with_masks.emplace_back(state, adaptive_token_mask);
+#ifdef XGRAMMAR_PROFILE_COMPILE
+    if (adaptive_token_mask->uncertain_bitset.Size() != 0) {
+      profile_uncertain_union_bitset_ |= adaptive_token_mask->uncertain_bitset;
+    } else {
+      for (int32_t sorted_vocab_index : adaptive_token_mask->uncertain_indices) {
+        profile_uncertain_union_bitset_.Set(sorted_decoded_vocab[sorted_vocab_index].first);
+      }
+    }
+#endif
+    if (adaptive_token_mask->store_type == StoreType::kAcceptedBitset) {
+      tmp_accepted_bitset_ |= adaptive_token_mask->accepted_bitset;
+    } else if (adaptive_token_mask->store_type == StoreType::kAccepted) {
+      for (auto idx : adaptive_token_mask->accepted_indices) {
         tmp_accepted_bitset_.Set(sorted_decoded_vocab[idx].first, true);
       }
     }
   }
 
-  for (const auto& [state, adaptive_token_mask_it] : latest_states_with_masks) {
-    const auto& adaptive_token_mask = adaptive_token_mask_it->second;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  profile_union_uncertain_tokens_ += profile_uncertain_union_bitset_.Count();
+  profile_unresolved_union_uncertain_tokens_ += tmp_unresolved_uncertain_bitset_.AssignDifference(
+      profile_uncertain_union_bitset_, tmp_accepted_bitset_
+  );
+  // Preserve the exact locally accepted set before per-leaf uncertain evaluation mutates it.
+  profile_local_explicit_accepted_bitset_ = tmp_accepted_bitset_;
+#endif
 
-    // For each ParserState, we will check every uncertain token and put them into the accepted or
-    // rejected list.
+  constexpr bool used_full_configuration_hybrid = false;
 
-    // Step 2. Update the accepted tokens in accepted_indices_delta, or the rejected tokens in
-    // rejected_indices_delta.
+  if (!used_full_configuration_hybrid) {
+    for (const auto& [state, adaptive_token_mask_ptr] : latest_states_with_masks) {
+      const auto& adaptive_token_mask = *adaptive_token_mask_ptr;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+      ++profile_leaf_masks_;
+      profile_uncertain_tokens_seen_ += adaptive_token_mask.uncertain_indices.size();
+#endif
+      constexpr size_t kMinUncertainTokensForTransitionCache = 128;
+      const bool use_transition_cache =
+          adaptive_token_mask.uncertain_indices.size() >= kMinUncertainTokensForTransitionCache &&
+          adaptive_token_mask.max_uncertain_token_length <
+              static_cast<int32_t>(ContinuationTransitionCache::MaxVirtualDepth());
+      const int32_t external_row_count =
+          use_transition_cache ? rule_id_to_completable_states_.size() : -1;
+      std::unique_ptr<ContinuationTransitionCache> transition_cache;
 
-    // If the accepted tokens are saved, it means it is likely to be smaller than the rejected
-    // tokens, so we will just find the accepted tokens, and vice versa.
+      // For each ParserState, we will check every uncertain token and put them into the accepted or
+      // rejected list.
 
-    tmp_rejected_indices_delta_.clear();
+      // Step 2. Update the accepted tokens in accepted_indices_delta, or the rejected tokens in
+      // rejected_indices_delta.
 
-    // Examine only the current one ParserState
-    PushOneStateToCheck(state);
+      // If the accepted tokens are saved, it means it is likely to be smaller than the rejected
+      // tokens, so we will just find the accepted tokens, and vice versa.
 
-    const std::string* prev_token = nullptr;
-    int prev_matched_size = 0;
-    if (debug_print) {
-      XGRAMMAR_LOG(INFO) << "The ParserState is " << state << ", the mask is "
-                         << adaptive_token_mask.Print(tokenizer_info_);
-    }
-    int last_rejected_uncertain_range = 0;
-    for (const auto& cur_token_idx : adaptive_token_mask.uncertain_indices) {
-      // Check if the current token is already accepted. If it is, we can skip it.
-      if (tmp_accepted_bitset_[sorted_decoded_vocab[cur_token_idx].first]) {
-        continue;
+      tmp_rejected_indices_delta_.clear();
+
+      if (const DynamicBitset* whitespace_continuation_batch =
+              FindOrBuildWhitespaceContinuationBatch(state, adaptive_token_mask)) {
+        tmp_accepted_bitset_ |= *whitespace_continuation_batch;
       }
 
-      // Check if the current token is in the rejected range. i.e. check if the current token
-      // is on the subtree of the rejected token.
-      if (cur_token_idx < last_rejected_uncertain_range) {
-        if (adaptive_token_mask.store_type == StoreType::kRejected) {
-          tmp_rejected_indices_delta_.push_back(cur_token_idx);
+      // Examine only the current one ParserState
+      PushOneStateToCheck(state);
+
+      const std::string* prev_token = nullptr;
+      int prev_matched_size = 0;
+      if (debug_print) {
+        XGRAMMAR_LOG(INFO) << "The ParserState is " << state << ", the mask is "
+                           << adaptive_token_mask.Print(tokenizer_info_);
+      }
+      int last_rejected_uncertain_range = 0;
+      const bool has_uncertain_bitset = adaptive_token_mask.uncertain_bitset.Size() != 0;
+      const bool stores_accepted_tokens =
+          adaptive_token_mask.store_type == StoreType::kAcceptedBitset ||
+          adaptive_token_mask.store_type == StoreType::kAccepted;
+      const bool uncertain_already_accepted =
+          has_uncertain_bitset &&
+          adaptive_token_mask.uncertain_bitset.IsSubsetOf(tmp_accepted_bitset_);
+      std::optional<int32_t> resolved_mask_configuration;
+      bool resolved_mask_cache_hit = false;
+      if (has_uncertain_bitset && stores_accepted_tokens && !uncertain_already_accepted) {
+        if (!resolved_mask_cache_started) {
+          resolved_uncertain_mask_cache_.BeginFill();
+          resolved_mask_cache_started = true;
         }
-        continue;
-      }
-
-      const auto& cur_token = sorted_decoded_vocab[cur_token_idx].second;
-      bool accepted = true;
-
-      // Step 2.1. Find the longest common prefix with the accepted part of the previous token.
-      // We can reuse the previous matched size to avoid unnecessary matching.
-      if (prev_token) {
-        int lcp_len = std::mismatch(
-                          cur_token.begin(), cur_token.end(), prev_token->begin(), prev_token->end()
-                      )
-                          .first -
-                      cur_token.begin();
-        if (lcp_len > prev_matched_size) {
-          last_rejected_uncertain_range = subtree_range[cur_token_idx];
-          accepted = false;
-        } else if (lcp_len < prev_matched_size) {
-          PopLastStates(prev_matched_size - lcp_len);
+        resolved_mask_configuration = resolved_uncertain_mask_cache_.InternCurrentConfiguration();
+        if (resolved_mask_configuration.has_value() &&
+            resolved_uncertain_mask_cache_.IsAllAccepted(
+                &adaptive_token_mask, *resolved_mask_configuration
+            )) {
+          tmp_accepted_bitset_ |= adaptive_token_mask.uncertain_bitset;
+          resolved_mask_cache_hit = true;
         }
-        prev_matched_size = std::min(prev_matched_size, lcp_len);
       }
-
-      // Step 2.2. Find if the current token is accepted or rejected.
-      if (accepted) {
-        for (int j = prev_matched_size; j < static_cast<int>(cur_token.size()); ++j) {
-          if (!Advance(cur_token[j])) {
-            last_rejected_uncertain_range = subtree_range[cur_token_idx];
-            accepted = false;
-            break;
+      const bool skip_uncertain_evaluation = uncertain_already_accepted || resolved_mask_cache_hit;
+      const bool uncertain_tokens_are_disjoint =
+          has_uncertain_bitset &&
+          !adaptive_token_mask.uncertain_bitset.Intersects(tmp_accepted_bitset_);
+      const std::vector<int32_t>* uncertain_indices_to_evaluate =
+          &adaptive_token_mask.uncertain_indices;
+      bool evaluates_sparse_unresolved_tokens = false;
+      if (!skip_uncertain_evaluation && has_uncertain_bitset && !uncertain_tokens_are_disjoint) {
+        const int unresolved_count = tmp_unresolved_uncertain_bitset_.AssignDifference(
+            adaptive_token_mask.uncertain_bitset, tmp_accepted_bitset_
+        );
+        // A later leaf can overlap almost completely with tokens accepted by earlier leaves. In
+        // that case, scanning every lexicographically sorted uncertain token merely to test one
+        // random bit dominates mask latency. Enumerate the much smaller unresolved bitset by token
+        // ID, map it back to sorted-vocabulary indices, and restore lexicographic order.
+        constexpr size_t kSparseUnresolvedFraction = 8;
+        if (static_cast<size_t>(unresolved_count) * kSparseUnresolvedFraction <=
+            adaptive_token_mask.uncertain_indices.size()) {
+          tmp_unresolved_uncertain_indices_.clear();
+          tmp_unresolved_uncertain_indices_.reserve(unresolved_count);
+          const auto& token_id_to_sorted_vocab_index =
+              tokenizer_info_->GetTokenIdToSortedVocabIndex();
+          for (int token_id = tmp_unresolved_uncertain_bitset_.FindFirstOne(); token_id != -1;
+               token_id = tmp_unresolved_uncertain_bitset_.FindNextOne(token_id)) {
+            const int32_t sorted_vocab_index = token_id_to_sorted_vocab_index[token_id];
+            XGRAMMAR_DCHECK(sorted_vocab_index >= 0);
+            tmp_unresolved_uncertain_indices_.push_back(sorted_vocab_index);
           }
-          prev_matched_size = j + 1;
+          XGRAMMAR_DCHECK(
+              tmp_unresolved_uncertain_indices_.size() == static_cast<size_t>(unresolved_count)
+          );
+          std::sort(
+              tmp_unresolved_uncertain_indices_.begin(), tmp_unresolved_uncertain_indices_.end()
+          );
+          uncertain_indices_to_evaluate = &tmp_unresolved_uncertain_indices_;
+          evaluates_sparse_unresolved_tokens = true;
+        }
+      }
+      // The precomputed adjacent LCPs remain valid when overlapping tokens are skipped: take the
+      // minimum across every skipped adjacency until the next evaluated token. Sparse unresolved
+      // indices are reordered from token-ID order, so only that path must fall back to a dynamic
+      // LCP.
+      const bool has_precomputed_uncertain_lcp =
+          !evaluates_sparse_unresolved_tokens &&
+          adaptive_token_mask.uncertain_lcp_with_previous.size() ==
+              adaptive_token_mask.uncertain_indices.size();
+      const bool evaluated_tokens_are_disjoint =
+          uncertain_tokens_are_disjoint || evaluates_sparse_unresolved_tokens;
+      const bool defer_uncertain_accepts =
+          !skip_uncertain_evaluation && has_uncertain_bitset && stores_accepted_tokens;
+      bool deferred_uncertain_has_rejection = false;
+      if (use_transition_cache && !skip_uncertain_evaluation &&
+          !adaptive_token_mask.uncertain_indices.empty()) {
+        transition_cache = std::make_unique<ContinuationTransitionCache>(this, external_row_count);
+      }
+      size_t uncertain_position = 0;
+      int lcp_with_last_evaluated_token = std::numeric_limits<int>::max();
+      if (uncertain_tokens_are_disjoint && has_precomputed_uncertain_lcp &&
+          defer_uncertain_accepts) {
+        // This is the dominant large-mask path: every uncertain token is unresolved, accepted
+        // results are accumulated as a complement bitset, and adjacent LCPs were precomputed at
+        // compile time. Keep the runtime loop free of the generic overlap, storage-mode, and
+        // dynamic-LCP branches that would otherwise run once per vocabulary token.
+        XGRAMMAR_DCHECK(transition_cache != nullptr);
+        prev_matched_size = EvaluateDisjointUncertainTokens(
+            adaptive_token_mask, transition_cache.get(), &deferred_uncertain_has_rejection
+        );
+
+        if (deferred_uncertain_has_rejection) {
+          tmp_accepted_bitset_ |= tmp_deferred_uncertain_accepted_bitset_;
+        } else {
+          tmp_accepted_bitset_ |= adaptive_token_mask.uncertain_bitset;
+          if (resolved_mask_configuration.has_value()) {
+            resolved_uncertain_mask_cache_.InsertAllAccepted(
+                &adaptive_token_mask, *resolved_mask_configuration
+            );
+          }
+        }
+      } else if (!skip_uncertain_evaluation) {
+        for (const auto& cur_token_idx : *uncertain_indices_to_evaluate) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+          ++profile_uncertain_loop_tokens_;
+#endif
+          if (has_precomputed_uncertain_lcp && prev_token) {
+            lcp_with_last_evaluated_token = std::min(
+                lcp_with_last_evaluated_token,
+                adaptive_token_mask.uncertain_lcp_with_previous[uncertain_position]
+            );
+          }
+          // Check if the current token is already accepted. If it is, we can skip it.
+          if (!evaluated_tokens_are_disjoint &&
+              tmp_accepted_bitset_[sorted_decoded_vocab[cur_token_idx].first]) {
+            ++uncertain_position;
+            continue;
+          }
+
+          // Check if the current token is in the rejected range. i.e. check if the current token
+          // is on the subtree of the rejected token.
+          if (cur_token_idx < last_rejected_uncertain_range) {
+            if (defer_uncertain_accepts) {
+              if (!deferred_uncertain_has_rejection) {
+                tmp_deferred_uncertain_accepted_bitset_ = adaptive_token_mask.uncertain_bitset;
+                deferred_uncertain_has_rejection = true;
+              }
+              tmp_deferred_uncertain_accepted_bitset_.Reset(
+                  sorted_decoded_vocab[cur_token_idx].first
+              );
+            } else if (adaptive_token_mask.store_type == StoreType::kRejected) {
+              tmp_rejected_indices_delta_.push_back(cur_token_idx);
+            }
+            ++uncertain_position;
+            continue;
+          }
+
+          const auto& cur_token = sorted_decoded_vocab[cur_token_idx].second;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+          ++profile_uncertain_parser_tokens_;
+#endif
+          bool accepted = true;
+
+          // Step 2.1. Find the longest common prefix with the accepted part of the previous token.
+          // We can reuse the previous matched size to avoid unnecessary matching.
+          if (prev_token) {
+            const int lcp_len = has_precomputed_uncertain_lcp ? lcp_with_last_evaluated_token
+                                                              : static_cast<int>(
+                                                                    std::mismatch(
+                                                                        cur_token.begin(),
+                                                                        cur_token.end(),
+                                                                        prev_token->begin(),
+                                                                        prev_token->end()
+                                                                    )
+                                                                        .first -
+                                                                    cur_token.begin()
+                                                                );
+            if (lcp_len > prev_matched_size) {
+              last_rejected_uncertain_range = subtree_range[cur_token_idx];
+              accepted = false;
+            } else if (lcp_len < prev_matched_size) {
+              if (transition_cache) {
+                transition_cache->PopLastStates(prev_matched_size - lcp_len);
+              } else {
+                PopLastStates(prev_matched_size - lcp_len);
+              }
+            }
+            prev_matched_size = std::min(prev_matched_size, lcp_len);
+          }
+
+          // Step 2.2. Find if the current token is accepted or rejected.
+          if (accepted) {
+            for (int j = prev_matched_size; j < static_cast<int>(cur_token.size()); ++j) {
+#ifdef XGRAMMAR_PROFILE_COMPILE
+              ++profile_uncertain_advance_calls_;
+#endif
+              const bool char_accepted = transition_cache ? transition_cache->Advance(cur_token[j])
+                                                          : Advance(cur_token[j]);
+              if (!char_accepted) {
+                last_rejected_uncertain_range = subtree_range[cur_token_idx];
+                accepted = false;
+                break;
+              }
+              prev_matched_size = j + 1;
+            }
+          }
+
+          if (!accepted && defer_uncertain_accepts) {
+            if (!deferred_uncertain_has_rejection) {
+              tmp_deferred_uncertain_accepted_bitset_ = adaptive_token_mask.uncertain_bitset;
+              deferred_uncertain_has_rejection = true;
+            }
+            tmp_deferred_uncertain_accepted_bitset_.Reset(sorted_decoded_vocab[cur_token_idx].first
+            );
+          }
+
+          // Step 2.3. Push the result to the delta list.
+          if (stores_accepted_tokens) {
+            if (accepted && !defer_uncertain_accepts) {
+              tmp_accepted_bitset_.Set(sorted_decoded_vocab[cur_token_idx].first, true);
+            }
+          } else {
+            if (!accepted) {
+              tmp_rejected_indices_delta_.push_back(cur_token_idx);
+            }
+          }
+
+          prev_token = &cur_token;
+          lcp_with_last_evaluated_token = std::numeric_limits<int>::max();
+          ++uncertain_position;
+        }
+        if (defer_uncertain_accepts) {
+          if (deferred_uncertain_has_rejection) {
+            tmp_accepted_bitset_ |= tmp_deferred_uncertain_accepted_bitset_;
+          } else {
+            tmp_accepted_bitset_ |= adaptive_token_mask.uncertain_bitset;
+            // Overlap and sparse evaluation skip tokens already accepted by another leaf, so they
+            // cannot prove that this leaf alone accepts the complete uncertain set for a future
+            // configuration.
+            if (uncertain_tokens_are_disjoint && resolved_mask_configuration.has_value()) {
+              resolved_uncertain_mask_cache_.InsertAllAccepted(
+                  &adaptive_token_mask, *resolved_mask_configuration
+              );
+            }
+          }
         }
       }
 
-      // Step 2.3. Push the result to the delta list.
-      if (adaptive_token_mask.store_type == StoreType::kAcceptedBitset ||
-          adaptive_token_mask.store_type == StoreType::kAccepted) {
-        if (accepted) {
-          tmp_accepted_bitset_.Set(sorted_decoded_vocab[cur_token_idx].first, true);
-        }
+      if (transition_cache) {
+        transition_cache->PopLastStates(prev_matched_size + 1);
       } else {
-        if (!accepted) {
-          tmp_rejected_indices_delta_.push_back(cur_token_idx);
-        }
+        PopLastStates(prev_matched_size + 1);
       }
-
-      prev_token = &cur_token;
+      // Step 3. Update the accepted_indices or rejected_indices
+      if (adaptive_token_mask.store_type == StoreType::kRejected) {
+        // rejected_indices = Intersect(
+        //     rejected_indices,
+        //     adaptive_token_mask.rejected_indices + rejected_indices_delta)
+        IntsetUnion(&tmp_rejected_indices_delta_, adaptive_token_mask.rejected_indices);
+        IntsetIntersection(&tmp_rejected_indices_, tmp_rejected_indices_delta_);
+      }
+      if (debug_print && transition_cache) {
+        const double cache_hit_rate =
+            transition_cache->Queries() == 0
+                ? 0.0
+                : static_cast<double>(transition_cache->Hits()) / transition_cache->Queries();
+        XGRAMMAR_LOG(INFO
+        ) << "ContinuationTransitionCache("
+          << "state=" << state << ", rule_name=" << grammar_->GetRule(state.rule_id).name
+          << ", queries=" << transition_cache->Queries() << ", hits=" << transition_cache->Hits()
+          << ", hit_rate=" << cache_hit_rate
+          << ", transitions=" << transition_cache->NumTransitions()
+          << ", canonical_rows=" << transition_cache->PeakCanonicalRows()
+          << ", canonical_configurations=" << transition_cache->PeakCanonicalConfigurations()
+          << ", peak_bytes=" << transition_cache->PeakBytes()
+          << ", enabled=" << transition_cache->IsEnabled()
+          << ", admitted=" << transition_cache->IsAdmitted()
+          << ", low_reuse_fallback=" << transition_cache->DisabledForLowReuse() << ")";
+      }
+#ifdef XGRAMMAR_PROFILE_COMPILE
+      if (transition_cache) {
+        profile_transition_cache_queries_ += transition_cache->Queries();
+        profile_transition_cache_hits_ += transition_cache->Hits();
+      }
+#endif
     }
+  }
 
-    PopLastStates(prev_matched_size + 1);
-    // Step 3. Update the accepted_indices or rejected_indices
-    if (adaptive_token_mask.store_type == StoreType::kRejected) {
-      // rejected_indices = Intersect(
-      //     rejected_indices,
-      //     adaptive_token_mask.rejected_indices + rejected_indices_delta)
-      IntsetUnion(&tmp_rejected_indices_delta_, adaptive_token_mask.rejected_indices);
-      IntsetIntersection(&tmp_rejected_indices_, tmp_rejected_indices_delta_);
-    }
+  if (debug_print && (resolved_uncertain_mask_cache_.Queries() != 0 ||
+                      resolved_uncertain_mask_cache_.FullMaskQueries() != 0)) {
+    XGRAMMAR_LOG(INFO) << "ResolvedUncertainMaskCache(queries="
+                       << resolved_uncertain_mask_cache_.Queries()
+                       << ", hits=" << resolved_uncertain_mask_cache_.Hits()
+                       << ", full_mask_queries=" << resolved_uncertain_mask_cache_.FullMaskQueries()
+                       << ", full_mask_hits=" << resolved_uncertain_mask_cache_.FullMaskHits()
+                       << ", rows=" << resolved_uncertain_mask_cache_.NumRows()
+                       << ", configurations=" << resolved_uncertain_mask_cache_.NumConfigurations()
+                       << ", results=" << resolved_uncertain_mask_cache_.NumResults()
+                       << ", full_mask_results="
+                       << resolved_uncertain_mask_cache_.NumFullMaskResults()
+                       << ", bytes=" << resolved_uncertain_mask_cache_.Bytes() << ")";
   }
 
   // Finally update the rejected_ids bitset
@@ -955,6 +4433,79 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
   SetTokenBitmask(
       bitmask_data_ptr, tmp_accepted_bitset_, tmp_rejected_indices_, can_reach_end, false
   );
+  constexpr auto kFullMaskCacheAdmissionLatency = std::chrono::microseconds(200);
+  if (details::Clock::now() - fill_started_at >= kFullMaskCacheAdmissionLatency) {
+    if (!resolved_mask_cache_started) {
+      resolved_uncertain_mask_cache_.BeginFill();
+      resolved_mask_cache_started = true;
+    }
+    if (!full_mask_configuration.has_value()) {
+      full_mask_configuration = resolved_uncertain_mask_cache_.InternCurrentConfiguration();
+    }
+    if (full_mask_configuration.has_value()) {
+      const DynamicBitset output_mask(
+          tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr)
+      );
+      resolved_uncertain_mask_cache_.InsertFullMask(
+          raw_state_hash, *full_mask_configuration, output_mask
+      );
+    }
+  }
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  if (!used_full_configuration_hybrid) {
+    // Prepare the counterfactual only after the production path's latency-based full-mask-cache
+    // admission decision. Otherwise profile overhead changes later cache hits and contaminates the
+    // baseline operation counts that this experiment is meant to compare against.
+    profile_has_rejected_storage_mask_ = false;
+    profile_rejected_storage_nonaccepted_intersection_.assign({-1});
+    for (const auto& [state, adaptive_token_mask_ptr] : latest_states_with_masks) {
+      const auto& adaptive_token_mask = *adaptive_token_mask_ptr;
+      if (adaptive_token_mask.store_type == StoreType::kRejected) {
+        profile_has_rejected_storage_mask_ = true;
+        profile_tmp_rejected_storage_nonaccepted_ = adaptive_token_mask.rejected_indices;
+        IntsetUnion(
+            &profile_tmp_rejected_storage_nonaccepted_, adaptive_token_mask.uncertain_indices
+        );
+        IntsetIntersection(
+            &profile_rejected_storage_nonaccepted_intersection_,
+            profile_tmp_rejected_storage_nonaccepted_
+        );
+      }
+    }
+    const auto& token_id_to_sorted_vocab_index = tokenizer_info_->GetTokenIdToSortedVocabIndex();
+    for (int32_t token_id = profile_uncertain_union_bitset_.FindFirstOne(); token_id != -1;
+         token_id = profile_uncertain_union_bitset_.FindNextOne(token_id)) {
+      if (!profile_local_explicit_accepted_bitset_[token_id]) {
+        const int32_t sorted_vocab_index = token_id_to_sorted_vocab_index[token_id];
+        XGRAMMAR_DCHECK(sorted_vocab_index >= 0);
+        profile_full_configuration_candidate_bitset_.Set(sorted_vocab_index);
+      }
+    }
+    if (profile_has_rejected_storage_mask_) {
+      // A kRejected mask implicitly accepts every token outside (rejected U uncertain).
+      // Across multiple such leaf masks, only the intersection of those non-accepted sets still
+      // needs full-context evaluation.
+      auto nonaccepted_it = profile_rejected_storage_nonaccepted_intersection_.cbegin();
+      for (int32_t sorted_vocab_index = profile_full_configuration_candidate_bitset_.FindFirstOne();
+           sorted_vocab_index != -1;) {
+        const int32_t next_sorted_vocab_index =
+            profile_full_configuration_candidate_bitset_.FindNextOne(sorted_vocab_index);
+        while (nonaccepted_it != profile_rejected_storage_nonaccepted_intersection_.cend() &&
+               *nonaccepted_it < sorted_vocab_index) {
+          ++nonaccepted_it;
+        }
+        if (nonaccepted_it == profile_rejected_storage_nonaccepted_intersection_.cend() ||
+            *nonaccepted_it != sorted_vocab_index) {
+          profile_full_configuration_candidate_bitset_.Reset(sorted_vocab_index);
+        }
+        sorted_vocab_index = next_sorted_vocab_index;
+      }
+    }
+    ProfileFullConfigurationTraversal(
+        DynamicBitset(tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr))
+    );
+  }
+#endif
   if (debug_print) {
     XGRAMMAR_LOG(INFO) << "Filled bitmask: " << PrintBitmask(bitmask_data_ptr, tokenizer_info_);
   }
@@ -1290,7 +4841,9 @@ bool GrammarMatcher::IsCompleted() const { return pimpl_->IsCompleted(); }
 void GrammarMatcher::Reset() { pimpl_->Reset(); }
 
 GrammarMatcher GrammarMatcher::Fork() const {
-  return GrammarMatcher(std::make_shared<Impl>(*pimpl_));
+  auto forked_impl = std::make_shared<Impl>(*pimpl_);
+  forked_impl->RebindAfterFork();
+  return GrammarMatcher(std::move(forked_impl));
 }
 
 int GrammarMatcher::GetMaxRollbackTokens() const { return pimpl_->GetMaxRollbackTokens(); }

--- a/cpp/support/compact_2d_array.h
+++ b/cpp/support/compact_2d_array.h
@@ -189,6 +189,20 @@ class Compact2DArray {
    */
   int32_t PushBack(const std::vector<DataType>& new_data);
 
+  /*! \brief Append an empty row. */
+  int32_t PushBackEmpty() {
+    const int32_t end = indptr_.back();
+    indptr_.push_back(end);
+    return static_cast<int32_t>(indptr_.size()) - 2;
+  }
+
+  /*!
+   * \brief Insert a row by copying elements referenced by stable pointers.
+   * \param new_data Pointers to the elements to be inserted.
+   * \return The index of the newly inserted row.
+   */
+  int32_t PushBackIndirect(const std::vector<const DataType*>& new_data);
+
   /*!
    * \brief Insert a new row of data into the Compact2DArray from a Row struct.
    * \param row The Row struct containing the data to be inserted.
@@ -225,8 +239,10 @@ class Compact2DArray {
    * \param cnt The number of rows to be popped.
    */
   void PopBack(const int32_t& cnt) {
-    indptr_.erase(indptr_.end() - cnt, indptr_.end());
-    data_.erase(data_.begin() + indptr_.back(), data_.end());
+    const size_t new_indptr_size = indptr_.size() - cnt;
+    const size_t new_data_size = indptr_[new_indptr_size - 1];
+    indptr_.resize(new_indptr_size);
+    data_.resize(new_data_size);
     return;
   }
 
@@ -345,6 +361,21 @@ template <typename DataType>
 inline int32_t Compact2DArray<DataType>::PushBack(const std::vector<DataType>& new_data) {
   CheckCanAppendData(new_data.size());
   data_.insert(data_.end(), new_data.begin(), new_data.end());
+  indptr_.push_back(static_cast<int32_t>(data_.size()));
+  return static_cast<int32_t>(indptr_.size()) - 2;
+}
+
+template <typename DataType>
+inline int32_t Compact2DArray<DataType>::PushBackIndirect(
+    const std::vector<const DataType*>& new_data
+) {
+  data_.reserve(data_.size() + new_data.size());
+  for (const DataType* element : new_data) {
+    data_.push_back(*element);
+  }
+  XGRAMMAR_DCHECK(data_.size() <= static_cast<size_t>(INT32_MAX))
+      << "Compact2DArray data_ size (" << data_.size()
+      << ") exceeds int32_t limit, likely due to unbounded grammar pattern causing state explosion";
   indptr_.push_back(static_cast<int32_t>(data_.size()));
   return static_cast<int32_t>(indptr_.size()) - 2;
 }

--- a/cpp/support/dynamic_bitset.h
+++ b/cpp/support/dynamic_bitset.h
@@ -163,6 +163,44 @@ class DynamicBitset {
     return *this;
   }
 
+  /*!
+   * \brief Replace this bitset with the set difference lhs \ rhs and return its population count.
+   */
+  int AssignDifference(const DynamicBitset& lhs, const DynamicBitset& rhs) {
+    XGRAMMAR_DCHECK(
+        size_ == lhs.size_ && size_ == rhs.size_ && buffer_size_ == lhs.buffer_size_ &&
+        buffer_size_ == rhs.buffer_size_
+    );
+    int count = 0;
+    for (int i = 0; i < buffer_size_; ++i) {
+      data_[i] = lhs.data_[i] & ~rhs.data_[i];
+      count += PopCount(data_[i]);
+    }
+    return count;
+  }
+
+  /*! \brief Return whether this bitset and another bitset have any common set bit. */
+  bool Intersects(const DynamicBitset& other) const {
+    XGRAMMAR_DCHECK(size_ == other.size_ && buffer_size_ == other.buffer_size_);
+    for (int i = 0; i < buffer_size_; ++i) {
+      if ((data_[i] & other.data_[i]) != 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /*! \brief Return whether every set bit in this bitset is also set in another bitset. */
+  bool IsSubsetOf(const DynamicBitset& other) const {
+    XGRAMMAR_DCHECK(size_ == other.size_ && buffer_size_ == other.buffer_size_);
+    for (int i = 0; i < buffer_size_; ++i) {
+      if ((data_[i] & ~other.data_[i]) != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   int FindFirstOne() const { return DoFindOneFrom(0); }
 
   int FindNextOne(int pos) const {

--- a/cpp/tokenizer_info.cc
+++ b/cpp/tokenizer_info.cc
@@ -7,12 +7,16 @@
 
 #include <picojson.h>
 
+#include <algorithm>
 #include <array>
 #include <memory>
 #include <optional>
 #include <stack>
 #include <string>
+#include <string_view>
+#ifdef XGRAMMAR_PROFILE_COMPILE
 #include <unordered_map>
+#endif
 #include <variant>
 #include <vector>
 
@@ -320,6 +324,134 @@ TokenizerInfo::Impl::Impl(
     trie_subtree_nodes_range_[top_pair.second] = sorted_decoded_vocab_.size();
     prefix_stack.pop();
   }
+
+  // Tokens that cross from a whitespace loop into its parent continuation are a dominant runtime
+  // cost. Store their arbitrary suffixes once per tokenizer, ordered so all matchers can traverse
+  // the shared suffix trie without sorting or copying token strings.
+  std::vector<std::pair<int32_t, int32_t>> mixed_whitespace_suffixes;
+  mixed_whitespace_suffixes.reserve(sorted_decoded_vocab_.size() / 2);
+  for (int32_t sorted_vocab_index = 0;
+       sorted_vocab_index < static_cast<int32_t>(sorted_decoded_vocab_.size());
+       ++sorted_vocab_index) {
+    const auto& token = sorted_decoded_vocab_[sorted_vocab_index].second;
+    int32_t suffix_offset = 0;
+    while (suffix_offset < static_cast<int32_t>(token.size())) {
+      const uint8_t byte = token[suffix_offset];
+      if (byte != 0x09 && byte != 0x0A && byte != 0x0B && byte != 0x0C && byte != 0x0D &&
+          byte != 0x20) {
+        break;
+      }
+      ++suffix_offset;
+    }
+    if (suffix_offset > 0 && suffix_offset < static_cast<int32_t>(token.size())) {
+      mixed_whitespace_suffixes.emplace_back(sorted_vocab_index, suffix_offset);
+    }
+  }
+  std::sort(
+      mixed_whitespace_suffixes.begin(),
+      mixed_whitespace_suffixes.end(),
+      [&](const auto& lhs, const auto& rhs) {
+        const auto& lhs_token = sorted_decoded_vocab_[lhs.first].second;
+        const auto& rhs_token = sorted_decoded_vocab_[rhs.first].second;
+        const std::string_view lhs_suffix(
+            lhs_token.data() + lhs.second, lhs_token.size() - lhs.second
+        );
+        const std::string_view rhs_suffix(
+            rhs_token.data() + rhs.second, rhs_token.size() - rhs.second
+        );
+        if (lhs_suffix != rhs_suffix) {
+          return lhs_suffix < rhs_suffix;
+        }
+        return lhs.first < rhs.first;
+      }
+  );
+  mixed_whitespace_suffix_sorted_indices_.reserve(mixed_whitespace_suffixes.size());
+  mixed_whitespace_suffix_offsets_.reserve(mixed_whitespace_suffixes.size());
+  mixed_whitespace_suffix_lcp_with_previous_.reserve(mixed_whitespace_suffixes.size());
+  std::string_view previous_suffix;
+  for (size_t entry_index = 0; entry_index < mixed_whitespace_suffixes.size(); ++entry_index) {
+    const auto [sorted_vocab_index, suffix_offset] = mixed_whitespace_suffixes[entry_index];
+    const auto& token = sorted_decoded_vocab_[sorted_vocab_index].second;
+    const std::string_view suffix(token.data() + suffix_offset, token.size() - suffix_offset);
+    int32_t lcp_length = 0;
+    if (entry_index != 0) {
+      const int32_t limit = std::min<int32_t>(suffix.size(), previous_suffix.size());
+      while (lcp_length < limit && suffix[lcp_length] == previous_suffix[lcp_length]) {
+        ++lcp_length;
+      }
+    }
+    mixed_whitespace_suffix_sorted_indices_.push_back(sorted_vocab_index);
+    mixed_whitespace_suffix_offsets_.push_back(suffix_offset);
+    mixed_whitespace_suffix_lcp_with_previous_.push_back(lcp_length);
+    previous_suffix = suffix;
+  }
+
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  std::unordered_map<std::string_view, std::pair<int32_t, int32_t>> token_by_bytes;
+  token_by_bytes.reserve(sorted_decoded_vocab_.size() * 2);
+  for (int32_t sorted_vocab_index = 0;
+       sorted_vocab_index < static_cast<int32_t>(sorted_decoded_vocab_.size());
+       ++sorted_vocab_index) {
+    const auto& [token_id, token] = sorted_decoded_vocab_[sorted_vocab_index];
+    token_by_bytes.emplace(std::string_view(token), std::make_pair(sorted_vocab_index, token_id));
+  }
+  // Resolve every non-empty token suffix to one byte-equivalent vocabulary token. These tables
+  // are only used by the compile profiler's suffix-certificate counterfactual.
+  suffix_lookup_indptr_.reserve(sorted_decoded_vocab_.size() + 1);
+  suffix_lookup_indptr_.push_back(0);
+  for (const auto& [token_id, token] : sorted_decoded_vocab_) {
+    static_cast<void>(token_id);
+    suffix_lookup_indptr_.push_back(
+        suffix_lookup_indptr_.back() + static_cast<int32_t>(token.size())
+    );
+    for (size_t suffix_offset = 0; suffix_offset < token.size(); ++suffix_offset) {
+      const auto suffix_it = token_by_bytes.find(std::string_view(token).substr(suffix_offset));
+      if (suffix_it == token_by_bytes.end()) {
+        suffix_lookup_sorted_indices_.push_back(-1);
+        suffix_lookup_token_ids_.push_back(-1);
+      } else {
+        suffix_lookup_sorted_indices_.push_back(suffix_it->second.first);
+        suffix_lookup_token_ids_.push_back(suffix_it->second.second);
+      }
+    }
+  }
+
+  // Store the end of the lexicographically contiguous vocabulary interval sharing each
+  // non-empty token prefix. The flat layout matches the suffix CSR entries above.
+  std::vector<int32_t> prefix_node_ids;
+  prefix_node_ids.reserve(suffix_lookup_token_ids_.size());
+  std::vector<int32_t> prefix_node_ends;
+  std::vector<int32_t> prefix_node_ids_by_depth;
+  const std::string* previous_token = nullptr;
+  for (int32_t sorted_vocab_index = 0;
+       sorted_vocab_index < static_cast<int32_t>(sorted_decoded_vocab_.size());
+       ++sorted_vocab_index) {
+    const auto& token = sorted_decoded_vocab_[sorted_vocab_index].second;
+    size_t lcp_length = 0;
+    if (previous_token != nullptr) {
+      lcp_length =
+          std::mismatch(token.begin(), token.end(), previous_token->begin(), previous_token->end())
+              .first -
+          token.begin();
+    }
+    while (prefix_node_ids_by_depth.size() > lcp_length) {
+      prefix_node_ends[prefix_node_ids_by_depth.back()] = sorted_vocab_index;
+      prefix_node_ids_by_depth.pop_back();
+    }
+    for (size_t prefix_length = lcp_length + 1; prefix_length <= token.size(); ++prefix_length) {
+      prefix_node_ids_by_depth.push_back(prefix_node_ends.size());
+      prefix_node_ends.push_back(sorted_decoded_vocab_.size());
+    }
+    prefix_node_ids.insert(
+        prefix_node_ids.end(), prefix_node_ids_by_depth.begin(), prefix_node_ids_by_depth.end()
+    );
+    previous_token = &token;
+  }
+  suffix_prefix_range_ends_.resize(prefix_node_ids.size());
+  for (size_t flat_index = 0; flat_index < prefix_node_ids.size(); ++flat_index) {
+    suffix_prefix_range_ends_[flat_index] = prefix_node_ends[prefix_node_ids[flat_index]];
+  }
+#endif
 }
 
 std::string TokenizerInfo::Impl::DumpMetadata() const {

--- a/cpp/tokenizer_info_impl.h
+++ b/cpp/tokenizer_info_impl.h
@@ -39,6 +39,23 @@ class TokenizerInfo::Impl {
   const std::vector<int32_t>& GetTokenIdToSortedVocabIndex() const {
     return token_id_to_sorted_vocab_index_;
   }
+  const std::vector<int32_t>& GetMixedWhitespaceSuffixSortedIndices() const {
+    return mixed_whitespace_suffix_sorted_indices_;
+  }
+  const std::vector<int32_t>& GetMixedWhitespaceSuffixOffsets() const {
+    return mixed_whitespace_suffix_offsets_;
+  }
+  const std::vector<int32_t>& GetMixedWhitespaceSuffixLcpWithPrevious() const {
+    return mixed_whitespace_suffix_lcp_with_previous_;
+  }
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  const std::vector<int32_t>& GetSuffixLookupIndptr() const { return suffix_lookup_indptr_; }
+  const std::vector<int32_t>& GetSuffixLookupSortedIndices() const {
+    return suffix_lookup_sorted_indices_;
+  }
+  const std::vector<int32_t>& GetSuffixLookupTokenIds() const { return suffix_lookup_token_ids_; }
+  const std::vector<int32_t>& GetSuffixPrefixRangeEnds() const { return suffix_prefix_range_ends_; }
+#endif
 
   std::string DumpMetadata() const;
   picojson::value DumpMetadataValue() const;
@@ -79,6 +96,22 @@ class TokenizerInfo::Impl {
   std::vector<int32_t> special_token_ids_;
   /*! \brief Reverse mapping: token_id -> index in sorted_decoded_vocab_. -1 if not present. */
   std::vector<int32_t> token_id_to_sorted_vocab_index_;
+  /*! \brief Mixed whitespace/text tokens sorted by the suffix after maximal leading whitespace. */
+  std::vector<int32_t> mixed_whitespace_suffix_sorted_indices_;
+  /*! \brief Maximal leading-whitespace length for each entry in the suffix-sorted table. */
+  std::vector<int32_t> mixed_whitespace_suffix_offsets_;
+  /*! \brief Adjacent longest-common-prefix lengths in the suffix-sorted table. */
+  std::vector<int32_t> mixed_whitespace_suffix_lcp_with_previous_;
+#ifdef XGRAMMAR_PROFILE_COMPILE
+  /*! \brief CSR offsets for suffix lookup metadata attached to each vocabulary token. */
+  std::vector<int32_t> suffix_lookup_indptr_;
+  /*! \brief Suffix lookup results as sorted-vocabulary indices, or -1 when absent. */
+  std::vector<int32_t> suffix_lookup_sorted_indices_;
+  /*! \brief Suffix lookup results as token IDs, or -1 when absent. */
+  std::vector<int32_t> suffix_lookup_token_ids_;
+  /*! \brief End of the lexicographic vocabulary interval sharing each token prefix. */
+  std::vector<int32_t> suffix_prefix_range_ends_;
+#endif
 
   /*!
    * \brief The tokens used to detect stop tokens from the vocabulary.

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -176,6 +176,183 @@ def test_token_operations():
     assert result == expected
 
 
+def test_large_crossing_token_mask_matches_string_acceptance():
+    def base26(value: int) -> str:
+        chars = []
+        for _ in range(4):
+            chars.append(chr(ord("a") + value % 26))
+            value //= 26
+        return "".join(reversed(chars))
+
+    def entry(value: int) -> str:
+        opening, closing = [("(", ")"), ("[", "]"), ("{", "}")][value % 3]
+        label = "a" * (value % 4 + 1) + base26(value)
+        return f" {label}:{opening}{base26(1049 - value)}{closing}"
+
+    accepted_tokens = [entry(i) for i in range(1050)]
+    rejected_tokens = [entry(i) + "!" for i in range(64)]
+    vocab = accepted_tokens + rejected_tokens + ['"']
+    tokenizer_info = xgr.TokenizerInfo(vocab, stop_token_ids=[])
+    grammar = xgr.Grammar.from_ebnf(
+        r"""
+root ::= "\"" entry{0,3} "\""
+entry ::= " " label ":" payload
+label ::= [a-z]+
+payload ::= "(" word ")" | "[" word "]" | "{" word "}"
+word ::= [a-z]+
+"""
+    )
+    compiler = xgr.GrammarCompiler(tokenizer_info, max_threads=1, cache_enabled=False)
+    compiled_grammar = compiler.compile_grammar(grammar)
+    matcher = xgr.GrammarMatcher(compiled_grammar)
+    assert matcher.accept_string('"')
+
+    bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    repeated_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(bitmask)
+    matcher.fill_next_token_bitmask(repeated_bitmask)
+    assert torch.equal(bitmask, repeated_bitmask)
+
+    # Fill twice to populate the resolved-mask cache, then fork. The copied cache must read the
+    # fork's Earley rows after the original advances, rather than retaining a pointer to the
+    # original matcher.
+    forked_after_cache = matcher.fork()
+    assert matcher.accept_token(0)
+    forked_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    forked_after_cache.fill_next_token_bitmask(forked_bitmask)
+    assert torch.equal(bitmask, forked_bitmask)
+    matcher.rollback(1)
+    matcher.fill_next_token_bitmask(repeated_bitmask)
+    assert torch.equal(bitmask, repeated_bitmask)
+
+    for token_id, token in enumerate(vocab):
+        expected = matcher.fork().accept_string(token)
+        word = int(bitmask[0, token_id // 32].item())
+        actual = bool(word & (1 << (token_id % 32)))
+        assert actual == expected, token
+
+
+def test_large_crossing_token_low_reuse_cache_falls_back_exactly():
+    prefix_count = 1050
+    accepted_tokens = ["a" + "b" * i for i in range(prefix_count)]
+    vocab = accepted_tokens + ["ac"]
+    tokenizer_info = xgr.TokenizerInfo(vocab, stop_token_ids=[])
+    grammar = xgr.Grammar.from_ebnf(
+        f'root ::= child tail\nchild ::= [a]+\ntail ::= "{"b" * (prefix_count + 1)}"'
+    )
+    compiler = xgr.GrammarCompiler(tokenizer_info, max_threads=1, cache_enabled=False)
+    compiled_grammar = compiler.compile_grammar(grammar)
+    matcher = xgr.GrammarMatcher(compiled_grammar)
+
+    bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    repeated_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(bitmask)
+    matcher.fill_next_token_bitmask(repeated_bitmask)
+    assert torch.equal(bitmask, repeated_bitmask)
+
+    for token_id in range(prefix_count):
+        word = int(bitmask[0, token_id // 32].item())
+        assert word & (1 << (token_id % 32))
+    rejected_token_id = prefix_count
+    word = int(bitmask[0, rejected_token_id // 32].item())
+    assert not word & (1 << (rejected_token_id % 32))
+
+    assert matcher.accept_string(accepted_tokens[-1])
+    assert not matcher.accept_string("c")
+
+
+def test_large_crossing_token_cache_rechecks_low_reuse_exactly():
+    reusable_tokens = ["a" + "b" * i for i in range(1, 65)]
+    unique_tokens = ["a" + "c" * i for i in range(1, 961)]
+    vocab = reusable_tokens + unique_tokens + ["ad"]
+    tokenizer_info = xgr.TokenizerInfo(vocab, stop_token_ids=[])
+    grammar = xgr.Grammar.from_ebnf(
+        f'root ::= child tail\nchild ::= [a]+\ntail ::= [b]+ | "{"c" * 960}"'
+    )
+    compiler = xgr.GrammarCompiler(tokenizer_info, max_threads=1, cache_enabled=False)
+    compiled_grammar = compiler.compile_grammar(grammar)
+    matcher = xgr.GrammarMatcher(compiled_grammar)
+
+    bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    repeated_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(bitmask)
+    matcher.fill_next_token_bitmask(repeated_bitmask)
+    assert torch.equal(bitmask, repeated_bitmask)
+
+    for token_id, token in enumerate(vocab):
+        expected = matcher.fork().accept_string(token)
+        word = int(bitmask[0, token_id // 32].item())
+        actual = bool(word & (1 << (token_id % 32)))
+        assert actual == expected, token
+
+
+def test_large_crossing_token_cache_disables_after_steady_fast_path():
+    def base26(value: int) -> str:
+        chars = []
+        for _ in range(4):
+            chars.append(chr(ord("a") + value % 26))
+            value //= 26
+        return "".join(reversed(chars))
+
+    # The loop tokens provide more than 4096 reusable transitions, which moves the continuation
+    # cache onto its steady fast path. The final token then crosses a long literal and exhausts the
+    # 128 canonical-configuration limit. Advancing after that fallback must use EarleyParser rather
+    # than the dense transition row released by Disable().
+    loop_tokens = ["ab" + base26(i) for i in range(5200)]
+    fixed_tail = "b" * 140 + "c"
+    vocab = loop_tokens + ["az:" + fixed_tail]
+    tokenizer_info = xgr.TokenizerInfo(vocab, stop_token_ids=[])
+    grammar = xgr.Grammar.from_ebnf(
+        f"""
+root ::= child tail
+child ::= [a]+
+tail ::= [a-z]+ ":" "{fixed_tail}"
+"""
+    )
+    compiler = xgr.GrammarCompiler(tokenizer_info, max_threads=1, cache_enabled=False)
+    compiled_grammar = compiler.compile_grammar(grammar)
+    matcher = xgr.GrammarMatcher(compiled_grammar)
+
+    bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    repeated_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(bitmask)
+    matcher.fill_next_token_bitmask(repeated_bitmask)
+    assert torch.equal(bitmask, repeated_bitmask)
+
+    for token_id in [0, len(loop_tokens) - 1, len(vocab) - 1]:
+        expected = matcher.fork().accept_string(vocab[token_id])
+        word = int(bitmask[0, token_id // 32].item())
+        actual = bool(word & (1 << (token_id % 32)))
+        assert actual == expected, vocab[token_id]
+
+
+def test_large_crossing_token_moderate_reuse_cache_falls_back_exactly():
+    fixed = "cdefghijklmn"
+    repeated_tail = (fixed + "b" * 6) * 100
+    accepted_tokens = ["a" + repeated_tail[:i] for i in range(1, len(repeated_tail) + 1)]
+    vocab = accepted_tokens + ["az"]
+    tokenizer_info = xgr.TokenizerInfo(vocab, stop_token_ids=[])
+    grammar = xgr.Grammar.from_ebnf(
+        f'root ::= child tail\nchild ::= [a]+\ntail ::= segment{{100}}\nsegment ::= "{fixed}" [b]+'
+    )
+    compiler = xgr.GrammarCompiler(tokenizer_info, max_threads=1, cache_enabled=False)
+    compiled_grammar = compiler.compile_grammar(grammar)
+    matcher = xgr.GrammarMatcher(compiled_grammar)
+
+    bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    repeated_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(bitmask)
+    matcher.fill_next_token_bitmask(repeated_bitmask)
+    assert torch.equal(bitmask, repeated_bitmask)
+
+    sampled_token_ids = [0, 31, 32, 255, 511, 1023, len(accepted_tokens) - 1, len(vocab) - 1]
+    for token_id in sampled_token_ids:
+        expected = matcher.fork().accept_string(vocab[token_id])
+        word = int(bitmask[0, token_id // 32].item())
+        actual = bool(word & (1 << (token_id % 32)))
+        assert actual == expected, vocab[token_id]
+
+
 def test_rollback():
     vocab = [
         # fmt: off

--- a/tests/python/test_grammar_matcher_ebnf.py
+++ b/tests/python/test_grammar_matcher_ebnf.py
@@ -873,6 +873,30 @@ def test_repeat_ref_range_from_zero():
     assert not _is_grammar_accept_string(grammar, "a" * 201)
 
 
+@pytest.mark.parametrize("upper", [64, 128, 256, 1024])
+@pytest.mark.parametrize(
+    ("character_class", "accepted_char", "rejected_char"), [("[a-z]", "a", "A"), ("[^b]", "é", "b")]
+)
+def test_character_class_repeat_ref_range_from_zero_boundaries(
+    upper: int, character_class: str, accepted_char: str, rejected_char: str
+):
+    """Bounded character classes preserve their bounds and negation across the unzip threshold."""
+    grammar = xgr.Grammar.from_ebnf(f"root ::= {character_class}{{0,{upper}}}")
+    if upper > 128:
+        _assert_repeat_ref_active(grammar)
+    else:
+        tokenizer_info = xgr.TokenizerInfo([])
+        compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+        fsm_str = _print_grammar_fsms(compiler.compile_grammar(grammar).grammar)
+        assert "Repeat(" not in fsm_str
+
+    assert _is_grammar_accept_string(grammar, "")
+    assert _is_grammar_accept_string(grammar, accepted_char)
+    assert _is_grammar_accept_string(grammar, accepted_char * upper)
+    assert not _is_grammar_accept_string(grammar, accepted_char * (upper + 1))
+    assert not _is_grammar_accept_string(grammar, rejected_char)
+
+
 def test_repeat_ref_nested_inner():
     """Test repeat containing a rule with choices (repeat wraps complex rule)."""
     grammar_str = """


### PR DESCRIPTION
## 改动

有限状态机是一种用状态和状态转换表示允许路径的数据结构。没有循环的状态图可以从终点向起点按拓扑顺序处理；拓扑顺序是保证每条转换的目标状态先于来源状态完成的排列。本改动让每个状态直接复用后续状态已经算好的数字摘要，使没有循环的状态图只需线性遍历一次。含循环的状态图继续使用原有算法。

本请求的正式性能数据是在 #722、#781、连续数组单状态摘要和并行状态摘要之后测得，因此当前分支按该顺序保留前置提交。本请求需要审查的独立提交是 `793de52b`。

## 性能

结构标签是把触发文本、函数参数规则和结束文本组合起来的生成约束。JSON Schema 是描述 JSON 数据结构及字段约束的规则。允许词元集合生成时间是生成每一步筛选合法词元所需的平均时间。

| 输入 | 编译时间 | 允许词元集合生成时间 |
|---|---:|---:|
| 大型结构标签 | 89.703 -> 87.060 毫秒，减少 2.9% | 31.908 -> 32.312 微秒，增加 1.3% |
| 小型结构标签 | 1.384 -> 1.352 毫秒，减少 2.3% | 22.921 -> 23.740 微秒，增加 3.6% |
| 大型 JSON Schema | 19.942 -> 18.722 毫秒，减少 6.1% | 19.343 -> 19.187 微秒，减少 0.8% |
| 小型 JSON Schema | 1.347 -> 1.233 毫秒，减少 8.5% | 28.651 -> 28.590 微秒，减少 0.2% |

四类输入的编译时间均下降，JSON Schema 的收益更明显。结构标签的允许词元集合生成时间有 1.3% 至 3.6% 的回退，改动本身不在生成阶段运行。

## 正确性

- 四类正式输入中，优化前后接受行为差异为 0。
- 使用严格警告检查完成发布构建。
- 从构建产物进行不可编辑安装后，编译器测试 11 项通过，9 项因需要额外模型词表而未执行。
- 提交前格式检查全部通过。
