### PR TITLE
Build token mask caches in worker-local maps

### DIFF
--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -6,6 +6,7 @@
 #include <xgrammar/compiler.h>
 
 #include <algorithm>
+#include <atomic>
 #include <bitset>
 #include <cctype>
 #include <cstddef>
@@ -1086,39 +1087,21 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   // 2. All byte strings (with element_in_string=0, 1, 2, ...)
   // since other positions will be expanded to the above positions
 
-  // TODO(Charlie): Figure out how to support ThreadPool and std::mutex in WebAssembly.
-  // Only declare the mutex if max_threads > 1, so single-threaded WebAssembly does not require it.
-  std::optional<std::mutex> adaptive_token_mask_cache_mutex;
-  if (max_threads_ > 1) {
-    adaptive_token_mask_cache_mutex.emplace();
-  }
+  struct AdaptiveTokenMaskTask {
+    ParserState state;
+    bool is_root_rule;
+  };
+  std::vector<AdaptiveTokenMaskTask> adaptive_token_mask_tasks;
 
-  auto add_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
+  auto compute_adaptive_token_mask = [&](const AdaptiveTokenMaskTask& task) {
     auto grammar_matcher = GrammarMatcherForTokenMaskCache(
         compiled_grammar_impl->grammar,
-        state,
+        task.state,
         tag_dispatch_rule_id_to_second_slicing_bitset,
         tokenizer_info_,
         rule_level_cache_
     );
-    auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask(is_root_rule);
-    if (max_threads_ > 1) {
-      std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex.value());
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
-    } else {
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
-    }
-  };
-
-  auto add_task_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
-    // Execute depending on whether we use thread_pool
-    if (max_threads_ > 1) {
-      thread_pool_->Execute([add_adaptive_token_mask, state, is_root_rule]() {
-        add_adaptive_token_mask(state, is_root_rule);
-      });
-    } else {
-      add_adaptive_token_mask(state, is_root_rule);
-    }
+    return grammar_matcher.GetAdaptiveTokenMask(task.is_root_rule);
   };
 
   auto root_rule_id = compiled_grammar_impl->grammar->GetRootRuleId();
@@ -1137,12 +1120,43 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
       if (!rule_fsm->GetFsm().IsScanableState(i)) {
         continue;
       }
-      add_task_adaptive_token_mask(cur_stack_element, rule_id == root_rule_id);
+      adaptive_token_mask_tasks.push_back({cur_stack_element, rule_id == root_rule_id});
     }
   }
 
-  if (max_threads_ > 1) {
+  const int32_t num_tasks = static_cast<int32_t>(adaptive_token_mask_tasks.size());
+  if (max_threads_ == 1) {
+    for (const auto& task : adaptive_token_mask_tasks) {
+      compiled_grammar_impl->adaptive_token_mask_cache.emplace(
+          task.state, compute_adaptive_token_mask(task)
+      );
+    }
+  } else if (num_tasks > 0) {
+    const int32_t num_workers = std::min(max_threads_, num_tasks);
+    using AdaptiveTokenMaskMap = decltype(compiled_grammar_impl->adaptive_token_mask_cache);
+    std::vector<AdaptiveTokenMaskMap> worker_results(num_workers);
+    for (auto& worker_result : worker_results) {
+      worker_result.reserve((num_tasks + num_workers - 1) / num_workers);
+    }
+
+    std::atomic<int32_t> next_task_id{0};
+    for (int32_t worker_id = 0; worker_id < num_workers; ++worker_id) {
+      thread_pool_->Execute([&, worker_id]() {
+        auto& worker_result = worker_results[worker_id];
+        int32_t task_id;
+        while ((task_id = next_task_id.fetch_add(1, std::memory_order_relaxed)) < num_tasks) {
+          const auto& task = adaptive_token_mask_tasks[task_id];
+          worker_result.emplace(task.state, compute_adaptive_token_mask(task));
+        }
+      });
+    }
     thread_pool_->Wait();
+
+    auto& result = compiled_grammar_impl->adaptive_token_mask_cache;
+    result.reserve(num_tasks);
+    for (auto& worker_result : worker_results) {
+      result.merge(worker_result);
+    }
   }
 
   return CompiledGrammar(compiled_grammar_impl);

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -22,6 +22,7 @@
 #include "fsm.h"
 #include "grammar_functor.h"
 #include "grammar_impl.h"
+#include "structural_tag.h"
 #include "support/dynamic_bitset.h"
 #include "support/int_set.h"
 #include "support/logging.h"
@@ -1172,7 +1173,8 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
 }
 
 CompiledGrammar GrammarCompilerSub::CompileStructuralTag(const std::string& structural_tag_json) {
-  auto result = Grammar::FromStructuralTag(structural_tag_json, tokenizer_info_);
+  auto result = StructuralTagToGrammar(structural_tag_json, tokenizer_info_, max_threads_, nullptr)
+                    .ToVariant();
   XGRAMMAR_CHECK(std::holds_alternative<Grammar>(result))
       << GetMessageFromVariantError(std::get<1>(result));
   return MultiThreadCompileGrammar(std::get<0>(result));

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1018,6 +1018,7 @@ class GrammarCompilerSub {
   )
       : tokenizer_info_(tokenizer_info),
         max_threads_(max_threads),
+        thread_pool_(max_threads > 1 ? std::make_unique<ThreadPool>(max_threads) : nullptr),
         rule_level_cache_(rule_level_cache) {}
 
   CompiledGrammar CompileBuiltinJSONGrammar();
@@ -1057,6 +1058,8 @@ class GrammarCompilerSub {
   const TokenizerInfo tokenizer_info_;
   /*! \brief The maximum number of threads to use. */
   const int max_threads_;
+  /*! \brief Workers reused across grammar conversion, optimization, and mask generation. */
+  const std::unique_ptr<ThreadPool> thread_pool_;
 
   /*! \brief The manager of the rule level cache.*/
   std::optional<RuleLevelCache> rule_level_cache_;
@@ -1064,7 +1067,8 @@ class GrammarCompilerSub {
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
-  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized, max_threads_);
+  compiled_grammar_impl->grammar =
+      GrammarOptimizer::Apply(grammar_unoptimized, max_threads_, thread_pool_.get());
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
@@ -1083,12 +1087,9 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   // since other positions will be expanded to the above positions
 
   // TODO(Charlie): Figure out how to support ThreadPool and std::mutex in WebAssembly.
-  // Only declare ThreadPool and mutex if max_threads > 1, so when max_threads = 1, we do
-  // not need ThreadPool or std::mutex, which throws error in runtime in WebAssembly.
-  std::optional<ThreadPool> thread_pool;
+  // Only declare the mutex if max_threads > 1, so single-threaded WebAssembly does not require it.
   std::optional<std::mutex> adaptive_token_mask_cache_mutex;
   if (max_threads_ > 1) {
-    thread_pool.emplace(max_threads_);
     adaptive_token_mask_cache_mutex.emplace();
   }
 
@@ -1112,7 +1113,7 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   auto add_task_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
     // Execute depending on whether we use thread_pool
     if (max_threads_ > 1) {
-      thread_pool->Execute([add_adaptive_token_mask, state, is_root_rule]() {
+      thread_pool_->Execute([add_adaptive_token_mask, state, is_root_rule]() {
         add_adaptive_token_mask(state, is_root_rule);
       });
     } else {
@@ -1141,7 +1142,7 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   }
 
   if (max_threads_ > 1) {
-    thread_pool->Join();
+    thread_pool_->Wait();
   }
 
   return CompiledGrammar(compiled_grammar_impl);
@@ -1173,8 +1174,9 @@ CompiledGrammar GrammarCompilerSub::CompileJSONSchema(
 }
 
 CompiledGrammar GrammarCompilerSub::CompileStructuralTag(const std::string& structural_tag_json) {
-  auto result = StructuralTagToGrammar(structural_tag_json, tokenizer_info_, max_threads_, nullptr)
-                    .ToVariant();
+  auto result =
+      StructuralTagToGrammar(structural_tag_json, tokenizer_info_, max_threads_, thread_pool_.get())
+          .ToVariant();
   XGRAMMAR_CHECK(std::holds_alternative<Grammar>(result))
       << GetMessageFromVariantError(std::get<1>(result));
   return MultiThreadCompileGrammar(std::get<0>(result));

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1063,7 +1063,7 @@ class GrammarCompilerSub {
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
-  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
+  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized, max_threads_);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -8,6 +8,7 @@
 #include <xgrammar/xgrammar.h>
 
 #include <array>
+#include <atomic>
 #include <bitset>
 #include <cstdint>
 #include <map>
@@ -28,6 +29,7 @@
 #include "support/container.h"
 #include "support/encoding.h"
 #include "support/logging.h"
+#include "support/thread_pool.h"
 #include "xgrammar/grammar.h"
 
 namespace xgrammar {
@@ -1306,14 +1308,38 @@ class GrammarFSMBuilderImpl {
   explicit GrammarFSMBuilderImpl(FSM& target_fsm, const std::string* rule_name = nullptr)
       : target_fsm_(target_fsm), rule_name_(rule_name) {}
 
-  static void Apply(Grammar* grammar) {
+  static void Apply(Grammar* grammar, int max_threads, ThreadPool* thread_pool) {
     FSM complete_fsm;
     std::vector<std::optional<FSMWithStartEndWithSize>> per_rule_fsms((*grammar)->NumRules());
     std::vector<int> state_mapping;
 
-    for (int i = 0; i < (*grammar)->NumRules(); ++i) {
-      auto rule_fsm = BuildRuleFSM(*grammar, i);
-      per_rule_fsms[i] = rule_fsm.AddToCompleteFSM(&complete_fsm, &state_mapping);
+    const int num_rules = (*grammar)->NumRules();
+    const int num_threads = std::max(1, std::min(max_threads, num_rules));
+    if (num_threads == 1) {
+      for (int i = 0; i < num_rules; ++i) {
+        auto rule_fsm = BuildRuleFSM(*grammar, i);
+        per_rule_fsms[i] = rule_fsm.AddToCompleteFSM(&complete_fsm, &state_mapping);
+      }
+    } else {
+      std::vector<std::optional<FSMWithStartEnd>> built_rule_fsms(num_rules);
+      std::atomic<int> next_rule_id{0};
+      std::optional<ThreadPool> owned_thread_pool;
+      if (thread_pool == nullptr) {
+        owned_thread_pool.emplace(num_threads);
+        thread_pool = &owned_thread_pool.value();
+      }
+      for (int thread_id = 0; thread_id < num_threads; ++thread_id) {
+        thread_pool->Execute([&]() {
+          int rule_id;
+          while ((rule_id = next_rule_id.fetch_add(1, std::memory_order_relaxed)) < num_rules) {
+            built_rule_fsms[rule_id] = BuildRuleFSM(*grammar, rule_id);
+          }
+        });
+      }
+      thread_pool->Wait();
+      for (int i = 0; i < num_rules; ++i) {
+        per_rule_fsms[i] = built_rule_fsms[i]->AddToCompleteFSM(&complete_fsm, &state_mapping);
+      }
     }
 
     for (int i = 0; i < (*grammar)->NumRules(); ++i) {
@@ -2981,7 +3007,7 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
 
 class GrammarOptimizerImpl {
  public:
-  static Grammar Apply(const Grammar& grammar) {
+  static Grammar Apply(const Grammar& grammar, int max_threads, ThreadPool* thread_pool) {
     // ByteStringFuser and RuleInliner rewrite the grammar in place, so work on a private copy: the
     // input grammar may be shared (e.g. a cached grammar) and must not be mutated. Copy the impl
     // directly (contiguous vector copies) instead of going through GrammarBuilder, which would
@@ -2996,7 +3022,7 @@ class GrammarOptimizerImpl {
     result->allow_empty_rule_ids = AllowEmptyRuleAnalyzer::Apply(result);
     ValidateLazyRules(result);
     RepetitionNormalizer::Apply(&result);
-    GrammarFSMBuilder::Apply(&result);
+    GrammarFSMBuilder::Apply(&result, max_threads, thread_pool);
     result->optimized = true;
     return result;
   }
@@ -3906,7 +3932,17 @@ Grammar StructureNormalizer::Apply(const Grammar& grammar) {
 
 /*************************** Forward grammar optimizers to their impl ***************************/
 
-void GrammarFSMBuilder::Apply(Grammar* grammar) { GrammarFSMBuilderImpl::Apply(grammar); }
+void GrammarFSMBuilder::Apply(Grammar* grammar) {
+  GrammarFSMBuilderImpl::Apply(grammar, 1, nullptr);
+}
+
+void GrammarFSMBuilder::Apply(Grammar* grammar, int max_threads) {
+  GrammarFSMBuilderImpl::Apply(grammar, max_threads, nullptr);
+}
+
+void GrammarFSMBuilder::Apply(Grammar* grammar, int max_threads, ThreadPool* thread_pool) {
+  GrammarFSMBuilderImpl::Apply(grammar, max_threads, thread_pool);
+}
 
 void RepetitionNormalizer::Apply(Grammar* grammar) { RepetitionNormalizerImpl().Apply(grammar); }
 
@@ -3998,7 +4034,15 @@ Grammar RepetitionRangeExpander::Apply(const Grammar& grammar) {
 }
 
 Grammar GrammarOptimizer::Apply(const Grammar& grammar) {
-  return GrammarOptimizerImpl::Apply(grammar);
+  return GrammarOptimizerImpl::Apply(grammar, 1, nullptr);
+}
+
+Grammar GrammarOptimizer::Apply(const Grammar& grammar, int max_threads) {
+  return GrammarOptimizerImpl::Apply(grammar, max_threads, nullptr);
+}
+
+Grammar GrammarOptimizer::Apply(const Grammar& grammar, int max_threads, ThreadPool* thread_pool) {
+  return GrammarOptimizerImpl::Apply(grammar, max_threads, thread_pool);
 }
 
 void ByteStringFuser::Apply(Grammar* grammar) { ByteStringFuserImpl().Apply(grammar); }

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -22,6 +22,8 @@
 
 namespace xgrammar {
 
+class ThreadPool;
+
 /*!
  * \brief Base class for visitors and mutators of the BNF grammar.
  * \tparam T The type of the return value of visitor functions. Typical values:
@@ -383,6 +385,8 @@ class GrammarFSMBuilder {
 
  public:
   static void Apply(Grammar* grammar);
+  static void Apply(Grammar* grammar, int max_threads);
+  static void Apply(Grammar* grammar, int max_threads, ThreadPool* thread_pool);
   static FSMWithStartEnd RuleRef(const GrammarExpr& expr);
   static FSMWithStartEnd CharacterClass(const GrammarExpr& expr);
   static FSMWithStartEnd ByteString(const GrammarExpr& expr);
@@ -440,6 +444,8 @@ class RepetitionRangeExpander {
 class GrammarOptimizer {
  public:
   static Grammar Apply(const Grammar& grammar);
+  static Grammar Apply(const Grammar& grammar, int max_threads);
+  static Grammar Apply(const Grammar& grammar, int max_threads, ThreadPool* thread_pool);
 };
 
 /*!

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -8,12 +8,16 @@
 #include <xgrammar/exception.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdint>
+#include <exception>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 
 #include "grammar_builder.h"
@@ -22,6 +26,7 @@
 #include "json_schema_converter.h"
 #include "support/logging.h"
 #include "support/recursion_guard.h"
+#include "support/thread_pool.h"
 #include "support/utils.h"
 #include "tokenizer_info_impl.h"
 #include "xgrammar/grammar.h"
@@ -1747,10 +1752,13 @@ std::optional<ISTError> StructuralTagAnalyzer::VisitSub(RepeatFormat* format) {
 
 class StructuralTagGrammarConverter {
  public:
-  static Result<Grammar, ISTError> Convert(const StructuralTag& structural_tag);
+  static Result<Grammar, ISTError> Convert(
+      const StructuralTag& structural_tag, int max_threads, ThreadPool* thread_pool
+  );
 
  private:
-  StructuralTagGrammarConverter() = default;
+  explicit StructuralTagGrammarConverter(int max_threads, ThreadPool* thread_pool)
+      : max_threads_(max_threads), thread_pool_(thread_pool) {}
 
   /*!
    * \brief Visit a Format and return the rule id of the added rule.
@@ -1779,6 +1787,9 @@ class StructuralTagGrammarConverter {
   Result<int, ISTError> VisitSub(const RepeatFormat& format);
   Result<int, ISTError> VisitSub(const DispatchFormat& format);
   Result<int, ISTError> VisitSub(const TokenDispatchFormat& format);
+  static std::string GetJSONSchemaFingerprint(const JSONSchemaFormat& format);
+  static Result<Grammar, ISTError> ConvertJSONSchemaFormat(const JSONSchemaFormat& format);
+  Result<int, ISTError> AddJSONSchemaGrammar(Grammar sub_grammar);
   Grammar AddRootRuleAndGetGrammar(int ref_rule_id);
 
   bool IsPrefix(const std::string& prefix, const std::string& full_str);
@@ -1792,6 +1803,8 @@ class StructuralTagGrammarConverter {
    * This enables deduplication of identical formats to reduce grammar size.
    */
   std::unordered_map<std::string, int> serialization_to_rule_id_;
+  int max_threads_;
+  ThreadPool* thread_pool_;
 };
 
 bool StructuralTagGrammarConverter::IsPrefix(
@@ -1801,9 +1814,10 @@ bool StructuralTagGrammarConverter::IsPrefix(
          std::string_view(full_str).substr(0, prefix.size()) == prefix;
 }
 
-Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(const StructuralTag& structural_tag
+Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(
+    const StructuralTag& structural_tag, int max_threads, ThreadPool* thread_pool
 ) {
-  StructuralTagGrammarConverter converter;
+  StructuralTagGrammarConverter converter(max_threads, thread_pool);
   auto result = converter.Visit(structural_tag.format);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
@@ -1824,13 +1838,11 @@ Grammar StructuralTagGrammarConverter::AddRootRuleAndGetGrammar(int ref_rule_id)
 Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format) {
   std::string fingerprint = FormatToJSONValue(format).serialize();
 
-  // Check if we've already processed an identical format
   auto it = serialization_to_rule_id_.find(fingerprint);
   if (it != serialization_to_rule_id_.end()) {
     return ResultOk(it->second);
   }
 
-  // Process the format and cache the result
   auto result =
       std::visit([&](auto&& arg) -> Result<int, ISTError> { return VisitSub(arg); }, format);
   if (result.IsOk()) {
@@ -1850,12 +1862,26 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const ConstStringF
 }
 
 Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFormat& format) {
+  auto result = ConvertJSONSchemaFormat(format);
+  if (result.IsErr()) {
+    return ResultErr(std::move(result).UnwrapErr());
+  }
+  return AddJSONSchemaGrammar(std::move(result).Unwrap());
+}
+
+std::string StructuralTagGrammarConverter::GetJSONSchemaFingerprint(const JSONSchemaFormat& format
+) {
+  return FormatToJSONValue(Format{format}).serialize();
+}
+
+Result<Grammar, ISTError> StructuralTagGrammarConverter::ConvertJSONSchemaFormat(
+    const JSONSchemaFormat& format
+) {
   auto json_format = JSONFormatFromString(format.style);
   if (!json_format.has_value()) {
     return ResultErr<ISTError>("Unsupported parsing type: " + format.style);
   }
-  // The whitespace cap comes from the JSONSchemaFormat node (per-tag).
-  auto sub_grammar = GrammarNormalizer::Apply(JSONSchemaToGrammar(
+  return ResultOk(GrammarNormalizer::Apply(JSONSchemaToGrammar(
       format.json_schema,
       /*any_whitespace=*/true,
       /*indent=*/std::nullopt,
@@ -1864,7 +1890,10 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const JSONSchemaFo
       /*max_whitespace_cnt=*/format.max_whitespace_cnt,
       /*any_order=*/format.any_order,
       /*json_format=*/*json_format
-  ));
+  )));
+}
+
+Result<int, ISTError> StructuralTagGrammarConverter::AddJSONSchemaGrammar(Grammar sub_grammar) {
   auto added_root_rule_id = SubGrammarAdder().Apply(&grammar_builder_, sub_grammar);
   return ResultOk(added_root_rule_id);
 }
@@ -1978,6 +2007,60 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTag
   std::vector<int> tag_content_rule_ids;
   tag_content_rule_ids.reserve(format.tags.size());
 
+  bool can_parallelize_json_schemas = max_threads_ > 1 && format.tags.size() > 1;
+  std::vector<int32_t> tag_to_schema_index(format.tags.size(), -1);
+  std::vector<const JSONSchemaFormat*> unique_schemas;
+  std::vector<std::string> schema_fingerprints(format.tags.size());
+  std::unordered_map<std::string, int32_t> fingerprint_to_schema_index;
+  if (can_parallelize_json_schemas) {
+    for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
+      const auto* schema = std::get_if<JSONSchemaFormat>(format.tags[it_tag].content.get());
+      if (schema == nullptr) {
+        can_parallelize_json_schemas = false;
+        break;
+      }
+      schema_fingerprints[it_tag] = GetJSONSchemaFingerprint(*schema);
+      auto [it, inserted] = fingerprint_to_schema_index.emplace(
+          schema_fingerprints[it_tag], static_cast<int32_t>(unique_schemas.size())
+      );
+      if (inserted) {
+        unique_schemas.push_back(schema);
+      }
+      tag_to_schema_index[it_tag] = it->second;
+    }
+  }
+
+  std::vector<std::optional<Result<Grammar, ISTError>>> schema_results;
+  std::vector<std::exception_ptr> schema_errors;
+  if (can_parallelize_json_schemas) {
+    int num_threads = std::min<int>(max_threads_, static_cast<int>(unique_schemas.size()));
+    schema_results.resize(unique_schemas.size());
+    schema_errors.resize(unique_schemas.size());
+    std::atomic<int32_t> next_schema_index{0};
+    std::optional<ThreadPool> owned_thread_pool;
+    ThreadPool* active_thread_pool = thread_pool_;
+    if (active_thread_pool == nullptr) {
+      owned_thread_pool.emplace(num_threads);
+      active_thread_pool = &owned_thread_pool.value();
+    }
+    for (int thread_id = 0; thread_id < num_threads; ++thread_id) {
+      active_thread_pool->Execute([&]() {
+        int32_t schema_index;
+        while ((schema_index = next_schema_index.fetch_add(1, std::memory_order_relaxed)) <
+               static_cast<int32_t>(unique_schemas.size())) {
+          try {
+            schema_results[schema_index].emplace(
+                ConvertJSONSchemaFormat(*unique_schemas[schema_index])
+            );
+          } catch (...) {
+            schema_errors[schema_index] = std::current_exception();
+          }
+        }
+      });
+    }
+    active_thread_pool->Wait();
+  }
+
   for (int it_tag = 0; it_tag < static_cast<int>(format.tags.size()); ++it_tag) {
     const auto& tag = format.tags[it_tag];
     if (!std::holds_alternative<std::string>(tag.begin)) {
@@ -2002,13 +2085,34 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TriggeredTag
     }
     trigger_to_tag_ids[matched_trigger_id].push_back(it_tag);
 
-    auto result = Visit(*tag.content);
-    if (result.IsErr()) {
-      return result;
+    if (can_parallelize_json_schemas) {
+      const auto& fingerprint = schema_fingerprints[it_tag];
+      auto cached = serialization_to_rule_id_.find(fingerprint);
+      if (cached != serialization_to_rule_id_.end()) {
+        tag_content_rule_ids.push_back(cached->second);
+        continue;
+      }
+      int32_t schema_index = tag_to_schema_index[it_tag];
+      if (schema_errors[schema_index]) {
+        std::rethrow_exception(schema_errors[schema_index]);
+      }
+      auto result = std::move(schema_results[schema_index].value());
+      schema_results[schema_index].reset();
+      if (result.IsErr()) {
+        return ResultErr(std::move(result).UnwrapErr());
+      }
+      auto added = AddJSONSchemaGrammar(std::move(result).Unwrap());
+      int rule_id = std::move(added).Unwrap();
+      serialization_to_rule_id_[fingerprint] = rule_id;
+      tag_content_rule_ids.push_back(rule_id);
+    } else {
+      auto result = Visit(*tag.content);
+      if (result.IsErr()) {
+        return result;
+      }
+      tag_content_rule_ids.push_back(std::move(result).Unwrap());
     }
-    tag_content_rule_ids.push_back(std::move(result).Unwrap());
   }
-
   // Step 2. Special Case: at_least_one && stop_after_first.
   if (format.at_least_one && format.stop_after_first) {
     std::vector<int> choice_elements;
@@ -2411,7 +2515,10 @@ Result<int, ISTError> StructuralTagGrammarConverter::VisitSub(const TokenDispatc
 /************** StructuralTag Conversion Public API **************/
 
 Result<Grammar, StructuralTagError> StructuralTagToGrammar(
-    const std::string& structural_tag_json, const std::optional<TokenizerInfo>& tokenizer_info
+    const std::string& structural_tag_json,
+    const std::optional<TokenizerInfo>& tokenizer_info,
+    int max_threads,
+    ThreadPool* thread_pool
 ) {
   auto structural_tag_result = StructuralTagParser::FromJSON(structural_tag_json);
   if (structural_tag_result.IsErr()) {
@@ -2429,7 +2536,7 @@ Result<Grammar, StructuralTagError> StructuralTagToGrammar(
     return ResultErr(std::move(err).value());
   }
 
-  auto result = StructuralTagGrammarConverter::Convert(structural_tag);
+  auto result = StructuralTagGrammarConverter::Convert(structural_tag, max_threads, thread_pool);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -24,6 +24,8 @@
 
 namespace xgrammar {
 
+class ThreadPool;
+
 /******************** Structural Tag Definition ********************/
 
 // TODO(yixin): Consider moving the definition to Public API.
@@ -389,11 +391,15 @@ struct StructuralTag {
 /*!
  * \brief Convert a structural tag JSON string to a grammar.
  * \param structural_tag_json The JSON string of the structural tag.
+ * \param tokenizer_info Optional tokenizer metadata for resolving named special tokens.
+ * \param max_threads Maximum number of threads used to convert independent JSON schemas.
  * \return A grammar if the JSON is valid, otherwise an error message in std::string.
  */
 Result<Grammar, StructuralTagError> StructuralTagToGrammar(
     const std::string& structural_tag_json,
-    const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt
+    const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt,
+    int max_threads = 1,
+    ThreadPool* thread_pool = nullptr
 );
 
 }  // namespace xgrammar

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -196,6 +196,21 @@ def test_parallel_structural_tag_schema_error():
         compiler.compile_structural_tag(tags, ["<function="])
 
 
+def test_compiler_thread_pool_reuse():
+    tags = [
+        xgr.StructuralTagItem(begin="<function=f>", schema='{"type":"object"}', end="</function>"),
+        xgr.StructuralTagItem(begin="<function=g>", schema='{"type":"array"}', end="</function>"),
+    ]
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]), max_threads=4)
+
+    first = compiler.compile_structural_tag(tags, ["<function="])
+    second = compiler.compile_structural_tag(tags, ["<function="])
+    plain = compiler.compile_grammar('root ::= "ok"')
+
+    assert str(first.grammar) == str(second.grammar)
+    assert _is_grammar_accept_string(plain.grammar, "ok")
+
+
 @pytest.mark.hf_token_required
 def test_structural_tag_mask_gen():
     # Define schemas for the test

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -161,7 +161,8 @@ def test_structural_tag():
         assert _is_grammar_accept_string(grammar, input, print_time=True)
 
 
-def test_structural_tag_compiler():
+@pytest.mark.parametrize("max_threads", [1, 8])
+def test_structural_tag_compiler(max_threads: int):
     class Schema1(BaseModel):
         arg1: str
         arg2: int
@@ -180,9 +181,19 @@ def test_structural_tag_compiler():
     # but here we use two triggers for testing such cases
     triggers = ["<function=f", "<function=g"]
 
-    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]))
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]), max_threads=max_threads)
     compiled_grammar = compiler.compile_structural_tag(tags, triggers)
     assert str(compiled_grammar.grammar) == expected_grammar_test_structural_tag_after_optimization
+
+
+def test_parallel_structural_tag_schema_error():
+    tags = [
+        xgr.StructuralTagItem(begin="<function=f>", schema='{"type":"object"}', end="</function>"),
+        xgr.StructuralTagItem(begin="<function=g>", schema="not-json", end="</function>"),
+    ]
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]), max_threads=8)
+    with pytest.raises(json.JSONDecodeError, match="Expecting value"):
+        compiler.compile_structural_tag(tags, ["<function="])
 
 
 @pytest.mark.hf_token_required


### PR DESCRIPTION
## 改动

词元是模型一次处理的文本单位。词元掩码是生成每个词元时用于排除不合法候选的布尔结果。原实现让所有工作线程在同一个结果表上加锁并插入。本改动让每个工作线程写入自己的结果表，全部任务完成后再把表节点移动合并，避免热点锁和串行内存分配。

本请求保持主分支原有的“每个状态一个任务”，没有带入历史实验中单独无明确收益的相同缓存键任务分组。本请求依赖 #790、#791 和 #792；当前分支保留这些前置提交，需要审查的独立提交是 `4e7aeaa1`。

## 单项性能

结构标签是把触发文本、函数参数规则和结束文本组合起来的生成约束。JSON Schema 是描述 JSON 数据结构及字段约束的规则。允许词元集合生成时间是生成每一步筛选合法词元所需的平均时间。

| 输入 | 编译时间 | 允许词元集合生成时间 |
|---|---:|---:|
| 大型结构标签 | 213.632 -> 194.677 毫秒，减少 8.9% | 10.971 -> 11.409 微秒，增加 4.0% |
| 小型结构标签 | 5.565 -> 6.023 毫秒，增加 8.2% | 12.049 -> 12.919 微秒，增加 7.2% |
| 大型 JSON Schema | 48.049 -> 48.783 毫秒，增加 1.5% | 28.088 -> 27.970 微秒，减少 0.4% |
| 小型 JSON Schema | 8.240 -> 8.295 毫秒，增加 0.7% | 69.419 -> 70.356 微秒，增加 1.4% |

收益集中在大型结构标签；小型结构标签有明显回退，评审重点是是否应为任务数量增加启用阈值。

## 143.810 毫秒组合

历史完整候选在固定 400 函数结构标签、32 个编译线程和 15 个稳定样本下得到：

| 实现 | 完整编译中位数 |
|---|---:|
| XGrammar 完整优化组合 | 143.810 毫秒 |
| llguidance | 151.295 毫秒 |

llguidance 是另一个用于语法约束生成的实现，这里作为外部参考。XGrammar 快 7.485 毫秒，即 4.95%。

该历史组合包含 #781、#783、#784、#785、#790、#791、#792 和本请求对应的优化。历史候选还包含相同缓存键任务分组；后续四类输入实验没有证明该分组有明确收益，因此本请求已排除它。143.810 毫秒是完整组合的历史实测结果，不应解读为本请求单独或本请求只加 #783 的结果。

## 正确性

- 四类正式输入中，优化前后接受行为差异为 0。
- 使用严格警告检查完成发布构建。
- 从构建产物进行不可编辑安装后，编译器和结构标签测试 21 项通过，21 项因需要额外模型词表而未执行。
- 编译器测试使用合成词表逐步比较 1 线程和 8 线程的精确词元掩码。
- 提交前格式检查全部通过。
