### PR TITLE
Accelerate structural tag dispatch

### DIFF
--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -37,22 +37,29 @@ namespace xgrammar {
 
 /************** AdaptiveTokenMaskCache Generator **************/
 
+struct TagDispatchTokenOptimization {
+  // Tokens that contain no trigger or exclude string after their first byte.
+  DynamicBitset definitely_accepted_since_second_byte;
+  // The sorted-vocabulary indices of all other tokens. Keeping the sparse complement avoids
+  // scanning the full vocabulary again for every state of a large TagDispatch automaton.
+  std::vector<int32_t> requires_full_match_since_second_byte;
+};
+
 /*! \brief The concrete implementation of GrammarMatcherNode. */
 class GrammarMatcherForTokenMaskCache : public EarleyParser {
  public:
   GrammarMatcherForTokenMaskCache(
       const Grammar& grammar,
       const ParserState& init_state,
-      const std::unordered_map<int32_t, DynamicBitset>&
-          tag_dispatch_rule_id_to_second_slicing_bitset,
+      const std::unordered_map<int32_t, TagDispatchTokenOptimization>&
+          tag_dispatch_token_optimizations,
       const TokenizerInfo& tokenizer_info,
       std::optional<RuleLevelCache>& rule_level_cache
   )
       : EarleyParser(grammar, init_state),
         init_rule_id_(init_state.rule_id),
         initial_state_(init_state),
-        tag_dispatch_rule_id_to_second_slicing_bitset_(tag_dispatch_rule_id_to_second_slicing_bitset
-        ),
+        tag_dispatch_token_optimizations_(tag_dispatch_token_optimizations),
         tokenizer_info_(tokenizer_info),
         rule_level_cache_(rule_level_cache) {}
   /*!
@@ -126,7 +133,8 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
    *  When we check a token, we first check if its first character can transit to the start state.
    *  If yes, then we check if it is in the bitset. If yes, then we accept it directly.
    */
-  const std::unordered_map<int32_t, DynamicBitset>& tag_dispatch_rule_id_to_second_slicing_bitset_;
+  const std::unordered_map<int32_t, TagDispatchTokenOptimization>&
+      tag_dispatch_token_optimizations_;
 
   const TokenizerInfo& tokenizer_info_;
 
@@ -545,24 +553,84 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
   int last_rejected_range = 0;
   const bool& is_exact_lookahead = grammar_->GetRule(init_rule_id_).is_exact_lookahead;
   std::optional<const DynamicBitset*> definite_accepted_bitset = std::nullopt;
+  const TagDispatchTokenOptimization* tag_dispatch_token_optimization = nullptr;
   const bool is_tag_dispatch_rule =
       grammar_->GetGrammarExpr(grammar_->GetRule(init_rule_id_).body_expr_id).type ==
       Grammar::Impl::GrammarExprType::kTagDispatch;
   if (is_tag_dispatch_rule) {
-    XGRAMMAR_DCHECK(tag_dispatch_rule_id_to_second_slicing_bitset_.count(init_rule_id_) > 0);
-    definite_accepted_bitset = &tag_dispatch_rule_id_to_second_slicing_bitset_.at(init_rule_id_);
+    XGRAMMAR_DCHECK(tag_dispatch_token_optimizations_.count(init_rule_id_) > 0);
+    tag_dispatch_token_optimization = &tag_dispatch_token_optimizations_.at(init_rule_id_);
+    definite_accepted_bitset =
+        &tag_dispatch_token_optimization->definitely_accepted_since_second_byte;
   }
   tmp_store_rejected_only_ = is_tag_dispatch_rule && speculative_calculation && fill_reject_indices;
+
+  std::vector<int32_t> sparse_candidate_indices;
+  if (tmp_store_rejected_only_) {
+    XGRAMMAR_DCHECK(tag_dispatch_token_optimization != nullptr);
+    const auto& requires_full_match =
+        tag_dispatch_token_optimization->requires_full_match_since_second_byte;
+    sparse_candidate_indices.reserve(requires_full_match.size());
+    for (int32_t i : requires_full_match) {
+      const auto& token = sorted_decoded_vocab[i].second;
+      XGRAMMAR_DCHECK(!token.empty());
+      const auto first_byte = static_cast<uint8_t>(token[0]);
+      if (first_char_mask[first_byte] && speculative_mask[first_byte]) {
+        sparse_candidate_indices.push_back(i);
+      }
+    }
+
+    // Any first byte that is accepted by the grammar but does not return the TagDispatch
+    // automaton to its start state also requires full matching. These byte ranges are disjoint
+    // from the indices collected above.
+    std::bitset<256> non_speculative_first_bytes = first_char_mask & ~speculative_mask;
+    if (non_speculative_first_bytes.any()) {
+      std::vector<std::pair<int32_t, int32_t>> non_speculative_intervals;
+      GetPossibleTokenIntervals(
+          sorted_decoded_vocab, non_speculative_first_bytes, non_speculative_intervals
+      );
+      for (const auto& [begin, end] : non_speculative_intervals) {
+        for (int32_t i = begin; i < end; ++i) {
+          sparse_candidate_indices.push_back(i);
+        }
+      }
+      std::sort(sparse_candidate_indices.begin(), sparse_candidate_indices.end());
+    }
+  }
 
   const std::string* prev_token = nullptr;
   int32_t skip_ptr = 0;
   const int32_t skip_size = static_cast<int32_t>(token_edge_accepted.size());
+  size_t sparse_candidate_ptr = 0;
+  auto next_token_index = [&](int32_t cursor, int32_t interval_end) {
+    if (!tmp_store_rejected_only_) {
+      return cursor;
+    }
+    while (sparse_candidate_ptr < sparse_candidate_indices.size() &&
+           sparse_candidate_indices[sparse_candidate_ptr] < cursor) {
+      ++sparse_candidate_ptr;
+    }
+    if (sparse_candidate_ptr == sparse_candidate_indices.size() ||
+        sparse_candidate_indices[sparse_candidate_ptr] >= interval_end) {
+      return interval_end;
+    }
+    return sparse_candidate_indices[sparse_candidate_ptr++];
+  };
   for (size_t interval_idx = 0; interval_idx < possible_intervals.size(); ++interval_idx) {
     const auto& interval = possible_intervals[interval_idx];
-    for (int i = interval.first; i < interval.second; ++i) {
+    int32_t cursor = interval.first;
+    while (cursor < interval.second) {
+      int32_t i = next_token_index(cursor, interval.second);
+      if (i == interval.second) {
+        break;
+      }
+      int32_t next_cursor = i + 1;
       // Skip tokens already accepted by token edges (avoid expensive Earley simulation).
       while (skip_ptr < skip_size && token_edge_accepted[skip_ptr] < i) ++skip_ptr;
-      if (skip_ptr < skip_size && token_edge_accepted[skip_ptr] == i) continue;
+      if (skip_ptr < skip_size && token_edge_accepted[skip_ptr] == i) {
+        cursor = next_cursor;
+        continue;
+      }
 
       // Check if the current token is in the rejected range. i.e. check if the current token
       // is on the subtree of the rejected token.
@@ -576,8 +644,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
                     : fill_reject_indices;
           }
         } else {
-          i = last_rejected_range - 1;
+          next_cursor = last_rejected_range;
         }
+        cursor = next_cursor;
         continue;
       }
       const auto& token = sorted_decoded_vocab[i].second;
@@ -590,6 +659,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
             if (!tmp_store_rejected_only_) {
               tmp_accepted_indices_.push_back(i);
             }
+            cursor = next_cursor;
             continue;
           }
           // If the token doesn't contain tags or stop strings since the second character, and it
@@ -600,6 +670,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
             if (!tmp_store_rejected_only_) {
               tmp_accepted_indices_.push_back(i);
             }
+            cursor = next_cursor;
             continue;
           }
         } else {
@@ -616,6 +687,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
             if (!tmp_store_rejected_only_) {
               tmp_accepted_indices_.push_back(i);
             }
+            cursor = next_cursor;
             continue;
           }
         }
@@ -690,7 +762,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
             tmp_rejected_indices_.push_back(j);
             tmp_rejected_by_lookahead_indices_.push_back(j);
           }
-          i = subtree_nodes_range[i] - 1;  // Skip the subtree nodes.
+          next_cursor = subtree_nodes_range[i];
         }
       } else {
         tmp_rejected_indices_.push_back(i);
@@ -702,6 +774,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
                   : fill_reject_indices;
         }
       }
+      cursor = next_cursor;
     }
     if (interval_idx != possible_intervals.size() - 1 && fill_reject_indices) {
       const auto& next_interval = possible_intervals[interval_idx + 1];
@@ -1082,12 +1155,12 @@ class GrammarCompilerSub {
   CompiledGrammar MultiThreadCompileGrammar(Grammar grammar);
   /*! \brief Optimization for TagDispatch.
    *  \param compiled_grammar_impl the compiled_grammar to be optimized.
-   *  \param tag_dispatch_rule_id_to_second_slicing_bitset Return value. Mapping from the rule_id to
-   * the definite accepted token mask.
+   *  \param tag_dispatch_token_optimizations Return value. Mapping from the rule_id to the
+   * TagDispatch vocabulary optimization.
    */
   void TagDispatchOptimization(
       std::shared_ptr<CompiledGrammar::Impl> compiled_grammar_impl,
-      std::unordered_map<int32_t, DynamicBitset>* tag_dispatch_rule_id_to_second_slicing_bitset
+      std::unordered_map<int32_t, TagDispatchTokenOptimization>* tag_dispatch_token_optimizations
   );
 
   /*! \brief The vocabulary associated with this storage class. */
@@ -1106,8 +1179,8 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
   }
-  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
-  TagDispatchOptimization(compiled_grammar_impl, &tag_dispatch_rule_id_to_second_slicing_bitset);
+  std::unordered_map<int32_t, TagDispatchTokenOptimization> tag_dispatch_token_optimizations;
+  TagDispatchOptimization(compiled_grammar_impl, &tag_dispatch_token_optimizations);
 
   // If the compiler is cache-enabled, then we hash the grammars for crossing-grammar caching.
   if (rule_level_cache_.has_value()) {
@@ -1133,7 +1206,7 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
     auto grammar_matcher = GrammarMatcherForTokenMaskCache(
         compiled_grammar_impl->grammar,
         state,
-        tag_dispatch_rule_id_to_second_slicing_bitset,
+        tag_dispatch_token_optimizations,
         tokenizer_info_,
         rule_level_cache_
     );
@@ -1232,10 +1305,10 @@ CompiledGrammar GrammarCompilerSub::CompileGrammar(
 
 void GrammarCompilerSub::TagDispatchOptimization(
     std::shared_ptr<CompiledGrammar::Impl> compiled_grammar_impl,
-    std::unordered_map<int32_t, DynamicBitset>* tag_dispatch_rule_id_to_second_slicing_bitset
+    std::unordered_map<int32_t, TagDispatchTokenOptimization>* tag_dispatch_token_optimizations
 ) {
   using GrammarExprType = Grammar::Impl::GrammarExprType;
-  tag_dispatch_rule_id_to_second_slicing_bitset->clear();
+  tag_dispatch_token_optimizations->clear();
 
   // Optimization for TagDispatch: Precompute the definitely accepted tokens.
   for (int i = 0; i < compiled_grammar_impl->grammar->NumRules(); i++) {
@@ -1256,21 +1329,23 @@ void GrammarCompilerSub::TagDispatchOptimization(
     patterns.insert(patterns.end(), tag_dispatch.excludes.begin(), tag_dispatch.excludes.end());
     AhoCorasick matcher(patterns);
 
-    DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
+    TagDispatchTokenOptimization optimization;
+    optimization.definitely_accepted_since_second_byte = DynamicBitset(sorted_decoded_vocab.size());
     for (int j = 0; j < static_cast<int32_t>(sorted_decoded_vocab.size()); j++) {
       const auto& token = sorted_decoded_vocab[j].second;
       if (token.empty()) {
-        definite_accepted_tokens_since_second_char.Set(j);
+        optimization.definitely_accepted_since_second_byte.Set(j);
         continue;
       }
 
       // Check if the token contains any string trigger or exclude string after first char.
       if (!matcher.ContainsMatch(token, 1)) {
-        definite_accepted_tokens_since_second_char.Set(j);
+        optimization.definitely_accepted_since_second_byte.Set(j);
+      } else {
+        optimization.requires_full_match_since_second_byte.push_back(j);
       }
     }
-    (*tag_dispatch_rule_id_to_second_slicing_bitset)[i] =
-        definite_accepted_tokens_since_second_char;
+    (*tag_dispatch_token_optimizations)[i] = std::move(optimization);
   }
 }
 

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -22,6 +22,7 @@
 #include "fsm.h"
 #include "grammar_functor.h"
 #include "grammar_impl.h"
+#include "support/aho_corasick.h"
 #include "support/dynamic_bitset.h"
 #include "support/int_set.h"
 #include "support/logging.h"
@@ -1210,9 +1211,16 @@ void GrammarCompilerSub::TagDispatchOptimization(
     Grammar::Impl::TagDispatch tag_dispatch =
         compiled_grammar_impl->GetGrammar()->GetTagDispatch(rule.body_expr_id);
     const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
+    std::vector<std::string> patterns;
+    patterns.reserve(tag_dispatch.tag_rule_pairs.size() + tag_dispatch.excludes.size());
+    for (const auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
+      patterns.push_back(trigger);
+    }
+    patterns.insert(patterns.end(), tag_dispatch.excludes.begin(), tag_dispatch.excludes.end());
+    AhoCorasick matcher(patterns);
+
     DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
     for (int j = 0; j < static_cast<int32_t>(sorted_decoded_vocab.size()); j++) {
-      bool definite_accept_since_second_char = true;
       const auto& token = sorted_decoded_vocab[j].second;
       if (token.empty()) {
         definite_accepted_tokens_since_second_char.Set(j);
@@ -1220,22 +1228,7 @@ void GrammarCompilerSub::TagDispatchOptimization(
       }
 
       // Check if the token contains any string trigger or exclude string after first char.
-      for (const auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
-        if (token.find(trigger, 1) != std::string::npos) {
-          definite_accept_since_second_char = false;
-          break;
-        }
-      }
-      if (definite_accept_since_second_char) {
-        for (const auto& excl : tag_dispatch.excludes) {
-          if (token.find(excl, 1) != std::string::npos) {
-            definite_accept_since_second_char = false;
-            break;
-          }
-        }
-      }
-
-      if (definite_accept_since_second_char) {
+      if (!matcher.ContainsMatch(token, 1)) {
         definite_accepted_tokens_since_second_char.Set(j);
       }
     }

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -140,10 +140,24 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   std::vector<int32_t> tmp_accepted_by_lookahead_indices_;
   std::vector<bool> tmp_can_reach_end_stack_;
   std::vector<bool> tmp_can_reach_end_prefix_or_stack_;
+  // Whether every token not explicitly classified as rejected or uncertain is known to be
+  // accepted. This lets TagDispatch masks use their natural "accept all + sparse delta"
+  // representation without first materializing every accepted vocabulary index.
+  bool tmp_store_rejected_only_ = false;
   // Temporary data for GetTokenEdgeAcceptedIndices.
   std::vector<int32_t> tmp_token_edge_accepted_;
   std::vector<int32_t> tmp_token_edge_excluded_;
 };
+
+AdaptiveTokenMask MakeRejectedAdaptiveTokenMask(
+    const std::vector<int32_t>& rejected_indices, const std::vector<int32_t>& uncertain_indices
+) {
+  AdaptiveTokenMask result;
+  result.store_type = AdaptiveTokenMask::StoreType::kRejected;
+  result.rejected_indices = rejected_indices;
+  result.uncertain_indices = uncertain_indices;
+  return result;
+}
 
 void GrammarMatcherForTokenMaskCache::AdaptCacheWithLookahead(
     AdaptiveTokenMask* cache_ptr, bool is_root_rule
@@ -538,6 +552,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
     XGRAMMAR_DCHECK(tag_dispatch_rule_id_to_second_slicing_bitset_.count(init_rule_id_) > 0);
     definite_accepted_bitset = &tag_dispatch_rule_id_to_second_slicing_bitset_.at(init_rule_id_);
   }
+  tmp_store_rejected_only_ = is_tag_dispatch_rule && speculative_calculation && fill_reject_indices;
 
   const std::string* prev_token = nullptr;
   int32_t skip_ptr = 0;
@@ -554,10 +569,12 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       if (i < last_rejected_range) {
         if (fill_reject_indices) {
           tmp_rejected_indices_.push_back(i);
-          fill_reject_indices =
-              tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
-                  ? false
-                  : fill_reject_indices;
+          if (!tmp_store_rejected_only_) {
+            fill_reject_indices =
+                tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
+                    ? false
+                    : fill_reject_indices;
+          }
         } else {
           i = last_rejected_range - 1;
         }
@@ -570,7 +587,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
         if (definite_accepted_bitset.has_value()) {
           // If the token is empty, it must be accepted.
           if (token.empty()) {
-            tmp_accepted_indices_.push_back(i);
+            if (!tmp_store_rejected_only_) {
+              tmp_accepted_indices_.push_back(i);
+            }
             continue;
           }
           // If the token doesn't contain tags or stop strings since the second character, and it
@@ -578,7 +597,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
           // accepted.
           if (speculative_mask[static_cast<uint8_t>(token[0])] &&
               (*definite_accepted_bitset.value())[i]) {
-            tmp_accepted_indices_.push_back(i);
+            if (!tmp_store_rejected_only_) {
+              tmp_accepted_indices_.push_back(i);
+            }
             continue;
           }
         } else {
@@ -592,7 +613,9 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
             }
           }
           if (all_accepted) {
-            tmp_accepted_indices_.push_back(i);
+            if (!tmp_store_rejected_only_) {
+              tmp_accepted_indices_.push_back(i);
+            }
             continue;
           }
         }
@@ -647,7 +670,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       if (accepted) {
         if (HasEnteredCharBudget()) {
           tmp_uncertain_indices_.push_back(i);
-        } else {
+        } else if (!tmp_store_rejected_only_) {
           tmp_accepted_indices_.push_back(i);
         }
       } else if (can_reach_end && prev_matched_size > 0) {
@@ -672,10 +695,12 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       } else {
         tmp_rejected_indices_.push_back(i);
         last_rejected_range = subtree_nodes_range[i];
-        fill_reject_indices =
-            tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
-                ? false
-                : fill_reject_indices;
+        if (!tmp_store_rejected_only_) {
+          fill_reject_indices =
+              tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
+                  ? false
+                  : fill_reject_indices;
+        }
       }
     }
     if (interval_idx != possible_intervals.size() - 1 && fill_reject_indices) {
@@ -683,9 +708,12 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       for (int i = interval.second; i < next_interval.first; ++i) {
         tmp_rejected_indices_.push_back(i);
       }
-      fill_reject_indices = tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
-                                ? false
-                                : fill_reject_indices;
+      if (!tmp_store_rejected_only_) {
+        fill_reject_indices =
+            tmp_rejected_indices_.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
+                ? false
+                : fill_reject_indices;
+      }
     }
   }
 
@@ -799,6 +827,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   tmp_accepted_by_lookahead_indices_.clear();
   tmp_can_reach_end_prefix_or_stack_.clear();
   tmp_can_reach_end_stack_.clear();
+  tmp_store_rejected_only_ = false;
   // For every character in the current token, stores whether it is possible to reach the end of
   // the rule when matching until this character. Store it in a stack for later rollback.
   tmp_can_reach_end_stack_.push_back(false);
@@ -869,19 +898,24 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     if (has_char_budget_rules_) {
       IntsetUnion(&tmp_uncertain_indices_, token_edge_accepted);
     } else {
-      IntsetUnion(&tmp_accepted_indices_, token_edge_accepted);
+      if (!tmp_store_rejected_only_) {
+        IntsetUnion(&tmp_accepted_indices_, token_edge_accepted);
+      }
       IntsetDifference(&tmp_uncertain_indices_, token_edge_accepted);
     }
     IntsetDifference(&tmp_rejected_indices_, token_edge_accepted);
   }
   if (rejected_filled) {
-    auto return_value = AdaptiveTokenMask(
-        tokenizer_info_.GetVocabSize(),
-        tokenizer_info_.GetSortedDecodedVocab(),
-        tmp_accepted_indices_,
-        tmp_rejected_indices_,
-        tmp_uncertain_indices_
-    );
+    auto return_value =
+        tmp_store_rejected_only_
+            ? MakeRejectedAdaptiveTokenMask(tmp_rejected_indices_, tmp_uncertain_indices_)
+            : AdaptiveTokenMask(
+                  tokenizer_info_.GetVocabSize(),
+                  tokenizer_info_.GetSortedDecodedVocab(),
+                  tmp_accepted_indices_,
+                  tmp_rejected_indices_,
+                  tmp_uncertain_indices_
+              );
     if (rule_level_cache_is_available) {
       if (lookahead_id == -1 && !is_root_rule) {
         // If the rule doesn't have a lookahead, then it is exactly the same fsm.
@@ -924,13 +958,16 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
           new_state_id,
           fsm.GetNodeNum(),
           fsm.GetEdgeNum(),
-          AdaptiveTokenMask(
-              tokenizer_info_.GetVocabSize(),
-              tokenizer_info_.GetSortedDecodedVocab(),
-              accepted_indices_without_lookahead,
-              rejected_indices_without_lookahead,
-              tmp_uncertain_indices_
-          )
+          tmp_store_rejected_only_ ? MakeRejectedAdaptiveTokenMask(
+                                         rejected_indices_without_lookahead, tmp_uncertain_indices_
+                                     )
+                                   : AdaptiveTokenMask(
+                                         tokenizer_info_.GetVocabSize(),
+                                         tokenizer_info_.GetSortedDecodedVocab(),
+                                         accepted_indices_without_lookahead,
+                                         rejected_indices_without_lookahead,
+                                         tmp_uncertain_indices_
+                                     )
       );
       if (lookahead_hash.has_value()) {
         auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();

--- a/cpp/support/aho_corasick.cc
+++ b/cpp/support/aho_corasick.cc
@@ -1,0 +1,86 @@
+/*!
+ * Copyright (c) 2026 by Contributors
+ * \file xgrammar/support/aho_corasick.cc
+ */
+
+#include "aho_corasick.h"
+
+#include <algorithm>
+#include <queue>
+
+namespace xgrammar {
+
+AhoCorasick::AhoCorasick(const std::vector<std::string>& patterns) {
+  size_t max_num_nodes = 1;
+  for (const auto& pattern : patterns) {
+    max_num_nodes += pattern.size();
+  }
+  nodes_.reserve(max_num_nodes);
+  nodes_.emplace_back();
+
+  // Build the trie.
+  for (const auto& pattern : patterns) {
+    int32_t state = 0;
+    for (unsigned char byte : pattern) {
+      int32_t& next_state = nodes_[state].next[byte];
+      if (next_state == -1) {
+        next_state = static_cast<int32_t>(nodes_.size());
+        nodes_.emplace_back();
+      }
+      state = next_state;
+    }
+    nodes_[state].is_terminal = true;
+  }
+
+  // Resolve root transitions and seed the breadth-first traversal.
+  std::queue<int32_t> queue;
+  for (int32_t byte = 0; byte < 256; ++byte) {
+    int32_t child = nodes_[0].next[byte];
+    if (child == -1) {
+      nodes_[0].next[byte] = 0;
+    } else {
+      nodes_[child].failure = 0;
+      queue.push(child);
+    }
+  }
+
+  // Compute full failure links, propagate terminal outputs through those links, and resolve
+  // missing transitions. Propagating terminal outputs is required for cases such as patterns
+  // {"bc", "abcd"} and input "abc": the trie state for "abc" is not directly terminal, but its
+  // failure state for the suffix "bc" is.
+  while (!queue.empty()) {
+    int32_t state = queue.front();
+    queue.pop();
+
+    const int32_t failure = nodes_[state].failure;
+    nodes_[state].is_terminal = nodes_[state].is_terminal || nodes_[failure].is_terminal;
+    for (int32_t byte = 0; byte < 256; ++byte) {
+      int32_t child = nodes_[state].next[byte];
+      if (child == -1) {
+        nodes_[state].next[byte] = nodes_[failure].next[byte];
+      } else {
+        nodes_[child].failure = nodes_[failure].next[byte];
+        queue.push(child);
+      }
+    }
+  }
+}
+
+bool AhoCorasick::ContainsMatch(std::string_view text, size_t start_offset) const {
+  if (start_offset > text.size()) {
+    return false;
+  }
+  int32_t state = 0;
+  if (nodes_[state].is_terminal) {
+    return true;
+  }
+  for (size_t index = start_offset; index < text.size(); ++index) {
+    state = nodes_[state].next[static_cast<uint8_t>(text[index])];
+    if (nodes_[state].is_terminal) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace xgrammar

--- a/cpp/support/aho_corasick.h
+++ b/cpp/support/aho_corasick.h
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) 2026 by Contributors
+ * \file xgrammar/support/aho_corasick.h
+ * \brief A byte-oriented Aho-Corasick matcher.
+ */
+#ifndef XGRAMMAR_SUPPORT_AHO_CORASICK_H_
+#define XGRAMMAR_SUPPORT_AHO_CORASICK_H_
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace xgrammar {
+
+/*!
+ * \brief A byte-oriented Aho-Corasick matcher for finding any of a set of patterns.
+ *
+ * The transition table is fully resolved when the matcher is constructed. Matching is therefore
+ * one table lookup per input byte, with no failure-link loop on the hot path.
+ */
+class AhoCorasick {
+ public:
+  explicit AhoCorasick(const std::vector<std::string>& patterns);
+
+  /*!
+   * \brief Return whether text contains any pattern at or after start_offset.
+   */
+  bool ContainsMatch(std::string_view text, size_t start_offset = 0) const;
+
+  int32_t NumStates() const { return static_cast<int32_t>(nodes_.size()); }
+
+ private:
+  struct Node {
+    Node() { next.fill(-1); }
+
+    std::array<int32_t, 256> next;
+    int32_t failure = 0;
+    bool is_terminal = false;
+  };
+
+  std::vector<Node> nodes_;
+};
+
+}  // namespace xgrammar
+
+#endif  // XGRAMMAR_SUPPORT_AHO_CORASICK_H_

--- a/tests/cpp/test_aho_corasick.cc
+++ b/tests/cpp/test_aho_corasick.cc
@@ -1,0 +1,75 @@
+/*!
+ * \file tests/cpp/test_aho_corasick.cc
+ * \brief Tests for the byte-oriented Aho-Corasick matcher.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "support/aho_corasick.h"
+
+using namespace xgrammar;
+
+TEST(AhoCorasickTest, FailureTransitionsFindOverlappingSuffix) {
+  AhoCorasick matcher({"bcd", "abce"});
+
+  EXPECT_TRUE(matcher.ContainsMatch("abcd"));
+  EXPECT_TRUE(matcher.ContainsMatch("zabcdz"));
+  EXPECT_FALSE(matcher.ContainsMatch("abc"));
+}
+
+TEST(AhoCorasickTest, TerminalOutputsPropagateThroughFailureLinks) {
+  AhoCorasick matcher({"bc", "abcd"});
+
+  EXPECT_TRUE(matcher.ContainsMatch("abc"));
+  EXPECT_TRUE(matcher.ContainsMatch("zabc"));
+  EXPECT_TRUE(matcher.ContainsMatch("abcd"));
+  EXPECT_FALSE(matcher.ContainsMatch("ab"));
+}
+
+TEST(AhoCorasickTest, HonorsStartOffsetAndBytePatterns) {
+  AhoCorasick matcher({"abc", "哈哈"});
+
+  EXPECT_TRUE(matcher.ContainsMatch("abc"));
+  EXPECT_FALSE(matcher.ContainsMatch("abc", 1));
+  EXPECT_TRUE(matcher.ContainsMatch("xabc", 1));
+  EXPECT_TRUE(matcher.ContainsMatch("x哈哈y", 1));
+}
+
+TEST(AhoCorasickTest, EmptyPatternMatchesAtAnyValidOffset) {
+  AhoCorasick matcher({""});
+
+  EXPECT_TRUE(matcher.ContainsMatch(""));
+  EXPECT_TRUE(matcher.ContainsMatch("abc", 1));
+  EXPECT_FALSE(matcher.ContainsMatch("abc", 4));
+}
+
+TEST(AhoCorasickTest, MatchesNaiveSearchExhaustively) {
+  const std::vector<std::string> patterns = {"a", "ab", "bab", "bc", "bca", "c", "caa"};
+  AhoCorasick matcher(patterns);
+
+  int32_t num_texts = 1;
+  for (int32_t length = 0; length <= 6; ++length) {
+    if (length != 0) {
+      num_texts *= 3;
+    }
+    for (int32_t encoded = 0; encoded < num_texts; ++encoded) {
+      int32_t value = encoded;
+      std::string text(length, 'a');
+      for (int32_t index = 0; index < length; ++index) {
+        text[index] = static_cast<char>('a' + value % 3);
+        value /= 3;
+      }
+      for (size_t start = 0; start <= text.size() + 1; ++start) {
+        bool expected = false;
+        for (const auto& pattern : patterns) {
+          expected = expected || text.find(pattern, start) != std::string::npos;
+        }
+        EXPECT_EQ(matcher.ContainsMatch(text, start), expected)
+            << "text=" << text << ", start=" << start;
+      }
+    }
+  }
+}

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -379,6 +379,67 @@ def test_excludes_overlapping_prefixes():
     )
 
 
+def test_tag_dispatch_sparse_candidates_match_direct_parser():
+    """Cached masks must agree with byte-by-byte parsing at every AC state."""
+    vocab = [
+        "a",
+        "ab",
+        "abc",
+        "abcd",
+        "abcd!",
+        "aba",
+        "abax",
+        "b",
+        "bc",
+        "bc!",
+        "bcd",
+        "c",
+        "d",
+        "!",
+        "x",
+        "xx",
+        "xbc",
+        "xbc!",
+        "cabcd",
+        "zaba",
+        "STOP",
+        "xSTOP",
+        "STO",
+        "TOP",
+        "ordinary",
+        "好",
+        "a好",
+    ]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf(
+        """root ::= TagDispatch(
+  ("abcd", body), ("bc", body),
+  loop_after_dispatch=true,
+  excludes=("aba", "STOP")
+)
+body ::= "!"
+"""
+    )
+    compiled = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, cache_enabled=False
+    ).compile_grammar(grammar)
+
+    for prefix in ["", "a", "ab", "abc", "bc", "x", "xb", "xab"]:
+        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        assert matcher.accept_string(prefix)
+        token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        matcher.fill_next_token_bitmask(token_bitmask)
+        rejected = set(_get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size))
+
+        for token_id, token in enumerate(vocab):
+            direct_matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+            assert direct_matcher.accept_string(prefix)
+            direct_accepted = direct_matcher.accept_token(token_id)
+            assert (
+                token_id not in rejected
+            ) == direct_accepted, f"cached mask disagrees at prefix={prefix!r}, token={token!r}"
+
+
 @pytest.mark.hf_token_required
 def test_utf8_structural_tag_begin_end():
     model = "deepseek-ai/DeepSeek-V3-0324"

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -440,6 +440,35 @@ body ::= "!"
             ) == direct_accepted, f"cached mask disagrees at prefix={prefix!r}, token={token!r}"
 
 
+def test_tag_dispatch_sparse_candidates_with_character_budget():
+    """Sparse tag-dispatch masks must preserve character-budget uncertainty."""
+    vocab = ["a", "aa", "b", "go", "xgo", "ordinary"]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf(
+        """root ::= TagDispatch(("go", body), loop_after_dispatch=false)
+body[max_chars=1] ::= [a]*
+"""
+    )
+    compiled = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, cache_enabled=False
+    ).compile_grammar(grammar)
+
+    for prefix in ["", "x", "g", "go"]:
+        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        assert matcher.accept_string(prefix)
+        token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        matcher.fill_next_token_bitmask(token_bitmask)
+        rejected = set(_get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size))
+
+        for token_id, token in enumerate(vocab):
+            direct_matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+            assert direct_matcher.accept_string(prefix)
+            direct_accepted = direct_matcher.accept_token(token_id)
+            assert (
+                token_id not in rejected
+            ) == direct_accepted, f"cached mask disagrees at prefix={prefix!r}, token={token!r}"
+
+
 @pytest.mark.hf_token_required
 def test_utf8_structural_tag_begin_end():
     model = "deepseek-ai/DeepSeek-V3-0324"


### PR DESCRIPTION
## 改动

结构化标签是把触发文本、函数参数规则和结束文本组合成生成约束的格式。标签分派是根据已生成前缀判断当前可以进入哪个标签的过程。本请求从 #711 拆出三项密切相关的标签分派优化：

- 使用 Aho-Corasick 多模式字符串匹配自动机一次查找所有可能的标签与停止文本，避免针对每个标签反复扫描。
- 用“默认允许，只记录少量拒绝与未确定项”的稀疏差异表保存词元允许集合。词元是模型词表中的基本单位，词元允许集合记录当前状态可以生成哪些词元。
- 生成标签分派结果时只遍历稀疏词元候选，不再扫描整份密集允许表。

这三项改动共享同一份标签匹配与稀疏结果数据，因此作为一个独立请求提交。#711 中的其他改动已分别由 #726、#727 和 #729 替代。

## 性能

使用 4,000 个密集标签的压力输入，数据来自 #711 中这三项改动的组合测量：

- 实际经过时间从 5,243 毫秒降到 1,115 毫秒，快 4.70 倍。
- 处理器累计时间从 29,433 毫秒降到 6,058 毫秒，快 4.86 倍。
- 密集、唯一与共享前缀标签在原测量中都通过行为对照。

## 验证

- [x] 在当前主分支上完成发布型构建，所有编译警告均按错误处理。
- [x] 66 项 C++ 语言测试全部通过，其中 5 项专门覆盖 Aho-Corasick 字符串匹配的失败跳转、重叠后缀、起始偏移、空模式和穷举对照。
- [x] 非可编辑的 Python 安装包构建成功。
- [x] Python 语言的结构化标签专项测试：9 项通过，12 项因需要远程词表而未选中。
- [x] Python 语言的字符长度限制专项测试：15 项全部通过。
- [x] 新增标签分派与字符长度限制交叉路径的对照测试，缓存词元允许集合与逐词元解析结果一致。
