### PR TITLE
[Bugfix][CI] link web wasm binding with em++ instead of emcc

### DIFF
--- a/web/build.sh
+++ b/web/build.sh
@@ -8,7 +8,7 @@ emcmake cmake ../.. -DXGRAMMAR_BUILD_PYTHON_BINDINGS=OFF\
 emmake make xgrammar -j8
 cd ..
 
-emcc -o src/xgrammar_binding.js src/xgrammar_binding.cc\
+em++ -o src/xgrammar_binding.js src/xgrammar_binding.cc\
   build/libxgrammar.a -lembind\
  -O3 -s EXPORT_ES6=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s NO_DYNAMIC_EXECUTION=1 -s MODULARIZE=1 -s SINGLE_FILE=1 -s EXPORTED_RUNTIME_METHODS=FS -s ALLOW_MEMORY_GROWTH=1\
  -I../include -I../3rdparty/picojson -I../3rdparty/dlpack/include


### PR DESCRIPTION
emscripten 6.0.6 disabled DEFAULT_TO_CXX by default, so emcc no longer links the C++ standard library and the final wasm link fails with undefined symbols such as std::__2::cout, std::__2::cerr and std::bad_variant_access. The Build Web-XGrammar workflow installs `emsdk latest`, so every build now hits this.

Use em++ for the link step, matching the compiler emcmake already selects for libxgrammar.a.