### PR TITLE
fix: reject pattern/format combined with minLength/maxLength

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1136,6 +1136,22 @@ Result<StringSpec, SchemaError> SchemaParser::ParseString(const picojson::object
             std::to_string(spec.max_length)
     );
   }
+  // GenerateString chooses exactly one branch for string constraints: a built-in
+  // format or a pattern (compiled as a regex) takes priority, and length bounds
+  // are silently dropped. Composing the two constraints (regex + length counting)
+  // is not supported by the grammar engine yet, so fail loudly at parse time
+  // instead of accepting a schema whose length bounds would never be enforced.
+  const bool has_builtin_format =
+      spec.format.has_value() && JSONSchemaConverter::IsBuiltinFormat(*spec.format);
+  if ((spec.pattern.has_value() || has_builtin_format) &&
+      (spec.min_length != 0 || spec.max_length != -1)) {
+    return ResultErr<SchemaError>(
+        SchemaErrorType::kUnsupportedSchema,
+        "combining pattern/format with minLength/maxLength is not supported yet; "
+        "the length bounds would be silently ignored. Remove the pattern/format "
+        "constraint or the length bounds, or use minLength/maxLength alone"
+    );
+  }
   return ResultOk(std::move(spec));
 }
 
@@ -3117,6 +3133,10 @@ int32_t JSONSchemaConverter::GenerateTypeArray(
 }
 
 // ==================== Static Helper Methods ====================
+
+bool JSONSchemaConverter::IsBuiltinFormat(const std::string& format) {
+  return JSONFormatToRegexPattern(format).has_value();
+}
 
 std::optional<std::string> JSONSchemaConverter::JSONFormatToRegexPattern(const std::string& format
 ) {

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -456,6 +456,11 @@ class JSONSchemaConverter {
   static const std::string kBasicEscape;
   static const std::string kBasicStringSub;
 
+  // Whether `format` maps to a built-in regex during string generation. Exposed
+  // for schema parsing so ParseString can reject combinations that GenerateString
+  // cannot represent (built-in format/pattern + non-default minLength/maxLength).
+  static bool IsBuiltinFormat(const std::string& format);
+
  protected:
   GenerateCacheManager rule_cache_manager_;
 

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2407,6 +2407,46 @@ def test_min_max_length():
     check_schema_with_instance(schema, instance_rejected, is_accepted=False, any_whitespace=True)
 
 
+def test_pattern_with_length_bounds_is_rejected():
+    # pattern + non-default length bounds: GenerateString would silently drop the
+    # bounds, so the schema must be rejected loudly at parse time instead.
+    schema = {"type": "string", "pattern": "^a+$", "maxLength": 2}
+    with pytest.raises(Exception) as e:
+        xgr.Grammar.from_json_schema(json.dumps(schema))
+    assert "minLength/maxLength" in str(e.value)
+    assert "pattern" in str(e.value)
+
+    schema = {"type": "string", "pattern": "^a+$", "minLength": 2}
+    with pytest.raises(Exception) as e:
+        xgr.Grammar.from_json_schema(json.dumps(schema))
+    assert "minLength/maxLength" in str(e.value)
+
+
+def test_builtin_format_with_length_bounds_is_rejected():
+    schema = {"type": "string", "format": "email", "maxLength": 20}
+    with pytest.raises(Exception) as e:
+        xgr.Grammar.from_json_schema(json.dumps(schema))
+    assert "minLength/maxLength" in str(e.value)
+    assert "format" in str(e.value)
+
+
+def test_pattern_format_and_length_bounds_alone_still_supported():
+    # pattern without bounds keeps compiling.
+    xgr.Grammar.from_json_schema(json.dumps({"type": "string", "pattern": "^a+$"}))
+    # Built-in format without bounds keeps compiling.
+    xgr.Grammar.from_json_schema(json.dumps({"type": "string", "format": "email"}))
+    # min/max without pattern/format keeps compiling.
+    xgr.Grammar.from_json_schema(
+        json.dumps({"type": "string", "minLength": 1, "maxLength": 10})
+    )
+    # Unknown format is ignored (falls through to the length branch), so bounds still apply.
+    xgr.Grammar.from_json_schema(
+        json.dumps(
+            {"type": "string", "format": "custom-unknown-format", "maxLength": 5}
+        )
+    )
+
+
 def test_type_array():
     schema = {
         "type": ["integer", "string"],


### PR DESCRIPTION
## Root Cause

`GenerateString` in `cpp/json_schema_converter.cc` picks exactly one branch for string constraints: a built-in `format` or a `pattern` (compiled as a regex) takes priority, and the `minLength`/`maxLength` branch is never reached. A schema like `{"type": "string", "pattern": "^a+$", "maxLength": 2}` was accepted by `Grammar.from_json_schema`, but the compiled grammar ignored `maxLength` entirely — the model could produce out-of-bound strings with no error anywhere (issue #749).

## Fix

Reject the combination loudly at schema parse time instead of silently dropping the bounds (composing regex + length counting is not supported by the grammar engine yet — the same direction vLLM takes downstream with a validation-time guard in vllm-project/vllm#49996):

- `ParseString` now returns `kUnsupportedSchema` when `pattern`, or a **built-in** `format` (one that maps to a regex in `GenerateString`), is combined with non-default `minLength`/`maxLength`.
- New public static `JSONSchemaConverter::IsBuiltinFormat()` exposes the built-in check to the parser. Unknown formats are annotations per JSON Schema and are unaffected — they still fall through to the length branch.

```cpp
const bool has_builtin_format =
    spec.format.has_value() && JSONSchemaConverter::IsBuiltinFormat(*spec.format);
if ((spec.pattern.has_value() || has_builtin_format) &&
    (spec.min_length != 0 || spec.max_length != -1)) {
  return ResultErr<SchemaError>(
      SchemaErrorType::kUnsupportedSchema,
      "combining pattern/format with minLength/maxLength is not supported yet; "
      "the length bounds would be silently ignored. ...");
}
```

## Test

- `test_pattern_with_length_bounds_is_rejected` — pattern + `maxLength` / + `minLength` raise with a clear message.
- `test_builtin_format_with_length_bounds_is_rejected` — built-in `format: "email"` + `maxLength` raises.
- `test_pattern_format_and_length_bounds_alone_still_supported` — pattern alone, format alone, min/max alone, and **unknown** format + bounds still compile (no behavior change outside the combination).
- Full run: `test_json_schema_converter.py` + `test_json_schema_direct_converter.py` → **547 passed**.
- `clang-format` (19.1.7) clean on the changed C++ files; `ruff check` clean.

## Diff scope

3 files, +65/-0 (`cpp/json_schema_converter.cc`, `cpp/json_schema_converter.h`, `tests/python/test_json_schema_converter.py`).

## AI Disclosure

AI-assisted root-cause analysis, initial draft, and test scaffolding; human review of the diff, error-path semantics, and test scope.

## Not PR-related failures

None observed locally; the two converter test files pass in full.
