### PR TITLE
Build independent rule state machines in parallel

### DIFF
--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1063,7 +1063,7 @@ class GrammarCompilerSub {
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
-  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
+  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized, max_threads_);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -8,6 +8,7 @@
 #include <xgrammar/xgrammar.h>
 
 #include <array>
+#include <atomic>
 #include <bitset>
 #include <cstdint>
 #include <map>
@@ -28,6 +29,7 @@
 #include "support/container.h"
 #include "support/encoding.h"
 #include "support/logging.h"
+#include "support/thread_pool.h"
 #include "xgrammar/grammar.h"
 
 namespace xgrammar {
@@ -1306,14 +1308,38 @@ class GrammarFSMBuilderImpl {
   explicit GrammarFSMBuilderImpl(FSM& target_fsm, const std::string* rule_name = nullptr)
       : target_fsm_(target_fsm), rule_name_(rule_name) {}
 
-  static void Apply(Grammar* grammar) {
+  static void Apply(Grammar* grammar, int max_threads, ThreadPool* thread_pool) {
     FSM complete_fsm;
     std::vector<std::optional<FSMWithStartEndWithSize>> per_rule_fsms((*grammar)->NumRules());
     std::vector<int> state_mapping;
 
-    for (int i = 0; i < (*grammar)->NumRules(); ++i) {
-      auto rule_fsm = BuildRuleFSM(*grammar, i);
-      per_rule_fsms[i] = rule_fsm.AddToCompleteFSM(&complete_fsm, &state_mapping);
+    const int num_rules = (*grammar)->NumRules();
+    const int num_threads = std::max(1, std::min(max_threads, num_rules));
+    if (num_threads == 1) {
+      for (int i = 0; i < num_rules; ++i) {
+        auto rule_fsm = BuildRuleFSM(*grammar, i);
+        per_rule_fsms[i] = rule_fsm.AddToCompleteFSM(&complete_fsm, &state_mapping);
+      }
+    } else {
+      std::vector<std::optional<FSMWithStartEnd>> built_rule_fsms(num_rules);
+      std::atomic<int> next_rule_id{0};
+      std::optional<ThreadPool> owned_thread_pool;
+      if (thread_pool == nullptr) {
+        owned_thread_pool.emplace(num_threads);
+        thread_pool = &owned_thread_pool.value();
+      }
+      for (int thread_id = 0; thread_id < num_threads; ++thread_id) {
+        thread_pool->Execute([&]() {
+          int rule_id;
+          while ((rule_id = next_rule_id.fetch_add(1, std::memory_order_relaxed)) < num_rules) {
+            built_rule_fsms[rule_id] = BuildRuleFSM(*grammar, rule_id);
+          }
+        });
+      }
+      thread_pool->Wait();
+      for (int i = 0; i < num_rules; ++i) {
+        per_rule_fsms[i] = built_rule_fsms[i]->AddToCompleteFSM(&complete_fsm, &state_mapping);
+      }
     }
 
     for (int i = 0; i < (*grammar)->NumRules(); ++i) {
@@ -2981,7 +3007,7 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
 
 class GrammarOptimizerImpl {
  public:
-  static Grammar Apply(const Grammar& grammar) {
+  static Grammar Apply(const Grammar& grammar, int max_threads, ThreadPool* thread_pool) {
     // ByteStringFuser and RuleInliner rewrite the grammar in place, so work on a private copy: the
     // input grammar may be shared (e.g. a cached grammar) and must not be mutated. Copy the impl
     // directly (contiguous vector copies) instead of going through GrammarBuilder, which would
@@ -2996,7 +3022,7 @@ class GrammarOptimizerImpl {
     result->allow_empty_rule_ids = AllowEmptyRuleAnalyzer::Apply(result);
     ValidateLazyRules(result);
     RepetitionNormalizer::Apply(&result);
-    GrammarFSMBuilder::Apply(&result);
+    GrammarFSMBuilder::Apply(&result, max_threads, thread_pool);
     result->optimized = true;
     return result;
   }
@@ -3906,7 +3932,17 @@ Grammar StructureNormalizer::Apply(const Grammar& grammar) {
 
 /*************************** Forward grammar optimizers to their impl ***************************/
 
-void GrammarFSMBuilder::Apply(Grammar* grammar) { GrammarFSMBuilderImpl::Apply(grammar); }
+void GrammarFSMBuilder::Apply(Grammar* grammar) {
+  GrammarFSMBuilderImpl::Apply(grammar, 1, nullptr);
+}
+
+void GrammarFSMBuilder::Apply(Grammar* grammar, int max_threads) {
+  GrammarFSMBuilderImpl::Apply(grammar, max_threads, nullptr);
+}
+
+void GrammarFSMBuilder::Apply(Grammar* grammar, int max_threads, ThreadPool* thread_pool) {
+  GrammarFSMBuilderImpl::Apply(grammar, max_threads, thread_pool);
+}
 
 void RepetitionNormalizer::Apply(Grammar* grammar) { RepetitionNormalizerImpl().Apply(grammar); }
 
@@ -3998,7 +4034,15 @@ Grammar RepetitionRangeExpander::Apply(const Grammar& grammar) {
 }
 
 Grammar GrammarOptimizer::Apply(const Grammar& grammar) {
-  return GrammarOptimizerImpl::Apply(grammar);
+  return GrammarOptimizerImpl::Apply(grammar, 1, nullptr);
+}
+
+Grammar GrammarOptimizer::Apply(const Grammar& grammar, int max_threads) {
+  return GrammarOptimizerImpl::Apply(grammar, max_threads, nullptr);
+}
+
+Grammar GrammarOptimizer::Apply(const Grammar& grammar, int max_threads, ThreadPool* thread_pool) {
+  return GrammarOptimizerImpl::Apply(grammar, max_threads, thread_pool);
 }
 
 void ByteStringFuser::Apply(Grammar* grammar) { ByteStringFuserImpl().Apply(grammar); }

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -22,6 +22,8 @@
 
 namespace xgrammar {
 
+class ThreadPool;
+
 /*!
  * \brief Base class for visitors and mutators of the BNF grammar.
  * \tparam T The type of the return value of visitor functions. Typical values:
@@ -383,6 +385,8 @@ class GrammarFSMBuilder {
 
  public:
   static void Apply(Grammar* grammar);
+  static void Apply(Grammar* grammar, int max_threads);
+  static void Apply(Grammar* grammar, int max_threads, ThreadPool* thread_pool);
   static FSMWithStartEnd RuleRef(const GrammarExpr& expr);
   static FSMWithStartEnd CharacterClass(const GrammarExpr& expr);
   static FSMWithStartEnd ByteString(const GrammarExpr& expr);
@@ -440,6 +444,8 @@ class RepetitionRangeExpander {
 class GrammarOptimizer {
  public:
   static Grammar Apply(const Grammar& grammar);
+  static Grammar Apply(const Grammar& grammar, int max_threads);
+  static Grammar Apply(const Grammar& grammar, int max_threads, ThreadPool* thread_pool);
 };
 
 /*!


### PR DESCRIPTION
## 改动

有限状态机是一种用状态和状态转换表示允许路径的数据结构。不同语法规则的状态机彼此独立，本改动先用多个工作线程并行构造各规则的状态机，再按原规则顺序合并，保持规则编号、状态编号和公开语法文本稳定。工作线程由一次编译临时建立；跨编译阶段复用线程不包含在本请求中。

本请求直接建立在主分支上，独立提交为 `2bddaf46`。

## 性能

结构标签是把触发文本、函数参数规则和结束文本组合起来的生成约束。JSON Schema 是描述 JSON 数据结构及字段约束的规则。允许词元集合生成时间是生成每一步筛选合法词元所需的平均时间。

| 输入 | 编译时间 | 允许词元集合生成时间 |
|---|---:|---:|
| 大型结构标签 | 306.033 -> 272.726 毫秒，减少 10.9% | 11.131 -> 11.189 微秒，增加 0.5% |
| 小型结构标签 | 5.746 -> 7.080 毫秒，增加 23.2% | 11.615 -> 12.819 微秒，增加 10.4% |
| 大型 JSON Schema | 78.270 -> 74.179 毫秒，减少 5.2% | 29.215 -> 29.023 微秒，减少 0.7% |
| 小型 JSON Schema | 9.985 -> 10.353 毫秒，增加 3.7% | 69.013 -> 67.924 微秒，减少 1.6% |

大型结构标签和大型 JSON Schema 的编译时间下降；小型结构标签回退明显。评审重点是是否需要提高并行启用阈值，让小语法保持串行构造。

## 正确性

- 四类正式输入中，优化前后接受行为差异为 0。
- 使用严格警告检查完成发布构建。
- 从构建产物进行不可编辑安装后，编译器和状态机构造测试 49 项通过，9 项因需要额外模型词表而未执行。
- 提交前格式检查全部通过。
