### PR TITLE
Convert structural tag schemas in parallel

### DIFF
--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -22,6 +22,7 @@
 #include "fsm.h"
 #include "grammar_functor.h"
 #include "grammar_impl.h"
+#include "structural_tag.h"
 #include "support/dynamic_bitset.h"
 #include "support/int_set.h"
 #include "support/logging.h"
@@ -1172,7 +1173,8 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
 }
 
 CompiledGrammar GrammarCompilerSub::CompileStructuralTag(const std::string& structural_tag_json) {
-  auto result = Grammar::FromStructuralTag(structural_tag_json, tokenizer_info_);
+  auto result = StructuralTagToGrammar(structural_tag_json, tokenizer_info_, max_threads_, nullptr)
+                    .ToVariant();
   XGRAMMAR_CHECK(std::holds_alternative<Grammar>(result))
       << GetMessageFromVariantError(std::get<1>(result));
   return MultiThreadCompileGrammar(std::get<0>(result));

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -8,12 +8,16 @@
 #include <xgrammar/exception.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdint>
+#include <exception>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 
 #include "grammar_builder.h"
@@ -22,6 +26,7 @@
 #include "json_schema_converter.h"
 #include "support/logging.h"
 #include "support/recursion_guard.h"
+#include "support/thread_pool.h"
 #include "support/utils.h"
 #include "tokenizer_info_impl.h"
 #include "xgrammar/grammar.h"
@@ -1747,10 +1752,13 @@ std::optional<ISTError> StructuralTagAnalyzer::VisitSub(RepeatFormat* format) {
 
 class StructuralTagGrammarConverter {
  public:
-  static Result<Grammar, ISTError> Convert(const StructuralTag& structural_tag);
+  static Result<Grammar, ISTError> Convert(
+      const StructuralTag& structural_tag, int max_threads, ThreadPool* thread_pool
+  );
 
  private:
-  StructuralTagGrammarConverter() = default;
+  explicit StructuralTagGrammarConverter(int max_threads, ThreadPool* thread_pool)
+      : max_threads_(max_threads), thread_pool_(thread_pool) {}
 
   /*!
    * \brief Visit a Format and return the rule id of the added rule.
@@ -1779,6 +1787,9 @@ class StructuralTagGrammarConverter {
   Result<int, ISTError> VisitSub(const RepeatFormat& format);
   Result<int, ISTError> VisitSub(const DispatchFormat& format);
   Result<int, ISTError> VisitSub(const TokenDispatchFormat& format);
+  static std::string GetJSONSchemaFingerprint(const JSONSchemaFormat& format);
+  static Result<Grammar, ISTError> ConvertJSONSchemaFormat(const JSONSchemaFormat& format);
+  Result<int, ISTError> AddJSONSchemaGrammar(Grammar sub_grammar);
   Grammar AddRootRuleAndGetGrammar(int ref_rule_id);
 
   bool IsPrefix(const std::string& prefix, const std::string& full_str);
@@ -1792,6 +1803,8 @@ class StructuralTagGrammarConverter {
    * This enables deduplication of identical formats to reduce grammar size.
    */
   std::unordered_map<std::string, int> serialization_to_rule_id_;
+  int max_threads_;
+  ThreadPool* thread_pool_;
 };
 
 bool StructuralTagGrammarConverter::IsPrefix(
@@ -1801,9 +1814,10 @@ bool StructuralTagGrammarConverter::IsPrefix(
          std::string_view(full_str).substr(0, prefix.size()) == prefix;
 }
 
-Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(const StructuralTag& structural_tag
+Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(
+    const StructuralTag& structural_tag, int max_threads, ThreadPool* thread_pool
 ) {
-  StructuralTagGrammarConverter converter;
+  StructuralTagGrammarConverter converter(max_threads, thread_pool);
   auto result = converter.Visit(structural_tag.format);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
@@ -1824,13 +1838,11 @@ Grammar StructuralTagGrammarConverter::AddRootRuleAndGetGrammar(int ref_rule_id)
 Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format) {
   std::string fingerprint = FormatToJSONValue(format).serialize();
 
-  // Check if we've already processed an identical format
   auto it = serialization_to_rule_id_.find(fingerprint);
   if (it != serialization_to_rule_id_.end()) {
     return ResultOk(it->second);
   }
 
-  // Process the format and cache the result
   auto result =
       std::visit([&](auto&& arg) -> Result<int, ISTError> { return VisitSub(arg); }, format);
   if (result.IsOk()) {
@@ -1850,12 +1862,26 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const ConstStringF
 }
 
 Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFormat& format) {
+  auto result = ConvertJSONSchemaFormat(format);
+  if (result.IsErr()) {
+    return ResultErr(std::move(result).UnwrapErr());
+  }
+  return AddJSONSchemaGrammar(std::move(result).Unwrap());
+}
+
+std::string StructuralTagGrammarConverter::GetJSONSchemaFingerprint(const JSONSchemaFormat& format
+) {
+  return FormatToJSONValue(Format{format}).serialize();
+}
+
+Result<Grammar, ISTError> StructuralTagGrammarConverter::ConvertJSONSchemaFormat(
+    const JSONSchemaFormat& format
+) {
   auto json_format = JSONFormatFromString(format.style);
   if (!json_format.has_value()) {
     return ResultErr<ISTError>("Unsupported parsing type: " + format.style);
   }
-  // The whitespace cap comes from the JSONSchemaFormat node (per-tag).
-  auto sub_grammar = GrammarNormalizer::Apply(JSONSchemaToGrammar(
+  return ResultOk(GrammarNormalizer::Apply(JSONSchemaToGrammar(
       format.json_schema,
       /*any_whitespace=*/true,
       /*indent=*/std::nullopt,
@@ -1864,7 +1890,10 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFo
       /*max_whitespace_cnt=*/format.max_whitespace_cnt,
       /*any_order=*/format.any_order,
       /*json_format=*/*json_format
-  ));
+  )));
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::AddJSONSchemaGrammar(Grammar sub_grammar) {
   auto added_root_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
   return ResultOk(added_root_rule_id);
 }
@@ -1978,6 +2007,60 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTag
   std::vector<int> tag_content_rule_ids;
   tag_content_rule_ids.reserve(format.tags.size());
 
+  bool can_parallelize_json_schemas = max_threads_ > 1 && format.tags.size() > 1;
+  std::vector<int32_t> tag_to_schema_index(format.tags.size(), -1);
+  std::vector<const JSONSchemaFormat*> unique_schemas;
+  std::vector<std::string> schema_fingerprints(format.tags.size());
+  std::unordered_map<std::string, int32_t> fingerprint_to_schema_index;
+  if (can_parallelize_json_schemas) {
+    for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
+      const auto* schema = std::get_if<JSONSchemaFormat>(format.tags[it_tag].content.get());
+      if (schema == nullptr) {
+        can_parallelize_json_schemas = false;
+        break;
+      }
+      schema_fingerprints[it_tag] = GetJSONSchemaFingerprint(*schema);
+      auto [it, inserted] = fingerprint_to_schema_index.emplace(
+          schema_fingerprints[it_tag], static_cast<int32_t>(unique_schemas.size())
+      );
+      if (inserted) {
+        unique_schemas.push_back(schema);
+      }
+      tag_to_schema_index[it_tag] = it->second;
+    }
+  }
+
+  std::vector<std::optional<Result<Grammar, ISTError>>> schema_results;
+  std::vector<std::exception_ptr> schema_errors;
+  if (can_parallelize_json_schemas) {
+    int num_threads = std::min<int>(max_threads_, static_cast<int>(unique_schemas.size()));
+    schema_results.resize(unique_schemas.size());
+    schema_errors.resize(unique_schemas.size());
+    std::atomic<int32_t> next_schema_index{0};
+    std::optional<ThreadPool> owned_thread_pool;
+    ThreadPool* active_thread_pool = thread_pool_;
+    if (active_thread_pool == nullptr) {
+      owned_thread_pool.emplace(num_threads);
+      active_thread_pool = &owned_thread_pool.value();
+    }
+    for (int thread_id = 0; thread_id < num_threads; ++thread_id) {
+      active_thread_pool->Execute([&]() {
+        int32_t schema_index;
+        while ((schema_index = next_schema_index.fetch_add(1, std::memory_order_relaxed)) <
+               static_cast<int32_t>(unique_schemas.size())) {
+          try {
+            schema_results[schema_index].emplace(
+                ConvertJSONSchemaFormat(*unique_schemas[schema_index])
+            );
+          } catch (...) {
+            schema_errors[schema_index] = std::current_exception();
+          }
+        }
+      });
+    }
+    active_thread_pool->Wait();
+  }
+
   for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
     const auto& tag = format.tags[it_tag];
     if (!std::holds_alternative<std::string>(tag.begin)) {
@@ -2002,13 +2085,34 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTag
     }
     trigger_to_tag_ids[matched_trigger_id].push_back(it_tag);
 
-    auto result = Visit(*tag.content);
-    if (result.IsErr()) {
-      return result;
+    if (can_parallelize_json_schemas) {
+      const auto& fingerprint = schema_fingerprints[it_tag];
+      auto cached = serialization_to_rule_id_.find(fingerprint);
+      if (cached != serialization_to_rule_id_.end()) {
+        tag_content_rule_ids.push_back(cached->second);
+        continue;
+      }
+      int32_t schema_index = tag_to_schema_index[it_tag];
+      if (schema_errors[schema_index]) {
+        std::rethrow_exception(schema_errors[schema_index]);
+      }
+      auto result = std::move(schema_results[schema_index].value());
+      schema_results[schema_index].reset();
+      if (result.IsErr()) {
+        return ResultErr(std::move(result).UnwrapErr());
+      }
+      auto added = AddJSONSchemaGrammar(std::move(result).Unwrap());
+      int rule_id = std::move(added).Unwrap();
+      serialization_to_rule_id_[fingerprint] = rule_id;
+      tag_content_rule_ids.push_back(rule_id);
+    } else {
+      auto result = Visit(*tag.content);
+      if (result.IsErr()) {
+        return result;
+      }
+      tag_content_rule_ids.push_back(std::move(result).Unwrap());
     }
-    tag_content_rule_ids.push_back(std::move(result).Unwrap());
   }
-
   // Step 2. Special Case: at_least_one && stop_after_first.
   if (format.at_least_one && format.stop_after_first) {
     std::vector<int> choice_elements;
@@ -2411,7 +2515,10 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TokenDispatc
 /************** StructuralTag Conversion Public API **************/
 
 Result<Grammar, StructuralTagError> StructuralTagToGrammar(
-    const std::string& structural_tag_json, const std::optional<TokenizerInfo>& tokenizer_info
+    const std::string& structural_tag_json,
+    const std::optional<TokenizerInfo>& tokenizer_info,
+    int max_threads,
+    ThreadPool* thread_pool
 ) {
   auto structural_tag_result = StructuralTagParser::FromJSON(structural_tag_json);
   if (structural_tag_result.IsErr()) {
@@ -2429,7 +2536,7 @@ Result<Grammar, StructuralTagError> StructuralTagToGrammar(
     return ResultErr(std::move(err).value());
   }
 
-  auto result = StructuralTagGrammarConverter::Convert(structural_tag);
+  auto result = StructuralTagGrammarConverter::Convert(structural_tag, max_threads, thread_pool);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -24,6 +24,8 @@
 
 namespace xgrammar {
 
+class ThreadPool;
+
 /******************** Structural Tag Definition ********************/
 
 // TODO(yixin): Consider moving the definition to Public API.
@@ -389,11 +391,15 @@ struct StructuralTag {
 /*!
  * \brief Convert a structural tag JSON string to a grammar.
  * \param structural_tag_json The JSON string of the structural tag.
+ * \param tokenizer_info Optional tokenizer metadata for resolving named special tokens.
+ * \param max_threads Maximum number of threads used to convert independent JSON schemas.
  * \return A grammar if the JSON is valid, otherwise an error message in std::string.
  */
 Result<Grammar, StructuralTagError> StructuralTagToGrammar(
     const std::string& structural_tag_json,
-    const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt
+    const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt,
+    int max_threads = 1,
+    ThreadPool* thread_pool = nullptr
 );
 
 }  // namespace xgrammar

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -161,7 +161,8 @@ def test_structural_tag():
         assert _is_grammar_accept_string(grammar, input, print_time=True)
 
 
-def test_structural_tag_compiler():
+@pytest.mark.parametrize("max_threads", [1, 8])
+def test_structural_tag_compiler(max_threads: int):
     class Schema1(BaseModel):
         arg1: str
         arg2: int
@@ -180,9 +181,19 @@ def test_structural_tag_compiler():
     # but here we use two triggers for testing such cases
     triggers = ["<function=f", "<function=g"]
 
-    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]))
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]), max_threads=max_threads)
     compiled_grammar = compiler.compile_structural_tag(tags, triggers)
     assert str(compiled_grammar.grammar) == expected_grammar_test_structural_tag_after_optimization
+
+
+def test_parallel_structural_tag_schema_error():
+    tags = [
+        xgr.StructuralTagItem(begin="<function=f>", schema='{"type":"object"}', end="</function>"),
+        xgr.StructuralTagItem(begin="<function=g>", schema="not-json", end="</function>"),
+    ]
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]), max_threads=8)
+    with pytest.raises(json.JSONDecodeError, match="Expecting value"):
+        compiler.compile_structural_tag(tags, ["<function="])
 
 
 @pytest.mark.hf_token_required


### PR DESCRIPTION
## 改动

JSON Schema 是描述 JSON 数据结构及字段约束的规则。大型结构标签会包含许多彼此独立的函数参数规则。本改动先去除重复规则，再用多个工作线程并行转换不同规则，最后按原函数顺序合并，保持规则编号、公开语法文本和错误顺序稳定。

本请求直接建立在主分支上，独立提交为 `65294b97`。规则状态机构造并行和跨阶段线程复用不包含在本请求中。

## 性能

结构标签是把触发文本、函数参数规则和结束文本组合起来的生成约束。词元是模型一次处理的文本单位。允许词元集合生成时间是生成每一步筛选合法词元所需的平均时间。

| 输入 | 编译时间 | 允许词元集合生成时间 |
|---|---:|---:|
| 大型结构标签 | 198.852 -> 181.070 毫秒，减少 8.9% | 7.374 -> 7.752 微秒，增加 5.1% |
| 小型结构标签 | 4.914 -> 4.939 毫秒，增加 0.5% | 7.531 -> 7.641 微秒，增加 1.5% |
| 大型 JSON Schema | 59.343 -> 57.146 毫秒，减少 3.7% | 18.610 -> 18.738 微秒，增加 0.7% |
| 小型 JSON Schema | 8.529 -> 8.239 毫秒，减少 3.4% | 49.972 -> 50.288 微秒，增加 0.6% |

大型结构标签的编译收益最明确；另外三类输入变化不超过 3.7%。

## 正确性

- 四类正式输入中，优化前后接受行为差异为 0。
- 使用严格警告检查完成发布构建。
- 从构建产物进行不可编辑安装后，结构标签转换和匹配测试 1033 项通过，12 项因需要额外模型词表而未执行。
- 测试覆盖单线程与 8 线程语法文本一致性，以及工作线程中的转换错误传播。
- 提交前格式检查全部通过。
