### PR TITLE
fix(json_schema): reject combining pattern/format with length constraints

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1111,24 +1111,49 @@ Result<NumberSpec, SchemaError> SchemaParser::ParseNumber(const picojson::object
 
 Result<StringSpec, SchemaError> SchemaParser::ParseString(const picojson::object& schema) {
   StringSpec spec;
+  bool has_generative = schema.count("format") || schema.count("pattern");
+  bool has_length = schema.count("minLength") || schema.count("maxLength");
+
+  if (has_generative && has_length) {
+    return ResultErr<SchemaError>(
+        SchemaErrorType::kUnsupportedSchema,
+        "Combining pattern/format with minLength/maxLength is currently unsupported"
+    );
+  }
+
   if (schema.count("format")) spec.format = schema.at("format").get<std::string>();
   if (schema.count("pattern")) spec.pattern = schema.at("pattern").get<std::string>();
+
   if (schema.count("minLength")) {
     if (!schema.at("minLength").is<int64_t>()) {
       return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "minLength must be an integer"
       );
     }
-    spec.min_length = static_cast<int>(schema.at("minLength").get<int64_t>());
+    int64_t min_len = schema.at("minLength").get<int64_t>();
+    if (min_len < 0) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kInvalidSchema, "minLength must be a non-negative integer"
+      );
+    }
+    spec.min_length = static_cast<int>(min_len);
   }
+
   if (schema.count("maxLength")) {
     if (!schema.at("maxLength").is<int64_t>()) {
       return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "maxLength must be an integer"
       );
     }
-    spec.max_length = static_cast<int>(schema.at("maxLength").get<int64_t>());
+    int64_t max_len = schema.at("maxLength").get<int64_t>();
+    if (max_len < 0) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kInvalidSchema, "maxLength must be a non-negative integer"
+      );
+    }
+    spec.max_length = static_cast<int>(max_len);
   }
+
   if (spec.max_length != -1 && spec.min_length > spec.max_length) {
     return ResultErr<SchemaError>(
         SchemaErrorType::kUnsatisfiableSchema,
@@ -1136,6 +1161,7 @@ Result<StringSpec, SchemaError> SchemaParser::ParseString(const picojson::object
             std::to_string(spec.max_length)
     );
   }
+
   return ResultOk(std::move(spec));
 }
 

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1111,24 +1111,65 @@ Result<NumberSpec, SchemaError> SchemaParser::ParseNumber(const picojson::object
 
 Result<StringSpec, SchemaError> SchemaParser::ParseString(const picojson::object& schema) {
   StringSpec spec;
-  if (schema.count("format")) spec.format = schema.at("format").get<std::string>();
-  if (schema.count("pattern")) spec.pattern = schema.at("pattern").get<std::string>();
+
+  if (schema.count("format")) {
+    if (!schema.at("format").is<std::string>()) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kInvalidSchema, "format must be a string"
+      );
+    }
+    spec.format = schema.at("format").get<std::string>();
+  }
+
+  if (schema.count("pattern")) {
+    if (!schema.at("pattern").is<std::string>()) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kInvalidSchema, "pattern must be a string"
+      );
+    }
+    spec.pattern = schema.at("pattern").get<std::string>();
+  }
+
   if (schema.count("minLength")) {
     if (!schema.at("minLength").is<int64_t>()) {
       return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "minLength must be an integer"
       );
     }
-    spec.min_length = static_cast<int>(schema.at("minLength").get<int64_t>());
+    int64_t min_len = schema.at("minLength").get<int64_t>();
+    if (min_len < 0) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kInvalidSchema, "minLength must be a non-negative integer"
+      );
+    }
+    if (min_len > std::numeric_limits<int>::max()) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kInvalidSchema, "minLength exceeds maximum supported value"
+      );
+    }
+    spec.min_length = static_cast<int>(min_len);
   }
+
   if (schema.count("maxLength")) {
     if (!schema.at("maxLength").is<int64_t>()) {
       return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "maxLength must be an integer"
       );
     }
-    spec.max_length = static_cast<int>(schema.at("maxLength").get<int64_t>());
+    int64_t max_len = schema.at("maxLength").get<int64_t>();
+    if (max_len < 0) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kInvalidSchema, "maxLength must be a non-negative integer"
+      );
+    }
+    if (max_len > std::numeric_limits<int>::max()) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kInvalidSchema, "maxLength exceeds maximum supported value"
+      );
+    }
+    spec.max_length = static_cast<int>(max_len);
   }
+
   if (spec.max_length != -1 && spec.min_length > spec.max_length) {
     return ResultErr<SchemaError>(
         SchemaErrorType::kUnsatisfiableSchema,
@@ -1136,6 +1177,20 @@ Result<StringSpec, SchemaError> SchemaParser::ParseString(const picojson::object
             std::to_string(spec.max_length)
     );
   }
+
+  // Check unsupported combination: pattern or built-in format with non-trivial length constraints
+  bool has_builtin_format =
+      spec.format.has_value() && JSONSchemaConverter::IsBuiltinFormat(*spec.format);
+  bool has_generative = spec.pattern.has_value() || has_builtin_format;
+  bool has_non_trivial_length = (spec.min_length > 0) || (spec.max_length != -1);
+
+  if (has_generative && has_non_trivial_length) {
+    return ResultErr<SchemaError>(
+        SchemaErrorType::kUnsupportedSchema,
+        "Combining pattern/format with minLength/maxLength is currently unsupported"
+    );
+  }
+
   return ResultOk(std::move(spec));
 }
 

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -296,6 +296,12 @@ class JSONSchemaConverter {
    */
   Grammar Convert(const SchemaSpecPtr& spec);
 
+  /*! \brief Check if a format string corresponds to a built-in format pattern. */
+  static bool IsBuiltinFormat(const std::string& format) {
+    return JSONFormatToRegexPattern(format).has_value();
+  }
+  static std::optional<std::string> JSONFormatToRegexPattern(const std::string& format);
+
  protected:
   using CharacterClassElement = GrammarBuilder::CharacterClassElement;
 
@@ -388,6 +394,7 @@ class JSONSchemaConverter {
 
   /*! \brief Get whitespace pattern. */
   std::string GetWhitespacePattern() const;
+
 
   int32_t Empty();
   int32_t ByteString(const std::string& value);
@@ -507,9 +514,6 @@ class JSONSchemaConverter {
       bool exclusive_start = false,
       bool exclusive_end = false
   );
-
- protected:
-  static std::optional<std::string> JSONFormatToRegexPattern(const std::string& format);
 
   // Expose for testing
   friend std::string GenerateRangeRegex(std::optional<int64_t> start, std::optional<int64_t> end);

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3533,5 +3533,46 @@ def test_prefix_items_no_additional_items_allows_shorter():
     check_schema_with_instance(schema, '["a", 1, true]', is_accepted=False)
 
 
+def test_pattern_format_with_length_constraints_raises():
+    """Combining pattern or built-in format with non-trivial length constraints must be rejected."""
+    unsupported_schemas = [
+        {"type": "string", "pattern": "^a+$", "maxLength": 2},
+        {"type": "string", "pattern": "^a+$", "minLength": 1},
+        {"type": "string", "format": "email", "maxLength": 10},
+        {"type": "string", "format": "email", "minLength": 5},
+    ]
+    for schema in unsupported_schemas:
+        with pytest.raises(
+            RuntimeError,
+            match="Combining pattern/format with minLength/maxLength is currently unsupported",
+        ):
+            xgr.Grammar.from_json_schema(schema)
+
+    # Trivial minLength: 0 does not conflict with pattern/format and should compile without error
+    trivial_schemas = [
+        {"type": "string", "pattern": "^a+$", "minLength": 0},
+        {"type": "string", "format": "email", "minLength": 0},
+    ]
+    for schema in trivial_schemas:
+        grammar = xgr.Grammar.from_json_schema(schema)
+        assert grammar is not None
+
+    negative_schemas = [
+        ({"type": "string", "minLength": -1}, "minLength must be a non-negative integer"),
+        ({"type": "string", "maxLength": -1}, "maxLength must be a non-negative integer"),
+    ]
+    for schema, match_msg in negative_schemas:
+        with pytest.raises(RuntimeError, match=match_msg):
+            xgr.Grammar.from_json_schema(schema)
+
+    invalid_type_schemas = [
+        ({"type": "string", "pattern": 123}, "pattern must be a string"),
+        ({"type": "string", "format": 123}, "format must be a string"),
+    ]
+    for schema, match_msg in invalid_type_schemas:
+        with pytest.raises(RuntimeError, match=match_msg):
+            xgr.Grammar.from_json_schema(schema)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3410,5 +3410,30 @@ def test_compile_json_schema_any_order(cache_enabled: bool):
     assert ordered != any_order
 
 
+def test_pattern_format_with_length_constraints_raises():
+    """Combining pattern or format with minLength or maxLength must be rejected."""
+    unsupported_schemas = [
+        {"type": "string", "pattern": "^a+$", "maxLength": 2},
+        {"type": "string", "pattern": "^a+$", "minLength": 1},
+        {"type": "string", "pattern": "^a+$", "minLength": 0},
+        {"type": "string", "format": "email", "maxLength": 10},
+        {"type": "string", "format": "email", "minLength": 5},
+    ]
+    for schema in unsupported_schemas:
+        with pytest.raises(
+            RuntimeError,
+            match="Combining pattern/format with minLength/maxLength is currently unsupported",
+        ):
+            xgr.Grammar.from_json_schema(schema)
+
+    negative_schemas = [
+        ({"type": "string", "minLength": -1}, "minLength must be a non-negative integer"),
+        ({"type": "string", "maxLength": -1}, "maxLength must be a non-negative integer"),
+    ]
+    for schema, match_msg in negative_schemas:
+        with pytest.raises(RuntimeError, match=match_msg):
+            xgr.Grammar.from_json_schema(schema)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
Fixes #749.

### Summary
When a string schema in JSON Schema combines a generative constraint (`pattern` or `format`) with length bounds (`minLength` or `maxLength`), `JSONSchemaConverter::GenerateString` previously returned early for the pattern/format rule and silently dropped the length bounds.

### Fix
This PR updates `SchemaParser::ParseString` in `cpp/json_schema_converter.cc` to return a `SchemaErrorType::kUnsupportedSchema` error when both generative constraints and length bounds are specified. This causes `Grammar.from_json_schema` to raise a clear `RuntimeError` at schema compilation time instead of silently ignoring the length bounds.

### Verification
- Added `test_pattern_format_with_length_constraints_raises` in `tests/python/test_json_schema_converter.py`.
- Ran unit tests: `1 passed`.