### PR TITLE
Preserve repetition ranges in eager compilation

### DIFF
--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -206,7 +206,9 @@ std::optional<SerializationError> DeserializeJSONValue(
 /************** CompiledGrammar **************/
 
 std::size_t MemorySize(const CompiledGrammar::Impl& impl) {
-  return MemorySize(impl.grammar) + MemorySize(impl.adaptive_token_mask_cache);
+  std::lock_guard<std::mutex> lock(impl.adaptive_token_mask_cache_mutex);
+  return MemorySize(impl.grammar) + MemorySize(impl.adaptive_token_mask_cache) +
+         MemorySize(impl.tag_dispatch_rule_id_to_second_slicing_bitset);
 }
 
 std::size_t CompiledGrammar::MemorySizeBytes() const { return MemorySize(*pimpl_); }
@@ -216,7 +218,12 @@ Grammar CompiledGrammar::GetGrammar() const { return pimpl_->GetGrammar(); }
 TokenizerInfo CompiledGrammar::GetTokenizerInfo() const { return pimpl_->GetTokenizerInfo(); }
 
 /*! \brief Return the serialized JSON string of the compiled grammar. */
-std::string CompiledGrammar::SerializeJSON() const { return AutoSerializeJSON(*this, true); }
+std::string CompiledGrammar::SerializeJSON() const {
+  if (pimpl_->enable_dynamic_compilation) {
+    pimpl_->MaterializeAdaptiveTokenMaskCache();
+  }
+  return AutoSerializeJSON(*this, true);
+}
 
 /*! \brief Deserialize a compiled grammar from a JSON string and tokenizer info. */
 std::variant<CompiledGrammar, SerializationError> CompiledGrammar::DeserializeJSON(

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -241,10 +241,8 @@ std::optional<SerializationError> DeserializeJSONValue(
 /************** CompiledGrammar **************/
 
 std::size_t MemorySize(const CompiledGrammar::Impl& impl) {
-  std::lock_guard<std::mutex> lock(impl.repeated_character_class_cache_mutex);
   return MemorySize(impl.grammar) + MemorySize(impl.token_mask_cache) +
-         MemorySize(impl.earley_parser_features) +
-         MemorySize(impl.repeated_character_class_token_masks);
+         MemorySize(impl.earley_parser_features);
 }
 
 std::size_t CompiledGrammar::MemorySizeBytes() const { return MemorySize(*pimpl_); }

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -241,8 +241,10 @@ std::optional<SerializationError> DeserializeJSONValue(
 /************** CompiledGrammar **************/
 
 std::size_t MemorySize(const CompiledGrammar::Impl& impl) {
+  std::lock_guard<std::mutex> lock(impl.repeated_character_class_cache_mutex);
   return MemorySize(impl.grammar) + MemorySize(impl.token_mask_cache) +
-         MemorySize(impl.earley_parser_features);
+         MemorySize(impl.earley_parser_features) +
+         MemorySize(impl.repeated_character_class_token_masks);
 }
 
 std::size_t CompiledGrammar::MemorySizeBytes() const { return MemorySize(*pimpl_); }

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -176,6 +176,10 @@ picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl) {
       impl.token_mask_cache.dynamic_ ? decltype(impl.token_mask_cache.masks_){}
                                      : impl.token_mask_cache.masks_
   );
+  result["repeat_token_mask_cache"] = AutoSerializeJSONValue(
+      impl.token_mask_cache.dynamic_ ? decltype(impl.token_mask_cache.repeat_masks_){}
+                                     : impl.token_mask_cache.repeat_masks_
+  );
   return picojson::value(result);
 }
 
@@ -227,7 +231,19 @@ std::optional<SerializationError> DeserializeJSONValue(
   if (object.find("adaptive_token_mask_cache") == object.end()) {
     return ConstructDeserializeError("Expect a 'adaptive_token_mask_cache' field", type_name);
   }
-  AutoDeserializeJSONValue(&(impl->token_mask_cache.masks_), object["adaptive_token_mask_cache"]);
+  if (auto error = AutoDeserializeJSONValue(
+          &(impl->token_mask_cache.masks_), object["adaptive_token_mask_cache"], type_name
+      )) {
+    return error;
+  }
+  if (object.find("repeat_token_mask_cache") == object.end()) {
+    return ConstructDeserializeError("Expect a 'repeat_token_mask_cache' field", type_name);
+  }
+  if (auto error = AutoDeserializeJSONValue(
+          &(impl->token_mask_cache.repeat_masks_), object["repeat_token_mask_cache"], type_name
+      )) {
+    return error;
+  }
   const auto dynamic_it = object.find("dynamic");
   if (dynamic_it != object.end() && !dynamic_it->second.is<bool>()) {
     return ConstructDeserializeError("Expect a boolean 'dynamic' field", type_name);

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -207,6 +207,8 @@ std::optional<SerializationError> DeserializeJSONValue(
   if (impl->earley_parser_features.fsm_state_flags.size() !=
           static_cast<std::size_t>(impl->grammar->complete_fsm.NumStates()) ||
       impl->earley_parser_features.rule_is_nullable.size() !=
+          static_cast<std::size_t>(impl->grammar->NumRules()) ||
+      impl->earley_parser_features.rule_is_context_independent.size() !=
           static_cast<std::size_t>(impl->grammar->NumRules())) {
     return ConstructDeserializeError(
         "Earley parser feature dimensions do not match the grammar", type_name

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -167,6 +167,7 @@ std::string AdaptiveTokenMask::Print(const TokenizerInfo& tokenizer_info) const 
 picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl) {
   auto result = picojson::object{};
   result["grammar"] = AutoSerializeJSONValue(impl.grammar);
+  result["earley_parser_features"] = AutoSerializeJSONValue(impl.earley_parser_features);
   result["tokenizer_metadata"] = impl.tokenizer_info->DumpMetadataValue();
   // In dynamic mode, serialize an empty mask cache; masks are generated on first use again
   // after deserialization.
@@ -192,6 +193,23 @@ std::optional<SerializationError> DeserializeJSONValue(
     return ConstructDeserializeError("Expect a 'grammar' field", type_name);
   }
   AutoDeserializeJSONValue(&(impl->grammar), object["grammar"], type_name);
+  const auto features_it = object.find("earley_parser_features");
+  if (features_it == object.end()) {
+    return ConstructDeserializeError("Expect an 'earley_parser_features' field", type_name);
+  }
+  if (auto error = AutoDeserializeJSONValue(
+          &(impl->earley_parser_features), features_it->second, type_name
+      )) {
+    return error;
+  }
+  if (impl->earley_parser_features.fsm_state_flags.size() !=
+          static_cast<std::size_t>(impl->grammar->complete_fsm.NumStates()) ||
+      impl->earley_parser_features.rule_is_nullable.size() !=
+          static_cast<std::size_t>(impl->grammar->NumRules())) {
+    return ConstructDeserializeError(
+        "Earley parser feature dimensions do not match the grammar", type_name
+    );
+  }
   if (object.find("tokenizer_metadata") == object.end()) {
     return ConstructDeserializeError("Expect a 'tokenizer_metadata' field", type_name);
   }
@@ -219,7 +237,8 @@ std::optional<SerializationError> DeserializeJSONValue(
 /************** CompiledGrammar **************/
 
 std::size_t MemorySize(const CompiledGrammar::Impl& impl) {
-  return MemorySize(impl.grammar) + MemorySize(impl.token_mask_cache);
+  return MemorySize(impl.grammar) + MemorySize(impl.token_mask_cache) +
+         MemorySize(impl.earley_parser_features);
 }
 
 std::size_t CompiledGrammar::MemorySizeBytes() const { return MemorySize(*pimpl_); }

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -192,7 +192,9 @@ std::optional<SerializationError> DeserializeJSONValue(
   if (object.find("grammar") == object.end()) {
     return ConstructDeserializeError("Expect a 'grammar' field", type_name);
   }
-  AutoDeserializeJSONValue(&(impl->grammar), object["grammar"], type_name);
+  if (auto error = AutoDeserializeJSONValue(&(impl->grammar), object["grammar"], type_name)) {
+    return error;
+  }
   const auto features_it = object.find("earley_parser_features");
   if (features_it == object.end()) {
     return ConstructDeserializeError("Expect an 'earley_parser_features' field", type_name);

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -212,8 +212,6 @@ std::optional<SerializationError> DeserializeJSONValue(
   }
   if (dynamic_it != object.end() && dynamic_it->second.get<bool>()) {
     impl->token_mask_cache.dynamic_ = true;
-    impl->token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_ =
-        ComputeTagDispatchSecondSlicingBitset(impl->grammar, tokenizer_info);
   }
   return std::nullopt;
 }

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -168,11 +168,12 @@ picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl) {
   auto result = picojson::object{};
   result["grammar"] = AutoSerializeJSONValue(impl.grammar);
   result["tokenizer_metadata"] = impl.tokenizer_info->DumpMetadataValue();
-  // In dynamic mode, serialize an empty mask cache. Deserialization detects the empty cache and
-  // restores dynamic mode, so masks are generated on first use again.
+  // In dynamic mode, serialize an empty mask cache; masks are generated on first use again
+  // after deserialization.
+  result["dynamic"] = picojson::value(impl.token_mask_cache.dynamic_);
   result["adaptive_token_mask_cache"] = AutoSerializeJSONValue(
-      impl.token_mask_cache.dynamic ? decltype(impl.token_mask_cache.masks){}
-                                    : impl.token_mask_cache.masks
+      impl.token_mask_cache.dynamic_ ? decltype(impl.token_mask_cache.masks_){}
+                                     : impl.token_mask_cache.masks_
   );
   return picojson::value(result);
 }
@@ -204,12 +205,14 @@ std::optional<SerializationError> DeserializeJSONValue(
   if (object.find("adaptive_token_mask_cache") == object.end()) {
     return ConstructDeserializeError("Expect a 'adaptive_token_mask_cache' field", type_name);
   }
-  AutoDeserializeJSONValue(&(impl->token_mask_cache.masks), object["adaptive_token_mask_cache"]);
-  if (impl->token_mask_cache.masks.empty()) {
-    // An empty mask cache means the grammar was compiled with dynamic compilation, so masks must
-    // be generated on first use.
-    impl->token_mask_cache.dynamic = true;
-    impl->token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset =
+  AutoDeserializeJSONValue(&(impl->token_mask_cache.masks_), object["adaptive_token_mask_cache"]);
+  const auto dynamic_it = object.find("dynamic");
+  if (dynamic_it != object.end() && !dynamic_it->second.is<bool>()) {
+    return ConstructDeserializeError("Expect a boolean 'dynamic' field", type_name);
+  }
+  if (dynamic_it != object.end() && dynamic_it->second.get<bool>()) {
+    impl->token_mask_cache.dynamic_ = true;
+    impl->token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_ =
         ComputeTagDispatchSecondSlicingBitset(impl->grammar, tokenizer_info);
   }
   return std::nullopt;

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -168,7 +168,12 @@ picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl) {
   auto result = picojson::object{};
   result["grammar"] = AutoSerializeJSONValue(impl.grammar);
   result["tokenizer_metadata"] = impl.tokenizer_info->DumpMetadataValue();
-  result["adaptive_token_mask_cache"] = AutoSerializeJSONValue(impl.adaptive_token_mask_cache);
+  // In dynamic mode, serialize an empty mask cache. Deserialization detects the empty cache and
+  // restores dynamic mode, so masks are generated on first use again.
+  result["adaptive_token_mask_cache"] = AutoSerializeJSONValue(
+      impl.token_mask_cache.dynamic ? decltype(impl.token_mask_cache.masks){}
+                                    : impl.token_mask_cache.masks
+  );
   return picojson::value(result);
 }
 
@@ -199,16 +204,21 @@ std::optional<SerializationError> DeserializeJSONValue(
   if (object.find("adaptive_token_mask_cache") == object.end()) {
     return ConstructDeserializeError("Expect a 'adaptive_token_mask_cache' field", type_name);
   }
-  AutoDeserializeJSONValue(&(impl->adaptive_token_mask_cache), object["adaptive_token_mask_cache"]);
+  AutoDeserializeJSONValue(&(impl->token_mask_cache.masks), object["adaptive_token_mask_cache"]);
+  if (impl->token_mask_cache.masks.empty()) {
+    // An empty mask cache means the grammar was compiled with dynamic compilation, so masks must
+    // be generated on first use.
+    impl->token_mask_cache.dynamic = true;
+    impl->token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset =
+        ComputeTagDispatchSecondSlicingBitset(impl->grammar, tokenizer_info);
+  }
   return std::nullopt;
 }
 
 /************** CompiledGrammar **************/
 
 std::size_t MemorySize(const CompiledGrammar::Impl& impl) {
-  std::lock_guard<std::mutex> lock(impl.adaptive_token_mask_cache_mutex);
-  return MemorySize(impl.grammar) + MemorySize(impl.adaptive_token_mask_cache) +
-         MemorySize(impl.tag_dispatch_rule_id_to_second_slicing_bitset);
+  return MemorySize(impl.grammar) + MemorySize(impl.token_mask_cache);
 }
 
 std::size_t CompiledGrammar::MemorySizeBytes() const { return MemorySize(*pimpl_); }
@@ -218,12 +228,7 @@ Grammar CompiledGrammar::GetGrammar() const { return pimpl_->GetGrammar(); }
 TokenizerInfo CompiledGrammar::GetTokenizerInfo() const { return pimpl_->GetTokenizerInfo(); }
 
 /*! \brief Return the serialized JSON string of the compiled grammar. */
-std::string CompiledGrammar::SerializeJSON() const {
-  if (pimpl_->enable_dynamic_compilation) {
-    pimpl_->MaterializeAdaptiveTokenMaskCache();
-  }
-  return AutoSerializeJSON(*this, true);
-}
+std::string CompiledGrammar::SerializeJSON() const { return AutoSerializeJSON(*this, true); }
 
 /*! \brief Deserialize a compiled grammar from a JSON string and tokenizer info. */
 std::variant<CompiledGrammar, SerializationError> CompiledGrammar::DeserializeJSON(

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -27,7 +27,6 @@
 namespace xgrammar {
 
 class RuleLevelCache;
-class CharacterClassTokenSummaryCache;
 
 /******************* CompiledGrammar Datastructures *******************/
 
@@ -123,22 +122,6 @@ XGRAMMAR_MEMBER_TABLE(
     &AdaptiveTokenMask::uncertain_indices
 );
 
-struct CharacterClassTokenSummary {
-  int32_t sorted_vocab_index;
-  int32_t locally_consumed_characters;
-  bool consumed_whole_token;
-  bool has_completed_character_prefix;
-};
-
-struct RepeatedCharacterClassTokenMask {
-  AdaptiveTokenMask adaptive_token_mask;
-  DynamicBitset accepted_prefix_tokens;
-
-  friend std::size_t MemorySize(const RepeatedCharacterClassTokenMask& mask) {
-    return MemorySize(mask.adaptive_token_mask) + MemorySize(mask.accepted_prefix_tokens);
-  }
-};
-
 /*!
  * \brief Manages the adaptive token masks of a compiled grammar. In eager mode (the default),
  * all masks are precomputed at compile time. In dynamic mode, masks are generated and cached on
@@ -173,10 +156,53 @@ class TokenMaskCache {
       bool is_root_rule,
       const Grammar& grammar,
       const TokenizerInfo& tokenizer_info,
-      const EarleyParserFeatures& features
+      const EarleyParserFeatures& features,
+      const ParserState* repeat_parent_state = nullptr
   );
 
  private:
+  struct RepeatTokenMaskKey {
+    ParserState state;
+    int32_t parent_node_id;
+    int32_t lower_bound_distance;
+    int32_t upper_bound_distance;
+
+    bool operator==(const RepeatTokenMaskKey& other) const {
+      return StateEqualForCache()(state, other.state) && parent_node_id == other.parent_node_id &&
+             lower_bound_distance == other.lower_bound_distance &&
+             upper_bound_distance == other.upper_bound_distance;
+    }
+  };
+
+  struct RepeatTokenMaskKeyHash {
+    size_t operator()(const RepeatTokenMaskKey& key) const {
+      return HashCombine(
+          StateHashForCache()(key.state),
+          key.parent_node_id,
+          key.lower_bound_distance,
+          key.upper_bound_distance
+      );
+    }
+  };
+
+  struct RepeatTokenSummary {
+    int32_t sorted_vocabulary_index;
+    int32_t locally_consumed_repetitions;
+    bool consumed_whole_token;
+    bool has_completed_repetition_prefix;
+  };
+
+  std::optional<AdaptiveTokenMask> TryGetSimpleRepeatTokenMask(
+      const ParserState& state,
+      int32_t upper_bound_distance,
+      const Grammar& grammar,
+      const TokenizerInfo& tokenizer_info
+  );
+
+  std::shared_ptr<const std::vector<RepeatTokenSummary>> GetSimpleRepeatTokenSummaries(
+      const ParserState& state, const Grammar& grammar, const TokenizerInfo& tokenizer_info
+  );
+
   /*! \brief Return the tag-dispatch bitset for a rule, computing and caching it on first use. */
   const DynamicBitset* GetTagDispatchSecondSlicingBitset(
       int32_t rule_id, const Grammar& grammar, const TokenizerInfo& tokenizer_info
@@ -190,6 +216,17 @@ class TokenMaskCache {
 
   /*! \brief Mapping from the parser state to the adaptive token mask. */
   std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache> masks_;
+
+  /*! \brief Context-aware masks for states entered through a repeat edge. */
+  std::unordered_map<RepeatTokenMaskKey, AdaptiveTokenMask, RepeatTokenMaskKeyHash> repeat_masks_;
+
+  /*! \brief Token summaries for repeated rules that only contain deterministic byte transitions. */
+  std::unordered_map<
+      ParserState,
+      std::shared_ptr<const std::vector<RepeatTokenSummary>>,
+      StateHashForCache,
+      StateEqualForCache>
+      repeat_token_summaries_;
 
   /*! \brief Tag-dispatch data computed on first use in dynamic mode. */
   std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset_;
@@ -207,8 +244,16 @@ class TokenMaskCache {
 
   friend std::size_t MemorySize(const TokenMaskCache& token_mask_cache) {
     std::lock_guard<std::mutex> lock(token_mask_cache.mutex_);
-    return MemorySize(token_mask_cache.masks_) +
-           MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_);
+    std::size_t result =
+        MemorySize(token_mask_cache.masks_) + MemorySize(token_mask_cache.repeat_masks_) +
+        MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_);
+    for (const auto& [state, summaries] : token_mask_cache.repeat_token_summaries_) {
+      result += sizeof(state) + sizeof(summaries);
+      if (summaries != nullptr) {
+        result += MemorySize(*summaries);
+      }
+    }
+    return result;
   }
 };
 
@@ -236,20 +281,6 @@ class CompiledGrammar::Impl {
 
   /*! \brief Grammar-wide flags and nullable rules shared by Earley parsers. */
   EarleyParserFeatures earley_parser_features;
-
-  /*! \brief Character-class token summaries shared by grammars from the same compiler. */
-  std::shared_ptr<CharacterClassTokenSummaryCache> character_class_token_summary_cache;
-
-  /*! \brief Repeated character-class masks shared by matchers using this compiled grammar. */
-  std::unordered_map<uint64_t, RepeatedCharacterClassTokenMask>
-      repeated_character_class_token_masks;
-
-  /*! \brief Protects repeated character-class summary and mask generation. */
-  mutable std::mutex repeated_character_class_cache_mutex;
-
-  const RepeatedCharacterClassTokenMask& GetRepeatedCharacterClassTokenMask(
-      int32_t character_class_expression_id, int32_t character_limit
-  );
 
   Grammar GetGrammar() const { return grammar; }
 

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -23,6 +24,8 @@
 #include "xgrammar/exception.h"
 
 namespace xgrammar {
+
+class RuleLevelCache;
 
 /******************* CompiledGrammar Datastructures *******************/
 
@@ -116,6 +119,14 @@ class TokenMaskCache {
    */
   explicit TokenMaskCache(bool dynamic) : dynamic_(dynamic) {}
 
+  /*! \brief Configure cross-grammar rule mask sharing for dynamic generation. */
+  void SetRuleLevelCache(
+      std::shared_ptr<RuleLevelCache> rule_level_cache, std::vector<uint8_t> rule_level_cacheable
+  ) {
+    rule_level_cache_ = std::move(rule_level_cache);
+    rule_level_cacheable_ = std::move(rule_level_cacheable);
+  }
+
   /*! \brief Whether missing token masks should be generated on first use. */
   bool IsDynamic() const { return dynamic_; }
 
@@ -140,6 +151,12 @@ class TokenMaskCache {
   /*! \brief Whether missing token masks should be generated on first use. */
   bool dynamic_{false};
 
+  /*! \brief Rule masks shared by grammars compiled with the same compiler. */
+  std::shared_ptr<RuleLevelCache> rule_level_cache_;
+
+  /*! \brief Whether each rule is independent of runtime parser context. */
+  std::vector<uint8_t> rule_level_cacheable_;
+
   /*! \brief Mapping from the parser state to the adaptive token mask. */
   std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache> masks_;
 
@@ -160,7 +177,8 @@ class TokenMaskCache {
   friend std::size_t MemorySize(const TokenMaskCache& token_mask_cache) {
     std::lock_guard<std::mutex> lock(token_mask_cache.mutex_);
     return MemorySize(token_mask_cache.masks_) +
-           MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_);
+           MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_) +
+           MemorySize(token_mask_cache.rule_level_cacheable_);
   }
 };
 

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -14,6 +14,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -122,6 +123,48 @@ XGRAMMAR_MEMBER_TABLE(
     &AdaptiveTokenMask::uncertain_indices
 );
 
+struct RepeatTokenMaskKey {
+  ParserState state;
+  int32_t parent_node_id;
+  int32_t lower_bound_distance;
+  int32_t upper_bound_distance;
+
+  bool operator==(const RepeatTokenMaskKey& other) const {
+    return StateEqualForCache()(state, other.state) && parent_node_id == other.parent_node_id &&
+           lower_bound_distance == other.lower_bound_distance &&
+           upper_bound_distance == other.upper_bound_distance;
+  }
+
+  bool operator<(const RepeatTokenMaskKey& other) const {
+    return std::tie(state, parent_node_id, lower_bound_distance, upper_bound_distance) <
+           std::tie(
+               other.state,
+               other.parent_node_id,
+               other.lower_bound_distance,
+               other.upper_bound_distance
+           );
+  }
+};
+
+struct RepeatTokenMaskKeyHash {
+  size_t operator()(const RepeatTokenMaskKey& key) const {
+    return HashCombine(
+        StateHashForCache()(key.state),
+        key.parent_node_id,
+        key.lower_bound_distance,
+        key.upper_bound_distance
+    );
+  }
+};
+
+XGRAMMAR_MEMBER_ARRAY(
+    RepeatTokenMaskKey,
+    &RepeatTokenMaskKey::state,
+    &RepeatTokenMaskKey::parent_node_id,
+    &RepeatTokenMaskKey::lower_bound_distance,
+    &RepeatTokenMaskKey::upper_bound_distance
+);
+
 /*!
  * \brief Manages the adaptive token masks of a compiled grammar. In eager mode (the default),
  * all masks are precomputed at compile time. In dynamic mode, masks are generated and cached on
@@ -143,9 +186,6 @@ class TokenMaskCache {
     rule_level_cache_ = std::move(rule_level_cache);
   }
 
-  /*! \brief Whether missing token masks should be generated on first use. */
-  bool IsDynamic() const { return dynamic_; }
-
   /*! \brief Insert a precomputed mask during eager compilation. Not thread-safe; the compiler
    * synchronizes concurrent insertions itself. */
   void Insert(const ParserState& state, AdaptiveTokenMask mask) { masks_[state] = std::move(mask); }
@@ -160,31 +200,27 @@ class TokenMaskCache {
       const ParserState* repeat_parent_state = nullptr
   );
 
+  /*! \brief Generate and store one repeat-context mask during eager compilation. */
+  void PrecomputeRepeat(
+      const ParserState& state,
+      const ParserState& repeat_parent_state,
+      const Grammar& grammar,
+      const TokenizerInfo& tokenizer_info,
+      const EarleyParserFeatures& features
+  );
+
+  /*! \brief Release summaries that are only needed while repeat masks are generated. */
+  void ClearRepeatTokenSummaries();
+
+  /*! \brief Build the cache key shared by compiled masks and the matcher fast path. */
+  RepeatTokenMaskKey GetRepeatTokenMaskKey(
+      const ParserState& state,
+      const ParserState& repeat_parent_state,
+      const Grammar& grammar,
+      const TokenizerInfo& tokenizer_info
+  ) const;
+
  private:
-  struct RepeatTokenMaskKey {
-    ParserState state;
-    int32_t parent_node_id;
-    int32_t lower_bound_distance;
-    int32_t upper_bound_distance;
-
-    bool operator==(const RepeatTokenMaskKey& other) const {
-      return StateEqualForCache()(state, other.state) && parent_node_id == other.parent_node_id &&
-             lower_bound_distance == other.lower_bound_distance &&
-             upper_bound_distance == other.upper_bound_distance;
-    }
-  };
-
-  struct RepeatTokenMaskKeyHash {
-    size_t operator()(const RepeatTokenMaskKey& key) const {
-      return HashCombine(
-          StateHashForCache()(key.state),
-          key.parent_node_id,
-          key.lower_bound_distance,
-          key.upper_bound_distance
-      );
-    }
-  };
-
   struct RepeatTokenSummary {
     int32_t sorted_vocabulary_index;
     int32_t locally_consumed_repetitions;
@@ -201,6 +237,15 @@ class TokenMaskCache {
 
   std::shared_ptr<const std::vector<RepeatTokenSummary>> GetSimpleRepeatTokenSummaries(
       const ParserState& state, const Grammar& grammar, const TokenizerInfo& tokenizer_info
+  );
+
+  AdaptiveTokenMask GenerateRepeatTokenMask(
+      const ParserState& state,
+      const ParserState& repeat_parent_state,
+      const RepeatTokenMaskKey& repeat_key,
+      const Grammar& grammar,
+      const TokenizerInfo& tokenizer_info,
+      const EarleyParserFeatures& features
   );
 
   /*! \brief Return the tag-dispatch bitset for a rule, computing and caching it on first use. */

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -28,6 +29,22 @@ namespace xgrammar {
 class RuleLevelCache;
 
 /******************* CompiledGrammar Datastructures *******************/
+
+XGRAMMAR_MEMBER_TABLE(
+    EarleyParserFeatures,
+    "fsm_state_flags",
+    &EarleyParserFeatures::fsm_state_flags,
+    "rule_is_nullable",
+    &EarleyParserFeatures::rule_is_nullable,
+    "has_budget_rules",
+    &EarleyParserFeatures::has_budget_rules,
+    "has_char_budget_rules",
+    &EarleyParserFeatures::has_char_budget_rules,
+    "capture_tracking",
+    &EarleyParserFeatures::capture_tracking,
+    "has_hidden_capture_rules",
+    &EarleyParserFeatures::has_hidden_capture_rules
+);
 
 /*!
  * \brief Preprocessed information, for a given specific ParserState, divides the token set
@@ -139,7 +156,8 @@ class TokenMaskCache {
       const ParserState& state,
       bool is_root_rule,
       const Grammar& grammar,
-      const TokenizerInfo& tokenizer_info
+      const TokenizerInfo& tokenizer_info,
+      const EarleyParserFeatures& features
   );
 
  private:
@@ -216,6 +234,9 @@ class CompiledGrammar::Impl {
 
   /*! \brief The adaptive token masks, precomputed or generated on first use. */
   TokenMaskCache token_mask_cache;
+
+  /*! \brief Grammar-wide flags and nullable rules shared by Earley parsers. */
+  EarleyParserFeatures earley_parser_features;
 
   Grammar GetGrammar() const { return grammar; }
 

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -27,6 +27,7 @@
 namespace xgrammar {
 
 class RuleLevelCache;
+class CharacterClassTokenSummaryCache;
 
 /******************* CompiledGrammar Datastructures *******************/
 
@@ -121,6 +122,22 @@ XGRAMMAR_MEMBER_TABLE(
     "uncertain_indices",
     &AdaptiveTokenMask::uncertain_indices
 );
+
+struct CharacterClassTokenSummary {
+  int32_t sorted_vocab_index;
+  int32_t locally_consumed_characters;
+  bool consumed_whole_token;
+  bool has_completed_character_prefix;
+};
+
+struct RepeatedCharacterClassTokenMask {
+  AdaptiveTokenMask adaptive_token_mask;
+  DynamicBitset accepted_prefix_tokens;
+
+  friend std::size_t MemorySize(const RepeatedCharacterClassTokenMask& mask) {
+    return MemorySize(mask.adaptive_token_mask) + MemorySize(mask.accepted_prefix_tokens);
+  }
+};
 
 /*!
  * \brief Manages the adaptive token masks of a compiled grammar. In eager mode (the default),
@@ -219,6 +236,20 @@ class CompiledGrammar::Impl {
 
   /*! \brief Grammar-wide flags and nullable rules shared by Earley parsers. */
   EarleyParserFeatures earley_parser_features;
+
+  /*! \brief Character-class token summaries shared by grammars from the same compiler. */
+  std::shared_ptr<CharacterClassTokenSummaryCache> character_class_token_summary_cache;
+
+  /*! \brief Repeated character-class masks shared by matchers using this compiled grammar. */
+  std::unordered_map<uint64_t, RepeatedCharacterClassTokenMask>
+      repeated_character_class_token_masks;
+
+  /*! \brief Protects repeated character-class summary and mask generation. */
+  mutable std::mutex repeated_character_class_cache_mutex;
+
+  const RepeatedCharacterClassTokenMask& GetRepeatedCharacterClassTokenMask(
+      int32_t character_class_expression_id, int32_t character_limit
+  );
 
   Grammar GetGrammar() const { return grammar; }
 

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -118,6 +119,19 @@ class CompiledGrammar::Impl {
   /*! \brief Mapping from the parser state to the adaptive token mask. */
   std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache>
       adaptive_token_mask_cache;
+
+  /*! \brief Protects on-demand token mask lookup and insertion. */
+  mutable std::mutex adaptive_token_mask_cache_mutex;
+
+  /*! \brief Whether missing token masks should be generated on first use. */
+  bool enable_dynamic_compilation{false};
+
+  /*! \brief Tag-dispatch data retained for on-demand token mask generation. */
+  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
+
+  const AdaptiveTokenMask& GetAdaptiveTokenMask(const ParserState& state, bool is_root_rule);
+
+  void MaterializeAdaptiveTokenMaskCache();
 
   Grammar GetGrammar() const { return grammar; }
 

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -36,6 +36,8 @@ XGRAMMAR_MEMBER_TABLE(
     &EarleyParserFeatures::fsm_state_flags,
     "rule_is_nullable",
     &EarleyParserFeatures::rule_is_nullable,
+    "rule_is_context_independent",
+    &EarleyParserFeatures::rule_is_context_independent,
     "has_budget_rules",
     &EarleyParserFeatures::has_budget_rules,
     "has_char_budget_rules",
@@ -137,11 +139,8 @@ class TokenMaskCache {
   explicit TokenMaskCache(bool dynamic) : dynamic_(dynamic) {}
 
   /*! \brief Configure cross-grammar rule mask sharing for dynamic generation. */
-  void SetRuleLevelCache(
-      std::shared_ptr<RuleLevelCache> rule_level_cache, std::vector<uint8_t> rule_level_cacheable
-  ) {
+  void SetRuleLevelCache(std::shared_ptr<RuleLevelCache> rule_level_cache) {
     rule_level_cache_ = std::move(rule_level_cache);
-    rule_level_cacheable_ = std::move(rule_level_cacheable);
   }
 
   /*! \brief Whether missing token masks should be generated on first use. */
@@ -172,9 +171,6 @@ class TokenMaskCache {
   /*! \brief Rule masks shared by grammars compiled with the same compiler. */
   std::shared_ptr<RuleLevelCache> rule_level_cache_;
 
-  /*! \brief Whether each rule is independent of runtime parser context. */
-  std::vector<uint8_t> rule_level_cacheable_;
-
   /*! \brief Mapping from the parser state to the adaptive token mask. */
   std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache> masks_;
 
@@ -195,8 +191,7 @@ class TokenMaskCache {
   friend std::size_t MemorySize(const TokenMaskCache& token_mask_cache) {
     std::lock_guard<std::mutex> lock(token_mask_cache.mutex_);
     return MemorySize(token_mask_cache.masks_) +
-           MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_) +
-           MemorySize(token_mask_cache.rule_level_cacheable_);
+           MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_);
   }
 };
 

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -201,19 +201,6 @@ class TokenMaskCache {
 };
 
 /*!
- * \brief Compute the bitset of tokens that are definitely accepted since the second character
- * for a tag-dispatch rule.
- */
-DynamicBitset ComputeTagDispatchSecondSlicingBitset(
-    const Grammar& grammar, const TokenizerInfo& tokenizer_info, int32_t rule_id
-);
-
-/*! \brief Compute the second-slicing bitsets for all tag-dispatch rules. */
-std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitsets(
-    const Grammar& grammar, const TokenizerInfo& tokenizer_info
-);
-
-/*!
  * \brief All information that we need to match tokens in the tokenizer to the specified grammar.
  * It is the result of preprocessing.
  * \sa xgrammar::GrammarMatcher

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -113,17 +113,8 @@ class TokenMaskCache {
   /*!
    * \brief Construct the cache with the mask generation mode.
    * \param dynamic Whether missing token masks should be generated on first use.
-   * \param tag_dispatch_rule_id_to_second_slicing_bitset Tag-dispatch data needed for on-demand
-   * token mask generation. Only used in dynamic mode.
    */
-  TokenMaskCache(
-      bool dynamic,
-      std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset
-  )
-      : dynamic_(dynamic),
-        tag_dispatch_rule_id_to_second_slicing_bitset_(
-            std::move(tag_dispatch_rule_id_to_second_slicing_bitset)
-        ) {}
+  explicit TokenMaskCache(bool dynamic) : dynamic_(dynamic) {}
 
   /*! \brief Whether missing token masks should be generated on first use. */
   bool IsDynamic() const { return dynamic_; }
@@ -141,14 +132,18 @@ class TokenMaskCache {
   );
 
  private:
+  /*! \brief Return the tag-dispatch bitset for a rule, computing and caching it on first use. */
+  const DynamicBitset* GetTagDispatchSecondSlicingBitset(
+      int32_t rule_id, const Grammar& grammar, const TokenizerInfo& tokenizer_info
+  );
+
   /*! \brief Whether missing token masks should be generated on first use. */
   bool dynamic_{false};
 
   /*! \brief Mapping from the parser state to the adaptive token mask. */
   std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache> masks_;
 
-  /*! \brief Tag-dispatch data needed for on-demand token mask generation. Only filled in
-   * dynamic mode. */
+  /*! \brief Tag-dispatch data computed on first use in dynamic mode. */
   std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset_;
 
   /*! \brief Protects on-demand token mask lookup and insertion. */
@@ -170,11 +165,15 @@ class TokenMaskCache {
 };
 
 /*!
- * \brief Compute, for each tag-dispatch rule, the bitset of tokens that are definitely accepted
- * since the second character. Used at compile time and to restore dynamic mode on
- * deserialization.
+ * \brief Compute the bitset of tokens that are definitely accepted since the second character
+ * for a tag-dispatch rule.
  */
-std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitset(
+DynamicBitset ComputeTagDispatchSecondSlicingBitset(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info, int32_t rule_id
+);
+
+/*! \brief Compute the second-slicing bitsets for all tag-dispatch rules. */
+std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitsets(
     const Grammar& grammar, const TokenizerInfo& tokenizer_info
 );
 
@@ -195,13 +194,7 @@ class CompiledGrammar::Impl {
   Impl() = default;
 
   /*! \brief Construct with the token mask generation mode. \sa TokenMaskCache */
-  Impl(
-      bool enable_dynamic_compilation,
-      std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset
-  )
-      : token_mask_cache(
-            enable_dynamic_compilation, std::move(tag_dispatch_rule_id_to_second_slicing_bitset)
-        ) {}
+  explicit Impl(bool enable_dynamic_compilation) : token_mask_cache(enable_dynamic_compilation) {}
 
   /*! \brief The adaptive token masks, precomputed or generated on first use. */
   TokenMaskCache token_mask_cache;

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -101,24 +101,36 @@ XGRAMMAR_MEMBER_TABLE(
 );
 
 /*!
- * \brief Manages the adaptive token masks of a compiled grammar. In eager mode (dynamic ==
- * false), all masks are precomputed at compile time. In dynamic mode, masks are generated and
- * cached on first use.
+ * \brief Manages the adaptive token masks of a compiled grammar. In eager mode (the default),
+ * all masks are precomputed at compile time. In dynamic mode, masks are generated and cached on
+ * first use.
  */
 class TokenMaskCache {
  public:
+  /*! \brief Construct an eager cache. Only for deserialization. */
+  TokenMaskCache() = default;
+
+  /*!
+   * \brief Construct the cache with the mask generation mode.
+   * \param dynamic Whether missing token masks should be generated on first use.
+   * \param tag_dispatch_rule_id_to_second_slicing_bitset Tag-dispatch data needed for on-demand
+   * token mask generation. Only used in dynamic mode.
+   */
+  TokenMaskCache(
+      bool dynamic,
+      std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset
+  )
+      : dynamic_(dynamic),
+        tag_dispatch_rule_id_to_second_slicing_bitset_(
+            std::move(tag_dispatch_rule_id_to_second_slicing_bitset)
+        ) {}
+
   /*! \brief Whether missing token masks should be generated on first use. */
-  bool dynamic{false};
+  bool IsDynamic() const { return dynamic_; }
 
-  /*! \brief Mapping from the parser state to the adaptive token mask. */
-  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache> masks;
-
-  /*! \brief Tag-dispatch data needed for on-demand token mask generation. Only filled in
-   * dynamic mode. */
-  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
-
-  /*! \brief Protects on-demand token mask lookup and insertion. */
-  mutable std::mutex mutex;
+  /*! \brief Insert a precomputed mask during eager compilation. Not thread-safe; the compiler
+   * synchronizes concurrent insertions itself. */
+  void Insert(const ParserState& state, AdaptiveTokenMask mask) { masks_[state] = std::move(mask); }
 
   /*! \brief Return the mask for the state. In dynamic mode, generate and cache it on miss. */
   const AdaptiveTokenMask& Get(
@@ -128,10 +140,32 @@ class TokenMaskCache {
       const TokenizerInfo& tokenizer_info
   );
 
+ private:
+  /*! \brief Whether missing token masks should be generated on first use. */
+  bool dynamic_{false};
+
+  /*! \brief Mapping from the parser state to the adaptive token mask. */
+  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache> masks_;
+
+  /*! \brief Tag-dispatch data needed for on-demand token mask generation. Only filled in
+   * dynamic mode. */
+  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset_;
+
+  /*! \brief Protects on-demand token mask lookup and insertion. */
+  mutable std::mutex mutex_;
+
+  friend struct member_trait<TokenMaskCache>;
+  friend picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl);
+  friend std::optional<SerializationError> DeserializeJSONValue(
+      CompiledGrammar::Impl* impl,
+      const picojson::value& json_value,
+      const TokenizerInfo& tokenizer_info
+  );
+
   friend std::size_t MemorySize(const TokenMaskCache& token_mask_cache) {
-    std::lock_guard<std::mutex> lock(token_mask_cache.mutex);
-    return MemorySize(token_mask_cache.masks) +
-           MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset);
+    std::lock_guard<std::mutex> lock(token_mask_cache.mutex_);
+    return MemorySize(token_mask_cache.masks_) +
+           MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_);
   }
 };
 
@@ -157,8 +191,17 @@ class CompiledGrammar::Impl {
   /*! \brief The tokenizer information. */
   TokenizerInfo tokenizer_info{NullObj{}};
 
-  /*! \brief Default constructor. */
+  /*! \brief Default constructor. Only for deserialization. */
   Impl() = default;
+
+  /*! \brief Construct with the token mask generation mode. \sa TokenMaskCache */
+  Impl(
+      bool enable_dynamic_compilation,
+      std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset
+  )
+      : token_mask_cache(
+            enable_dynamic_compilation, std::move(tag_dispatch_rule_id_to_second_slicing_bitset)
+        ) {}
 
   /*! \brief The adaptive token masks, precomputed or generated on first use. */
   TokenMaskCache token_mask_cache;
@@ -177,7 +220,7 @@ class CompiledGrammar::Impl {
   friend std::size_t MemorySize(const Impl& impl);
 };
 
-XGRAMMAR_MEMBER_TABLE(TokenMaskCache, "adaptive_token_mask_cache", &TokenMaskCache::masks);
+XGRAMMAR_MEMBER_TABLE(TokenMaskCache, "adaptive_token_mask_cache", &TokenMaskCache::masks_);
 
 XGRAMMAR_MEMBER_TABLE(
     CompiledGrammar::Impl,

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -101,6 +101,50 @@ XGRAMMAR_MEMBER_TABLE(
 );
 
 /*!
+ * \brief Manages the adaptive token masks of a compiled grammar. In eager mode (dynamic ==
+ * false), all masks are precomputed at compile time. In dynamic mode, masks are generated and
+ * cached on first use.
+ */
+class TokenMaskCache {
+ public:
+  /*! \brief Whether missing token masks should be generated on first use. */
+  bool dynamic{false};
+
+  /*! \brief Mapping from the parser state to the adaptive token mask. */
+  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache> masks;
+
+  /*! \brief Tag-dispatch data needed for on-demand token mask generation. Only filled in
+   * dynamic mode. */
+  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
+
+  /*! \brief Protects on-demand token mask lookup and insertion. */
+  mutable std::mutex mutex;
+
+  /*! \brief Return the mask for the state. In dynamic mode, generate and cache it on miss. */
+  const AdaptiveTokenMask& Get(
+      const ParserState& state,
+      bool is_root_rule,
+      const Grammar& grammar,
+      const TokenizerInfo& tokenizer_info
+  );
+
+  friend std::size_t MemorySize(const TokenMaskCache& token_mask_cache) {
+    std::lock_guard<std::mutex> lock(token_mask_cache.mutex);
+    return MemorySize(token_mask_cache.masks) +
+           MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset);
+  }
+};
+
+/*!
+ * \brief Compute, for each tag-dispatch rule, the bitset of tokens that are definitely accepted
+ * since the second character. Used at compile time and to restore dynamic mode on
+ * deserialization.
+ */
+std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitset(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info
+);
+
+/*!
  * \brief All information that we need to match tokens in the tokenizer to the specified grammar.
  * It is the result of preprocessing.
  * \sa xgrammar::GrammarMatcher
@@ -116,22 +160,8 @@ class CompiledGrammar::Impl {
   /*! \brief Default constructor. */
   Impl() = default;
 
-  /*! \brief Mapping from the parser state to the adaptive token mask. */
-  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache>
-      adaptive_token_mask_cache;
-
-  /*! \brief Protects on-demand token mask lookup and insertion. */
-  mutable std::mutex adaptive_token_mask_cache_mutex;
-
-  /*! \brief Whether missing token masks should be generated on first use. */
-  bool enable_dynamic_compilation{false};
-
-  /*! \brief Tag-dispatch data retained for on-demand token mask generation. */
-  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
-
-  const AdaptiveTokenMask& GetAdaptiveTokenMask(const ParserState& state, bool is_root_rule);
-
-  void MaterializeAdaptiveTokenMaskCache();
+  /*! \brief The adaptive token masks, precomputed or generated on first use. */
+  TokenMaskCache token_mask_cache;
 
   Grammar GetGrammar() const { return grammar; }
 
@@ -147,14 +177,16 @@ class CompiledGrammar::Impl {
   friend std::size_t MemorySize(const Impl& impl);
 };
 
+XGRAMMAR_MEMBER_TABLE(TokenMaskCache, "adaptive_token_mask_cache", &TokenMaskCache::masks);
+
 XGRAMMAR_MEMBER_TABLE(
     CompiledGrammar::Impl,
     "grammar",
     &CompiledGrammar::Impl::grammar,
     "tokenizer_info",
     &CompiledGrammar::Impl::tokenizer_info,
-    "adaptive_token_mask_cache",
-    &CompiledGrammar::Impl::adaptive_token_mask_cache
+    "token_mask_cache",
+    &CompiledGrammar::Impl::token_mask_cache
 );
 
 }  // namespace xgrammar

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -507,6 +507,10 @@ EarleyParserFeatures::EarleyParserFeatures(const Grammar& grammar)
       } else if (edge.IsRuleRef() || edge.IsEpsilon() || edge.IsRepeatRef()) {
         flags |= kFsmStateNonTerminal;
       }
+      if (edge.IsRepeatRef()) {
+        XGRAMMAR_DCHECK(edges.size() == 1);
+        flags |= kFsmStateRepeatSource;
+      }
     }
   }
 

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -25,6 +25,31 @@ using GrammarExpr = Grammar::Impl::GrammarExpr;
 
 bool EarleyParser::IsCompleted() const { return is_completed_.back(); }
 
+void EarleyParser::ClearTemporaryContainers() {
+  tmp_pending_states_.clear();
+  tmp_states_to_be_added_.clear();
+  tmp_states_visited_in_queue_.Clear();
+  tmp_completed_lazy_occurrences_.clear();
+}
+
+void EarleyParser::ExpandPendingStates(bool debug_print) {
+  size_t process_index = 0;
+  while (process_index < tmp_pending_states_.size()) {
+    const ParserState& state = *tmp_pending_states_[process_index++];
+    if (process_index == tmp_pending_states_.size()) {
+      tmp_pending_states_.clear();
+      process_index = 0;
+    }
+    auto [scanable, completable] = Predict(state, debug_print);
+    if (completable) {
+      Complete(state, debug_print);
+    }
+    if (scanable) {
+      tmp_states_to_be_added_.push_back(&state);
+    }
+  }
+}
+
 bool EarleyParser::CompletionConsumedMarker(const ParserState& state) const {
   const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(state.rule_id).body_expr_id);
   if (body.type != GrammarExprType::kTagDispatch) {
@@ -385,12 +410,10 @@ void EarleyParser::Scan(const ParserState& state, const uint8_t ch) {
 */
 bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   // Initialize the containers.
-  XGRAMMAR_DCHECK(tmp_process_state_queue_.empty())
-      << "The tmp_process_state_queue_ should be empty before the scan.";
-  tmp_states_visited_in_queue_.Clear();
-  tmp_states_to_be_added_.clear();
+  XGRAMMAR_DCHECK(tmp_pending_states_.empty())
+      << "The tmp_pending_states_ should be empty before the scan.";
+  ClearTemporaryContainers();
   tmp_accept_stop_token_ = false;
-  tmp_completed_lazy_occurrences_.clear();
   if (features_->has_char_budget_rules) {
     tmp_char_budget_entered_ = char_budget_entry_history_.back();
     char_count_history_.push_back(GetCurrentCharIndex() + StartsUTF8Codepoint(ch));
@@ -405,10 +428,11 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   }
 
   // Check if the character is accepted.
-  if (tmp_process_state_queue_.empty() && tmp_states_to_be_added_.empty()) {
+  if (tmp_pending_states_.empty() && tmp_states_to_be_added_.empty()) {
     if (features_->has_char_budget_rules) {
       char_count_history_.pop_back();
     }
+    ClearTemporaryContainers();
     return false;
   }
 
@@ -417,34 +441,25 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }
-  while (!tmp_process_state_queue_.empty()) {
-    const auto state = std::move(tmp_process_state_queue_.front());
-    tmp_process_state_queue_.pop();
-    auto [scanable, completable] = Predict(state, debug_print);
-    if (completable) {
-      Complete(state, debug_print);
-    }
-    if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
-    }
-  }
+  ExpandPendingStates(debug_print);
 
   // Check if the grammar is completed, and add the scannable states to the history.
   if (!tmp_completed_lazy_occurrences_.empty()) {
     RemoveCommittedLazyStates();
   }
   is_completed_.push_back(tmp_accept_stop_token_);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
   if (features_->has_char_budget_rules) {
     char_budget_entry_history_.push_back(tmp_char_budget_entered_);
   }
+  ClearTemporaryContainers();
   return true;
 }
 
 void EarleyParser::RemoveCommittedLazyStates() {
-  auto is_committed = [&](const ParserState& state) {
+  auto is_committed = [&](const ParserState* state) {
     for (const auto& [rule_id, rule_start_pos] : tmp_completed_lazy_occurrences_) {
-      if (state.rule_id == rule_id && state.rule_start_pos == rule_start_pos) {
+      if (state->rule_id == rule_id && state->rule_start_pos == rule_start_pos) {
         return true;
       }
     }
@@ -536,35 +551,24 @@ ParserState EarleyParser::RootInitialState() const {
 }
 
 void EarleyParser::PushStateAndExpand(const ParserState& state) {
-  tmp_states_visited_in_queue_.Clear();
+  ClearTemporaryContainers();
   tmp_accept_stop_token_ = false;
-  tmp_states_to_be_added_.clear();
-  tmp_completed_lazy_occurrences_.clear();
   Enqueue(state);
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
   if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }
-  while (!tmp_process_state_queue_.empty()) {
-    const auto state = tmp_process_state_queue_.front();
-    tmp_process_state_queue_.pop();
-    auto [scanable, completable] = Predict(state);
-    if (completable) {
-      Complete(state);
-    }
-    if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
-    }
-  }
+  ExpandPendingStates();
   if (!tmp_completed_lazy_occurrences_.empty()) {
     RemoveCommittedLazyStates();
   }
   is_completed_.push_back(tmp_accept_stop_token_);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
   if (features_->has_char_budget_rules) {
     char_count_history_.push_back(GetCurrentCharIndex());
     char_budget_entry_history_.push_back(tmp_char_budget_entered_);
   }
+  ClearTemporaryContainers();
 }
 
 void EarleyParser::Reset() {
@@ -579,7 +583,7 @@ void EarleyParser::Reset() {
   char_budget_entry_history_.clear();
   tmp_char_budget_entered_ = false;
   capture_recording_ = false;
-  XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
+  XGRAMMAR_DCHECK(tmp_pending_states_.empty());
   PushStateAndExpand(RootInitialState());
 }
 
@@ -876,7 +880,7 @@ void EarleyParser::AdvanceByteString(
       Enqueue(new_state);
       // Assert: In a sequence, the bytestring can't be skipped. So the state can't be repeated.
     } else {
-      tmp_states_to_be_added_.push_back(new_state);
+      EnqueueWithoutProcessing(new_state);
     }
   }
   return;
@@ -951,7 +955,7 @@ void EarleyParser::AdvanceCharacterClass(
         // For positive classes: only continue if some range could match
         bool should_continue = is_negative ? true : could_match;
         if (should_continue) {
-          tmp_states_to_be_added_.push_back(new_state);
+          EnqueueWithoutProcessing(new_state);
         }
       }
     }
@@ -991,7 +995,7 @@ void EarleyParser::AdvanceCharacterClass(
       auto new_state = state;
       new_state.sub_element_id = num_bytes - 1;
       new_state.partial_codepoint = partial;
-      tmp_states_to_be_added_.push_back(new_state);
+      EnqueueWithoutProcessing(new_state);
     }
     return;
   }
@@ -1084,7 +1088,7 @@ void EarleyParser::AdvanceCharacterClassStar(
         // For positive classes: only continue if some range could match
         bool should_continue = is_negative ? true : could_match;
         if (should_continue) {
-          tmp_states_to_be_added_.push_back(new_state);
+          EnqueueWithoutProcessing(new_state);
         }
       }
     }
@@ -1124,7 +1128,7 @@ void EarleyParser::AdvanceCharacterClassStar(
       auto new_state = state;
       new_state.sub_element_id = num_bytes - 1;
       new_state.partial_codepoint = partial;
-      tmp_states_to_be_added_.push_back(new_state);
+      EnqueueWithoutProcessing(new_state);
     }
     return;
   }
@@ -1150,15 +1154,15 @@ void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
     if ((!edge.IsCharRange()) || ch < edge.min || ch > edge.max) {
       continue;
     }
-    auto new_state = state;
-    new_state.element_id = edge.target;
+    ParserState transitioned_state = state;
+    transitioned_state.element_id = edge.target;
     const uint8_t flags = features_->fsm_state_flags[edge.target];
     if (!(flags & EarleyParserFeatures::kFsmStateNonTerminal) &&
         !(flags & EarleyParserFeatures::kFsmStateEnd) &&
         (flags & EarleyParserFeatures::kFsmStateScanable)) {
-      EnqueueWithoutProcessing(std::move(new_state));
+      EnqueueWithoutProcessing(transitioned_state);
     } else {
-      Enqueue(std::move(new_state));
+      Enqueue(transitioned_state);
     }
   }
 }
@@ -1193,12 +1197,10 @@ void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
 bool EarleyParser::AdvanceAtomicToken(
     int32_t token_id, bool debug_print, int32_t token_char_count
 ) {
-  XGRAMMAR_DCHECK(tmp_process_state_queue_.empty())
-      << "The tmp_process_state_queue_ should be empty before AdvanceAtomicToken.";
-  tmp_states_visited_in_queue_.Clear();
-  tmp_states_to_be_added_.clear();
+  XGRAMMAR_DCHECK(tmp_pending_states_.empty())
+      << "The tmp_pending_states_ should be empty before AdvanceAtomicToken.";
+  ClearTemporaryContainers();
   tmp_accept_stop_token_ = false;
-  tmp_completed_lazy_occurrences_.clear();
   if (features_->has_char_budget_rules) {
     tmp_char_budget_entered_ = char_budget_entry_history_.back();
     char_count_history_.push_back(GetCurrentCharIndex() + token_char_count);
@@ -1210,69 +1212,45 @@ bool EarleyParser::AdvanceAtomicToken(
     }
     ScanAtomicToken(state, token_id);
   }
-  if (tmp_process_state_queue_.empty() && tmp_states_to_be_added_.empty()) {
+  if (tmp_pending_states_.empty() && tmp_states_to_be_added_.empty()) {
     if (features_->has_char_budget_rules) {
       char_count_history_.pop_back();
     }
+    ClearTemporaryContainers();
     return false;
   }
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
   if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }
-  while (!tmp_process_state_queue_.empty()) {
-    const auto state = std::move(tmp_process_state_queue_.front());
-    tmp_process_state_queue_.pop();
-    auto [scanable, completable] = Predict(state, debug_print);
-    if (completable) {
-      Complete(state, debug_print);
-    }
-    if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
-    }
-  }
+  ExpandPendingStates(debug_print);
   if (!tmp_completed_lazy_occurrences_.empty()) {
     RemoveCommittedLazyStates();
   }
   is_completed_.push_back(tmp_accept_stop_token_);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
   if (features_->has_char_budget_rules) {
     char_budget_entry_history_.push_back(tmp_char_budget_entered_);
   }
+  ClearTemporaryContainers();
   return true;
 }
 
-bool RepeatDetector::IsVisited(const ParserState& state) const {
-  // If the size is larger than the threshold, then we use the set to check.
-  if (size_ > transition_threshold_) {
-    return visited_set_.find(state) != visited_set_.end();
-  }
-  return std::find_if(
-             visited_vector_.begin(),
-             visited_vector_.begin() + size_,
-             [&state](const ParserState& s) { return StateEqualForParsing()(state, s); }
-         ) != visited_vector_.begin() + size_;
-}
-
-void RepeatDetector::Insert(const ParserState& state) {
-  if (size_ == transition_threshold_) {
-    for (const auto& s : visited_vector_) {
-      visited_set_.insert(s);
+const ParserState* RepeatDetector::InsertInSet(const ParserState& state) {
+  if (!using_set_) {
+    for (const auto& existing : visited_vector_) {
+      visited_set_.insert(existing);
     }
+    using_set_ = true;
   }
-  size_++;
-  if (size_ > transition_threshold_) {
-    visited_set_.insert(state);
-  } else {
-    visited_vector_[size_ - 1] = state;
+  const auto [it, inserted] = visited_set_.insert(state);
+  if (inserted) {
+    ++size_;
+    return &*it;
   }
+  return nullptr;
 }
 
-void RepeatDetector::Clear() {
-  if (size_ > transition_threshold_) {
-    visited_set_.clear();
-  }
-  size_ = 0;
-}
+void RepeatDetector::ClearSet() { visited_set_.clear(); }
 
 }  // namespace xgrammar

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -41,28 +41,30 @@ std::vector<CaptureOccurrence> EarleyParser::CollectStopCaptureTargets(const Par
   // materialization time cannot distinguish an actual captured ancestor from an unrelated
   // Earley branch that happens to cover the same input.
   std::vector<CaptureOccurrence> targets;
-  std::vector<CaptureOccurrence> pending{{state.rule_id, state.rule_start_pos}};
-  std::unordered_set<int64_t> visited;
+  std::vector<ParserState> pending{state};
+  std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
+      visited;
   while (!pending.empty()) {
-    CaptureOccurrence occurrence = pending.back();
+    ParserState completion = pending.back();
     pending.pop_back();
-    int64_t occurrence_key = (static_cast<int64_t>(occurrence.rule_id) << 32) |
-                             static_cast<uint32_t>(occurrence.start_pos);
-    if (!visited.insert(occurrence_key).second) {
+    if (!visited.insert(completion).second) {
       continue;
     }
-    if (RuleHasCapture(occurrence.rule_id)) {
+    CaptureOccurrence occurrence{completion.rule_id, completion.rule_start_pos};
+    if (RuleHasCapture(completion.rule_id) &&
+        std::find(targets.begin(), targets.end(), occurrence) == targets.end()) {
       targets.push_back(occurrence);
     }
-    if (occurrence.start_pos == ParserState::kNoPrevInputPos) {
+    if (completion.rule_start_pos == ParserState::kNoPrevInputPos) {
       continue;
     }
-    const auto& parent_states = rule_id_to_completable_states_[occurrence.start_pos];
+    const auto& parent_states = rule_id_to_completable_states_[completion.rule_start_pos];
     for (const auto& [ref_rule_id, parent_state] : parent_states) {
-      if (ref_rule_id != occurrence.rule_id || parent_state.rule_id < 0) {
+      if (ref_rule_id != completion.rule_id || parent_state.rule_id < 0 ||
+          !IsCompletionCompatibleWithParent(completion, parent_state)) {
         continue;
       }
-      pending.push_back({parent_state.rule_id, parent_state.rule_start_pos});
+      pending.push_back(parent_state);
     }
   }
   return targets;
@@ -150,7 +152,7 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
   // Check all the possible parent states.
   const auto& parent_states_map = rule_id_to_completable_states_[state.rule_start_pos];
   for (const auto& [ref_id, parent_state] : parent_states_map) {
-    if (ref_id != state.rule_id) {
+    if (ref_id != state.rule_id || !IsCompletionCompatibleWithParent(state, parent_state)) {
       continue;
     }
     XGRAMMAR_DCHECK(
@@ -633,7 +635,10 @@ void EarleyParser::ExpandNextRuleRefElement(
       const auto& parent_states_map = rule_id_to_completable_states_[state.rule_start_pos];
       std::vector<std::pair<int32_t, ParserState>> to_added_states;
       for (const auto& parent_state_iter : parent_states_map) {
-        if (parent_state_iter.first != state.rule_id) continue;
+        if (parent_state_iter.first != state.rule_id ||
+            !IsCompletionCompatibleWithParent(state, parent_state_iter.second)) {
+          continue;
+        }
         const auto& parent_state = parent_state_iter.second;
         if (!in_vec(parent_state)) {
           to_added_states.push_back({ref_rule_id, parent_state});
@@ -770,7 +775,10 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
         const auto& parent_states_map = rule_id_to_completable_states_[state.rule_start_pos];
         std::vector<std::pair<int32_t, ParserState>> to_added_states;
         for (const auto& parent_state_iter : parent_states_map) {
-          if (parent_state_iter.first != state.rule_id) continue;
+          if (parent_state_iter.first != state.rule_id ||
+              !IsCompletionCompatibleWithParent(state, parent_state_iter.second)) {
+            continue;
+          }
           const auto& parent_state = parent_state_iter.second;
           if (!in_vec(parent_state)) {
             to_added_states.push_back({ref_rule_id, parent_state});

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -482,7 +482,8 @@ void EarleyParser::RemoveCommittedLazyStates() {
 
 EarleyParserFeatures::EarleyParserFeatures(const Grammar& grammar)
     : fsm_state_flags(grammar->complete_fsm.NumStates(), kFsmStateInitialized),
-      rule_is_nullable(grammar->NumRules(), 0) {
+      rule_is_nullable(grammar->NumRules(), 0),
+      rule_is_context_independent(grammar->NumRules(), 1) {
   XGRAMMAR_CHECK(grammar->optimized)
       << "Cannot build Earley parser features for an unoptimized grammar";
 
@@ -502,6 +503,7 @@ EarleyParserFeatures::EarleyParserFeatures(const Grammar& grammar)
     }
   }
 
+  std::vector<std::vector<int32_t>> referenced_rules(grammar->NumRules());
   for (int32_t rule_id = 0; rule_id < grammar->NumRules(); ++rule_id) {
     const auto& rule = grammar->GetRule(rule_id);
     const auto& rule_fsm = grammar->per_rule_fsms[rule_id];
@@ -510,6 +512,9 @@ EarleyParserFeatures::EarleyParserFeatures(const Grammar& grammar)
       fsm_state_flags[end_state] |= kFsmStateEnd;
     }
     const auto* suffix_stop_info = grammar->GetSuffixStopInfo(rule_id);
+    rule_is_context_independent[rule_id] =
+        !(rule.max_tokens >= 0 || rule.max_chars >= 0 || rule.is_lazy ||
+          rule.temperature.has_value() || suffix_stop_info != nullptr);
     has_budget_rules = has_budget_rules || rule.max_tokens >= 0;
     has_char_budget_rules = has_char_budget_rules || rule.max_chars >= 0;
     capture_tracking =
@@ -519,6 +524,37 @@ EarleyParserFeatures::EarleyParserFeatures(const Grammar& grammar)
         has_hidden_capture_rules ||
         (suffix_stop_info != nullptr &&
          (suffix_stop_info->hidden_suffix_bytes > 0 || suffix_stop_info->hidden_stop_bytes > 0));
+
+    const auto& fsm = rule_fsm->GetFsm();
+    std::unordered_set<int32_t> reachable_states;
+    fsm.GetReachableStates(&reachable_states);
+    for (int32_t state_id : reachable_states) {
+      for (const auto& edge : fsm.GetFsm().GetEdges(state_id)) {
+        if (edge.IsRuleRef()) {
+          referenced_rules[rule_id].push_back(edge.GetRefRuleId());
+        } else if (edge.IsRepeatRef()) {
+          referenced_rules[rule_id].push_back(
+              grammar->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex()).RuleId()
+          );
+        }
+      }
+    }
+  }
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (int32_t rule_id = 0; rule_id < grammar->NumRules(); ++rule_id) {
+      if (rule_is_context_independent[rule_id]) {
+        continue;
+      }
+      for (int32_t referenced_rule_id : referenced_rules[rule_id]) {
+        if (rule_is_context_independent[referenced_rule_id]) {
+          rule_is_context_independent[referenced_rule_id] = 0;
+          changed = true;
+        }
+      }
+    }
   }
   for (int32_t rule_id : grammar->allow_empty_rule_ids) {
     rule_is_nullable[rule_id] = true;

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -230,10 +230,13 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
         });
       }
       // If the repeat count is less than the max repeat count, we can continue to
-      // visit the repeat state for another round.
-      if ((max_repeat_count == -1 &&
-           (!completed_without_input || new_state.repeat_count < min_repeat_count)) ||
-          (max_repeat_count != -1 && new_state.repeat_count < max_repeat_count)) {
+      // visit the repeat state for another round. Once the lower bound is met, another
+      // zero-input repetition cannot enable a new string and only changes the count. Finite
+      // repetitions retain those derivations when their captures are observable.
+      const bool preserve_empty_capture = max_repeat_count != -1 && features_->capture_tracking;
+      if ((!completed_without_input || new_state.repeat_count < min_repeat_count ||
+           preserve_empty_capture) &&
+          (max_repeat_count == -1 || new_state.repeat_count < max_repeat_count)) {
         Enqueue(new_state);
       }
       continue;
@@ -268,8 +271,12 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
             parent_state.char_budget_deadline
         });
       }
-      if ((info.Upper() == -1 && (!completed_without_input || new_count < info.Lower())) ||
-          (info.Upper() != -1 && new_count < info.Upper())) {
+      // Once the lower bound is met, another zero-input repetition cannot enable a new string and
+      // only changes the count. Finite repetitions retain those derivations when their captures
+      // are observable.
+      const bool preserve_empty_capture = info.Upper() != -1 && features_->capture_tracking;
+      if ((!completed_without_input || new_count < info.Lower() || preserve_empty_capture) &&
+          (info.Upper() == -1 || new_count < info.Upper())) {
         Enqueue(ParserState{
             parent_state.rule_id,
             parent_state.sequence_id,
@@ -564,7 +571,8 @@ EarleyParserFeatures::EarleyParserFeatures(const Grammar& grammar)
 EarleyParser::EarleyParser(
     const Grammar& grammar,
     std::optional<ParserState> initial_state,
-    const EarleyParserFeatures* features
+    const EarleyParserFeatures* features,
+    std::optional<ParserState> initial_parent_state
 )
     : grammar_(grammar), features_(features) {
   if (!grammar->optimized) {
@@ -575,7 +583,9 @@ EarleyParser::EarleyParser(
     owned_features_ = EarleyParserFeatures(grammar);
     features_ = &owned_features_;
   }
-  PushStateAndExpand(initial_state.has_value() ? *initial_state : RootInitialState());
+  PushStateAndExpand(
+      initial_state.has_value() ? *initial_state : RootInitialState(), initial_parent_state
+  );
 }
 
 ParserState EarleyParser::RootInitialState() const {
@@ -595,11 +605,17 @@ ParserState EarleyParser::RootInitialState() const {
   );
 }
 
-void EarleyParser::PushStateAndExpand(const ParserState& state) {
+void EarleyParser::PushStateAndExpand(
+    const ParserState& state, std::optional<ParserState> initial_parent_state
+) {
   ClearTemporaryContainers();
   tmp_accept_stop_token_ = false;
   Enqueue(state);
-  rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
+  std::vector<std::pair<int32_t, ParserState>> initial_parent_states;
+  if (initial_parent_state.has_value()) {
+    initial_parent_states.emplace_back(state.rule_id, *initial_parent_state);
+  }
+  rule_id_to_completable_states_.PushBack(std::move(initial_parent_states));
   if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -175,6 +175,8 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
 
   // Check all the possible parent states.
   const auto& parent_states_map = rule_id_to_completable_states_[state.rule_start_pos];
+  const bool completed_without_input =
+      state.rule_start_pos == static_cast<int32_t>(rule_id_to_completable_states_.size()) - 1;
   for (const auto& [ref_id, parent_state] : parent_states_map) {
     if (ref_id != state.rule_id || !IsCompletionCompatibleWithParent(state, parent_state)) {
       continue;
@@ -229,7 +231,9 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
       }
       // If the repeat count is less than the max repeat count, we can continue to
       // visit the repeat state for another round.
-      if (new_state.repeat_count < max_repeat_count) {
+      if ((max_repeat_count == -1 &&
+           (!completed_without_input || new_state.repeat_count < min_repeat_count)) ||
+          (max_repeat_count != -1 && new_state.repeat_count < max_repeat_count)) {
         Enqueue(new_state);
       }
       continue;
@@ -237,16 +241,20 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
     // If the rule is referenced by a fsm, we need to advance the fsm.
     XGRAMMAR_DCHECK(grammar_->per_rule_fsms[parent_state.rule_id].has_value());
 
-    // Check if the parent_state sits on a kRepeatRef edge
-    bool handled_as_repeat = false;
-    for (const auto& edge : grammar_->complete_fsm.GetEdges(parent_state.element_id)) {
-      // Because of invariance, a state with a kRepeatRef edge has exactly one outgoing edge.
-      if (!edge.IsRepeatRef()) continue;
+    // A repeat edge is the only outgoing edge of its source state, so repeat_count belongs to
+    // exactly one repetition.
+    const auto& parent_edges = grammar_->complete_fsm.GetEdges(parent_state.element_id);
+    if (parent_edges.size() == 1 && parent_edges[0].IsRepeatRef()) {
+      const auto& edge = parent_edges[0];
       auto info = grammar_->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
-      if (info.RuleId() != ref_id) continue;
-      handled_as_repeat = true;
+      // A normal rule reference may land on a repeat source state. It is a repeat completion
+      // only when the completed rule matches the repeat edge.
+      if (info.RuleId() != ref_id) {
+        Enqueue(parent_state);
+        continue;
+      }
       int32_t new_count = parent_state.repeat_count + 1;
-      if (new_count >= info.Lower()) {
+      if (new_count >= info.Lower() && (info.Upper() == -1 || new_count <= info.Upper())) {
         Enqueue(ParserState{
             parent_state.rule_id,
             parent_state.sequence_id,
@@ -260,7 +268,8 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
             parent_state.char_budget_deadline
         });
       }
-      if (new_count < info.Upper()) {
+      if ((info.Upper() == -1 && (!completed_without_input || new_count < info.Lower())) ||
+          (info.Upper() != -1 && new_count < info.Upper())) {
         Enqueue(ParserState{
             parent_state.rule_id,
             parent_state.sequence_id,
@@ -274,11 +283,9 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
             parent_state.char_budget_deadline
         });
       }
-      break;
+      continue;
     }
-    if (!handled_as_repeat) {
-      Enqueue(parent_state);
-    }
+    Enqueue(parent_state);
   }
 }
 
@@ -333,8 +340,10 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
       const int32_t& max_repeat_count = element_expr[2];
       // If the current repeat count is less than the max repeat count,
       // we can expand the next rule reference element.
-      XGRAMMAR_DCHECK(state.repeat_count <= max_repeat_count);
-      ExpandNextRuleRefElement(state, grammar_expr, &element_expr, debug_print);
+      XGRAMMAR_DCHECK(max_repeat_count == -1 || state.repeat_count <= max_repeat_count);
+      if (max_repeat_count == -1 || state.repeat_count < max_repeat_count) {
+        ExpandNextRuleRefElement(state, grammar_expr, &element_expr, debug_print);
+      }
       if (state.repeat_count >= min_repeat_count) {
         Enqueue(ParserState{
             state.rule_id,
@@ -719,12 +728,15 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
       target = edge.target;
       ref_rule_id = edge.GetRefRuleId();
     } else if (edge.IsRepeatRef()) {
+      XGRAMMAR_DCHECK(grammar_->complete_fsm.GetEdges(state.element_id).size() == 1)
+          << "A state with a kRepeatRef edge must have exactly one outgoing edge.";
       is_repeat = true;
       repeat_info = grammar_->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
       target = edge.target;
       ref_rule_id = repeat_info.RuleId();
 
-      if (state.repeat_count >= repeat_info.Lower()) {
+      if (state.repeat_count >= repeat_info.Lower() &&
+          (repeat_info.Upper() == -1 || state.repeat_count <= repeat_info.Upper())) {
         Enqueue(ParserState{
             state.rule_id,
             state.sequence_id,
@@ -738,7 +750,7 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
             state.char_budget_deadline
         });
       }
-      if (state.repeat_count >= repeat_info.Upper()) {
+      if (repeat_info.Upper() != -1 && state.repeat_count >= repeat_info.Upper()) {
         continue;
       }
     } else {

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -31,8 +31,7 @@ bool EarleyParser::CompletionConsumedMarker(const ParserState& state) const {
     return true;
   }
   XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
-  const auto& fsm = grammar_->per_rule_fsms[state.rule_id]->GetFsm().GetFsm();
-  return fsm.GetEdges(state.element_id).size() == 0;
+  return grammar_->complete_fsm.GetEdges(state.element_id).size() == 0;
 }
 
 std::vector<CaptureOccurrence> EarleyParser::CollectStopCaptureTargets(const ParserState& state
@@ -114,10 +113,10 @@ void EarleyParser::PopLastStates(int32_t cnt) {
   rule_id_to_completable_states_.PopBack(cnt);
   is_completed_.erase(is_completed_.end() - cnt, is_completed_.end());
   scanable_state_history_.PopBack(cnt);
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     capture_event_history_.PopBack(cnt);
   }
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     char_count_history_.erase(char_count_history_.end() - cnt, char_count_history_.end());
     char_budget_entry_history_.erase(
         char_budget_entry_history_.end() - cnt, char_budget_entry_history_.end()
@@ -215,8 +214,7 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
 
     // Check if the parent_state sits on a kRepeatRef edge
     bool handled_as_repeat = false;
-    const auto& parent_fsm = grammar_->per_rule_fsms[parent_state.rule_id].value();
-    for (const auto& edge : parent_fsm.GetFsm().GetFsm().GetEdges(parent_state.element_id)) {
+    for (const auto& edge : grammar_->complete_fsm.GetEdges(parent_state.element_id)) {
       // Because of invariance, a state with a kRepeatRef edge has exactly one outgoing edge.
       if (!edge.IsRepeatRef()) continue;
       auto info = grammar_->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
@@ -265,11 +263,13 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
   // Check if the rule has a corresponding FSM.
   if (state.rule_id != -1) {
     XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
-    const uint8_t flags = GetFsmStateFlags(state.rule_id, state.element_id);
-    if (flags & kFsmStateNonTerminal) {
+    const uint8_t flags = features_->fsm_state_flags[state.element_id];
+    if (flags & EarleyParserFeatures::kFsmStateNonTerminal) {
       ExpandNextRuleRefElementOnFSM(state, debug_print);
     }
-    return std::make_pair(flags & kFsmStateScanable, flags & kFsmStateEnd);
+    return std::make_pair(
+        flags & EarleyParserFeatures::kFsmStateScanable, flags & EarleyParserFeatures::kFsmStateEnd
+    );
   }
   const GrammarExpr& grammar_expr = grammar_->GetGrammarExpr(state.sequence_id);
   XGRAMMAR_DCHECK(
@@ -391,7 +391,7 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   tmp_states_to_be_added_.clear();
   tmp_accept_stop_token_ = false;
   tmp_completed_lazy_occurrences_.clear();
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     tmp_char_budget_entered_ = char_budget_entry_history_.back();
     char_count_history_.push_back(GetCurrentCharIndex() + StartsUTF8Codepoint(ch));
   }
@@ -406,7 +406,7 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
 
   // Check if the character is accepted.
   if (tmp_process_state_queue_.empty() && tmp_states_to_be_added_.empty()) {
-    if (has_char_budget_rules_) {
+    if (features_->has_char_budget_rules) {
       char_count_history_.pop_back();
     }
     return false;
@@ -414,7 +414,7 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
 
   // execute Predict and Complete for all states in the queue until empty.
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }
   while (!tmp_process_state_queue_.empty()) {
@@ -435,7 +435,7 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   }
   is_completed_.push_back(tmp_accept_stop_token_);
   scanable_state_history_.PushBack(tmp_states_to_be_added_);
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     char_budget_entry_history_.push_back(tmp_char_budget_entered_);
   }
   return true;
@@ -456,70 +456,66 @@ void EarleyParser::RemoveCommittedLazyStates() {
   );
 }
 
-EarleyParser::EarleyParser(const Grammar& grammar, std::optional<ParserState> initial_state)
-    : grammar_(grammar),
-      fsm_state_flags_cache_(grammar->NumRules()),
-      rule_is_nullable_(grammar->NumRules(), 0) {
+EarleyParserFeatures::EarleyParserFeatures(const Grammar& grammar)
+    : fsm_state_flags(grammar->complete_fsm.NumStates(), kFsmStateInitialized),
+      rule_is_nullable(grammar->NumRules(), 0) {
+  XGRAMMAR_CHECK(grammar->optimized)
+      << "Cannot build Earley parser features for an unoptimized grammar";
+
+  const auto& complete_fsm_edges = grammar->complete_fsm.GetEdges();
+  for (int32_t state_id = 0; state_id < grammar->complete_fsm.NumStates(); ++state_id) {
+    const auto edges = complete_fsm_edges[state_id];
+    uint8_t& flags = fsm_state_flags[state_id];
+    if (edges.size() != 0) {
+      flags |= kFsmStateHasEdges;
+    }
+    for (const auto& edge : edges) {
+      if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken()) {
+        flags |= kFsmStateScanable;
+      } else if (edge.IsRuleRef() || edge.IsEpsilon() || edge.IsRepeatRef()) {
+        flags |= kFsmStateNonTerminal;
+      }
+    }
+  }
+
+  for (int32_t rule_id = 0; rule_id < grammar->NumRules(); ++rule_id) {
+    const auto& rule = grammar->GetRule(rule_id);
+    const auto& rule_fsm = grammar->per_rule_fsms[rule_id];
+    XGRAMMAR_DCHECK(rule_fsm.has_value());
+    for (int32_t end_state : rule_fsm->GetFsm().GetEnds()) {
+      fsm_state_flags[end_state] |= kFsmStateEnd;
+    }
+    const auto* suffix_stop_info = grammar->GetSuffixStopInfo(rule_id);
+    has_budget_rules = has_budget_rules || rule.max_tokens >= 0;
+    has_char_budget_rules = has_char_budget_rules || rule.max_chars >= 0;
+    capture_tracking =
+        capture_tracking || !rule.capture_name.empty() ||
+        (suffix_stop_info != nullptr && !suffix_stop_info->stop_capture_name.empty());
+    has_hidden_capture_rules =
+        has_hidden_capture_rules ||
+        (suffix_stop_info != nullptr &&
+         (suffix_stop_info->hidden_suffix_bytes > 0 || suffix_stop_info->hidden_stop_bytes > 0));
+  }
+  for (int32_t rule_id : grammar->allow_empty_rule_ids) {
+    rule_is_nullable[rule_id] = true;
+  }
+}
+
+EarleyParser::EarleyParser(
+    const Grammar& grammar,
+    std::optional<ParserState> initial_state,
+    const EarleyParserFeatures* features
+)
+    : grammar_(grammar), features_(features) {
   if (!grammar->optimized) {
     XGRAMMAR_LOG(FATAL) << "The grammar is not optimized. Please optimize the grammar before using "
                            "the Earley parser.";
   }
-  for (int32_t i = 0; i < grammar_->NumRules(); ++i) {
-    has_budget_rules_ = has_budget_rules_ || grammar_->GetRule(i).max_tokens >= 0;
-    has_char_budget_rules_ = has_char_budget_rules_ || grammar_->GetRule(i).max_chars >= 0;
-    if (has_budget_rules_ && has_char_budget_rules_) {
-      break;
-    }
-  }
-  for (int32_t i = 0; i < grammar_->NumRules(); ++i) {
-    const auto& rule = grammar_->GetRule(i);
-    const auto* suffix_stop_info = grammar_->GetSuffixStopInfo(i);
-    capture_tracking_ =
-        capture_tracking_ || !rule.capture_name.empty() ||
-        (suffix_stop_info != nullptr && !suffix_stop_info->stop_capture_name.empty());
-    has_hidden_capture_rules_ =
-        has_hidden_capture_rules_ ||
-        (suffix_stop_info != nullptr &&
-         (suffix_stop_info->hidden_suffix_bytes > 0 || suffix_stop_info->hidden_stop_bytes > 0));
-    if (capture_tracking_ && has_hidden_capture_rules_) {
-      break;
-    }
-  }
-  for (int32_t rule_id : grammar_->allow_empty_rule_ids) {
-    rule_is_nullable_[rule_id] = true;
+  if (features_ == nullptr) {
+    owned_features_ = EarleyParserFeatures(grammar);
+    features_ = &owned_features_;
   }
   PushStateAndExpand(initial_state.has_value() ? *initial_state : RootInitialState());
-}
-
-uint8_t EarleyParser::InitializeFsmStateFlags(int32_t rule_id, int32_t state_id) {
-  XGRAMMAR_DCHECK(grammar_->per_rule_fsms[rule_id].has_value());
-  const auto& fsm = grammar_->per_rule_fsms[rule_id]->GetFsm();
-  auto& flags_cache = fsm_state_flags_cache_[rule_id];
-  if (flags_cache.empty()) {
-    flags_cache.resize(fsm.NumStates());
-  }
-  XGRAMMAR_DCHECK(state_id >= 0 && state_id < static_cast<int32_t>(flags_cache.size()));
-  uint8_t& flags = flags_cache[state_id];
-  if (flags & kFsmStateInitialized) {
-    return flags;
-  }
-
-  flags = kFsmStateInitialized;
-  if (fsm.IsEndState(state_id)) {
-    flags |= kFsmStateEnd;
-  }
-  const auto& edges = fsm.GetFsm().GetEdges(state_id);
-  if (edges.size() != 0) {
-    flags |= kFsmStateHasEdges;
-  }
-  for (const auto& edge : edges) {
-    if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken()) {
-      flags |= kFsmStateScanable;
-    } else if (edge.IsRuleRef() || edge.IsEpsilon() || edge.IsRepeatRef()) {
-      flags |= kFsmStateNonTerminal;
-    }
-  }
-  return flags;
 }
 
 ParserState EarleyParser::RootInitialState() const {
@@ -546,7 +542,7 @@ void EarleyParser::PushStateAndExpand(const ParserState& state) {
   tmp_completed_lazy_occurrences_.clear();
   Enqueue(state);
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }
   while (!tmp_process_state_queue_.empty()) {
@@ -565,7 +561,7 @@ void EarleyParser::PushStateAndExpand(const ParserState& state) {
   }
   is_completed_.push_back(tmp_accept_stop_token_);
   scanable_state_history_.PushBack(tmp_states_to_be_added_);
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     char_count_history_.push_back(GetCurrentCharIndex());
     char_budget_entry_history_.push_back(tmp_char_budget_entered_);
   }
@@ -576,7 +572,7 @@ void EarleyParser::Reset() {
   scanable_state_history_.PopBack(scanable_state_history_.size());
   is_completed_.clear();
   stop_token_is_accepted_ = false;
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     capture_event_history_.PopBack(capture_event_history_.size());
   }
   char_count_history_.clear();
@@ -650,7 +646,7 @@ void EarleyParser::ExpandNextRuleRefElement(
     }
   }
 
-  if (IsRuleNullable(ref_rule_id)) {
+  if (features_->rule_is_nullable[ref_rule_id] != 0) {
     XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kSequence);
     Enqueue(ParserState{
         state.rule_id,
@@ -692,10 +688,8 @@ void EarleyParser::ExpandNextRuleRefElement(
 
 void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool debug_print) {
   XGRAMMAR_DCHECK(state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value());
-  const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
-
   // Add the rule reference pairs, and enqueue the epsilon edges.
-  for (const auto& edge : fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
+  for (const auto& edge : grammar_->complete_fsm.GetEdges(state.element_id)) {
     if (edge.IsEpsilon()) {
       Enqueue(ParserState{
           state.rule_id,
@@ -752,8 +746,9 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
                          << grammar_->GetRule(state.rule_id).name << " predict the new rule "
                          << ref_rule_id << ": " << grammar_->GetRule(ref_rule_id).name << ".";
     }
-    const uint8_t target_flags = GetFsmStateFlags(state.rule_id, target);
-    if (!is_repeat && !(target_flags & kFsmStateHasEdges) && (target_flags & kFsmStateEnd) &&
+    const uint8_t target_flags = features_->fsm_state_flags[target];
+    if (!is_repeat && !(target_flags & EarleyParserFeatures::kFsmStateHasEdges) &&
+        (target_flags & EarleyParserFeatures::kFsmStateEnd) &&
         state.rule_start_pos != static_cast<int32_t>(rule_id_to_completable_states_.size() - 1) &&
         !RuleNeedsCaptureEvent(state.rule_id) && !RuleNeedsCaptureEvent(ref_rule_id)) {
       // It's a right recursion. We can optimize it. The optimization elides the completion of
@@ -827,7 +822,7 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
     }
 
     // Check if the reference rule can be empty.
-    if (!is_repeat && IsRuleNullable(ref_rule_id)) {
+    if (!is_repeat && features_->rule_is_nullable[ref_rule_id] != 0) {
       Enqueue(ParserState{
           state.rule_id,
           state.sequence_id,
@@ -1151,15 +1146,16 @@ void EarleyParser::AdvanceCharacterClassStar(
 
 void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
   XGRAMMAR_DCHECK(state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value());
-  const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
-  for (const auto& edge : current_fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
+  for (const auto& edge : grammar_->complete_fsm.GetEdges(state.element_id)) {
     if ((!edge.IsCharRange()) || ch < edge.min || ch > edge.max) {
       continue;
     }
     auto new_state = state;
     new_state.element_id = edge.target;
-    const uint8_t flags = GetFsmStateFlags(state.rule_id, edge.target);
-    if (!(flags & kFsmStateNonTerminal) && !(flags & kFsmStateEnd) && (flags & kFsmStateScanable)) {
+    const uint8_t flags = features_->fsm_state_flags[edge.target];
+    if (!(flags & EarleyParserFeatures::kFsmStateNonTerminal) &&
+        !(flags & EarleyParserFeatures::kFsmStateEnd) &&
+        (flags & EarleyParserFeatures::kFsmStateScanable)) {
       EnqueueWithoutProcessing(std::move(new_state));
     } else {
       Enqueue(std::move(new_state));
@@ -1171,7 +1167,7 @@ void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
   if (state.rule_id == -1) return;
   XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
   const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
-  for (const auto& edge : current_fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
+  for (const auto& edge : grammar_->complete_fsm.GetEdges(state.element_id)) {
     bool matched = false;
     if (edge.IsToken()) {
       auto info = current_fsm.GetFsm().GetFsm().GetTokenEdgeInfo(edge.GetAuxIndex());
@@ -1183,8 +1179,10 @@ void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
     if (!matched) continue;
     auto new_state = state;
     new_state.element_id = edge.target;
-    const uint8_t flags = GetFsmStateFlags(state.rule_id, edge.target);
-    if (!(flags & kFsmStateNonTerminal) && !(flags & kFsmStateEnd) && (flags & kFsmStateScanable)) {
+    const uint8_t flags = features_->fsm_state_flags[edge.target];
+    if (!(flags & EarleyParserFeatures::kFsmStateNonTerminal) &&
+        !(flags & EarleyParserFeatures::kFsmStateEnd) &&
+        (flags & EarleyParserFeatures::kFsmStateScanable)) {
       EnqueueWithoutProcessing(std::move(new_state));
     } else {
       Enqueue(std::move(new_state));
@@ -1201,7 +1199,7 @@ bool EarleyParser::AdvanceAtomicToken(
   tmp_states_to_be_added_.clear();
   tmp_accept_stop_token_ = false;
   tmp_completed_lazy_occurrences_.clear();
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     tmp_char_budget_entered_ = char_budget_entry_history_.back();
     char_count_history_.push_back(GetCurrentCharIndex() + token_char_count);
   }
@@ -1213,13 +1211,13 @@ bool EarleyParser::AdvanceAtomicToken(
     ScanAtomicToken(state, token_id);
   }
   if (tmp_process_state_queue_.empty() && tmp_states_to_be_added_.empty()) {
-    if (has_char_budget_rules_) {
+    if (features_->has_char_budget_rules) {
       char_count_history_.pop_back();
     }
     return false;
   }
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }
   while (!tmp_process_state_queue_.empty()) {
@@ -1238,7 +1236,7 @@ bool EarleyParser::AdvanceAtomicToken(
   }
   is_completed_.push_back(tmp_accept_stop_token_);
   scanable_state_history_.PushBack(tmp_states_to_be_added_);
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     char_budget_entry_history_.push_back(tmp_char_budget_entered_);
   }
   return true;

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -11,7 +11,6 @@
 #include <limits>
 #include <optional>
 #include <ostream>
-#include <queue>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -248,6 +247,11 @@ class RepeatDetector {
   std::unordered_set<ParserState, StateHashForParsing, StateEqualForParsing> visited_set_;
 
   int size_ = 0;
+  bool using_set_ = false;
+
+  const ParserState* InsertInSet(const ParserState& state);
+
+  void ClearSet();
 
  public:
   RepeatDetector(const int transition_threshold = 50)
@@ -255,20 +259,35 @@ class RepeatDetector {
     visited_vector_.resize(transition_threshold_);
   }
 
-  /*!
-   * \brief Check if the element is visited.
-   * \return True if visited, false otherwise.
-   */
-  bool IsVisited(const ParserState& state) const;
+  /*! \brief Copy the detector configuration without copying temporary visited states. */
+  RepeatDetector(const RepeatDetector& other)
+      : transition_threshold_(other.transition_threshold_) {}
 
-  /*!
-   * \brief Add the state into the visited states.
-   * \param state The state to be added.
-   */
-  void Insert(const ParserState& state);
+  /*! \brief Insert a state only if absent and return its stable address, or nullptr. */
+  const ParserState* InsertIfAbsent(const ParserState& state) {
+    if (!using_set_ && size_ < transition_threshold_) {
+      if (visited_vector_.empty()) {
+        visited_vector_.resize(transition_threshold_);
+      }
+      for (int i = 0; i < size_; ++i) {
+        if (StateEqualForParsing()(state, visited_vector_[i])) {
+          return nullptr;
+        }
+      }
+      visited_vector_[size_] = state;
+      return &visited_vector_[size_++];
+    }
+    return InsertInSet(state);
+  }
 
   /*! \brief Reset the detector. */
-  void Clear();
+  void Clear() {
+    if (using_set_) {
+      ClearSet();
+    }
+    size_ = 0;
+    using_set_ = false;
+  }
 };
 
 struct StateEqualForCompletionContext {
@@ -389,13 +408,16 @@ class EarleyParser {
    * \brief A temporary vector only used in Advance, used to add states in the
    * scanable_state_history.
    */
-  std::vector<ParserState> tmp_states_to_be_added_;
+  std::vector<const ParserState*> tmp_states_to_be_added_;
 
-  /*! \brief It's the processing queue of the earley parser. */
-  std::queue<ParserState> tmp_process_state_queue_;
+  /*! \brief Stable pointers to visited states awaiting prediction/completion. */
+  std::vector<const ParserState*> tmp_pending_states_;
 
   /*! \brief The class is used to check if a state has been added into the queue. */
   RepeatDetector tmp_states_visited_in_queue_;
+
+  /*! \brief Clear temporary containers after their state pointers have been consumed. */
+  void ClearTemporaryContainers();
 
   /*! \brief Check if the stop token is accepted. */
   bool stop_token_is_accepted_ = false;
@@ -533,15 +555,6 @@ class EarleyParser {
   void RemoveCommittedLazyStates();
 
   /*!
-   * \brief Check if the state has been added into the queue.
-   * \param state The state to check.
-   * \return True if in the vector, false otherwise.
-   */
-  bool IsStateVisitedInQueue(const ParserState& state) const {
-    return tmp_states_visited_in_queue_.IsVisited(state);
-  }
-
-  /*!
    * \brief The scanning operation of the Earley parser. Put the new states in the queue.
    */
   void Scan(const ParserState& state, const uint8_t ch);
@@ -566,6 +579,9 @@ class EarleyParser {
    * \return Second: If the state is completable, then return true, otherwise return false.
    */
   std::pair<bool, bool> Predict(const ParserState& state, bool debug_print = false);
+
+  /*! \brief Expand pending states through prediction and completion. */
+  void ExpandPendingStates(bool debug_print = false);
 
   /*! \brief The initial state expanded from the root rule of the grammar. */
   ParserState RootInitialState() const;
@@ -659,9 +675,8 @@ class EarleyParser {
    * \details The state is enqueued if it is not visited in the queue.
    */
   void Enqueue(const ParserState& state) {
-    if (!IsStateVisitedInQueue(state)) {
-      tmp_process_state_queue_.push(state);
-      tmp_states_visited_in_queue_.Insert(state);
+    if (const ParserState* inserted = tmp_states_visited_in_queue_.InsertIfAbsent(state)) {
+      tmp_pending_states_.push_back(inserted);
     }
   }
 
@@ -670,9 +685,8 @@ class EarleyParser {
    * \param state The state to be enqueued.
    */
   void EnqueueWithoutProcessing(const ParserState& state) {
-    if (!IsStateVisitedInQueue(state)) {
-      tmp_states_visited_in_queue_.Insert(state);
-      tmp_states_to_be_added_.push_back(state);
+    if (const ParserState* inserted = tmp_states_visited_in_queue_.InsertIfAbsent(state)) {
+      tmp_states_to_be_added_.push_back(inserted);
     }
   }
 

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -271,6 +271,22 @@ class RepeatDetector {
   void Clear();
 };
 
+struct StateEqualForCompletionContext {
+  bool operator()(const ParserState& left, const ParserState& right) const {
+    return left.rule_id == right.rule_id && left.rule_start_pos == right.rule_start_pos &&
+           left.budget_deadline == right.budget_deadline &&
+           left.char_budget_deadline == right.char_budget_deadline;
+  }
+};
+
+struct StateHashForCompletionContext {
+  size_t operator()(const ParserState& state) const {
+    return HashCombine(
+        state.rule_id, state.rule_start_pos, state.budget_deadline, state.char_budget_deadline
+    );
+  }
+};
+
 /*! \brief A concrete occurrence of a captured rule in an Earley parent chain. */
 struct CaptureOccurrence {
   /*! \brief The id of the captured rule. */
@@ -441,6 +457,18 @@ class EarleyParser {
                            ? std::numeric_limits<int32_t>::max()
                            : current_char_index + own;
     return parent_deadline >= 0 ? std::min(deadline, parent_deadline) : deadline;
+  }
+
+  /*! \brief Whether completion under equal or tighter deadlines can advance the parent. */
+  static bool IsCompletionCompatibleWithParent(
+      const ParserState& completed_state, const ParserState& parent_state
+  ) {
+    return (parent_state.budget_deadline < 0 ||
+            (completed_state.budget_deadline >= 0 &&
+             completed_state.budget_deadline <= parent_state.budget_deadline)) &&
+           (parent_state.char_budget_deadline < 0 ||
+            (completed_state.char_budget_deadline >= 0 &&
+             completed_state.char_budget_deadline <= parent_state.char_budget_deadline));
   }
 
   /*! \brief Whether the state's derivation may not consume another Unicode codepoint. */

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -323,6 +323,31 @@ struct CaptureEvent {
   std::vector<CaptureOccurrence> stop_capture_targets;
 };
 
+/*! \brief Immutable grammar-wide features shared by short-lived Earley parsers. */
+struct EarleyParserFeatures {
+  enum FsmStateFlag : uint8_t {
+    kFsmStateInitialized = 1 << 0,
+    kFsmStateScanable = 1 << 1,
+    kFsmStateNonTerminal = 1 << 2,
+    kFsmStateEnd = 1 << 3,
+    kFsmStateHasEdges = 1 << 4,
+  };
+
+  std::vector<uint8_t> fsm_state_flags;
+  std::vector<uint8_t> rule_is_nullable;
+  bool has_budget_rules = false;
+  bool has_char_budget_rules = false;
+  bool capture_tracking = false;
+  bool has_hidden_capture_rules = false;
+
+  EarleyParserFeatures() = default;
+  explicit EarleyParserFeatures(const Grammar& grammar);
+
+  friend std::size_t MemorySize(const EarleyParserFeatures& features) {
+    return MemorySize(features.fsm_state_flags) + MemorySize(features.rule_is_nullable);
+  }
+};
+
 class EarleyParser {
   /*!
    * \brief Here is an article about Earley Parser.
@@ -375,37 +400,11 @@ class EarleyParser {
   /*! \brief Check if the stop token is accepted. */
   bool stop_token_is_accepted_ = false;
 
-  enum FsmStateFlag : uint8_t {
-    kFsmStateInitialized = 1 << 0,
-    kFsmStateScanable = 1 << 1,
-    kFsmStateNonTerminal = 1 << 2,
-    kFsmStateEnd = 1 << 3,
-    kFsmStateHasEdges = 1 << 4,
-  };
+  /*! \brief Parser features built only when the caller does not provide them. */
+  EarleyParserFeatures owned_features_;
 
-  /*! \brief Lazily-computed FSM state properties, indexed by rule id and state id. */
-  std::vector<std::vector<uint8_t>> fsm_state_flags_cache_;
-
-  /*! \brief Whether each rule can match the empty string. */
-  std::vector<uint8_t> rule_is_nullable_;
-
-  /*! \brief Compute and cache properties for a state in a per-rule FSM. */
-  uint8_t InitializeFsmStateFlags(int32_t rule_id, int32_t state_id);
-
-  /*! \brief Return cached properties for a state in a per-rule FSM. */
-  uint8_t GetFsmStateFlags(int32_t rule_id, int32_t state_id) {
-    XGRAMMAR_DCHECK(rule_id >= 0 && rule_id < static_cast<int32_t>(fsm_state_flags_cache_.size()));
-    auto& flags_cache = fsm_state_flags_cache_[rule_id];
-    if (!flags_cache.empty()) {
-      XGRAMMAR_DCHECK(state_id >= 0 && state_id < static_cast<int32_t>(flags_cache.size()));
-      if (flags_cache[state_id] != 0) {
-        return flags_cache[state_id];
-      }
-    }
-    return InitializeFsmStateFlags(rule_id, state_id);
-  }
-
-  bool IsRuleNullable(int32_t rule_id) const { return rule_is_nullable_[rule_id] != 0; }
+  /*! \brief Grammar-wide features used by this parser. */
+  const EarleyParserFeatures* features_;
 
   /*! \brief The index of the LLM token currently being accepted, set by the matcher; -1
    * before any token. budget_deadline values are compared against it. */
@@ -415,14 +414,8 @@ class EarleyParser {
    * the matcher for accepts that follow an enforcing mask computation. */
   bool skip_expired_states_ = false;
 
-  /*! \brief Whether any rule of the grammar has a token budget. */
-  bool has_budget_rules_ = false;
-
   /*! \brief The number of Unicode codepoints accepted at every parser history row. */
   std::vector<int32_t> char_count_history_;
-
-  /*! \brief Whether any rule of the grammar has a character budget. */
-  bool has_char_budget_rules_ = false;
 
   /*! \brief Whether a character-budgeted occurrence was entered since the initial parser row. */
   std::vector<bool> char_budget_entry_history_;
@@ -478,13 +471,6 @@ class EarleyParser {
 
   static bool StartsUTF8Codepoint(uint8_t byte) { return (byte & 0xC0) != 0x80; }
 
-  /*! \brief Whether any rule of the grammar has a capture or stop_capture name. Fixed at
-   * construction. When false, the capture machinery is fully disabled and has no overhead. */
-  bool capture_tracking_ = false;
-
-  /*! \brief Whether the grammar contains suffix/stop spans that may affect captures. */
-  bool has_hidden_capture_rules_ = false;
-
   /*!
    * \brief Whether capture events are currently recorded in Complete(). Only enabled during
    * definitive advances (accepting a token or string), not during speculative exploration
@@ -496,18 +482,19 @@ class EarleyParser {
   /*!
    * \brief The history of capture events. capture_event_history_[i] stores the events recorded
    * when input position i was created. Kept aligned with scanable_state_history_ row-by-row
-   * whenever capture_tracking_ is true, so PopLastStates rolls back events automatically.
+   * whenever capture tracking is enabled, so PopLastStates rolls back events automatically.
    */
   Compact2DArray<CaptureEvent> capture_event_history_;
 
   /*! \brief Returns true if the rule exists and has a capture name. */
   bool RuleHasCapture(int32_t rule_id) const {
-    return capture_tracking_ && rule_id >= 0 && !grammar_->GetRule(rule_id).capture_name.empty();
+    return features_->capture_tracking && rule_id >= 0 &&
+           !grammar_->GetRule(rule_id).capture_name.empty();
   }
 
   /*! \brief Returns true if completing this rule can hide bytes from a capture. */
   bool RuleHasHiddenBytes(int32_t rule_id) const {
-    if (!capture_tracking_ || !has_hidden_capture_rules_ || rule_id < 0) {
+    if (!features_->capture_tracking || !features_->has_hidden_capture_rules || rule_id < 0) {
       return false;
     }
     const auto* suffix_stop_info = grammar_->GetSuffixStopInfo(rule_id);
@@ -695,9 +682,12 @@ class EarleyParser {
    * \param grammar The grammar to be parsed. It must be optimized.
    * \param initial_state The state to start parsing from. If not provided, parsing starts
    * from the root rule of the grammar.
+   * \param features Shared parser features. If not provided, they are built from the grammar.
    */
   explicit EarleyParser(
-      const Grammar& grammar, std::optional<ParserState> initial_state = std::nullopt
+      const Grammar& grammar,
+      std::optional<ParserState> initial_state = std::nullopt,
+      const EarleyParserFeatures* features = nullptr
   );
 
   /*!
@@ -761,10 +751,10 @@ class EarleyParser {
     rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
     is_completed_.push_back(completed);
     scanable_state_history_.PushBack(states);
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       capture_event_history_.PushBack(std::vector<CaptureEvent>());
     }
-    if (has_char_budget_rules_) {
+    if (features_->has_char_budget_rules) {
       char_count_history_.push_back(GetCurrentCharIndex());
       char_budget_entry_history_.push_back(char_budget_entry_history_.back());
     }
@@ -772,7 +762,7 @@ class EarleyParser {
 
   /*! \brief Push a character-count row for a parser row created by the matcher. */
   void PushCharCountRow(int32_t char_count, bool char_budget_entered) {
-    if (!has_char_budget_rules_) {
+    if (!features_->has_char_budget_rules) {
       return;
     }
     char_count_history_.push_back(char_count);
@@ -784,15 +774,12 @@ class EarleyParser {
   }
 
   bool HasEnteredCharBudget() const {
-    return has_char_budget_rules_ && char_budget_entry_history_.back();
+    return features_->has_char_budget_rules && char_budget_entry_history_.back();
   }
-
-  /*! \brief Whether the grammar has any captured rule. */
-  bool IsCaptureTrackingEnabled() const { return capture_tracking_; }
 
   /*! \brief Copy the capture events of the latest input position. */
   std::vector<CaptureEvent> CopyLastCaptureRow() const {
-    if (!capture_tracking_) {
+    if (!features_->capture_tracking) {
       return {};
     }
     auto row = capture_event_history_[capture_event_history_.size() - 1];
@@ -805,7 +792,7 @@ class EarleyParser {
    * capture history aligned with the state history.
    */
   void PushCaptureRow(const std::vector<CaptureEvent>& events) {
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       capture_event_history_.PushBack(events);
     }
   }

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -706,11 +706,13 @@ class EarleyParser {
    * \param initial_state The state to start parsing from. If not provided, parsing starts
    * from the root rule of the grammar.
    * \param features Shared parser features. If not provided, they are built from the grammar.
+   * \param initial_parent_state Optional parent used when generating a context-aware token mask.
    */
   explicit EarleyParser(
       const Grammar& grammar,
       std::optional<ParserState> initial_state = std::nullopt,
-      const EarleyParserFeatures* features = nullptr
+      const EarleyParserFeatures* features = nullptr,
+      std::optional<ParserState> initial_parent_state = std::nullopt
   );
 
   /*!
@@ -739,8 +741,11 @@ class EarleyParser {
   /*!
    * \brief Push the initial state into the Earley parser.
    * \param state The initial state to be pushed.
+   * \param initial_parent_state Optional parent of the initial state.
    */
-  void PushStateAndExpand(const ParserState& state);
+  void PushStateAndExpand(
+      const ParserState& state, std::optional<ParserState> initial_parent_state = std::nullopt
+  );
 
   /*!
    * \brief Reset the parser.

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -350,6 +350,7 @@ struct EarleyParserFeatures {
     kFsmStateNonTerminal = 1 << 2,
     kFsmStateEnd = 1 << 3,
     kFsmStateHasEdges = 1 << 4,
+    kFsmStateRepeatSource = 1 << 5,
   };
 
   std::vector<uint8_t> fsm_state_flags;

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -354,6 +354,8 @@ struct EarleyParserFeatures {
 
   std::vector<uint8_t> fsm_state_flags;
   std::vector<uint8_t> rule_is_nullable;
+  /*! \brief Whether each rule is independent of runtime parser state. */
+  std::vector<uint8_t> rule_is_context_independent;
   bool has_budget_rules = false;
   bool has_char_budget_rules = false;
   bool capture_tracking = false;
@@ -362,8 +364,15 @@ struct EarleyParserFeatures {
   EarleyParserFeatures() = default;
   explicit EarleyParserFeatures(const Grammar& grammar);
 
+  /*! \brief Whether the rule is independent of runtime parser state. */
+  bool IsRuleContextIndependent(int32_t rule_id) const {
+    return rule_id >= 0 && rule_id < static_cast<int32_t>(rule_is_context_independent.size()) &&
+           rule_is_context_independent[rule_id];
+  }
+
   friend std::size_t MemorySize(const EarleyParserFeatures& features) {
-    return MemorySize(features.fsm_state_flags) + MemorySize(features.rule_is_nullable);
+    return MemorySize(features.fsm_state_flags) + MemorySize(features.rule_is_nullable) +
+           MemorySize(features.rule_is_context_independent);
   }
 };
 

--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -228,6 +228,19 @@ class FSM::Impl : public FSMImplBase<std::vector<std::vector<FSMEdge>>> {
 
   std::vector<FSMEdge>& GetEdges(int state) { return edges_[state]; }
 
+  void ValidateRepeatEdgeInvariant() const {
+    for (int32_t state = 0; state < static_cast<int32_t>(edges_.size()); ++state) {
+      const auto& edges = edges_[state];
+      if (edges.size() <= 1) {
+        continue;
+      }
+      XGRAMMAR_CHECK(std::none_of(
+          edges.begin(), edges.end(), [](const FSMEdge& edge) { return edge.IsRepeatRef(); }
+      )) << "A state with a kRepeatRef edge must have exactly one outgoing edge, but state "
+         << state << " has " << edges.size() << ".";
+    }
+  }
+
   void Advance(
       const std::unordered_set<int>& from,
       int value,
@@ -243,6 +256,16 @@ class FSM::Impl : public FSMImplBase<std::vector<std::vector<FSMEdge>>> {
 
   void AddEdge(int from, int to, int32_t min, int32_t max) {
     XGRAMMAR_DCHECK(from < static_cast<int>(edges_.size()));
+    if constexpr (kInternalChecksEnabled) {
+      const auto& outgoing_edges = edges_[from];
+      if (min == FSMEdge::EdgeType::kRepeatRef) {
+        XGRAMMAR_DCHECK(outgoing_edges.empty())
+            << "A state with a kRepeatRef edge must have no other outgoing edges.";
+      } else {
+        XGRAMMAR_DCHECK(outgoing_edges.empty() || !outgoing_edges.front().IsRepeatRef())
+            << "A state with a kRepeatRef edge must have no other outgoing edges.";
+      }
+    }
     edges_[from].push_back({min, max, to});
   }
 
@@ -255,8 +278,6 @@ class FSM::Impl : public FSMImplBase<std::vector<std::vector<FSMEdge>>> {
   void AddEOSEdge(int from, int to) { AddEdge(from, to, FSMEdge::EdgeType::kEOS, 0); }
 
   void AddRepeatEdge(int from, int to, int32_t rule_id, int32_t lower, int32_t upper) {
-    XGRAMMAR_DCHECK(edges_[from].empty())
-        << "A state with a kRepeatRef edge must have no other outgoing edges.";
     XGRAMMAR_DCHECK(edge_aux_data_.size() <= INT32_MAX);
     int32_t aux_index = static_cast<int32_t>(edge_aux_data_.size());
     edge_aux_data_.reserve(edge_aux_data_.size() + 3);
@@ -275,7 +296,7 @@ class FSM::Impl : public FSMImplBase<std::vector<std::vector<FSMEdge>>> {
     for (int32_t id : token_ids) {
       edge_aux_data_.push_back(id);
     }
-    edges_[from].push_back(FSMEdge(FSMEdge::EdgeType::kToken, aux_index, to));
+    AddEdge(from, to, FSMEdge::EdgeType::kToken, aux_index);
   }
 
   void AddExcludeTokenEdge(int from, int to, const std::vector<int32_t>& token_ids) {
@@ -287,7 +308,7 @@ class FSM::Impl : public FSMImplBase<std::vector<std::vector<FSMEdge>>> {
     for (int32_t id : token_ids) {
       edge_aux_data_.push_back(id);
     }
-    edges_[from].push_back(FSMEdge(FSMEdge::EdgeType::kExcludeToken, aux_index, to));
+    AddEdge(from, to, FSMEdge::EdgeType::kExcludeToken, aux_index);
   }
 
   void AddFSM(const FSM& fsm, std::vector<int>* state_mapping);
@@ -464,10 +485,18 @@ CompactFSM FSM::Impl::ToCompact() {
 FSM::FSM(int num_states) : pimpl_(std::make_shared<Impl>(num_states)) {}
 
 FSM::FSM(const std::vector<std::vector<FSMEdge>>& edges, std::vector<int32_t> edge_aux_data)
-    : pimpl_(std::make_shared<Impl>(edges, std::move(edge_aux_data))) {}
+    : pimpl_(std::make_shared<Impl>(edges, std::move(edge_aux_data))) {
+  if constexpr (kInternalChecksEnabled) {
+    pimpl_->ValidateRepeatEdgeInvariant();
+  }
+}
 
 FSM::FSM(std::vector<std::vector<FSMEdge>>&& edges, std::vector<int32_t> edge_aux_data)
-    : pimpl_(std::make_shared<Impl>(std::move(edges), std::move(edge_aux_data))) {}
+    : pimpl_(std::make_shared<Impl>(std::move(edges), std::move(edge_aux_data))) {
+  if constexpr (kInternalChecksEnabled) {
+    pimpl_->ValidateRepeatEdgeInvariant();
+  }
+}
 
 int FSM::NumStates() const { return pimpl_->NumStates(); }
 
@@ -520,6 +549,8 @@ std::string FSM::EdgesToString(std::optional<std::vector<int>> states) const {
 }
 
 const std::vector<FSMEdge>& FSM::GetEdges(int state) const { return pimpl_->GetEdges(state); }
+
+void FSM::ValidateRepeatEdgeInvariant() const { pimpl_->ValidateRepeatEdgeInvariant(); }
 
 std::vector<std::vector<FSMEdge>>& FSM::GetEdges() { return pimpl_->GetEdges(); }
 
@@ -1241,6 +1272,9 @@ bool FSMWithStartEnd::IsDFA() {
 }
 
 FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
+  if constexpr (kInternalChecksEnabled) {
+    fsm_->ValidateRepeatEdgeInvariant();
+  }
   if (is_dfa_) {
     return *this;
   }
@@ -1253,11 +1287,13 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
   std::vector<std::pair<int32_t, int32_t>> epsilon_edges;
 
   std::vector<bool> has_exclude_token(NumStates(), false);
+  std::vector<bool> has_repeat_edge(NumStates(), false);
   for (int i = 0; i < NumStates(); i++) {
     for (const auto& edge : fsm_->GetEdges(i)) {
       if (edge.IsExcludeToken()) {
         has_exclude_token[i] = true;
-        break;
+      } else if (edge.IsRepeatRef()) {
+        has_repeat_edge[i] = true;
       }
     }
   }
@@ -1272,6 +1308,7 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
         // paths reaching b would be wrongly accepted. (If b is accepting, a effectively
         // accepts already via the epsilon edge, so merging is safe.)
         if (edges.size() == 1 && !has_exclude_token[i] && !has_exclude_token[edge.target] &&
+            !has_repeat_edge[i] && !has_repeat_edge[edge.target] &&
             (!IsEndState(i) || IsEndState(edge.target))) {
           union_find_set.Add(i);
           union_find_set.Add(edge.target);
@@ -1304,7 +1341,7 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
     const int& from = equiv_node[from_raw];
     const int& to = equiv_node[to_raw];
     if (in_degree[to] == 1 && equiv_node[GetStart()] != to && !has_exclude_token[from_raw] &&
-        !has_exclude_token[to_raw]) {
+        !has_exclude_token[to_raw] && !has_repeat_edge[from_raw] && !has_repeat_edge[to_raw]) {
       union_find_set.Add(from);
       union_find_set.Add(to);
       union_find_set.Union(from, to);
@@ -1331,10 +1368,17 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
       cnt++;
     }
   }
-  return RebuildWithMapping(new_to_old, cnt);
+  auto result = RebuildWithMapping(new_to_old, cnt);
+  if constexpr (kInternalChecksEnabled) {
+    result.GetFsm().ValidateRepeatEdgeInvariant();
+  }
+  return result;
 }
 
 FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states) const {
+  if constexpr (kInternalChecksEnabled) {
+    fsm_->ValidateRepeatEdgeInvariant();
+  }
   if (max_result_num_states < NumStates()) {
     return *this;
   }
@@ -1381,6 +1425,8 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states
   std::vector<int> single_incoming_source;
   // The only successor state when outgoing_distinct_count[state] == 1.
   std::vector<int> single_outgoing_target;
+  // Whether a state has a repeat edge. Repeat states must remain isolated.
+  std::vector<bool> has_repeat_edge;
   // Terminal end states collected for leaf-state merging.
   std::vector<int32_t> no_successor_end_states;
   // Terminal non-end states collected for leaf-state merging.
@@ -1393,11 +1439,15 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states
     // First pass: count row sizes for the incoming/outgoing CSR arrays.
     incoming_row_sizes.assign(n, 0);
     outgoing_row_sizes.assign(n, 0);
+    has_repeat_edge.assign(n, false);
     for (int source = 0; source < n; ++source) {
       const auto& edges = result.GetFsm().GetEdges(source);
       outgoing_row_sizes[source] = static_cast<int32_t>(edges.size());
       for (const auto& edge : edges) {
         ++incoming_row_sizes[edge.target];
+        if (edge.IsRepeatRef()) {
+          has_repeat_edge[source] = true;
+        }
       }
     }
 
@@ -1454,7 +1504,7 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states
     // Case 1: Like ab | ac | ad, then they can be merged into a(b | c | d).
     bool is_equiv_successor = false;
     for (int i = 0; i < n; i++) {
-      if (incoming_distinct_count[i] != 1 || union_find_set.Count(i)) {
+      if (incoming_distinct_count[i] != 1 || union_find_set.Count(i) || has_repeat_edge[i]) {
         continue;
       }
       int previous_state = single_incoming_source[i];
@@ -1469,7 +1519,7 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states
         }
         auto edges_to_sibling = siblings.Slice(group_begin, group_end);
         group_begin = group_end;
-        if (sibling <= i || incoming_distinct_count[sibling] != 1 ||
+        if (sibling <= i || incoming_distinct_count[sibling] != 1 || has_repeat_edge[sibling] ||
             result.IsEndState(sibling) != result.IsEndState(i)) {
           continue;
         }
@@ -1510,7 +1560,7 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states
         }
         continue;  // Skip states with no successors.
       }
-      if (outgoing_count != 1 || union_find_set.Count(i)) {
+      if (outgoing_count != 1 || union_find_set.Count(i) || has_repeat_edge[i]) {
         continue;  // Skip states with multiple successors.
       }
       int next_state = single_outgoing_target[i];
@@ -1524,7 +1574,7 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states
         }
         // Avoid chaining a Case 2 merge onto a state already merged earlier in this iteration
         // (typically by Case 1), which can over-merge via transitive closure.
-        if (sibling <= i || union_find_set.Count(sibling) ||
+        if (sibling <= i || union_find_set.Count(sibling) || has_repeat_edge[sibling] ||
             outgoing_distinct_count[sibling] != 1 ||
             result.IsEndState(i) != result.IsEndState(sibling)) {
           continue;
@@ -1593,6 +1643,9 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states
       result = result.RebuildWithMapping(old_to_new, cnt);
       result.GetFsm()->SortEdges();
     }
+  }
+  if constexpr (kInternalChecksEnabled) {
+    result.GetFsm().ValidateRepeatEdgeInvariant();
   }
   return result;
 }

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -253,6 +253,9 @@ class FSM {
    */
   const std::vector<FSMEdge>& GetEdges(int state) const;
 
+  /*! \brief Check that a state with a repeat edge has no other outgoing edges. */
+  void ValidateRepeatEdgeInvariant() const;
+
   /*!
    * \brief Convert the edges of the FSM to a string. Used in printing the FSM.
    * \return The string representation of the edges of the FSM.

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1539,7 +1539,7 @@ class GrammarCompilerSub {
 };
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
-  Grammar grammar = GrammarOptimizer::Apply(grammar_unoptimized);
+  Grammar grammar = GrammarOptimizer::Apply(grammar_unoptimized, !enable_dynamic_compilation_);
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>(enable_dynamic_compilation_);
   compiled_grammar_impl->grammar = std::move(grammar);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -11,6 +11,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -69,6 +70,14 @@ class RuleLevelCache {
       const int32_t edge_cnt,
       AdaptiveTokenMask&& token_mask
   );
+
+  std::optional<DynamicBitset> GetTagDispatchSlicingBitset(const std::vector<std::string>& patterns
+  );
+
+  bool AddTagDispatchSlicingBitset(
+      const std::vector<std::string>& patterns, const DynamicBitset& bitset
+  );
+
   RuleLevelCache(size_t max_cache_memory_size = kUnlimitedSize);
 
   void ClearCache();
@@ -88,6 +97,8 @@ class RuleLevelCache::Impl {
       int32_t /*The number of states*/,
       int32_t /* The number of edges*/>;
   using NodeType = std::pair<NodeKey, AdaptiveTokenMask>;
+  using TagDispatchKey = std::vector<std::string>;
+  using TagDispatchNodeType = std::pair<TagDispatchKey, DynamicBitset>;
 
   explicit Impl(size_t max_cache_memory_size) : max_cache_memory_size_(max_cache_memory_size) {}
 
@@ -114,6 +125,10 @@ class RuleLevelCache::Impl {
       AdaptiveTokenMask&& token_mask
   );
 
+  std::optional<DynamicBitset> GetTagDispatchSlicingBitset(const TagDispatchKey& patterns);
+
+  bool AddTagDispatchSlicingBitset(const TagDispatchKey& patterns, const DynamicBitset& bitset);
+
   void ClearCache();
 
   friend size_t MemorySize(const Impl* impl) {
@@ -122,6 +137,8 @@ class RuleLevelCache::Impl {
       std::lock_guard<std::mutex> lock(shard.mutex);
       total += shard.current_cache_memory_size;
     }
+    std::lock_guard<std::mutex> lock(impl->tag_dispatch_cache_.mutex);
+    total += impl->tag_dispatch_cache_.current_cache_memory_size;
     return total;
   }
 
@@ -134,6 +151,7 @@ class RuleLevelCache::Impl {
    * them (large grammars issue millions of cache operations).
    */
   static constexpr size_t kNumShards = 16;
+  static constexpr size_t kNumCachePartitions = kNumShards + 1;
 
   struct Shard {
     mutable std::mutex mutex;
@@ -143,6 +161,13 @@ class RuleLevelCache::Impl {
     std::unordered_map<NodeKey, int> cache;
   };
 
+  struct TagDispatchCache {
+    mutable std::mutex mutex;
+    int64_t current_cache_memory_size = 0;
+    List<TagDispatchNodeType> cache_list;
+    std::map<TagDispatchKey, int> cache;
+  };
+
   Shard& GetShard(const NodeKey& key) {
     return shards_[HashCombine(std::get<0>(key), std::get<1>(key)) % kNumShards];
   }
@@ -150,11 +175,12 @@ class RuleLevelCache::Impl {
   /*! \brief The memory budget of one shard. Eviction is performed per shard. */
   size_t ShardMaxSize() const {
     return max_cache_memory_size_ == kUnlimitedSize ? kUnlimitedSize
-                                                    : max_cache_memory_size_ / kNumShards;
+                                                    : max_cache_memory_size_ / kNumCachePartitions;
   }
 
   const size_t max_cache_memory_size_;
   std::array<Shard, kNumShards> shards_;
+  TagDispatchCache tag_dispatch_cache_;
 };
 
 std::optional<AdaptiveTokenMask> RuleLevelCache::GetCache(
@@ -184,6 +210,18 @@ bool RuleLevelCache::AddCache(
     AdaptiveTokenMask&& token_mask
 ) {
   return pimpl_->AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, std::move(token_mask));
+}
+
+std::optional<DynamicBitset> RuleLevelCache::GetTagDispatchSlicingBitset(
+    const std::vector<std::string>& patterns
+) {
+  return pimpl_->GetTagDispatchSlicingBitset(patterns);
+}
+
+bool RuleLevelCache::AddTagDispatchSlicingBitset(
+    const std::vector<std::string>& patterns, const DynamicBitset& bitset
+) {
+  return pimpl_->AddTagDispatchSlicingBitset(patterns, bitset);
 }
 
 void RuleLevelCache::ClearCache() { pimpl_->ClearCache(); }
@@ -265,6 +303,55 @@ bool RuleLevelCache::Impl::AddCache(
   return true;
 }
 
+std::optional<DynamicBitset> RuleLevelCache::Impl::GetTagDispatchSlicingBitset(
+    const TagDispatchKey& patterns
+) {
+  std::lock_guard<std::mutex> lock(tag_dispatch_cache_.mutex);
+  auto it = tag_dispatch_cache_.cache.find(patterns);
+  if (it == tag_dispatch_cache_.cache.end()) {
+    return std::nullopt;
+  }
+  tag_dispatch_cache_.cache_list.MoveBack(it->second);
+  return List<TagDispatchNodeType>::iterator(it->second, tag_dispatch_cache_.cache_list)->second;
+}
+
+bool RuleLevelCache::Impl::AddTagDispatchSlicingBitset(
+    const TagDispatchKey& patterns, const DynamicBitset& bitset
+) {
+  const size_t max_size = ShardMaxSize();
+  // The patterns are stored in both cache_list and cache.
+  const size_t new_item_size = 2 * MemorySize(patterns) + MemorySize(bitset);
+  std::lock_guard<std::mutex> lock(tag_dispatch_cache_.mutex);
+  if (max_size != kUnlimitedSize && new_item_size > max_size) {
+    return false;
+  }
+  auto existing = tag_dispatch_cache_.cache.find(patterns);
+  if (existing != tag_dispatch_cache_.cache.end()) {
+    tag_dispatch_cache_.cache_list.MoveBack(existing->second);
+    return false;
+  }
+
+  if (max_size != kUnlimitedSize) {
+    while (tag_dispatch_cache_.current_cache_memory_size >
+           static_cast<int64_t>(max_size - new_item_size)) {
+      auto oldest_it = tag_dispatch_cache_.cache_list.begin();
+      if (oldest_it == tag_dispatch_cache_.cache_list.end()) {
+        break;
+      }
+      tag_dispatch_cache_.current_cache_memory_size -=
+          2 * MemorySize(oldest_it->first) + MemorySize(oldest_it->second);
+      tag_dispatch_cache_.cache.erase(oldest_it->first);
+      tag_dispatch_cache_.cache_list.Erase(oldest_it);
+    }
+  }
+
+  auto new_it = tag_dispatch_cache_.cache_list.PushBack(TagDispatchNodeType(patterns, bitset));
+  tag_dispatch_cache_.current_cache_memory_size +=
+      2 * MemorySize(new_it->first) + MemorySize(new_it->second);
+  tag_dispatch_cache_.cache[new_it->first] = new_it.Index();
+  return true;
+}
+
 RuleLevelCache::RuleLevelCache(size_t max_cache_memory_size)
     : pimpl_(std::make_shared<Impl>(max_cache_memory_size)) {}
 
@@ -275,6 +362,10 @@ void RuleLevelCache::Impl::ClearCache() {
     shard.cache.clear();
     shard.current_cache_memory_size = 0;
   }
+  std::lock_guard<std::mutex> lock(tag_dispatch_cache_.mutex);
+  tag_dispatch_cache_.cache_list.Clear();
+  tag_dispatch_cache_.cache.clear();
+  tag_dispatch_cache_.current_cache_memory_size = 0;
 }
 
 size_t MemorySize(const RuleLevelCache& manager) { return MemorySize(manager.ImplPtr()); }
@@ -1299,18 +1390,33 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask() {
   }
 }
 
+static DynamicBitset ComputeTagDispatchSecondSlicingBitset(
+    const Grammar& grammar,
+    const TokenizerInfo& tokenizer_info,
+    int32_t rule_id,
+    RuleLevelCache* rule_level_cache
+);
+
+static std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitsets(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info, RuleLevelCache* rule_level_cache
+);
+
 const DynamicBitset* TokenMaskCache::GetTagDispatchSecondSlicingBitset(
     int32_t rule_id, const Grammar& grammar, const TokenizerInfo& tokenizer_info
 ) {
+  std::shared_ptr<RuleLevelCache> rule_level_cache;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     const auto existing = tag_dispatch_rule_id_to_second_slicing_bitset_.find(rule_id);
     if (existing != tag_dispatch_rule_id_to_second_slicing_bitset_.end()) {
       return &existing->second;
     }
+    rule_level_cache = rule_level_cache_;
   }
 
-  DynamicBitset bitset = ComputeTagDispatchSecondSlicingBitset(grammar, tokenizer_info, rule_id);
+  DynamicBitset bitset = ComputeTagDispatchSecondSlicingBitset(
+      grammar, tokenizer_info, rule_id, rule_level_cache.get()
+  );
 
   std::lock_guard<std::mutex> lock(mutex_);
   return &tag_dispatch_rule_id_to_second_slicing_bitset_.try_emplace(rule_id, std::move(bitset))
@@ -1457,8 +1563,11 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
     return CompiledGrammar(compiled_grammar_impl);
   }
 
-  auto tag_dispatch_rule_id_to_second_slicing_bitset =
-      ComputeTagDispatchSecondSlicingBitsets(compiled_grammar_impl->grammar, tokenizer_info_);
+  auto tag_dispatch_rule_id_to_second_slicing_bitset = ComputeTagDispatchSecondSlicingBitsets(
+      compiled_grammar_impl->grammar,
+      tokenizer_info_,
+      rule_level_cache_.has_value() ? &rule_level_cache_.value() : nullptr
+  );
 
   // Step 3. Compute the adaptive token mask cache
   // The token mask cache is computed for these positions in the grammar:
@@ -1589,50 +1698,56 @@ CompiledGrammar GrammarCompilerSub::CompileGrammar(
   return MultiThreadCompileGrammar(Grammar::FromEBNF(ebnf_str, root_rule_name));
 }
 
-DynamicBitset ComputeTagDispatchSecondSlicingBitset(
-    const Grammar& grammar, const TokenizerInfo& tokenizer_info, int32_t rule_id
+static DynamicBitset ComputeTagDispatchSecondSlicingBitset(
+    const Grammar& grammar,
+    const TokenizerInfo& tokenizer_info,
+    int32_t rule_id,
+    RuleLevelCache* rule_level_cache
 ) {
   using GrammarExprType = Grammar::Impl::GrammarExprType;
   const auto& rule = grammar->GetRule(rule_id);
   const auto& rule_body = grammar->GetGrammarExpr(rule.body_expr_id);
   XGRAMMAR_DCHECK(rule_body.type == GrammarExprType::kTagDispatch);
   Grammar::Impl::TagDispatch tag_dispatch = grammar->GetTagDispatch(rule.body_expr_id);
-  const auto& sorted_decoded_vocab = tokenizer_info.GetSortedDecodedVocab();
-  DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
-  for (int token_index = 0; token_index < static_cast<int32_t>(sorted_decoded_vocab.size());
-       ++token_index) {
-    bool definite_accept_since_second_char = true;
-    const auto& token = sorted_decoded_vocab[token_index].second;
-    if (token.empty()) {
-      definite_accepted_tokens_since_second_char.Set(token_index);
-      continue;
-    }
+  std::vector<std::string> patterns;
+  patterns.reserve(tag_dispatch.tag_rule_pairs.size() + tag_dispatch.excludes.size());
+  for (const auto& tag_rule_pair : tag_dispatch.tag_rule_pairs) {
+    patterns.push_back(tag_rule_pair.first);
+  }
+  patterns.insert(patterns.end(), tag_dispatch.excludes.begin(), tag_dispatch.excludes.end());
+  std::sort(patterns.begin(), patterns.end());
+  patterns.erase(std::unique(patterns.begin(), patterns.end()), patterns.end());
 
-    // Check if the token contains any string trigger or exclude string after first char.
-    for (const auto& tag_rule_pair : tag_dispatch.tag_rule_pairs) {
-      if (token.find(tag_rule_pair.first, 1) != std::string::npos) {
-        definite_accept_since_second_char = false;
-        break;
-      }
-    }
-    if (definite_accept_since_second_char) {
-      for (const auto& exclude : tag_dispatch.excludes) {
-        if (token.find(exclude, 1) != std::string::npos) {
-          definite_accept_since_second_char = false;
-          break;
-        }
-      }
-    }
-
-    if (definite_accept_since_second_char) {
-      definite_accepted_tokens_since_second_char.Set(token_index);
+  if (rule_level_cache != nullptr) {
+    auto cached = rule_level_cache->GetTagDispatchSlicingBitset(patterns);
+    if (cached.has_value()) {
+      return std::move(cached.value());
     }
   }
-  return definite_accepted_tokens_since_second_char;
+
+  const auto& sorted_decoded_vocab = tokenizer_info.GetSortedDecodedVocab();
+  DynamicBitset computed(sorted_decoded_vocab.size());
+  for (int32_t token_index = 0; token_index < static_cast<int32_t>(sorted_decoded_vocab.size());
+       ++token_index) {
+    const auto& token = sorted_decoded_vocab[token_index].second;
+    const bool definitely_accepted =
+        token.empty() ||
+        std::none_of(patterns.begin(), patterns.end(), [&](const std::string& pattern) {
+          return token.find(pattern, 1) != std::string::npos;
+        });
+    if (definitely_accepted) {
+      computed.Set(token_index);
+    }
+  }
+
+  if (rule_level_cache != nullptr) {
+    rule_level_cache->AddTagDispatchSlicingBitset(patterns, computed);
+  }
+  return computed;
 }
 
-std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitsets(
-    const Grammar& grammar, const TokenizerInfo& tokenizer_info
+static std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitsets(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info, RuleLevelCache* rule_level_cache
 ) {
   using GrammarExprType = Grammar::Impl::GrammarExprType;
   std::unordered_map<int32_t, DynamicBitset> result;
@@ -1640,7 +1755,8 @@ std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitset
     const auto& rule = grammar->GetRule(rule_id);
     if (grammar->GetGrammarExpr(rule.body_expr_id).type == GrammarExprType::kTagDispatch) {
       result.emplace(
-          rule_id, ComputeTagDispatchSecondSlicingBitset(grammar, tokenizer_info, rule_id)
+          rule_id,
+          ComputeTagDispatchSecondSlicingBitset(grammar, tokenizer_info, rule_id, rule_level_cache)
       );
     }
   }

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1003,6 +1003,65 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   }
 }
 
+const AdaptiveTokenMask& CompiledGrammar::Impl::GetAdaptiveTokenMask(
+    const ParserState& state, bool is_root_rule
+) {
+  if (!enable_dynamic_compilation) {
+    const auto it = adaptive_token_mask_cache.find(state);
+    XGRAMMAR_CHECK(it != adaptive_token_mask_cache.end())
+        << "The token mask cache is incomplete while dynamic compilation is disabled: " << state;
+    return it->second;
+  }
+
+  std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex);
+  const auto existing = adaptive_token_mask_cache.find(state);
+  if (existing != adaptive_token_mask_cache.end()) {
+    return existing->second;
+  }
+
+  const ParserState cache_state(
+      state.rule_id,
+      state.sequence_id,
+      state.element_id,
+      ParserState::kNoPrevInputPos,
+      -1,
+      state.sub_element_id
+  );
+  std::optional<RuleLevelCache> no_rule_level_cache;
+  AdaptiveTokenMask mask = GrammarMatcherForTokenMaskCache(
+                               grammar,
+                               cache_state,
+                               tag_dispatch_rule_id_to_second_slicing_bitset,
+                               tokenizer_info,
+                               no_rule_level_cache
+  )
+                               .GetAdaptiveTokenMask(is_root_rule);
+  return adaptive_token_mask_cache.emplace(cache_state, std::move(mask)).first->second;
+}
+
+void CompiledGrammar::Impl::MaterializeAdaptiveTokenMaskCache() {
+  if (tokenizer_info.GetVocabSize() == 0) {
+    return;
+  }
+  const int32_t root_rule_id = grammar->GetRootRuleId();
+  for (int32_t rule_id = 0; rule_id < static_cast<int32_t>(grammar->NumRules()); ++rule_id) {
+    const auto& rule_fsm = grammar->per_rule_fsms[rule_id];
+    XGRAMMAR_DCHECK(rule_fsm.has_value());
+    ParserState state(
+        rule_id, grammar->GetRule(rule_id).body_expr_id, 0, ParserState::kNoPrevInputPos, -1, 0
+    );
+    std::unordered_set<int> reachable_states;
+    rule_fsm->GetFsm().GetReachableStates(&reachable_states);
+    for (int32_t element_id : reachable_states) {
+      if (!rule_fsm->GetFsm().IsScanableState(element_id)) {
+        continue;
+      }
+      state.element_id = element_id;
+      GetAdaptiveTokenMask(state, rule_id == root_rule_id);
+    }
+  }
+}
+
 /******************* GrammarCompilerNoCache *******************/
 
 /*!
@@ -1013,11 +1072,13 @@ class GrammarCompilerSub {
   GrammarCompilerSub(
       const TokenizerInfo& tokenizer_info,
       int max_threads,
-      std::optional<RuleLevelCache> rule_level_cache
+      std::optional<RuleLevelCache> rule_level_cache,
+      bool enable_dynamic_compilation
   )
       : tokenizer_info_(tokenizer_info),
         max_threads_(max_threads),
-        rule_level_cache_(rule_level_cache) {}
+        rule_level_cache_(rule_level_cache),
+        enable_dynamic_compilation_(enable_dynamic_compilation) {}
 
   CompiledGrammar CompileBuiltinJSONGrammar();
 
@@ -1059,17 +1120,27 @@ class GrammarCompilerSub {
 
   /*! \brief The manager of the rule level cache.*/
   std::optional<RuleLevelCache> rule_level_cache_;
+
+  /*! \brief Whether token masks are generated on first use. */
+  const bool enable_dynamic_compilation_;
 };
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
   compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
+  compiled_grammar_impl->enable_dynamic_compilation = enable_dynamic_compilation_;
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
   }
   std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
   TagDispatchOptimization(compiled_grammar_impl, &tag_dispatch_rule_id_to_second_slicing_bitset);
+
+  if (enable_dynamic_compilation_) {
+    compiled_grammar_impl->tag_dispatch_rule_id_to_second_slicing_bitset =
+        std::move(tag_dispatch_rule_id_to_second_slicing_bitset);
+    return CompiledGrammar(compiled_grammar_impl);
+  }
 
   // If the compiler is cache-enabled, then we hash the grammars for crossing-grammar caching.
   if (rule_level_cache_.has_value()) {
@@ -1343,9 +1414,10 @@ class GrammarCompiler::Impl {
       const TokenizerInfo& tokenizer_info,
       int max_threads,
       bool cache_enabled,
-      int64_t max_memory_bytes
+      int64_t max_memory_bytes,
+      bool enable_dynamic_compilation
   )
-      : cache_enabled_(cache_enabled),
+      : cache_enabled_(cache_enabled && (!enable_dynamic_compilation || max_memory_bytes == -1)),
         rule_level_cache_(
             cache_enabled
                 ? std::optional<RuleLevelCache>(
@@ -1355,7 +1427,9 @@ class GrammarCompiler::Impl {
                   )
                 : std::nullopt
         ),
-        no_cache_compiler_(tokenizer_info, max_threads, rule_level_cache_),
+        no_cache_compiler_(
+            tokenizer_info, max_threads, rule_level_cache_, enable_dynamic_compilation
+        ),
         grammar_level_cache_(
             max_memory_bytes == -1 ? static_cast<std::size_t>(-1)
                                    : static_cast<std::size_t>(max_memory_bytes / 3 * 2),
@@ -1541,8 +1615,18 @@ GrammarCompiler::GrammarCompiler(
     bool cache_enabled,
     int64_t max_memory_bytes
 )
-    : pimpl_(std::make_shared<Impl>(tokenizer_info, max_threads, cache_enabled, max_memory_bytes)) {
-}
+    : GrammarCompiler(tokenizer_info, max_threads, cache_enabled, max_memory_bytes, false) {}
+
+GrammarCompiler::GrammarCompiler(
+    const TokenizerInfo& tokenizer_info,
+    int max_threads,
+    bool cache_enabled,
+    int64_t max_memory_bytes,
+    bool enable_dynamic_compilation
+)
+    : pimpl_(std::make_shared<Impl>(
+          tokenizer_info, max_threads, cache_enabled, max_memory_bytes, enable_dynamic_compilation
+      )) {}
 
 CompiledGrammar GrammarCompiler::CompileJSONSchema(
     const std::string& schema,

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -336,9 +336,10 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
       const DynamicBitset* tag_dispatch_second_slicing_bitset,
       const TokenizerInfo& tokenizer_info,
       std::optional<RuleLevelCache>& rule_level_cache,
-      bool is_root_rule
+      bool is_root_rule,
+      const EarleyParserFeatures& features
   )
-      : EarleyParser(grammar, init_state),
+      : EarleyParser(grammar, init_state, &features),
         init_rule_id_(init_state.rule_id),
         initial_state_(init_state),
         is_root_rule_(is_root_rule),
@@ -816,7 +817,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
 
   XGRAMMAR_DCHECK(init_rule_id_ != -1 && grammar_->per_rule_fsms[init_rule_id_].has_value());
   auto [speculative_calculation, speculative_mask] = GetSpeculativeCalculation();
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     speculative_calculation = false;
   }
 
@@ -1098,7 +1099,8 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask() {
   tmp_can_reach_end_prefix_or_stack_.push_back(false);
 
   // Try to get the crossing cache.
-  bool rule_level_cache_is_available = !has_char_budget_rules_ && rule_level_cache_.has_value() &&
+  bool rule_level_cache_is_available = !features_->has_char_budget_rules &&
+                                       rule_level_cache_.has_value() &&
                                        grammar_->per_rule_fsm_hashes[init_rule_id_].has_value();
   std::optional<uint64_t> fsm_hash = std::nullopt;
   int32_t new_state_id = -1;
@@ -1159,7 +1161,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask() {
   // Token edges are rechecked at runtime when a character budget is present because accepting
   // one can enter a budgeted rule within the same token.
   if (!token_edge_accepted.empty()) {
-    if (has_char_budget_rules_) {
+    if (features_->has_char_budget_rules) {
       IntsetUnion(&tmp_uncertain_indices_, token_edge_accepted);
     } else {
       IntsetUnion(&tmp_accepted_indices_, token_edge_accepted);
@@ -1319,7 +1321,8 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
     const ParserState& state,
     bool is_root_rule,
     const Grammar& grammar,
-    const TokenizerInfo& tokenizer_info
+    const TokenizerInfo& tokenizer_info,
+    const EarleyParserFeatures& features
 ) {
   if (!dynamic_) {
     const auto it = masks_.find(state);
@@ -1366,7 +1369,8 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
                                tag_dispatch_second_slicing_bitset,
                                tokenizer_info,
                                retained_rule_level_cache,
-                               is_root_rule
+                               is_root_rule,
+                               features
   )
                                .GetAdaptiveTokenMask();
 
@@ -1433,6 +1437,8 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>(enable_dynamic_compilation_);
   compiled_grammar_impl->grammar = std::move(grammar);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
+  compiled_grammar_impl->earley_parser_features =
+      EarleyParserFeatures(compiled_grammar_impl->grammar);
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
   }
@@ -1483,7 +1489,8 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
         tag_dispatch_second_slicing_bitset,
         tokenizer_info_,
         rule_level_cache_,
-        is_root_rule
+        is_root_rule,
+        compiled_grammar_impl->earley_parser_features
     );
     auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask();
     if (max_threads_ > 1) {

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1553,6 +1553,106 @@ std::optional<AdaptiveTokenMask> TokenMaskCache::TryGetSimpleRepeatTokenMask(
   );
 }
 
+RepeatTokenMaskKey TokenMaskCache::GetRepeatTokenMaskKey(
+    const ParserState& state,
+    const ParserState& repeat_parent_state,
+    const Grammar& grammar,
+    const TokenizerInfo& tokenizer_info
+) const {
+  const auto& parent_edges = grammar->complete_fsm.GetEdges(repeat_parent_state.element_id);
+  XGRAMMAR_DCHECK(parent_edges.size() == 1 && parent_edges[0].IsRepeatRef());
+  const auto repeat_info = grammar->complete_fsm.GetRepeatEdgeInfo(parent_edges[0].GetAuxIndex());
+  XGRAMMAR_DCHECK(repeat_info.RuleId() == state.rule_id);
+
+  const int32_t far_distance = tokenizer_info.ImplPtr()->GetMaxTokenBytes() + 1;
+  const auto normalize_distance = [far_distance](int64_t distance) {
+    return static_cast<int32_t>(std::min<int64_t>(std::max<int64_t>(distance, 0), far_distance));
+  };
+  return RepeatTokenMaskKey{
+      ParserState(state.rule_id, state.sequence_id, state.element_id, 0, -1, state.sub_element_id),
+      repeat_parent_state.element_id,
+      normalize_distance(
+          static_cast<int64_t>(repeat_info.Lower()) - repeat_parent_state.repeat_count
+      ),
+      repeat_info.Upper() == -1
+          ? -1
+          : normalize_distance(
+                static_cast<int64_t>(repeat_info.Upper()) - repeat_parent_state.repeat_count
+            )
+  };
+}
+
+AdaptiveTokenMask TokenMaskCache::GenerateRepeatTokenMask(
+    const ParserState& state,
+    const ParserState& repeat_parent_state,
+    const RepeatTokenMaskKey& repeat_key,
+    const Grammar& grammar,
+    const TokenizerInfo& tokenizer_info,
+    const EarleyParserFeatures& features
+) {
+  auto generated_mask =
+      TryGetSimpleRepeatTokenMask(state, repeat_key.upper_bound_distance, grammar, tokenizer_info);
+  if (generated_mask.has_value()) {
+    return std::move(*generated_mask);
+  }
+
+  const DynamicBitset* tag_dispatch_second_slicing_bitset = nullptr;
+  const auto& rule = grammar->GetRule(state.rule_id);
+  if (grammar->GetGrammarExpr(rule.body_expr_id).type ==
+      Grammar::Impl::GrammarExprType::kTagDispatch) {
+    tag_dispatch_second_slicing_bitset =
+        GetTagDispatchSecondSlicingBitset(state.rule_id, grammar, tokenizer_info);
+  }
+  ParserState cache_parent_state(
+      repeat_parent_state.rule_id,
+      repeat_parent_state.sequence_id,
+      repeat_parent_state.element_id,
+      ParserState::kNoPrevInputPos,
+      -1,
+      repeat_parent_state.sub_element_id,
+      repeat_parent_state.repeat_count
+  );
+  std::optional<RuleLevelCache> no_rule_level_cache;
+  return GrammarMatcherForTokenMaskCache(
+             grammar,
+             repeat_key.state,
+             tag_dispatch_second_slicing_bitset,
+             tokenizer_info,
+             no_rule_level_cache,
+             false,
+             features,
+             cache_parent_state
+  )
+      .GetAdaptiveTokenMask();
+}
+
+void TokenMaskCache::PrecomputeRepeat(
+    const ParserState& state,
+    const ParserState& repeat_parent_state,
+    const Grammar& grammar,
+    const TokenizerInfo& tokenizer_info,
+    const EarleyParserFeatures& features
+) {
+  const auto repeat_key =
+      GetRepeatTokenMaskKey(state, repeat_parent_state, grammar, tokenizer_info);
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (repeat_masks_.find(repeat_key) != repeat_masks_.end()) {
+      return;
+    }
+  }
+  auto generated_mask = GenerateRepeatTokenMask(
+      state, repeat_parent_state, repeat_key, grammar, tokenizer_info, features
+  );
+  std::lock_guard<std::mutex> lock(mutex_);
+  repeat_masks_.emplace(repeat_key, std::move(generated_mask));
+}
+
+void TokenMaskCache::ClearRepeatTokenSummaries() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  repeat_token_summaries_.clear();
+}
+
 const AdaptiveTokenMask& TokenMaskCache::Get(
     const ParserState& state,
     bool is_root_rule,
@@ -1561,7 +1661,18 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
     const EarleyParserFeatures& features,
     const ParserState* repeat_parent_state
 ) {
+  std::optional<RepeatTokenMaskKey> repeat_key;
+  if (repeat_parent_state != nullptr) {
+    repeat_key = GetRepeatTokenMaskKey(state, *repeat_parent_state, grammar, tokenizer_info);
+  }
+
   if (!dynamic_) {
+    if (repeat_key.has_value()) {
+      const auto it = repeat_masks_.find(*repeat_key);
+      XGRAMMAR_CHECK(it != repeat_masks_.end())
+          << "The repeat token mask cache is incomplete while dynamic compilation is disabled";
+      return it->second;
+    }
     const auto it = masks_.find(state);
     XGRAMMAR_CHECK(it != masks_.end())
         << "The token mask cache is incomplete while dynamic compilation is disabled: " << state;
@@ -1576,44 +1687,7 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
       -1,
       state.sub_element_id
   );
-  std::optional<RepeatTokenMaskKey> repeat_key;
-  std::optional<ParserState> cache_parent_state;
   const bool context_is_root_rule = repeat_parent_state == nullptr && is_root_rule;
-  if (repeat_parent_state != nullptr) {
-    const auto& parent_edges = grammar->complete_fsm.GetEdges(repeat_parent_state->element_id);
-    XGRAMMAR_DCHECK(parent_edges.size() == 1 && parent_edges[0].IsRepeatRef());
-    const auto repeat_info = grammar->complete_fsm.GetRepeatEdgeInfo(parent_edges[0].GetAuxIndex());
-    XGRAMMAR_DCHECK(repeat_info.RuleId() == state.rule_id);
-
-    // Counts farther than one token from either bound have the same mask. A non-nullable
-    // repetition consumes at least one byte, while nullable repetitions have lower bound zero and
-    // redundant empty completions are skipped by the parser.
-    const int32_t far_distance = tokenizer_info.ImplPtr()->GetMaxTokenBytes() + 1;
-    const auto normalize_distance = [far_distance](int64_t distance) {
-      return static_cast<int32_t>(std::min<int64_t>(std::max<int64_t>(distance, 0), far_distance));
-    };
-    repeat_key = RepeatTokenMaskKey{
-        cache_state,
-        repeat_parent_state->element_id,
-        normalize_distance(
-            static_cast<int64_t>(repeat_info.Lower()) - repeat_parent_state->repeat_count
-        ),
-        repeat_info.Upper() == -1
-            ? -1
-            : normalize_distance(
-                  static_cast<int64_t>(repeat_info.Upper()) - repeat_parent_state->repeat_count
-              )
-    };
-    cache_parent_state = ParserState(
-        repeat_parent_state->rule_id,
-        repeat_parent_state->sequence_id,
-        repeat_parent_state->element_id,
-        ParserState::kNoPrevInputPos,
-        -1,
-        repeat_parent_state->sub_element_id,
-        repeat_parent_state->repeat_count
-    );
-  }
 
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -1628,6 +1702,14 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
         return existing->second;
       }
     }
+  }
+
+  if (repeat_key.has_value()) {
+    auto generated_mask = GenerateRepeatTokenMask(
+        state, *repeat_parent_state, *repeat_key, grammar, tokenizer_info, features
+    );
+    std::lock_guard<std::mutex> lock(mutex_);
+    return repeat_masks_.emplace(*repeat_key, std::move(generated_mask)).first->second;
   }
 
   const DynamicBitset* tag_dispatch_second_slicing_bitset = nullptr;
@@ -1645,31 +1727,19 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
       features.IsRuleContextIndependent(state.rule_id)) {
     retained_rule_level_cache = *rule_level_cache_;
   }
-  std::optional<AdaptiveTokenMask> generated_mask;
-  if (repeat_key.has_value()) {
-    generated_mask = TryGetSimpleRepeatTokenMask(
-        state, repeat_key->upper_bound_distance, grammar, tokenizer_info
-    );
-  }
-  if (!generated_mask.has_value()) {
-    generated_mask = GrammarMatcherForTokenMaskCache(
-                         grammar,
-                         cache_state,
-                         tag_dispatch_second_slicing_bitset,
-                         tokenizer_info,
-                         retained_rule_level_cache,
-                         context_is_root_rule,
-                         features,
-                         cache_parent_state
-    )
-                         .GetAdaptiveTokenMask();
-  }
+  auto generated_mask = GrammarMatcherForTokenMaskCache(
+                            grammar,
+                            cache_state,
+                            tag_dispatch_second_slicing_bitset,
+                            tokenizer_info,
+                            retained_rule_level_cache,
+                            context_is_root_rule,
+                            features
+  )
+                            .GetAdaptiveTokenMask();
 
   std::lock_guard<std::mutex> lock(mutex_);
-  if (repeat_key.has_value()) {
-    return repeat_masks_.emplace(*repeat_key, std::move(*generated_mask)).first->second;
-  }
-  return masks_.emplace(cache_state, std::move(*generated_mask)).first->second;
+  return masks_.emplace(cache_state, std::move(generated_mask)).first->second;
 }
 
 /******************* GrammarCompilerNoCache *******************/
@@ -1726,8 +1796,36 @@ class GrammarCompilerSub {
   const bool enable_dynamic_compilation_;
 };
 
+static std::vector<int32_t> GetRepeatPhaseRepresentativeCounts(
+    int32_t lower_bound, int32_t upper_bound, int32_t far_distance
+) {
+  std::vector<int32_t> result;
+  const auto add_count = [&](int64_t count) {
+    if (count < 0 || count > std::numeric_limits<int32_t>::max() ||
+        (upper_bound != -1 && count >= upper_bound)) {
+      return;
+    }
+    result.push_back(static_cast<int32_t>(count));
+  };
+
+  // Zero represents the phase far below the lower bound when that phase exists.
+  add_count(0);
+  for (int32_t distance = 0; distance < far_distance; ++distance) {
+    add_count(static_cast<int64_t>(lower_bound) - distance);
+  }
+  if (upper_bound != -1) {
+    // A child is predicted only while repeat_count is strictly below the upper bound.
+    for (int32_t distance = 1; distance < far_distance; ++distance) {
+      add_count(static_cast<int64_t>(upper_bound) - distance);
+    }
+  }
+  std::sort(result.begin(), result.end());
+  result.erase(std::unique(result.begin(), result.end()), result.end());
+  return result;
+}
+
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
-  Grammar grammar = GrammarOptimizer::Apply(grammar_unoptimized, !enable_dynamic_compilation_);
+  Grammar grammar = GrammarOptimizer::Apply(grammar_unoptimized, false);
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>(enable_dynamic_compilation_);
   compiled_grammar_impl->grammar = std::move(grammar);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
@@ -1812,10 +1910,32 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
     }
   };
 
-  auto root_rule_id = compiled_grammar_impl->grammar->GetRootRuleId();
+  auto precompute_repeat_mask = [&](const ParserState& state,
+                                    const ParserState& repeat_parent_state) {
+    compiled_grammar_impl->token_mask_cache.PrecomputeRepeat(
+        state,
+        repeat_parent_state,
+        compiled_grammar_impl->grammar,
+        tokenizer_info_,
+        compiled_grammar_impl->earley_parser_features
+    );
+  };
+  auto add_task_repeat_mask = [&](const ParserState& state,
+                                  const ParserState& repeat_parent_state) {
+    if (max_threads_ > 1) {
+      thread_pool->Execute([precompute_repeat_mask, state, repeat_parent_state]() {
+        precompute_repeat_mask(state, repeat_parent_state);
+      });
+    } else {
+      precompute_repeat_mask(state, repeat_parent_state);
+    }
+  };
 
-  for (int32_t rule_id = 0; rule_id < static_cast<int>(compiled_grammar_impl->grammar->NumRules());
-       ++rule_id) {
+  auto root_rule_id = compiled_grammar_impl->grammar->GetRootRuleId();
+  const int32_t number_of_rules = static_cast<int32_t>(compiled_grammar_impl->grammar->NumRules());
+  std::vector<std::vector<int32_t>> scanable_states(number_of_rules);
+
+  for (int32_t rule_id = 0; rule_id < number_of_rules; ++rule_id) {
     auto rule = compiled_grammar_impl->grammar->GetRule(rule_id);
     const auto& rule_fsm = compiled_grammar_impl->grammar->per_rule_fsms[rule_id];
     XGRAMMAR_DCHECK(rule_fsm.has_value());
@@ -1828,13 +1948,60 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
       if (!rule_fsm->GetFsm().IsScanableState(i)) {
         continue;
       }
+      scanable_states[rule_id].push_back(i);
       add_task_adaptive_token_mask(cur_stack_element, rule_id == root_rule_id);
+    }
+  }
+
+  const int32_t far_distance = tokenizer_info_.ImplPtr()->GetMaxTokenBytes() + 1;
+  for (int32_t parent_rule_id = 0; parent_rule_id < number_of_rules; ++parent_rule_id) {
+    const auto& parent_rule = compiled_grammar_impl->grammar->GetRule(parent_rule_id);
+    const auto& parent_rule_fsm =
+        compiled_grammar_impl->grammar->per_rule_fsms[parent_rule_id].value();
+    std::unordered_set<int> reachable_states;
+    parent_rule_fsm.GetFsm().GetReachableStates(&reachable_states);
+    for (int32_t parent_node_id : reachable_states) {
+      const auto& parent_edges =
+          compiled_grammar_impl->grammar->complete_fsm.GetEdges(parent_node_id);
+      if (parent_edges.size() != 1 || !parent_edges[0].IsRepeatRef()) {
+        continue;
+      }
+      const auto repeat_info = compiled_grammar_impl->grammar->complete_fsm.GetRepeatEdgeInfo(
+          parent_edges[0].GetAuxIndex()
+      );
+      const int32_t repeated_rule_id = repeat_info.RuleId();
+      if (!compiled_grammar_impl->earley_parser_features.IsRuleContextIndependent(repeated_rule_id
+          )) {
+        continue;
+      }
+      const auto representative_counts = GetRepeatPhaseRepresentativeCounts(
+          repeat_info.Lower(), repeat_info.Upper(), far_distance
+      );
+      const auto& repeated_rule = compiled_grammar_impl->grammar->GetRule(repeated_rule_id);
+      for (int32_t repeat_count : representative_counts) {
+        const ParserState repeat_parent_state(
+            parent_rule_id,
+            parent_rule.body_expr_id,
+            parent_node_id,
+            ParserState::kNoPrevInputPos,
+            -1,
+            0,
+            repeat_count
+        );
+        for (int32_t repeated_rule_state : scanable_states[repeated_rule_id]) {
+          const ParserState state(
+              repeated_rule_id, repeated_rule.body_expr_id, repeated_rule_state, 0
+          );
+          add_task_repeat_mask(state, repeat_parent_state);
+        }
+      }
     }
   }
 
   if (max_threads_ > 1) {
     thread_pool->Join();
   }
+  compiled_grammar_impl->token_mask_cache.ClearRepeatTokenSummaries();
 
   return CompiledGrammar(compiled_grammar_impl);
 }

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -384,6 +384,8 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
       std::optional<RuleLevelCache>& rule_level_cache,
       bool is_root_rule,
       const EarleyParserFeatures& features,
+      int32_t lookahead_assertion_id,
+      bool is_exact_lookahead,
       std::optional<ParserState> initial_parent_state = std::nullopt
   )
       : EarleyParser(grammar, init_state, &features, initial_parent_state),
@@ -391,6 +393,8 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
         initial_state_(init_state),
         is_root_rule_(is_root_rule),
         has_parent_context_(initial_parent_state.has_value()),
+        lookahead_assertion_id_(lookahead_assertion_id),
+        is_exact_lookahead_(is_exact_lookahead),
         tag_dispatch_second_slicing_bitset_(tag_dispatch_second_slicing_bitset),
         tokenizer_info_(tokenizer_info),
         rule_level_cache_(rule_level_cache) {
@@ -465,6 +469,13 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   // Whether the initial rule has one known parent.
   bool has_parent_context_;
 
+  // The lookahead assertion applied at the completion points of the known context. It belongs to
+  // the initial rule normally, or to the parent rule when a parent context is present.
+  int32_t lookahead_assertion_id_;
+
+  // Whether the lookahead assertion exactly characterizes all possible continuations.
+  bool is_exact_lookahead_;
+
   /*!
    * \brief The bitset used for second slicing when the initial rule is a TagDispatch rule.
    * \note If a rule is a TagDispatch rule, then there will be an AC automaton for its triggers.
@@ -500,15 +511,14 @@ void GrammarMatcherForTokenMaskCache::AdaptCacheWithLookahead(
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
   const auto& subtree_nodes_range = tokenizer_info_.GetTrieSubtreeNodesRange();
   const std::string* prev_token = nullptr;
-  bool is_exact_lookahead = grammar_->GetRule(init_rule_id_).is_exact_lookahead;
+  bool is_exact_lookahead = is_exact_lookahead_;
   int prev_matched_size = 0;
   int last_rejected_range = 0;
   int last_uncertain_range = 0;
   if (is_root_rule) {
     tmp_rejected_indices_ = cache.uncertain_indices;
   } else {
-    const auto& lookahead_id = grammar_->GetRule(init_rule_id_).lookahead_assertion_id;
-    if (lookahead_id == -1) {
+    if (lookahead_assertion_id_ == -1) {
       return;
     }
     for (const auto& uncertain_index : cache.uncertain_indices) {
@@ -662,12 +672,11 @@ std::pair<bool, bool> GrammarMatcherForTokenMaskCache::IsTokenPassLookaheadAsser
 ) {
   bool accepted = true;
   bool can_reach_end = true;
-  auto lookahead_assertion_id = grammar_->GetRule(init_rule_id_).lookahead_assertion_id;
-  if (lookahead_assertion_id == -1) {
+  if (lookahead_assertion_id_ == -1) {
     return {accepted, can_reach_end};
   }
   auto lookahead_state =
-      ParserState(/*rule_id*/ -1, lookahead_assertion_id, 0, ParserState::kNoPrevInputPos, 0);
+      ParserState(/*rule_id*/ -1, lookahead_assertion_id_, 0, ParserState::kNoPrevInputPos, 0);
   PushStateAndExpand(lookahead_state);
   int token_len = token.size();
   if (IsCompleted()) {
@@ -880,7 +889,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
 
   int prev_matched_size = 0;
   int last_rejected_range = 0;
-  const bool& is_exact_lookahead = grammar_->GetRule(init_rule_id_).is_exact_lookahead;
+  const bool is_exact_lookahead = is_exact_lookahead_;
   std::optional<const DynamicBitset*> definite_accepted_bitset = std::nullopt;
   const bool is_tag_dispatch_rule =
       grammar_->GetGrammarExpr(grammar_->GetRule(init_rule_id_).body_expr_id).type ==
@@ -1002,34 +1011,23 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
           tmp_accepted_indices_.push_back(i);
         }
       } else if (can_reach_end && prev_matched_size > 0) {
-        if (has_parent_context_) {
-          if (!is_root_rule) {
+        auto [lookahead_accepted, lookahead_completed] =
+            IsTokenPassLookaheadAssertion(token, tmp_can_reach_end_stack_);
+        if ((!is_root_rule) && lookahead_accepted) {
+          if (lookahead_completed || !is_exact_lookahead) {
+            tmp_uncertain_indices_.push_back(i);
+          } else if (HasEnteredCharBudget()) {
             tmp_uncertain_indices_.push_back(i);
           } else {
-            for (int j = i; j < subtree_nodes_range[i]; ++j) {
-              tmp_rejected_indices_.push_back(j);
-            }
-            i = subtree_nodes_range[i] - 1;
+            tmp_accepted_indices_.push_back(i);
+            tmp_accepted_by_lookahead_indices_.push_back(i);
           }
         } else {
-          auto [lookahead_accepted, lookahead_completed] =
-              IsTokenPassLookaheadAssertion(token, tmp_can_reach_end_stack_);
-          if ((!is_root_rule) && lookahead_accepted) {
-            if (lookahead_completed || !is_exact_lookahead) {
-              tmp_uncertain_indices_.push_back(i);
-            } else if (HasEnteredCharBudget()) {
-              tmp_uncertain_indices_.push_back(i);
-            } else {
-              tmp_accepted_indices_.push_back(i);
-              tmp_accepted_by_lookahead_indices_.push_back(i);
-            }
-          } else {
-            for (int j = i; j < subtree_nodes_range[i]; ++j) {
-              tmp_rejected_indices_.push_back(j);
-              tmp_rejected_by_lookahead_indices_.push_back(j);
-            }
-            i = subtree_nodes_range[i] - 1;  // Skip the subtree nodes.
+          for (int j = i; j < subtree_nodes_range[i]; ++j) {
+            tmp_rejected_indices_.push_back(j);
+            tmp_rejected_by_lookahead_indices_.push_back(j);
           }
+          i = subtree_nodes_range[i] - 1;  // Skip the subtree nodes.
         }
       } else {
         tmp_rejected_indices_.push_back(i);
@@ -1173,8 +1171,8 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask() {
   std::optional<uint64_t> fsm_hash = std::nullopt;
   int32_t new_state_id = -1;
   std::optional<AdaptiveTokenMask> crossing_cache = std::nullopt;
-  int lookahead_id = grammar_->GetRule(initial_state_.rule_id).lookahead_assertion_id;
-  bool is_exact_lookahead = grammar_->GetRule(initial_state_.rule_id).is_exact_lookahead;
+  int lookahead_id = lookahead_assertion_id_;
+  bool is_exact_lookahead = is_exact_lookahead_;
   std::optional<uint64_t> lookahead_hash = std::nullopt;
   if (rule_level_cache_is_available) {
     lookahead_hash = GrammarFSMHasher::HashSequence(grammar_, lookahead_id);
@@ -1613,14 +1611,19 @@ AdaptiveTokenMask TokenMaskCache::GenerateRepeatTokenMask(
       repeat_parent_state.repeat_count
   );
   std::optional<RuleLevelCache> no_rule_level_cache;
+  // The completion points of this parser correspond to the parent rule, so the parent rule's
+  // lookahead assertion applies to tokens crossing them.
+  const auto& parent_rule = grammar->GetRule(repeat_parent_state.rule_id);
   return GrammarMatcherForTokenMaskCache(
              grammar,
              repeat_key.state,
              tag_dispatch_second_slicing_bitset,
              tokenizer_info,
              no_rule_level_cache,
-             false,
+             repeat_parent_state.rule_id == grammar->GetRootRuleId(),
              features,
+             parent_rule.lookahead_assertion_id,
+             parent_rule.is_exact_lookahead,
              cache_parent_state
   )
       .GetAdaptiveTokenMask();
@@ -1734,7 +1737,9 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
                             tokenizer_info,
                             retained_rule_level_cache,
                             context_is_root_rule,
-                            features
+                            features,
+                            rule.lookahead_assertion_id,
+                            rule.is_exact_lookahead
   )
                             .GetAdaptiveTokenMask();
 
@@ -1877,6 +1882,7 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
     if (tag_dispatch_bitset_it != tag_dispatch_rule_id_to_second_slicing_bitset.end()) {
       tag_dispatch_second_slicing_bitset = &tag_dispatch_bitset_it->second;
     }
+    const auto& state_rule = compiled_grammar_impl->grammar->GetRule(state.rule_id);
     auto grammar_matcher = GrammarMatcherForTokenMaskCache(
         compiled_grammar_impl->grammar,
         state,
@@ -1884,7 +1890,9 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
         tokenizer_info_,
         rule_level_cache_,
         is_root_rule,
-        compiled_grammar_impl->earley_parser_features
+        compiled_grammar_impl->earley_parser_features,
+        state_rule.lookahead_assertion_id,
+        state_rule.is_exact_lookahead
     );
     auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask();
     if (max_threads_ > 1) {

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -372,52 +372,6 @@ size_t MemorySize(const RuleLevelCache& manager) { return MemorySize(manager.Imp
 
 /************** AdaptiveTokenMaskCache Generator **************/
 
-std::vector<uint8_t> GetRuleLevelCacheableRules(const Grammar& grammar) {
-  const int32_t num_rules = grammar->NumRules();
-  std::vector<uint8_t> context_dependent(num_rules, 0);
-  std::vector<std::vector<int32_t>> referenced_rules(num_rules);
-  for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
-    const auto& rule = grammar->GetRule(rule_id);
-    context_dependent[rule_id] = rule.max_tokens >= 0 || rule.max_chars >= 0 || rule.is_lazy ||
-                                 rule.temperature.has_value() ||
-                                 grammar->GetSuffixStopInfo(rule_id) != nullptr;
-    const auto& fsm = grammar->per_rule_fsms[rule_id]->GetFsm();
-    std::unordered_set<int32_t> reachable_states;
-    fsm.GetReachableStates(&reachable_states);
-    for (int32_t state_id : reachable_states) {
-      for (const auto& edge : fsm.GetFsm().GetEdges(state_id)) {
-        if (edge.IsRuleRef()) {
-          referenced_rules[rule_id].push_back(edge.GetRefRuleId());
-        } else if (edge.IsRepeatRef()) {
-          referenced_rules[rule_id].push_back(
-              grammar->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex()).RuleId()
-          );
-        }
-      }
-    }
-  }
-
-  bool changed = true;
-  while (changed) {
-    changed = false;
-    for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
-      if (!context_dependent[rule_id]) {
-        continue;
-      }
-      for (int32_t referenced_rule_id : referenced_rules[rule_id]) {
-        if (!context_dependent[referenced_rule_id]) {
-          context_dependent[referenced_rule_id] = 1;
-          changed = true;
-        }
-      }
-    }
-  }
-  for (uint8_t& value : context_dependent) {
-    value = !value;
-  }
-  return context_dependent;
-}
-
 /*! \brief The concrete implementation of GrammarMatcherNode. */
 class GrammarMatcherForTokenMaskCache : public EarleyParser {
  public:
@@ -1464,9 +1418,7 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
       state.sub_element_id
   );
   std::optional<RuleLevelCache> retained_rule_level_cache;
-  if (rule_level_cache_ != nullptr && state.rule_id >= 0 &&
-      state.rule_id < static_cast<int32_t>(rule_level_cacheable_.size()) &&
-      rule_level_cacheable_[state.rule_id]) {
+  if (rule_level_cache_ != nullptr && features.IsRuleContextIndependent(state.rule_id)) {
     retained_rule_level_cache = *rule_level_cache_;
   }
   AdaptiveTokenMask mask = GrammarMatcherForTokenMaskCache(
@@ -1556,8 +1508,7 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   if (enable_dynamic_compilation_) {
     if (rule_level_cache_.has_value()) {
       compiled_grammar_impl->token_mask_cache.SetRuleLevelCache(
-          std::make_shared<RuleLevelCache>(rule_level_cache_.value()),
-          GetRuleLevelCacheableRules(compiled_grammar_impl->grammar)
+          std::make_shared<RuleLevelCache>(rule_level_cache_.value())
       );
     }
     return CompiledGrammar(compiled_grammar_impl);

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -373,193 +373,6 @@ size_t MemorySize(const RuleLevelCache& manager) { return MemorySize(manager.Imp
 
 /************** AdaptiveTokenMaskCache Generator **************/
 
-class CharacterClassTokenSummaryCache {
- public:
-  using SummaryList = std::vector<CharacterClassTokenSummary>;
-
-  std::shared_ptr<const SummaryList> GetOrCreate(
-      const Grammar::Impl::GrammarExpr& character_class,
-      const std::vector<std::pair<int32_t, std::string>>& sorted_vocabulary
-  ) {
-    std::vector<int32_t> key(character_class.begin(), character_class.end());
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      const auto existing = cache_.find(key);
-      if (existing != cache_.end()) {
-        return existing->second;
-      }
-    }
-
-    auto computed =
-        std::make_shared<const SummaryList>(BuildSummaries(character_class, sorted_vocabulary));
-    std::lock_guard<std::mutex> lock(mutex_);
-    return cache_.emplace(std::move(key), std::move(computed)).first->second;
-  }
-
-  void Clear() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    cache_.clear();
-  }
-
- private:
-  static SummaryList BuildSummaries(
-      const Grammar::Impl::GrammarExpr& character_class,
-      const std::vector<std::pair<int32_t, std::string>>& sorted_vocabulary
-  ) {
-    XGRAMMAR_DCHECK(character_class.type == Grammar::Impl::GrammarExprType::kCharacterClass);
-    auto character_class_fsm = GrammarFSMBuilder::CharacterClass(character_class);
-    if (character_class_fsm.IsDFA()) {
-      return BuildDeterministicSummaries(character_class_fsm, sorted_vocabulary);
-    }
-    return BuildNondeterministicSummaries(character_class_fsm, sorted_vocabulary);
-  }
-
-  static SummaryList BuildDeterministicSummaries(
-      const FSMWithStartEnd& character_class_fsm,
-      const std::vector<std::pair<int32_t, std::string>>& sorted_vocabulary
-  ) {
-    const auto& finite_state_machine = character_class_fsm.GetFsm();
-    const int32_t initial_state = character_class_fsm.GetStart();
-    std::vector<std::array<int32_t, 256>> transitions(finite_state_machine.NumStates());
-    for (auto& transition : transitions) {
-      transition.fill(FSM::kNoNextState);
-    }
-    for (int32_t state = 0; state < finite_state_machine.NumStates(); ++state) {
-      for (const auto& edge : finite_state_machine.GetEdges(state)) {
-        if (!edge.IsCharRange()) {
-          continue;
-        }
-        for (int32_t byte = std::max(edge.min, 0); byte <= std::min(edge.max, 255); ++byte) {
-          transitions[state][byte] = edge.target;
-        }
-      }
-    }
-    std::vector<uint8_t> is_end_state(finite_state_machine.NumStates(), 0);
-    for (int32_t state : character_class_fsm.GetEnds()) {
-      is_end_state[state] = 1;
-    }
-
-    SummaryList summaries;
-    summaries.reserve(sorted_vocabulary.size());
-    for (int32_t sorted_vocabulary_index = 0;
-         sorted_vocabulary_index < static_cast<int32_t>(sorted_vocabulary.size());
-         ++sorted_vocabulary_index) {
-      int32_t current_state = initial_state;
-      int32_t completed_characters = 0;
-      bool consumed_whole_token = true;
-      bool has_incomplete_character = false;
-      for (uint8_t byte : sorted_vocabulary[sorted_vocabulary_index].second) {
-        const int32_t next_state = transitions[current_state][byte];
-        if (next_state == FSM::kNoNextState) {
-          consumed_whole_token = false;
-          has_incomplete_character = false;
-          break;
-        }
-        if (is_end_state[next_state]) {
-          ++completed_characters;
-          current_state = initial_state;
-          has_incomplete_character = false;
-        } else {
-          current_state = next_state;
-          has_incomplete_character = true;
-        }
-      }
-      AppendSummary(
-          &summaries,
-          sorted_vocabulary_index,
-          completed_characters,
-          consumed_whole_token,
-          has_incomplete_character
-      );
-    }
-    return summaries;
-  }
-
-  static SummaryList BuildNondeterministicSummaries(
-      const FSMWithStartEnd& character_class_fsm,
-      const std::vector<std::pair<int32_t, std::string>>& sorted_vocabulary
-  ) {
-    const auto& finite_state_machine = character_class_fsm.GetFsm();
-    std::unordered_set<int> initial_states{character_class_fsm.GetStart()};
-    finite_state_machine.GetEpsilonClosure(&initial_states);
-
-    SummaryList summaries;
-    summaries.reserve(sorted_vocabulary.size());
-    std::unordered_set<int> current_states;
-    std::unordered_set<int> next_states;
-    for (int32_t sorted_vocabulary_index = 0;
-         sorted_vocabulary_index < static_cast<int32_t>(sorted_vocabulary.size());
-         ++sorted_vocabulary_index) {
-      current_states = initial_states;
-      int32_t completed_characters = 0;
-      bool consumed_whole_token = true;
-      bool has_incomplete_character = false;
-      for (uint8_t byte : sorted_vocabulary[sorted_vocabulary_index].second) {
-        finite_state_machine.Advance(
-            current_states, byte, &next_states, FSMEdge::EdgeType::kCharRange, true
-        );
-        if (next_states.empty()) {
-          consumed_whole_token = false;
-          has_incomplete_character = false;
-          break;
-        }
-        const bool completed_character =
-            std::any_of(next_states.begin(), next_states.end(), [&](int32_t state) {
-              return character_class_fsm.IsEndState(state);
-            });
-        if (completed_character) {
-          ++completed_characters;
-          current_states = initial_states;
-          has_incomplete_character = false;
-        } else {
-          current_states.swap(next_states);
-          has_incomplete_character = true;
-        }
-      }
-
-      AppendSummary(
-          &summaries,
-          sorted_vocabulary_index,
-          completed_characters,
-          consumed_whole_token,
-          has_incomplete_character
-      );
-    }
-    return summaries;
-  }
-
-  static void AppendSummary(
-      SummaryList* summaries,
-      int32_t sorted_vocabulary_index,
-      int32_t completed_characters,
-      bool consumed_whole_token,
-      bool has_incomplete_character
-  ) {
-    if (consumed_whole_token || completed_characters > 0) {
-      summaries->push_back(CharacterClassTokenSummary{
-          sorted_vocabulary_index,
-          completed_characters +
-              static_cast<int32_t>(consumed_whole_token && has_incomplete_character),
-          consumed_whole_token,
-          completed_characters > 0
-      });
-    }
-  }
-
-  struct KeyHash {
-    size_t operator()(const std::vector<int32_t>& key) const {
-      uint64_t result = 0;
-      for (int32_t value : key) {
-        HashCombineBinary(result, static_cast<uint64_t>(value));
-      }
-      return result;
-    }
-  };
-
-  std::mutex mutex_;
-  std::unordered_map<std::vector<int32_t>, std::shared_ptr<const SummaryList>, KeyHash> cache_;
-};
-
 /*! \brief The concrete implementation of GrammarMatcherNode. */
 class GrammarMatcherForTokenMaskCache : public EarleyParser {
  public:
@@ -570,16 +383,21 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
       const TokenizerInfo& tokenizer_info,
       std::optional<RuleLevelCache>& rule_level_cache,
       bool is_root_rule,
-      const EarleyParserFeatures& features
+      const EarleyParserFeatures& features,
+      std::optional<ParserState> initial_parent_state = std::nullopt
   )
-      : EarleyParser(grammar, init_state, &features),
+      : EarleyParser(grammar, init_state, &features, initial_parent_state),
         init_rule_id_(init_state.rule_id),
         initial_state_(init_state),
         is_root_rule_(is_root_rule),
+        has_parent_context_(initial_parent_state.has_value()),
         tag_dispatch_second_slicing_bitset_(tag_dispatch_second_slicing_bitset),
         tokenizer_info_(tokenizer_info),
         rule_level_cache_(rule_level_cache) {
-    XGRAMMAR_DCHECK(is_root_rule == (init_state.rule_id == grammar->GetRootRuleId()));
+    XGRAMMAR_DCHECK(
+        initial_parent_state.has_value() ||
+        is_root_rule == (init_state.rule_id == grammar->GetRootRuleId())
+    );
   }
   /*!
    * \brief Get the adaptive token mask for the given ParserState.
@@ -641,8 +459,11 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   // The initial state of the parser.
   ParserState initial_state_;
 
-  // Whether the initial rule is the grammar's root rule.
+  // Whether reaching the end of the known context reaches the grammar root.
   bool is_root_rule_;
+
+  // Whether the initial rule has one known parent.
+  bool has_parent_context_;
 
   /*!
    * \brief The bitset used for second slicing when the initial rule is a TagDispatch rule.
@@ -957,6 +778,9 @@ int GetPossibleTokenIntervals(
 
 std::pair<bool, std::bitset<256>> GrammarMatcherForTokenMaskCache::GetSpeculativeCalculation() {
   using GrammarExprType = Grammar::Impl::GrammarExprType;
+  if (has_parent_context_) {
+    return {false, std::bitset<256>()};
+  }
   // If the initial rule is a tag dispatch, we will check if it can achieve its initial state.
   const auto& rule = grammar_->GetRule(init_rule_id_);
   if (rule.is_lazy) {
@@ -1178,23 +1002,34 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
           tmp_accepted_indices_.push_back(i);
         }
       } else if (can_reach_end && prev_matched_size > 0) {
-        auto [lookahead_accepted, lookahead_completed] =
-            IsTokenPassLookaheadAssertion(token, tmp_can_reach_end_stack_);
-        if ((!is_root_rule) && lookahead_accepted) {
-          if (lookahead_completed || !is_exact_lookahead) {
-            tmp_uncertain_indices_.push_back(i);
-          } else if (HasEnteredCharBudget()) {
+        if (has_parent_context_) {
+          if (!is_root_rule) {
             tmp_uncertain_indices_.push_back(i);
           } else {
-            tmp_accepted_indices_.push_back(i);
-            tmp_accepted_by_lookahead_indices_.push_back(i);
+            for (int j = i; j < subtree_nodes_range[i]; ++j) {
+              tmp_rejected_indices_.push_back(j);
+            }
+            i = subtree_nodes_range[i] - 1;
           }
         } else {
-          for (int j = i; j < subtree_nodes_range[i]; j++) {
-            tmp_rejected_indices_.push_back(j);
-            tmp_rejected_by_lookahead_indices_.push_back(j);
+          auto [lookahead_accepted, lookahead_completed] =
+              IsTokenPassLookaheadAssertion(token, tmp_can_reach_end_stack_);
+          if ((!is_root_rule) && lookahead_accepted) {
+            if (lookahead_completed || !is_exact_lookahead) {
+              tmp_uncertain_indices_.push_back(i);
+            } else if (HasEnteredCharBudget()) {
+              tmp_uncertain_indices_.push_back(i);
+            } else {
+              tmp_accepted_indices_.push_back(i);
+              tmp_accepted_by_lookahead_indices_.push_back(i);
+            }
+          } else {
+            for (int j = i; j < subtree_nodes_range[i]; ++j) {
+              tmp_rejected_indices_.push_back(j);
+              tmp_rejected_by_lookahead_indices_.push_back(j);
+            }
+            i = subtree_nodes_range[i] - 1;  // Skip the subtree nodes.
           }
-          i = subtree_nodes_range[i] - 1;  // Skip the subtree nodes.
         }
       } else {
         tmp_rejected_indices_.push_back(i);
@@ -1332,7 +1167,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask() {
   tmp_can_reach_end_prefix_or_stack_.push_back(false);
 
   // Try to get the crossing cache.
-  bool rule_level_cache_is_available = !features_->has_char_budget_rules &&
+  bool rule_level_cache_is_available = !has_parent_context_ && !features_->has_char_budget_rules &&
                                        rule_level_cache_.has_value() &&
                                        grammar_->per_rule_fsm_hashes[init_rule_id_].has_value();
   std::optional<uint64_t> fsm_hash = std::nullopt;
@@ -1565,12 +1400,166 @@ const DynamicBitset* TokenMaskCache::GetTagDispatchSecondSlicingBitset(
               .first->second;
 }
 
+std::shared_ptr<const std::vector<TokenMaskCache::RepeatTokenSummary>>
+TokenMaskCache::GetSimpleRepeatTokenSummaries(
+    const ParserState& state, const Grammar& grammar, const TokenizerInfo& tokenizer_info
+) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto existing = repeat_token_summaries_.find(state);
+    if (existing != repeat_token_summaries_.end()) {
+      return existing->second;
+    }
+  }
+
+  std::shared_ptr<const std::vector<RepeatTokenSummary>> result;
+  if (state.sub_element_id == 0 && state.partial_codepoint == 0 &&
+      grammar->per_rule_fsms[state.rule_id].has_value()) {
+    const auto& rule_finite_state_machine = grammar->per_rule_fsms[state.rule_id]->GetFsm();
+    const auto& finite_state_machine = rule_finite_state_machine.GetFsm();
+    const int32_t start_state = rule_finite_state_machine.GetStart();
+    if (!rule_finite_state_machine.IsEndState(start_state)) {
+      std::vector<uint8_t> discovered_states(finite_state_machine.NumStates(), 0);
+      std::vector<int32_t> pending_states{state.element_id};
+      discovered_states[state.element_id] = 1;
+      if (!discovered_states[start_state]) {
+        discovered_states[start_state] = 1;
+        pending_states.push_back(start_state);
+      }
+
+      bool eligible = true;
+      for (size_t pending_index = 0; pending_index < pending_states.size() && eligible;
+           ++pending_index) {
+        const int32_t current_state = pending_states[pending_index];
+        const auto& edges = finite_state_machine.GetEdges(current_state);
+        if (rule_finite_state_machine.IsEndState(current_state) && edges.size() != 0) {
+          eligible = false;
+          break;
+        }
+
+        for (const auto& edge : edges) {
+          if (!edge.IsCharRange()) {
+            eligible = false;
+            break;
+          }
+          if (!discovered_states[edge.target]) {
+            discovered_states[edge.target] = 1;
+            pending_states.push_back(edge.target);
+          }
+        }
+      }
+
+      std::vector<int32_t> state_to_local_id(finite_state_machine.NumStates(), -1);
+      for (int32_t local_state_id = 0; local_state_id < static_cast<int32_t>(pending_states.size());
+           ++local_state_id) {
+        state_to_local_id[pending_states[local_state_id]] = local_state_id;
+      }
+      std::vector<std::array<int32_t, 256>> transitions(pending_states.size());
+      if (eligible) {
+        for (int32_t local_state_id = 0;
+             local_state_id < static_cast<int32_t>(pending_states.size()) && eligible;
+             ++local_state_id) {
+          auto& state_transitions = transitions[local_state_id];
+          state_transitions.fill(FSM::kNoNextState);
+          for (const auto& edge : finite_state_machine.GetEdges(pending_states[local_state_id])) {
+            const int32_t target_local_id = state_to_local_id[edge.target];
+            for (int32_t byte = std::max(edge.min, 0); byte <= std::min(edge.max, 255); ++byte) {
+              if (state_transitions[byte] != FSM::kNoNextState &&
+                  state_transitions[byte] != target_local_id) {
+                eligible = false;
+                break;
+              }
+              state_transitions[byte] = target_local_id;
+            }
+            if (!eligible) {
+              break;
+            }
+          }
+        }
+      }
+
+      if (eligible) {
+        std::vector<RepeatTokenSummary> summaries;
+        const auto& sorted_vocabulary = tokenizer_info.GetSortedDecodedVocab();
+        summaries.reserve(sorted_vocabulary.size());
+        for (int32_t sorted_vocabulary_index = 0;
+             sorted_vocabulary_index < static_cast<int32_t>(sorted_vocabulary.size());
+             ++sorted_vocabulary_index) {
+          int32_t current_state = state_to_local_id[state.element_id];
+          int32_t completed_repetitions = 0;
+          bool consumed_whole_token = true;
+          bool consumed_current_repetition = false;
+          for (uint8_t byte : sorted_vocabulary[sorted_vocabulary_index].second) {
+            const int32_t next_state = transitions[current_state][byte];
+            if (next_state == FSM::kNoNextState) {
+              consumed_whole_token = false;
+              break;
+            }
+            current_state = next_state;
+            consumed_current_repetition = true;
+            if (rule_finite_state_machine.IsEndState(pending_states[current_state])) {
+              ++completed_repetitions;
+              current_state = state_to_local_id[start_state];
+              consumed_current_repetition = false;
+            }
+          }
+          if (consumed_whole_token || completed_repetitions > 0) {
+            summaries.push_back(RepeatTokenSummary{
+                sorted_vocabulary_index,
+                completed_repetitions +
+                    static_cast<int32_t>(consumed_whole_token && consumed_current_repetition),
+                consumed_whole_token,
+                completed_repetitions > 0
+            });
+          }
+        }
+        result = std::make_shared<const std::vector<RepeatTokenSummary>>(std::move(summaries));
+      }
+    }
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  return repeat_token_summaries_.try_emplace(state, std::move(result)).first->second;
+}
+
+std::optional<AdaptiveTokenMask> TokenMaskCache::TryGetSimpleRepeatTokenMask(
+    const ParserState& state,
+    int32_t upper_bound_distance,
+    const Grammar& grammar,
+    const TokenizerInfo& tokenizer_info
+) {
+  const auto summaries = GetSimpleRepeatTokenSummaries(state, grammar, tokenizer_info);
+  if (summaries == nullptr) {
+    return std::nullopt;
+  }
+
+  std::vector<int32_t> accepted_indices;
+  std::vector<int32_t> uncertain_indices;
+  accepted_indices.reserve(summaries->size());
+  for (const auto& summary : *summaries) {
+    if (summary.consumed_whole_token &&
+        (upper_bound_distance == -1 || summary.locally_consumed_repetitions <= upper_bound_distance
+        )) {
+      accepted_indices.push_back(summary.sorted_vocabulary_index);
+    } else if (summary.has_completed_repetition_prefix) {
+      uncertain_indices.push_back(summary.sorted_vocabulary_index);
+    }
+  }
+  return AdaptiveTokenMask(
+      tokenizer_info.GetVocabSize(),
+      tokenizer_info.GetSortedDecodedVocab(),
+      accepted_indices,
+      uncertain_indices
+  );
+}
+
 const AdaptiveTokenMask& TokenMaskCache::Get(
     const ParserState& state,
     bool is_root_rule,
     const Grammar& grammar,
     const TokenizerInfo& tokenizer_info,
-    const EarleyParserFeatures& features
+    const EarleyParserFeatures& features,
+    const ParserState* repeat_parent_state
 ) {
   if (!dynamic_) {
     const auto it = masks_.find(state);
@@ -1579,11 +1568,65 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
     return it->second;
   }
 
+  const ParserState cache_state(
+      state.rule_id,
+      state.sequence_id,
+      state.element_id,
+      repeat_parent_state == nullptr ? ParserState::kNoPrevInputPos : 0,
+      -1,
+      state.sub_element_id
+  );
+  std::optional<RepeatTokenMaskKey> repeat_key;
+  std::optional<ParserState> cache_parent_state;
+  const bool context_is_root_rule = repeat_parent_state == nullptr && is_root_rule;
+  if (repeat_parent_state != nullptr) {
+    const auto& parent_edges = grammar->complete_fsm.GetEdges(repeat_parent_state->element_id);
+    XGRAMMAR_DCHECK(parent_edges.size() == 1 && parent_edges[0].IsRepeatRef());
+    const auto repeat_info = grammar->complete_fsm.GetRepeatEdgeInfo(parent_edges[0].GetAuxIndex());
+    XGRAMMAR_DCHECK(repeat_info.RuleId() == state.rule_id);
+
+    // Counts farther than one token from either bound have the same mask. A non-nullable
+    // repetition consumes at least one byte, while nullable repetitions have lower bound zero and
+    // redundant empty completions are skipped by the parser.
+    const int32_t far_distance = tokenizer_info.ImplPtr()->GetMaxTokenBytes() + 1;
+    const auto normalize_distance = [far_distance](int64_t distance) {
+      return static_cast<int32_t>(std::min<int64_t>(std::max<int64_t>(distance, 0), far_distance));
+    };
+    repeat_key = RepeatTokenMaskKey{
+        cache_state,
+        repeat_parent_state->element_id,
+        normalize_distance(
+            static_cast<int64_t>(repeat_info.Lower()) - repeat_parent_state->repeat_count
+        ),
+        repeat_info.Upper() == -1
+            ? -1
+            : normalize_distance(
+                  static_cast<int64_t>(repeat_info.Upper()) - repeat_parent_state->repeat_count
+              )
+    };
+    cache_parent_state = ParserState(
+        repeat_parent_state->rule_id,
+        repeat_parent_state->sequence_id,
+        repeat_parent_state->element_id,
+        ParserState::kNoPrevInputPos,
+        -1,
+        repeat_parent_state->sub_element_id,
+        repeat_parent_state->repeat_count
+    );
+  }
+
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    const auto existing = masks_.find(state);
-    if (existing != masks_.end()) {
-      return existing->second;
+    if (repeat_key.has_value()) {
+      const auto existing = repeat_masks_.find(*repeat_key);
+      if (existing != repeat_masks_.end()) {
+        return existing->second;
+      }
+    } else {
+      const auto existing = masks_.find(cache_state);
+      if (existing != masks_.end()) {
+        return existing->second;
+      }
     }
   }
 
@@ -1597,84 +1640,36 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
 
   // Generate the mask outside the lock so a miss does not block other lookups. Two threads may
   // generate the same mask concurrently; emplace keeps the first inserted one.
-  const ParserState cache_state(
-      state.rule_id,
-      state.sequence_id,
-      state.element_id,
-      ParserState::kNoPrevInputPos,
-      -1,
-      state.sub_element_id
-  );
   std::optional<RuleLevelCache> retained_rule_level_cache;
-  if (rule_level_cache_ != nullptr && features.IsRuleContextIndependent(state.rule_id)) {
+  if (repeat_parent_state == nullptr && rule_level_cache_ != nullptr &&
+      features.IsRuleContextIndependent(state.rule_id)) {
     retained_rule_level_cache = *rule_level_cache_;
   }
-  AdaptiveTokenMask mask = GrammarMatcherForTokenMaskCache(
-                               grammar,
-                               cache_state,
-                               tag_dispatch_second_slicing_bitset,
-                               tokenizer_info,
-                               retained_rule_level_cache,
-                               is_root_rule,
-                               features
-  )
-                               .GetAdaptiveTokenMask();
+  std::optional<AdaptiveTokenMask> generated_mask;
+  if (repeat_key.has_value()) {
+    generated_mask = TryGetSimpleRepeatTokenMask(
+        state, repeat_key->upper_bound_distance, grammar, tokenizer_info
+    );
+  }
+  if (!generated_mask.has_value()) {
+    generated_mask = GrammarMatcherForTokenMaskCache(
+                         grammar,
+                         cache_state,
+                         tag_dispatch_second_slicing_bitset,
+                         tokenizer_info,
+                         retained_rule_level_cache,
+                         context_is_root_rule,
+                         features,
+                         cache_parent_state
+    )
+                         .GetAdaptiveTokenMask();
+  }
 
   std::lock_guard<std::mutex> lock(mutex_);
-  return masks_.emplace(cache_state, std::move(mask)).first->second;
-}
-
-const RepeatedCharacterClassTokenMask& CompiledGrammar::Impl::GetRepeatedCharacterClassTokenMask(
-    int32_t character_class_expression_id, int32_t character_limit
-) {
-  std::lock_guard<std::mutex> lock(repeated_character_class_cache_mutex);
-  const uint64_t cache_key = (static_cast<uint64_t>(character_class_expression_id) << 32) |
-                             static_cast<uint32_t>(character_limit + 1);
-  const auto existing_mask = repeated_character_class_token_masks.find(cache_key);
-  if (existing_mask != repeated_character_class_token_masks.end()) {
-    return existing_mask->second;
+  if (repeat_key.has_value()) {
+    return repeat_masks_.emplace(*repeat_key, std::move(*generated_mask)).first->second;
   }
-
-  if (character_class_token_summary_cache == nullptr) {
-    character_class_token_summary_cache = std::make_shared<CharacterClassTokenSummaryCache>();
-  }
-  const auto& sorted_vocabulary = tokenizer_info.GetSortedDecodedVocab();
-  const auto summaries = character_class_token_summary_cache->GetOrCreate(
-      grammar->GetGrammarExpr(character_class_expression_id), sorted_vocabulary
-  );
-  std::vector<int32_t> accepted_indices;
-  std::vector<int32_t> uncertain_indices;
-  DynamicBitset accepted_prefix_tokens(tokenizer_info.GetVocabSize());
-  for (const auto& summary : *summaries) {
-    if (character_limit < 0) {
-      if (summary.consumed_whole_token) {
-        accepted_indices.push_back(summary.sorted_vocab_index);
-      } else if (summary.has_completed_character_prefix) {
-        uncertain_indices.push_back(summary.sorted_vocab_index);
-      }
-      continue;
-    }
-    if (!summary.consumed_whole_token || summary.locally_consumed_characters > character_limit) {
-      uncertain_indices.push_back(summary.sorted_vocab_index);
-    } else {
-      accepted_prefix_tokens.Set(sorted_vocabulary[summary.sorted_vocab_index].first);
-    }
-  }
-
-  return repeated_character_class_token_masks
-      .emplace(
-          cache_key,
-          RepeatedCharacterClassTokenMask{
-              AdaptiveTokenMask(
-                  tokenizer_info.GetVocabSize(),
-                  sorted_vocabulary,
-                  accepted_indices,
-                  uncertain_indices
-              ),
-              std::move(accepted_prefix_tokens)
-          }
-      )
-      .first->second;
+  return masks_.emplace(cache_state, std::move(*generated_mask)).first->second;
 }
 
 /******************* GrammarCompilerNoCache *******************/
@@ -1715,8 +1710,6 @@ class GrammarCompilerSub {
 
   CompiledGrammar CompileGrammar(const std::string& ebnf_str, std::string root_rule_name);
 
-  void ClearCharacterClassTokenSummaryCache() { character_class_token_summary_cache_->Clear(); }
-
  private:
   /*! \brief The main logic. Compile the grammar with multi-threading. */
   CompiledGrammar MultiThreadCompileGrammar(Grammar grammar);
@@ -1728,9 +1721,6 @@ class GrammarCompilerSub {
 
   /*! \brief The manager of the rule level cache.*/
   std::optional<RuleLevelCache> rule_level_cache_;
-
-  std::shared_ptr<CharacterClassTokenSummaryCache> character_class_token_summary_cache_ =
-      std::make_shared<CharacterClassTokenSummaryCache>();
 
   /*! \brief Whether token masks are generated on first use. */
   const bool enable_dynamic_compilation_;
@@ -1752,8 +1742,6 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
     GrammarFSMHasher().Apply(&compiled_grammar_impl->grammar);
   }
   if (enable_dynamic_compilation_) {
-    compiled_grammar_impl->character_class_token_summary_cache =
-        character_class_token_summary_cache_;
     if (rule_level_cache_.has_value()) {
       compiled_grammar_impl->token_mask_cache.SetRuleLevelCache(
           std::make_shared<RuleLevelCache>(rule_level_cache_.value())
@@ -2236,7 +2224,6 @@ CompiledGrammar GrammarCompiler::Impl::CompileGrammar(
 
 void GrammarCompiler::Impl::ClearCache() {
   grammar_level_cache_.Clear();
-  no_cache_compiler_.ClearCharacterClassTokenSummaryCache();
   if (rule_level_cache_.has_value()) {
     rule_level_cache_->ClearCache();
   }

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -18,6 +18,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -371,6 +372,175 @@ void RuleLevelCache::Impl::ClearCache() {
 size_t MemorySize(const RuleLevelCache& manager) { return MemorySize(manager.ImplPtr()); }
 
 /************** AdaptiveTokenMaskCache Generator **************/
+
+class CharacterClassTokenSummaryCache {
+ public:
+  using SummaryList = std::vector<CharacterClassTokenSummary>;
+
+  std::shared_ptr<const SummaryList> GetOrCreate(
+      const Grammar::Impl::GrammarExpr& character_class,
+      const std::vector<std::pair<int32_t, std::string>>& sorted_vocabulary
+  ) {
+    std::vector<int32_t> key(character_class.begin(), character_class.end());
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      const auto existing = cache_.find(key);
+      if (existing != cache_.end()) {
+        return existing->second;
+      }
+    }
+
+    auto computed =
+        std::make_shared<const SummaryList>(BuildSummaries(character_class, sorted_vocabulary));
+    std::lock_guard<std::mutex> lock(mutex_);
+    return cache_.emplace(std::move(key), std::move(computed)).first->second;
+  }
+
+  void Clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    cache_.clear();
+  }
+
+ private:
+  static SummaryList BuildSummaries(
+      const Grammar::Impl::GrammarExpr& character_class,
+      const std::vector<std::pair<int32_t, std::string>>& sorted_vocabulary
+  ) {
+    XGRAMMAR_DCHECK(character_class.type == Grammar::Impl::GrammarExprType::kCharacterClass);
+    auto character_class_fsm = GrammarFSMBuilder::CharacterClass(character_class);
+    if (character_class_fsm.IsDFA()) {
+      return BuildDeterministicSummaries(character_class_fsm, sorted_vocabulary);
+    }
+    return BuildNondeterministicSummaries(character_class_fsm, sorted_vocabulary);
+  }
+
+  static SummaryList BuildDeterministicSummaries(
+      const FSMWithStartEnd& character_class_fsm,
+      const std::vector<std::pair<int32_t, std::string>>& sorted_vocabulary
+  ) {
+    const auto& finite_state_machine = character_class_fsm.GetFsm();
+    const int32_t initial_state = character_class_fsm.GetStart();
+
+    SummaryList summaries;
+    summaries.reserve(sorted_vocabulary.size());
+    for (int32_t sorted_vocabulary_index = 0;
+         sorted_vocabulary_index < static_cast<int32_t>(sorted_vocabulary.size());
+         ++sorted_vocabulary_index) {
+      int32_t current_state = initial_state;
+      int32_t completed_characters = 0;
+      bool consumed_whole_token = true;
+      bool has_incomplete_character = false;
+      for (uint8_t byte : sorted_vocabulary[sorted_vocabulary_index].second) {
+        const int32_t next_state = finite_state_machine.GetNextState(current_state, byte);
+        if (next_state == FSM::kNoNextState) {
+          consumed_whole_token = false;
+          has_incomplete_character = false;
+          break;
+        }
+        if (character_class_fsm.IsEndState(next_state)) {
+          ++completed_characters;
+          current_state = initial_state;
+          has_incomplete_character = false;
+        } else {
+          current_state = next_state;
+          has_incomplete_character = true;
+        }
+      }
+      AppendSummary(
+          &summaries,
+          sorted_vocabulary_index,
+          completed_characters,
+          consumed_whole_token,
+          has_incomplete_character
+      );
+    }
+    return summaries;
+  }
+
+  static SummaryList BuildNondeterministicSummaries(
+      const FSMWithStartEnd& character_class_fsm,
+      const std::vector<std::pair<int32_t, std::string>>& sorted_vocabulary
+  ) {
+    const auto& finite_state_machine = character_class_fsm.GetFsm();
+    std::unordered_set<int> initial_states{character_class_fsm.GetStart()};
+    finite_state_machine.GetEpsilonClosure(&initial_states);
+
+    SummaryList summaries;
+    summaries.reserve(sorted_vocabulary.size());
+    std::unordered_set<int> current_states;
+    std::unordered_set<int> next_states;
+    for (int32_t sorted_vocabulary_index = 0;
+         sorted_vocabulary_index < static_cast<int32_t>(sorted_vocabulary.size());
+         ++sorted_vocabulary_index) {
+      current_states = initial_states;
+      int32_t completed_characters = 0;
+      bool consumed_whole_token = true;
+      bool has_incomplete_character = false;
+      for (uint8_t byte : sorted_vocabulary[sorted_vocabulary_index].second) {
+        finite_state_machine.Advance(
+            current_states, byte, &next_states, FSMEdge::EdgeType::kCharRange, true
+        );
+        if (next_states.empty()) {
+          consumed_whole_token = false;
+          has_incomplete_character = false;
+          break;
+        }
+        const bool completed_character =
+            std::any_of(next_states.begin(), next_states.end(), [&](int32_t state) {
+              return character_class_fsm.IsEndState(state);
+            });
+        if (completed_character) {
+          ++completed_characters;
+          current_states = initial_states;
+          has_incomplete_character = false;
+        } else {
+          current_states.swap(next_states);
+          has_incomplete_character = true;
+        }
+      }
+
+      AppendSummary(
+          &summaries,
+          sorted_vocabulary_index,
+          completed_characters,
+          consumed_whole_token,
+          has_incomplete_character
+      );
+    }
+    return summaries;
+  }
+
+  static void AppendSummary(
+      SummaryList* summaries,
+      int32_t sorted_vocabulary_index,
+      int32_t completed_characters,
+      bool consumed_whole_token,
+      bool has_incomplete_character
+  ) {
+    if (consumed_whole_token || completed_characters > 0) {
+      summaries->push_back(CharacterClassTokenSummary{
+          sorted_vocabulary_index,
+          completed_characters +
+              static_cast<int32_t>(consumed_whole_token && has_incomplete_character),
+          consumed_whole_token,
+          completed_characters > 0
+      });
+    }
+  }
+
+  struct KeyHash {
+    size_t operator()(const std::vector<int32_t>& key) const {
+      uint64_t result = 0;
+      for (int32_t value : key) {
+        HashCombineBinary(result, static_cast<uint64_t>(value));
+      }
+      return result;
+    }
+  };
+
+  std::mutex mutex_;
+  std::unordered_map<std::vector<int32_t>, std::shared_ptr<const SummaryList>, KeyHash> cache_;
+};
 
 /*! \brief The concrete implementation of GrammarMatcherNode. */
 class GrammarMatcherForTokenMaskCache : public EarleyParser {
@@ -1436,6 +1606,59 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
   return masks_.emplace(cache_state, std::move(mask)).first->second;
 }
 
+const RepeatedCharacterClassTokenMask& CompiledGrammar::Impl::GetRepeatedCharacterClassTokenMask(
+    int32_t character_class_expression_id, int32_t character_limit
+) {
+  std::lock_guard<std::mutex> lock(repeated_character_class_cache_mutex);
+  const uint64_t cache_key = (static_cast<uint64_t>(character_class_expression_id) << 32) |
+                             static_cast<uint32_t>(character_limit + 1);
+  const auto existing_mask = repeated_character_class_token_masks.find(cache_key);
+  if (existing_mask != repeated_character_class_token_masks.end()) {
+    return existing_mask->second;
+  }
+
+  if (character_class_token_summary_cache == nullptr) {
+    character_class_token_summary_cache = std::make_shared<CharacterClassTokenSummaryCache>();
+  }
+  const auto& sorted_vocabulary = tokenizer_info.GetSortedDecodedVocab();
+  const auto summaries = character_class_token_summary_cache->GetOrCreate(
+      grammar->GetGrammarExpr(character_class_expression_id), sorted_vocabulary
+  );
+  std::vector<int32_t> accepted_indices;
+  std::vector<int32_t> uncertain_indices;
+  DynamicBitset accepted_prefix_tokens(tokenizer_info.GetVocabSize());
+  for (const auto& summary : *summaries) {
+    if (character_limit < 0) {
+      if (summary.consumed_whole_token) {
+        accepted_indices.push_back(summary.sorted_vocab_index);
+      } else if (summary.has_completed_character_prefix) {
+        uncertain_indices.push_back(summary.sorted_vocab_index);
+      }
+      continue;
+    }
+    if (!summary.consumed_whole_token || summary.locally_consumed_characters > character_limit) {
+      uncertain_indices.push_back(summary.sorted_vocab_index);
+    } else {
+      accepted_prefix_tokens.Set(sorted_vocabulary[summary.sorted_vocab_index].first);
+    }
+  }
+
+  return repeated_character_class_token_masks
+      .emplace(
+          cache_key,
+          RepeatedCharacterClassTokenMask{
+              AdaptiveTokenMask(
+                  tokenizer_info.GetVocabSize(),
+                  sorted_vocabulary,
+                  accepted_indices,
+                  uncertain_indices
+              ),
+              std::move(accepted_prefix_tokens)
+          }
+      )
+      .first->second;
+}
+
 /******************* GrammarCompilerNoCache *******************/
 
 /*!
@@ -1474,6 +1697,8 @@ class GrammarCompilerSub {
 
   CompiledGrammar CompileGrammar(const std::string& ebnf_str, std::string root_rule_name);
 
+  void ClearCharacterClassTokenSummaryCache() { character_class_token_summary_cache_->Clear(); }
+
  private:
   /*! \brief The main logic. Compile the grammar with multi-threading. */
   CompiledGrammar MultiThreadCompileGrammar(Grammar grammar);
@@ -1485,6 +1710,9 @@ class GrammarCompilerSub {
 
   /*! \brief The manager of the rule level cache.*/
   std::optional<RuleLevelCache> rule_level_cache_;
+
+  std::shared_ptr<CharacterClassTokenSummaryCache> character_class_token_summary_cache_ =
+      std::make_shared<CharacterClassTokenSummaryCache>();
 
   /*! \brief Whether token masks are generated on first use. */
   const bool enable_dynamic_compilation_;
@@ -1506,6 +1734,8 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
     GrammarFSMHasher().Apply(&compiled_grammar_impl->grammar);
   }
   if (enable_dynamic_compilation_) {
+    compiled_grammar_impl->character_class_token_summary_cache =
+        character_class_token_summary_cache_;
     if (rule_level_cache_.has_value()) {
       compiled_grammar_impl->token_mask_cache.SetRuleLevelCache(
           std::make_shared<RuleLevelCache>(rule_level_cache_.value())
@@ -1988,6 +2218,7 @@ CompiledGrammar GrammarCompiler::Impl::CompileGrammar(
 
 void GrammarCompiler::Impl::ClearCache() {
   grammar_level_cache_.Clear();
+  no_cache_compiler_.ClearCharacterClassTokenSummaryCache();
   if (rule_level_cache_.has_value()) {
     rule_level_cache_->ClearCache();
   }

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -420,6 +420,24 @@ class CharacterClassTokenSummaryCache {
   ) {
     const auto& finite_state_machine = character_class_fsm.GetFsm();
     const int32_t initial_state = character_class_fsm.GetStart();
+    std::vector<std::array<int32_t, 256>> transitions(finite_state_machine.NumStates());
+    for (auto& transition : transitions) {
+      transition.fill(FSM::kNoNextState);
+    }
+    for (int32_t state = 0; state < finite_state_machine.NumStates(); ++state) {
+      for (const auto& edge : finite_state_machine.GetEdges(state)) {
+        if (!edge.IsCharRange()) {
+          continue;
+        }
+        for (int32_t byte = std::max(edge.min, 0); byte <= std::min(edge.max, 255); ++byte) {
+          transitions[state][byte] = edge.target;
+        }
+      }
+    }
+    std::vector<uint8_t> is_end_state(finite_state_machine.NumStates(), 0);
+    for (int32_t state : character_class_fsm.GetEnds()) {
+      is_end_state[state] = 1;
+    }
 
     SummaryList summaries;
     summaries.reserve(sorted_vocabulary.size());
@@ -431,13 +449,13 @@ class CharacterClassTokenSummaryCache {
       bool consumed_whole_token = true;
       bool has_incomplete_character = false;
       for (uint8_t byte : sorted_vocabulary[sorted_vocabulary_index].second) {
-        const int32_t next_state = finite_state_machine.GetNextState(current_state, byte);
+        const int32_t next_state = transitions[current_state][byte];
         if (next_state == FSM::kNoNextState) {
           consumed_whole_token = false;
           has_incomplete_character = false;
           break;
         }
-        if (character_class_fsm.IsEndState(next_state)) {
+        if (is_end_state[next_state]) {
           ++completed_characters;
           current_state = initial_state;
           has_incomplete_character = false;

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1003,19 +1003,22 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   }
 }
 
-const AdaptiveTokenMask& CompiledGrammar::Impl::GetAdaptiveTokenMask(
-    const ParserState& state, bool is_root_rule
+const AdaptiveTokenMask& TokenMaskCache::Get(
+    const ParserState& state,
+    bool is_root_rule,
+    const Grammar& grammar,
+    const TokenizerInfo& tokenizer_info
 ) {
-  if (!enable_dynamic_compilation) {
-    const auto it = adaptive_token_mask_cache.find(state);
-    XGRAMMAR_CHECK(it != adaptive_token_mask_cache.end())
+  if (!dynamic) {
+    const auto it = masks.find(state);
+    XGRAMMAR_CHECK(it != masks.end())
         << "The token mask cache is incomplete while dynamic compilation is disabled: " << state;
     return it->second;
   }
 
-  std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex);
-  const auto existing = adaptive_token_mask_cache.find(state);
-  if (existing != adaptive_token_mask_cache.end()) {
+  std::lock_guard<std::mutex> lock(mutex);
+  const auto existing = masks.find(state);
+  if (existing != masks.end()) {
     return existing->second;
   }
 
@@ -1036,30 +1039,7 @@ const AdaptiveTokenMask& CompiledGrammar::Impl::GetAdaptiveTokenMask(
                                no_rule_level_cache
   )
                                .GetAdaptiveTokenMask(is_root_rule);
-  return adaptive_token_mask_cache.emplace(cache_state, std::move(mask)).first->second;
-}
-
-void CompiledGrammar::Impl::MaterializeAdaptiveTokenMaskCache() {
-  if (tokenizer_info.GetVocabSize() == 0) {
-    return;
-  }
-  const int32_t root_rule_id = grammar->GetRootRuleId();
-  for (int32_t rule_id = 0; rule_id < static_cast<int32_t>(grammar->NumRules()); ++rule_id) {
-    const auto& rule_fsm = grammar->per_rule_fsms[rule_id];
-    XGRAMMAR_DCHECK(rule_fsm.has_value());
-    ParserState state(
-        rule_id, grammar->GetRule(rule_id).body_expr_id, 0, ParserState::kNoPrevInputPos, -1, 0
-    );
-    std::unordered_set<int> reachable_states;
-    rule_fsm->GetFsm().GetReachableStates(&reachable_states);
-    for (int32_t element_id : reachable_states) {
-      if (!rule_fsm->GetFsm().IsScanableState(element_id)) {
-        continue;
-      }
-      state.element_id = element_id;
-      GetAdaptiveTokenMask(state, rule_id == root_rule_id);
-    }
-  }
+  return masks.emplace(cache_state, std::move(mask)).first->second;
 }
 
 /******************* GrammarCompilerNoCache *******************/
@@ -1103,15 +1083,6 @@ class GrammarCompilerSub {
  private:
   /*! \brief The main logic. Compile the grammar with multi-threading. */
   CompiledGrammar MultiThreadCompileGrammar(Grammar grammar);
-  /*! \brief Optimization for TagDispatch.
-   *  \param compiled_grammar_impl the compiled_grammar to be optimized.
-   *  \param tag_dispatch_rule_id_to_second_slicing_bitset Return value. Mapping from the rule_id to
-   * the definite accepted token mask.
-   */
-  void TagDispatchOptimization(
-      std::shared_ptr<CompiledGrammar::Impl> compiled_grammar_impl,
-      std::unordered_map<int32_t, DynamicBitset>* tag_dispatch_rule_id_to_second_slicing_bitset
-  );
 
   /*! \brief The vocabulary associated with this storage class. */
   const TokenizerInfo tokenizer_info_;
@@ -1129,15 +1100,15 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
   compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
-  compiled_grammar_impl->enable_dynamic_compilation = enable_dynamic_compilation_;
+  compiled_grammar_impl->token_mask_cache.dynamic = enable_dynamic_compilation_;
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
   }
-  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
-  TagDispatchOptimization(compiled_grammar_impl, &tag_dispatch_rule_id_to_second_slicing_bitset);
+  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset =
+      ComputeTagDispatchSecondSlicingBitset(compiled_grammar_impl->grammar, tokenizer_info_);
 
   if (enable_dynamic_compilation_) {
-    compiled_grammar_impl->tag_dispatch_rule_id_to_second_slicing_bitset =
+    compiled_grammar_impl->token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset =
         std::move(tag_dispatch_rule_id_to_second_slicing_bitset);
     return CompiledGrammar(compiled_grammar_impl);
   }
@@ -1173,9 +1144,9 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
     auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask(is_root_rule);
     if (max_threads_ > 1) {
       std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex.value());
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
+      compiled_grammar_impl->token_mask_cache.masks[state] = cur_adaptive_token_mask_cache;
     } else {
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
+      compiled_grammar_impl->token_mask_cache.masks[state] = cur_adaptive_token_mask_cache;
     }
   };
 
@@ -1263,24 +1234,22 @@ CompiledGrammar GrammarCompilerSub::CompileGrammar(
   return MultiThreadCompileGrammar(Grammar::FromEBNF(ebnf_str, root_rule_name));
 }
 
-void GrammarCompilerSub::TagDispatchOptimization(
-    std::shared_ptr<CompiledGrammar::Impl> compiled_grammar_impl,
-    std::unordered_map<int32_t, DynamicBitset>* tag_dispatch_rule_id_to_second_slicing_bitset
+std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitset(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info
 ) {
   using GrammarExprType = Grammar::Impl::GrammarExprType;
-  tag_dispatch_rule_id_to_second_slicing_bitset->clear();
+  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
 
   // Optimization for TagDispatch: Precompute the definitely accepted tokens.
-  for (int i = 0; i < compiled_grammar_impl->grammar->NumRules(); i++) {
-    const auto& rule = compiled_grammar_impl->grammar->GetRule(i);
-    const auto& rule_body = compiled_grammar_impl->grammar->GetGrammarExpr(rule.body_expr_id);
+  for (int i = 0; i < grammar->NumRules(); i++) {
+    const auto& rule = grammar->GetRule(i);
+    const auto& rule_body = grammar->GetGrammarExpr(rule.body_expr_id);
     if (rule_body.type != GrammarExprType::kTagDispatch) {
       continue;
     }
     XGRAMMAR_DCHECK(rule_body.type == GrammarExprType::kTagDispatch);
-    Grammar::Impl::TagDispatch tag_dispatch =
-        compiled_grammar_impl->GetGrammar()->GetTagDispatch(rule.body_expr_id);
-    const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
+    Grammar::Impl::TagDispatch tag_dispatch = grammar->GetTagDispatch(rule.body_expr_id);
+    const auto& sorted_decoded_vocab = tokenizer_info.GetSortedDecodedVocab();
     DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
     for (int j = 0; j < static_cast<int32_t>(sorted_decoded_vocab.size()); j++) {
       bool definite_accept_since_second_char = true;
@@ -1310,9 +1279,9 @@ void GrammarCompilerSub::TagDispatchOptimization(
         definite_accepted_tokens_since_second_char.Set(j);
       }
     }
-    (*tag_dispatch_rule_id_to_second_slicing_bitset)[i] =
-        definite_accepted_tokens_since_second_char;
+    tag_dispatch_rule_id_to_second_slicing_bitset[i] = definite_accepted_tokens_since_second_char;
   }
+  return tag_dispatch_rule_id_to_second_slicing_bitset;
 }
 
 /******************* GrammarCompiler::Impl *******************/
@@ -1608,14 +1577,6 @@ int64_t GrammarCompiler::Impl::CacheLimitBytes() const {
 }
 
 /******************* GrammarCompiler *******************/
-
-GrammarCompiler::GrammarCompiler(
-    const TokenizerInfo& tokenizer_info,
-    int max_threads,
-    bool cache_enabled,
-    int64_t max_memory_bytes
-)
-    : GrammarCompiler(tokenizer_info, max_threads, cache_enabled, max_memory_bytes, false) {}
 
 GrammarCompiler::GrammarCompiler(
     const TokenizerInfo& tokenizer_info,

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -42,16 +42,14 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   GrammarMatcherForTokenMaskCache(
       const Grammar& grammar,
       const ParserState& init_state,
-      const std::unordered_map<int32_t, DynamicBitset>&
-          tag_dispatch_rule_id_to_second_slicing_bitset,
+      const DynamicBitset* tag_dispatch_second_slicing_bitset,
       const TokenizerInfo& tokenizer_info,
       std::optional<RuleLevelCache>& rule_level_cache
   )
       : EarleyParser(grammar, init_state),
         init_rule_id_(init_state.rule_id),
         initial_state_(init_state),
-        tag_dispatch_rule_id_to_second_slicing_bitset_(tag_dispatch_rule_id_to_second_slicing_bitset
-        ),
+        tag_dispatch_second_slicing_bitset_(tag_dispatch_second_slicing_bitset),
         tokenizer_info_(tokenizer_info),
         rule_level_cache_(rule_level_cache) {}
   /*!
@@ -117,7 +115,7 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   ParserState initial_state_;
 
   /*!
-   * \brief This is a mapping from TagDispatch rule id to the bitset used for second slicing.
+   * \brief The bitset used for second slicing when the initial rule is a TagDispatch rule.
    * \note If a rule is a TagDispatch rule, then there will be an AC automaton for its triggers.
    *  Which means that it can accept a lot of tokens. However, it will be slow to check a lot of
    *  tokens. The DynamicBitset here is used to do a second slicing: if a token's substr(1, n - 1)
@@ -125,7 +123,7 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
    *  When we check a token, we first check if its first character can transit to the start state.
    *  If yes, then we check if it is in the bitset. If yes, then we accept it directly.
    */
-  const std::unordered_map<int32_t, DynamicBitset>& tag_dispatch_rule_id_to_second_slicing_bitset_;
+  const DynamicBitset* tag_dispatch_second_slicing_bitset_;
 
   const TokenizerInfo& tokenizer_info_;
 
@@ -534,8 +532,8 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       grammar_->GetGrammarExpr(grammar_->GetRule(init_rule_id_).body_expr_id).type ==
       Grammar::Impl::GrammarExprType::kTagDispatch;
   if (is_tag_dispatch_rule) {
-    XGRAMMAR_DCHECK(tag_dispatch_rule_id_to_second_slicing_bitset_.count(init_rule_id_) > 0);
-    definite_accepted_bitset = &tag_dispatch_rule_id_to_second_slicing_bitset_.at(init_rule_id_);
+    XGRAMMAR_DCHECK(tag_dispatch_second_slicing_bitset_ != nullptr);
+    definite_accepted_bitset = tag_dispatch_second_slicing_bitset_;
   }
 
   const std::string* prev_token = nullptr;
@@ -1003,6 +1001,24 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   }
 }
 
+const DynamicBitset* TokenMaskCache::GetTagDispatchSecondSlicingBitset(
+    int32_t rule_id, const Grammar& grammar, const TokenizerInfo& tokenizer_info
+) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto existing = tag_dispatch_rule_id_to_second_slicing_bitset_.find(rule_id);
+    if (existing != tag_dispatch_rule_id_to_second_slicing_bitset_.end()) {
+      return &existing->second;
+    }
+  }
+
+  DynamicBitset bitset = ComputeTagDispatchSecondSlicingBitset(grammar, tokenizer_info, rule_id);
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  return &tag_dispatch_rule_id_to_second_slicing_bitset_.try_emplace(rule_id, std::move(bitset))
+              .first->second;
+}
+
 const AdaptiveTokenMask& TokenMaskCache::Get(
     const ParserState& state,
     bool is_root_rule,
@@ -1024,6 +1040,14 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
     }
   }
 
+  const DynamicBitset* tag_dispatch_second_slicing_bitset = nullptr;
+  const auto& rule = grammar->GetRule(state.rule_id);
+  if (grammar->GetGrammarExpr(rule.body_expr_id).type ==
+      Grammar::Impl::GrammarExprType::kTagDispatch) {
+    tag_dispatch_second_slicing_bitset =
+        GetTagDispatchSecondSlicingBitset(state.rule_id, grammar, tokenizer_info);
+  }
+
   // Generate the mask outside the lock so a miss does not block other lookups. Two threads may
   // generate the same mask concurrently; emplace keeps the first inserted one.
   const ParserState cache_state(
@@ -1038,7 +1062,7 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
   AdaptiveTokenMask mask = GrammarMatcherForTokenMaskCache(
                                grammar,
                                cache_state,
-                               tag_dispatch_rule_id_to_second_slicing_bitset_,
+                               tag_dispatch_second_slicing_bitset,
                                tokenizer_info,
                                no_rule_level_cache
   )
@@ -1104,23 +1128,15 @@ class GrammarCompilerSub {
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
   Grammar grammar = GrammarOptimizer::Apply(grammar_unoptimized);
-  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
-  if (tokenizer_info_.GetVocabSize() > 0) {
-    tag_dispatch_rule_id_to_second_slicing_bitset =
-        ComputeTagDispatchSecondSlicingBitset(grammar, tokenizer_info_);
-  }
-  // In dynamic mode, the cache keeps the tag-dispatch data for on-demand mask generation; in
-  // eager mode, it is only used during the mask generation below.
-  auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>(
-      enable_dynamic_compilation_,
-      enable_dynamic_compilation_ ? std::move(tag_dispatch_rule_id_to_second_slicing_bitset)
-                                  : std::unordered_map<int32_t, DynamicBitset>{}
-  );
+  auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>(enable_dynamic_compilation_);
   compiled_grammar_impl->grammar = std::move(grammar);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
   if (tokenizer_info_.GetVocabSize() == 0 || enable_dynamic_compilation_) {
     return CompiledGrammar(compiled_grammar_impl);
   }
+
+  auto tag_dispatch_rule_id_to_second_slicing_bitset =
+      ComputeTagDispatchSecondSlicingBitsets(compiled_grammar_impl->grammar, tokenizer_info_);
 
   // If the compiler is cache-enabled, then we hash the grammars for crossing-grammar caching.
   if (rule_level_cache_.has_value()) {
@@ -1143,10 +1159,16 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   }
 
   auto add_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
+    const DynamicBitset* tag_dispatch_second_slicing_bitset = nullptr;
+    const auto tag_dispatch_bitset_it =
+        tag_dispatch_rule_id_to_second_slicing_bitset.find(state.rule_id);
+    if (tag_dispatch_bitset_it != tag_dispatch_rule_id_to_second_slicing_bitset.end()) {
+      tag_dispatch_second_slicing_bitset = &tag_dispatch_bitset_it->second;
+    }
     auto grammar_matcher = GrammarMatcherForTokenMaskCache(
         compiled_grammar_impl->grammar,
         state,
-        tag_dispatch_rule_id_to_second_slicing_bitset,
+        tag_dispatch_second_slicing_bitset,
         tokenizer_info_,
         rule_level_cache_
     );
@@ -1247,54 +1269,62 @@ CompiledGrammar GrammarCompilerSub::CompileGrammar(
   return MultiThreadCompileGrammar(Grammar::FromEBNF(ebnf_str, root_rule_name));
 }
 
-std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitset(
-    const Grammar& grammar, const TokenizerInfo& tokenizer_info
+DynamicBitset ComputeTagDispatchSecondSlicingBitset(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info, int32_t rule_id
 ) {
   using GrammarExprType = Grammar::Impl::GrammarExprType;
-  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
-
-  // Optimization for TagDispatch: Precompute the definitely accepted tokens.
-  for (int i = 0; i < grammar->NumRules(); i++) {
-    const auto& rule = grammar->GetRule(i);
-    const auto& rule_body = grammar->GetGrammarExpr(rule.body_expr_id);
-    if (rule_body.type != GrammarExprType::kTagDispatch) {
+  const auto& rule = grammar->GetRule(rule_id);
+  const auto& rule_body = grammar->GetGrammarExpr(rule.body_expr_id);
+  XGRAMMAR_DCHECK(rule_body.type == GrammarExprType::kTagDispatch);
+  Grammar::Impl::TagDispatch tag_dispatch = grammar->GetTagDispatch(rule.body_expr_id);
+  const auto& sorted_decoded_vocab = tokenizer_info.GetSortedDecodedVocab();
+  DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
+  for (int token_index = 0; token_index < static_cast<int32_t>(sorted_decoded_vocab.size());
+       ++token_index) {
+    bool definite_accept_since_second_char = true;
+    const auto& token = sorted_decoded_vocab[token_index].second;
+    if (token.empty()) {
+      definite_accepted_tokens_since_second_char.Set(token_index);
       continue;
     }
-    XGRAMMAR_DCHECK(rule_body.type == GrammarExprType::kTagDispatch);
-    Grammar::Impl::TagDispatch tag_dispatch = grammar->GetTagDispatch(rule.body_expr_id);
-    const auto& sorted_decoded_vocab = tokenizer_info.GetSortedDecodedVocab();
-    DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
-    for (int j = 0; j < static_cast<int32_t>(sorted_decoded_vocab.size()); j++) {
-      bool definite_accept_since_second_char = true;
-      const auto& token = sorted_decoded_vocab[j].second;
-      if (token.empty()) {
-        definite_accepted_tokens_since_second_char.Set(j);
-        continue;
-      }
 
-      // Check if the token contains any string trigger or exclude string after first char.
-      for (const auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
-        if (token.find(trigger, 1) != std::string::npos) {
+    // Check if the token contains any string trigger or exclude string after first char.
+    for (const auto& tag_rule_pair : tag_dispatch.tag_rule_pairs) {
+      if (token.find(tag_rule_pair.first, 1) != std::string::npos) {
+        definite_accept_since_second_char = false;
+        break;
+      }
+    }
+    if (definite_accept_since_second_char) {
+      for (const auto& exclude : tag_dispatch.excludes) {
+        if (token.find(exclude, 1) != std::string::npos) {
           definite_accept_since_second_char = false;
           break;
         }
       }
-      if (definite_accept_since_second_char) {
-        for (const auto& excl : tag_dispatch.excludes) {
-          if (token.find(excl, 1) != std::string::npos) {
-            definite_accept_since_second_char = false;
-            break;
-          }
-        }
-      }
-
-      if (definite_accept_since_second_char) {
-        definite_accepted_tokens_since_second_char.Set(j);
-      }
     }
-    tag_dispatch_rule_id_to_second_slicing_bitset[i] = definite_accepted_tokens_since_second_char;
+
+    if (definite_accept_since_second_char) {
+      definite_accepted_tokens_since_second_char.Set(token_index);
+    }
   }
-  return tag_dispatch_rule_id_to_second_slicing_bitset;
+  return definite_accepted_tokens_since_second_char;
+}
+
+std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitsets(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info
+) {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  std::unordered_map<int32_t, DynamicBitset> result;
+  for (int32_t rule_id = 0; rule_id < static_cast<int32_t>(grammar->NumRules()); ++rule_id) {
+    const auto& rule = grammar->GetRule(rule_id);
+    if (grammar->GetGrammarExpr(rule.body_expr_id).type == GrammarExprType::kTagDispatch) {
+      result.emplace(
+          rule_id, ComputeTagDispatchSecondSlicingBitset(grammar, tokenizer_info, rule_id)
+      );
+    }
+  }
+  return result;
 }
 
 /******************* GrammarCompiler::Impl *******************/

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -44,20 +44,22 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
       const ParserState& init_state,
       const DynamicBitset* tag_dispatch_second_slicing_bitset,
       const TokenizerInfo& tokenizer_info,
-      std::optional<RuleLevelCache>& rule_level_cache
+      std::optional<RuleLevelCache>& rule_level_cache,
+      bool is_root_rule
   )
       : EarleyParser(grammar, init_state),
         init_rule_id_(init_state.rule_id),
         initial_state_(init_state),
+        is_root_rule_(is_root_rule),
         tag_dispatch_second_slicing_bitset_(tag_dispatch_second_slicing_bitset),
         tokenizer_info_(tokenizer_info),
-        rule_level_cache_(rule_level_cache) {}
+        rule_level_cache_(rule_level_cache) {
+    XGRAMMAR_DCHECK(is_root_rule == (init_state.rule_id == grammar->GetRootRuleId()));
+  }
   /*!
    * \brief Get the adaptive token mask for the given ParserState.
-   * \param is_root_rule Whether to consider the parent rule. If false, there will be
-   * no uncertain tokens. Useful for the root rule.
    */
-  AdaptiveTokenMask GetAdaptiveTokenMask(bool is_root_rule);
+  AdaptiveTokenMask GetAdaptiveTokenMask();
 
   /*!
    * \brief Get the token mask for the given ParserState.
@@ -113,6 +115,9 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
 
   // The initial state of the parser.
   ParserState initial_state_;
+
+  // Whether the initial rule is the grammar's root rule.
+  bool is_root_rule_;
 
   /*!
    * \brief The bitset used for second slicing when the initial rule is a TagDispatch rule.
@@ -788,7 +793,7 @@ const std::vector<int32_t>& GrammarMatcherForTokenMaskCache::GetTokenEdgeAccepte
   return tmp_token_edge_accepted_;
 }
 
-AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_root_rule) {
+AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask() {
   tmp_accepted_indices_.clear();
   tmp_rejected_indices_.clear();
   tmp_uncertain_indices_.clear();
@@ -839,7 +844,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     );
     // If the rule doesn't have a lookahead, then it is exactly the same fsm.
     if (crossing_cache.has_value()) {
-      AdaptCacheWithLookahead(&crossing_cache.value(), is_root_rule);
+      AdaptCacheWithLookahead(&crossing_cache.value(), is_root_rule_);
       return std::move(crossing_cache.value());
     }
   }
@@ -856,7 +861,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     rejected_filled = false;
   } else {
     rejected_filled = GetTokenMaskWithFirstCharacterCheck(
-        first_character_mask, is_root_rule, token_edge_accepted
+        first_character_mask, is_root_rule_, token_edge_accepted
     );
   }
 
@@ -880,7 +885,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
         tmp_uncertain_indices_
     );
     if (rule_level_cache_is_available) {
-      if (lookahead_id == -1 && !is_root_rule) {
+      if (lookahead_id == -1 && !is_root_rule_) {
         // If the rule doesn't have a lookahead, then it is exactly the same fsm.
         auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
         rule_level_cache_->AddCache(
@@ -952,7 +957,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     if (rule_level_cache_is_available) {
       // Prepare for cache.
       auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
-      if (lookahead_id == -1 && !is_root_rule) {
+      if (lookahead_id == -1 && !is_root_rule_) {
         // If the rule doesn't have a lookahead, then it is exactly the same fsm.
         rule_level_cache_->AddCache(
             fsm_hash.value(), new_state_id, fsm.GetNodeNum(), fsm.GetEdgeNum(), return_value
@@ -1064,9 +1069,10 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
                                cache_state,
                                tag_dispatch_second_slicing_bitset,
                                tokenizer_info,
-                               no_rule_level_cache
+                               no_rule_level_cache,
+                               is_root_rule
   )
-                               .GetAdaptiveTokenMask(is_root_rule);
+                               .GetAdaptiveTokenMask();
 
   std::lock_guard<std::mutex> lock(mutex_);
   return masks_.emplace(cache_state, std::move(mask)).first->second;
@@ -1170,9 +1176,10 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
         state,
         tag_dispatch_second_slicing_bitset,
         tokenizer_info_,
-        rule_level_cache_
+        rule_level_cache_,
+        is_root_rule
     );
-    auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask(is_root_rule);
+    auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask();
     if (max_threads_ > 1) {
       std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex.value());
       compiled_grammar_impl->token_mask_cache.Insert(
@@ -1429,7 +1436,7 @@ class GrammarCompiler::Impl {
       int64_t max_memory_bytes,
       bool enable_dynamic_compilation
   )
-      : cache_enabled_(cache_enabled && (!enable_dynamic_compilation || max_memory_bytes == -1)),
+      : cache_enabled_(cache_enabled),
         rule_level_cache_(
             cache_enabled
                 ? std::optional<RuleLevelCache>(

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -36,6 +36,52 @@ namespace xgrammar {
 
 /************** AdaptiveTokenMaskCache Generator **************/
 
+std::vector<uint8_t> GetRuleLevelCacheableRules(const Grammar& grammar) {
+  const int32_t num_rules = grammar->NumRules();
+  std::vector<uint8_t> context_dependent(num_rules, 0);
+  std::vector<std::vector<int32_t>> referenced_rules(num_rules);
+  for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
+    const auto& rule = grammar->GetRule(rule_id);
+    context_dependent[rule_id] = rule.max_tokens >= 0 || rule.max_chars >= 0 || rule.is_lazy ||
+                                 rule.temperature.has_value() ||
+                                 grammar->GetSuffixStopInfo(rule_id) != nullptr;
+    const auto& fsm = grammar->per_rule_fsms[rule_id]->GetFsm();
+    std::unordered_set<int32_t> reachable_states;
+    fsm.GetReachableStates(&reachable_states);
+    for (int32_t state_id : reachable_states) {
+      for (const auto& edge : fsm.GetFsm().GetEdges(state_id)) {
+        if (edge.IsRuleRef()) {
+          referenced_rules[rule_id].push_back(edge.GetRefRuleId());
+        } else if (edge.IsRepeatRef()) {
+          referenced_rules[rule_id].push_back(
+              grammar->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex()).RuleId()
+          );
+        }
+      }
+    }
+  }
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
+      if (!context_dependent[rule_id]) {
+        continue;
+      }
+      for (int32_t referenced_rule_id : referenced_rules[rule_id]) {
+        if (!context_dependent[referenced_rule_id]) {
+          context_dependent[referenced_rule_id] = 1;
+          changed = true;
+        }
+      }
+    }
+  }
+  for (uint8_t& value : context_dependent) {
+    value = !value;
+  }
+  return context_dependent;
+}
+
 /*! \brief The concrete implementation of GrammarMatcherNode. */
 class GrammarMatcherForTokenMaskCache : public EarleyParser {
  public:
@@ -1063,13 +1109,18 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
       -1,
       state.sub_element_id
   );
-  std::optional<RuleLevelCache> no_rule_level_cache;
+  std::optional<RuleLevelCache> retained_rule_level_cache;
+  if (rule_level_cache_ != nullptr && state.rule_id >= 0 &&
+      state.rule_id < static_cast<int32_t>(rule_level_cacheable_.size()) &&
+      rule_level_cacheable_[state.rule_id]) {
+    retained_rule_level_cache = *rule_level_cache_;
+  }
   AdaptiveTokenMask mask = GrammarMatcherForTokenMaskCache(
                                grammar,
                                cache_state,
                                tag_dispatch_second_slicing_bitset,
                                tokenizer_info,
-                               no_rule_level_cache,
+                               retained_rule_level_cache,
                                is_root_rule
   )
                                .GetAdaptiveTokenMask();
@@ -1137,17 +1188,27 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>(enable_dynamic_compilation_);
   compiled_grammar_impl->grammar = std::move(grammar);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
-  if (tokenizer_info_.GetVocabSize() == 0 || enable_dynamic_compilation_) {
+  if (tokenizer_info_.GetVocabSize() == 0) {
+    return CompiledGrammar(compiled_grammar_impl);
+  }
+
+  // Rule hashes are needed by both eager and on-demand cross-grammar mask reuse.
+  if (rule_level_cache_.has_value()) {
+    GrammarFSMHasher().Apply(&compiled_grammar_impl->grammar);
+  }
+  if (enable_dynamic_compilation_) {
+    if (rule_level_cache_.has_value()) {
+      compiled_grammar_impl->token_mask_cache.SetRuleLevelCache(
+          std::make_shared<RuleLevelCache>(rule_level_cache_.value()),
+          GetRuleLevelCacheableRules(compiled_grammar_impl->grammar)
+      );
+    }
     return CompiledGrammar(compiled_grammar_impl);
   }
 
   auto tag_dispatch_rule_id_to_second_slicing_bitset =
       ComputeTagDispatchSecondSlicingBitsets(compiled_grammar_impl->grammar, tokenizer_info_);
 
-  // If the compiler is cache-enabled, then we hash the grammars for crossing-grammar caching.
-  if (rule_level_cache_.has_value()) {
-    GrammarFSMHasher().Apply(&compiled_grammar_impl->grammar);
-  }
   // Step 3. Compute the adaptive token mask cache
   // The token mask cache is computed for these positions in the grammar:
   // 1. All character class or character class star (with last_utf8_bytes=0, 1, 2, 3)

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -1009,19 +1009,23 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
     const Grammar& grammar,
     const TokenizerInfo& tokenizer_info
 ) {
-  if (!dynamic) {
-    const auto it = masks.find(state);
-    XGRAMMAR_CHECK(it != masks.end())
+  if (!dynamic_) {
+    const auto it = masks_.find(state);
+    XGRAMMAR_CHECK(it != masks_.end())
         << "The token mask cache is incomplete while dynamic compilation is disabled: " << state;
     return it->second;
   }
 
-  std::lock_guard<std::mutex> lock(mutex);
-  const auto existing = masks.find(state);
-  if (existing != masks.end()) {
-    return existing->second;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto existing = masks_.find(state);
+    if (existing != masks_.end()) {
+      return existing->second;
+    }
   }
 
+  // Generate the mask outside the lock so a miss does not block other lookups. Two threads may
+  // generate the same mask concurrently; emplace keeps the first inserted one.
   const ParserState cache_state(
       state.rule_id,
       state.sequence_id,
@@ -1034,12 +1038,14 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
   AdaptiveTokenMask mask = GrammarMatcherForTokenMaskCache(
                                grammar,
                                cache_state,
-                               tag_dispatch_rule_id_to_second_slicing_bitset,
+                               tag_dispatch_rule_id_to_second_slicing_bitset_,
                                tokenizer_info,
                                no_rule_level_cache
   )
                                .GetAdaptiveTokenMask(is_root_rule);
-  return masks.emplace(cache_state, std::move(mask)).first->second;
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  return masks_.emplace(cache_state, std::move(mask)).first->second;
 }
 
 /******************* GrammarCompilerNoCache *******************/
@@ -1097,19 +1103,22 @@ class GrammarCompilerSub {
 };
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
-  auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
-  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
-  compiled_grammar_impl->tokenizer_info = tokenizer_info_;
-  compiled_grammar_impl->token_mask_cache.dynamic = enable_dynamic_compilation_;
-  if (tokenizer_info_.GetVocabSize() == 0) {
-    return CompiledGrammar(compiled_grammar_impl);
+  Grammar grammar = GrammarOptimizer::Apply(grammar_unoptimized);
+  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
+  if (tokenizer_info_.GetVocabSize() > 0) {
+    tag_dispatch_rule_id_to_second_slicing_bitset =
+        ComputeTagDispatchSecondSlicingBitset(grammar, tokenizer_info_);
   }
-  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset =
-      ComputeTagDispatchSecondSlicingBitset(compiled_grammar_impl->grammar, tokenizer_info_);
-
-  if (enable_dynamic_compilation_) {
-    compiled_grammar_impl->token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset =
-        std::move(tag_dispatch_rule_id_to_second_slicing_bitset);
+  // In dynamic mode, the cache keeps the tag-dispatch data for on-demand mask generation; in
+  // eager mode, it is only used during the mask generation below.
+  auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>(
+      enable_dynamic_compilation_,
+      enable_dynamic_compilation_ ? std::move(tag_dispatch_rule_id_to_second_slicing_bitset)
+                                  : std::unordered_map<int32_t, DynamicBitset>{}
+  );
+  compiled_grammar_impl->grammar = std::move(grammar);
+  compiled_grammar_impl->tokenizer_info = tokenizer_info_;
+  if (tokenizer_info_.GetVocabSize() == 0 || enable_dynamic_compilation_) {
     return CompiledGrammar(compiled_grammar_impl);
   }
 
@@ -1144,9 +1153,13 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
     auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask(is_root_rule);
     if (max_threads_ > 1) {
       std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex.value());
-      compiled_grammar_impl->token_mask_cache.masks[state] = cur_adaptive_token_mask_cache;
+      compiled_grammar_impl->token_mask_cache.Insert(
+          state, std::move(cur_adaptive_token_mask_cache)
+      );
     } else {
-      compiled_grammar_impl->token_mask_cache.masks[state] = cur_adaptive_token_mask_cache;
+      compiled_grammar_impl->token_mask_cache.Insert(
+          state, std::move(cur_adaptive_token_mask_cache)
+      );
     }
   };
 

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -6,12 +6,16 @@
 #include <xgrammar/compiler.h>
 
 #include <algorithm>
+#include <array>
 #include <bitset>
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -22,6 +26,7 @@
 #include "fsm.h"
 #include "grammar_functor.h"
 #include "grammar_impl.h"
+#include "support/container.h"
 #include "support/dynamic_bitset.h"
 #include "support/int_set.h"
 #include "support/logging.h"
@@ -33,6 +38,245 @@
 #include "xgrammar/tokenizer_info.h"
 
 namespace xgrammar {
+
+/******************* RuleLevelCache *******************/
+
+/*!
+ * \brief Store token masks shared by structurally equivalent rules across grammars.
+ * \details The cache uses least-recently-used eviction.
+ */
+class RuleLevelCache {
+ public:
+  static const size_t kUnlimitedSize = static_cast<size_t>(-1);
+
+  std::optional<AdaptiveTokenMask> GetCache(
+      const uint64_t& fsm_hash,
+      int32_t fsm_new_node_id,
+      const int32_t& state_cnt,
+      const int32_t edge_cnt
+  );
+  bool AddCache(
+      const uint64_t& fsm_hash,
+      int32_t fsm_new_node_id,
+      const int32_t& state_cnt,
+      const int32_t edge_cnt,
+      const AdaptiveTokenMask& token_mask
+  );
+  bool AddCache(
+      const uint64_t& fsm_hash,
+      int32_t fsm_new_node_id,
+      const int32_t& state_cnt,
+      const int32_t edge_cnt,
+      AdaptiveTokenMask&& token_mask
+  );
+  RuleLevelCache(size_t max_cache_memory_size = kUnlimitedSize);
+
+  void ClearCache();
+
+  size_t GetMaxSize() const;
+
+  friend size_t MemorySize(const RuleLevelCache& manager);
+
+  XGRAMMAR_DEFINE_PIMPL_METHODS(RuleLevelCache);
+};
+
+class RuleLevelCache::Impl {
+ public:
+  using NodeKey = std::tuple<
+      uint64_t /*The hash value of the FSM*/,
+      int32_t /* The normalized node id*/,
+      int32_t /*The number of states*/,
+      int32_t /* The number of edges*/>;
+  using NodeType = std::pair<NodeKey, AdaptiveTokenMask>;
+
+  explicit Impl(size_t max_cache_memory_size) : max_cache_memory_size_(max_cache_memory_size) {}
+
+  std::optional<AdaptiveTokenMask> GetCache(
+      const uint64_t& fsm_hash,
+      int32_t fsm_new_node_id,
+      const int32_t& state_cnt,
+      const int32_t edge_cnt
+  );
+
+  bool AddCache(
+      const uint64_t& fsm_hash,
+      int32_t fsm_new_node_id,
+      const int32_t& state_cnt,
+      const int32_t edge_cnt,
+      const AdaptiveTokenMask& token_mask
+  );
+
+  bool AddCache(
+      const uint64_t& fsm_hash,
+      int32_t fsm_new_node_id,
+      const int32_t& state_cnt,
+      const int32_t edge_cnt,
+      AdaptiveTokenMask&& token_mask
+  );
+
+  void ClearCache();
+
+  friend size_t MemorySize(const Impl* impl) {
+    int64_t total = 0;
+    for (const auto& shard : impl->shards_) {
+      total += shard.current_cache_memory_size;
+    }
+    return total;
+  }
+
+  size_t GetMaxSize() const { return max_cache_memory_size_; }
+
+ private:
+  /*!
+   * \brief The cache is sharded to reduce lock contention: the token mask cache generation
+   * queries and inserts from all compilation threads, and a single global mutex would serialize
+   * them (large grammars issue millions of cache operations).
+   */
+  static constexpr size_t kNumShards = 16;
+
+  struct Shard {
+    std::mutex mutex;
+    int64_t current_cache_memory_size = 0;
+    // The cache map: (fsm_hash, node_id, ...) -> index in cache_list
+    List<NodeType> cache_list;
+    std::unordered_map<NodeKey, int> cache;
+  };
+
+  Shard& GetShard(const NodeKey& key) {
+    return shards_[HashCombine(std::get<0>(key), std::get<1>(key)) % kNumShards];
+  }
+
+  /*! \brief The memory budget of one shard. Eviction is performed per shard. */
+  size_t ShardMaxSize() const {
+    return max_cache_memory_size_ == kUnlimitedSize ? kUnlimitedSize
+                                                    : max_cache_memory_size_ / kNumShards;
+  }
+
+  const size_t max_cache_memory_size_;
+  std::array<Shard, kNumShards> shards_;
+};
+
+std::optional<AdaptiveTokenMask> RuleLevelCache::GetCache(
+    const uint64_t& fsm_hash,
+    int32_t fsm_new_node_id,
+    const int32_t& state_cnt,
+    const int32_t edge_cnt
+) {
+  return pimpl_->GetCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
+}
+
+bool RuleLevelCache::AddCache(
+    const uint64_t& fsm_hash,
+    int32_t fsm_new_node_id,
+    const int32_t& state_cnt,
+    const int32_t edge_cnt,
+    const AdaptiveTokenMask& token_mask
+) {
+  return pimpl_->AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, token_mask);
+}
+
+bool RuleLevelCache::AddCache(
+    const uint64_t& fsm_hash,
+    int32_t fsm_new_node_id,
+    const int32_t& state_cnt,
+    const int32_t edge_cnt,
+    AdaptiveTokenMask&& token_mask
+) {
+  return pimpl_->AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, std::move(token_mask));
+}
+
+void RuleLevelCache::ClearCache() { pimpl_->ClearCache(); }
+
+size_t RuleLevelCache::GetMaxSize() const { return pimpl_->GetMaxSize(); }
+
+std::optional<AdaptiveTokenMask> RuleLevelCache::Impl::GetCache(
+    const uint64_t& fsm_hash,
+    int32_t fsm_new_node_id,
+    const int32_t& state_cnt,
+    const int32_t edge_cnt
+) {
+  // Find in the cache.
+  NodeKey key = std::make_tuple(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
+  Shard& shard = GetShard(key);
+  std::lock_guard<std::mutex> lock(shard.mutex);
+  auto it = shard.cache.find(key);
+  if (it == shard.cache.end()) {
+    return std::nullopt;
+  }
+
+  // Move the node to the back of the list.
+  shard.cache_list.MoveBack(it->second);
+  return List<NodeType>::iterator(it->second, shard.cache_list)->second;
+}
+
+bool RuleLevelCache::Impl::AddCache(
+    const uint64_t& fsm_hash,
+    int32_t fsm_new_node_id,
+    const int32_t& state_cnt,
+    const int32_t edge_cnt,
+    const AdaptiveTokenMask& token_mask
+) {
+  return AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, AdaptiveTokenMask(token_mask));
+}
+
+bool RuleLevelCache::Impl::AddCache(
+    const uint64_t& fsm_hash,
+    int32_t fsm_new_node_id,
+    const int32_t& state_cnt,
+    const int32_t edge_cnt,
+    AdaptiveTokenMask&& token_mask
+) {
+  // Check if we can add to the cache.
+  NodeKey key = std::make_tuple(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
+  Shard& shard = GetShard(key);
+  const size_t shard_max_size = ShardMaxSize();
+  std::lock_guard<std::mutex> lock(shard.mutex);
+  if (shard_max_size != kUnlimitedSize && MemorySize(token_mask) > shard_max_size) {
+    // The token mask is too large to be cached.
+    return false;
+  }
+  if (shard.cache.find(key) != shard.cache.end()) {
+    // Already exists.
+    return false;
+  }
+
+  // Evict old entries if needed.
+  if (shard_max_size != kUnlimitedSize) {
+    size_t new_item_size = MemorySize(token_mask);
+    while ((shard.current_cache_memory_size) > static_cast<int64_t>(shard_max_size - new_item_size)
+    ) {
+      auto oldest_it = shard.cache_list.begin();
+      if (oldest_it == shard.cache_list.end()) {
+        // This should not happen if the size of the new item is smaller than
+        // the shard budget, but this is a safeguard.
+        break;
+      }
+      shard.current_cache_memory_size -= MemorySize(oldest_it->second);
+      shard.cache.erase(oldest_it->first);
+      shard.cache_list.Erase(oldest_it);
+    }
+  }
+
+  // Add to the cache.
+  auto new_it = shard.cache_list.PushBack(NodeType(key, std::move(token_mask)));
+  shard.current_cache_memory_size += MemorySize(new_it->second);
+  shard.cache[key] = new_it.Index();
+  return true;
+}
+
+RuleLevelCache::RuleLevelCache(size_t max_cache_memory_size)
+    : pimpl_(std::make_shared<Impl>(max_cache_memory_size)) {}
+
+void RuleLevelCache::Impl::ClearCache() {
+  for (auto& shard : shards_) {
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    shard.cache_list.Clear();
+    shard.cache.clear();
+    shard.current_cache_memory_size = 0;
+  }
+}
+
+size_t MemorySize(const RuleLevelCache& manager) { return MemorySize(manager.ImplPtr()); }
 
 /************** AdaptiveTokenMaskCache Generator **************/
 

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -119,6 +119,7 @@ class RuleLevelCache::Impl {
   friend size_t MemorySize(const Impl* impl) {
     int64_t total = 0;
     for (const auto& shard : impl->shards_) {
+      std::lock_guard<std::mutex> lock(shard.mutex);
       total += shard.current_cache_memory_size;
     }
     return total;
@@ -135,7 +136,7 @@ class RuleLevelCache::Impl {
   static constexpr size_t kNumShards = 16;
 
   struct Shard {
-    std::mutex mutex;
+    mutable std::mutex mutex;
     int64_t current_cache_memory_size = 0;
     // The cache map: (fsm_hash, node_id, ...) -> index in cache_list
     List<NodeType> cache_list;

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -3413,6 +3413,7 @@ std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index)
     bool is_start = current_old_state_id == fsm.GetStart();
     int current_new_state_id = original_state_id_to_new_id[current_old_state_id];
     bfs_queue.pop();
+    hash_and_target.clear();
 
     // Check if the current state is an end state.
     if (fsm.IsEndState(current_old_state_id)) {
@@ -3526,6 +3527,7 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
     int current_old_state_id = bfs_queue.front();
     int current_new_state_id = original_state_id_to_new_id[current_old_state_id];
     bfs_queue.pop();
+    hash_and_target.clear();
 
     // Check if the current state is an end state.
     if (fsm.IsEndState(current_old_state_id)) {

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -3821,9 +3821,10 @@ std::optional<uint64_t> GrammarFSMHasherImpl::HashSequence(
   const auto& sequence_expr = grammar->GetGrammarExpr(sequence_id);
   XGRAMMAR_DCHECK(sequence_expr.type == GrammarExprType::kSequence)
       << "GrammarExpr is not a sequence";
+  hash_result = HashCombine(hash_result, sequence_expr.size());
   for (const auto& expr_id : sequence_expr) {
     const auto& expr = grammar->GetGrammarExpr(expr_id);
-    hash_result = HashCombine(hash_result, static_cast<int32_t>(expr.type));
+    hash_result = HashCombine(hash_result, static_cast<int32_t>(expr.type), expr.size());
     switch (expr.type) {
       case (GrammarExprType::kByteString):
       case (GrammarExprType::kCharacterClass):

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -3151,7 +3151,7 @@ class LazyBodyFlattenerImpl : public GrammarMutator {
 
 class GrammarOptimizerImpl {
  public:
-  static Grammar Apply(const Grammar& grammar) {
+  static Grammar Apply(const Grammar& grammar, bool expand_repetition_ranges) {
     // ByteStringFuser and RuleInliner rewrite the grammar in place, so work on a private copy: the
     // input grammar may be shared (e.g. a cached grammar) and must not be mutated. Copy the impl
     // directly (contiguous vector copies) instead of going through GrammarBuilder, which would
@@ -3159,7 +3159,9 @@ class GrammarOptimizerImpl {
     Grammar result(std::make_shared<Grammar::Impl>(*grammar.operator->()));
     ByteStringFuser::Apply(&result);
     RuleInliner::Apply(&result);
-    result = RepetitionRangeExpander::Apply(result);
+    if (expand_repetition_ranges) {
+      result = RepetitionRangeExpander::Apply(result);
+    }
     result = LazyBodyFlattenerImpl().Apply(result);
     result = DeadCodeEliminator::Apply(result);
     result = LookaheadAssertionAnalyzer::Apply(result);
@@ -3642,36 +3644,41 @@ std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index)
     // First, check the edges which are rule references (including repeat refs).
     // To keep consistent, we need to sort them with hashes.
     int32_t unhashed_rules_count = 0;
-    auto hash_rule_like_edge = [&](int32_t ref_rule_id, int32_t target) {
+    auto hash_rule_like_edge = [&](int32_t ref_rule_id,
+                                   int32_t target,
+                                   std::optional<std::pair<int32_t, int32_t>> repeat_bounds) {
+      uint64_t edge_hash;
       if (ref_rule_id == fsm_index) {
-        hash_and_target.insert({kSelfRecursionFlag, target});
-        return true;
-      }
-      if (!grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].has_value()) {
+        edge_hash = kSelfRecursionFlag;
+      } else if (!grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].has_value()) {
         if (!is_start) {
           return false;
-        } else {
-          unhashed_rules_count++;
-          if (unhashed_rules_count > 1) {
-            return false;
-          }
-          hash_and_target.insert({kUnKnownFlag, target});
         }
-        return true;
+        unhashed_rules_count++;
+        if (unhashed_rules_count > 1) {
+          return false;
+        }
+        edge_hash = kUnKnownFlag;
+      } else {
+        edge_hash = grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].value();
       }
-      hash_and_target.insert({grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].value(), target}
-      );
+      if (repeat_bounds.has_value()) {
+        edge_hash = HashCombine(edge_hash, repeat_bounds->first, repeat_bounds->second);
+      }
+      hash_and_target.insert({edge_hash, target});
       return true;
     };
 
     for (const auto& edge : sorted_edges_[current_old_state_id]) {
       if (edge.IsRuleRef()) {
-        if (!hash_rule_like_edge(edge.GetRefRuleId(), edge.target)) {
+        if (!hash_rule_like_edge(edge.GetRefRuleId(), edge.target, std::nullopt)) {
           return {false, 0};
         }
       } else if (edge.IsRepeatRef()) {
         auto info = grammar_->ImplPtr()->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
-        if (!hash_rule_like_edge(info.RuleId(), edge.target)) {
+        if (!hash_rule_like_edge(
+                info.RuleId(), edge.target, std::make_pair(info.Lower(), info.Upper())
+            )) {
           return {false, 0};
         }
       }
@@ -3997,8 +4004,8 @@ Grammar RepetitionRangeExpander::Apply(const Grammar& grammar) {
   return RepetitionRangeExpanderImpl().Apply(grammar);
 }
 
-Grammar GrammarOptimizer::Apply(const Grammar& grammar) {
-  return GrammarOptimizerImpl::Apply(grammar);
+Grammar GrammarOptimizer::Apply(const Grammar& grammar, bool expand_repetition_ranges) {
+  return GrammarOptimizerImpl::Apply(grammar, expand_repetition_ranges);
 }
 
 void ByteStringFuser::Apply(Grammar* grammar) { ByteStringFuserImpl().Apply(grammar); }

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1138,6 +1138,32 @@ class RuleRefGraphFinder : public GrammarVisitor<std::vector<std::vector<int32_t
   int32_t cur_rule_id_;
 };
 
+static Result<const FSMWithStartEnd*> GetOrBuildRegexFSM(
+    const std::string& regex,
+    bool json_string,
+    std::unordered_map<std::string, FSMWithStartEnd>& regex_fsm_cache
+) {
+  std::string cache_key;
+  cache_key.reserve(regex.size() + 1);
+  cache_key.push_back(static_cast<char>(json_string));
+  cache_key.append(regex);
+
+  auto cached = regex_fsm_cache.find(cache_key);
+  if (cached != regex_fsm_cache.end()) {
+    return ResultOk<const FSMWithStartEnd*>(&cached->second);
+  }
+
+  auto build_result = json_string ? RegexFSMBuilder::BuildWithForbiddenChars(
+                                        regex, GrammarFSMBuilder::JSONStringForbiddenChars()
+                                    )
+                                  : RegexFSMBuilder::Build(regex);
+  if (build_result.IsErr()) {
+    return ResultErr(std::move(build_result).UnwrapErr());
+  }
+  cached = regex_fsm_cache.emplace(std::move(cache_key), std::move(build_result).Unwrap()).first;
+  return ResultOk<const FSMWithStartEnd*>(&cached->second);
+}
+
 /*!
  * \brief Analyzes which rules in a grammar can match the empty string.
  */
@@ -1146,11 +1172,18 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
   AllowEmptyRuleAnalyzerImpl() = default;
 
   std::vector<int32_t> Apply(const Grammar& grammar) final {
+    std::unordered_map<std::string, FSMWithStartEnd> regex_fsm_cache;
+    return Apply(grammar, regex_fsm_cache);
+  }
+
+  std::vector<int32_t> Apply(
+      const Grammar& grammar, std::unordered_map<std::string, FSMWithStartEnd>& regex_fsm_cache
+  ) {
     InitGrammar(grammar);
 
     // Step 1: Find rules that explicitly allow empty string
     std::unordered_set<int32_t> empty_rule_id_set;
-    FindExplicitEmptyRules(&empty_rule_id_set);
+    FindExplicitEmptyRules(&empty_rule_id_set, regex_fsm_cache);
 
     // Step 2: Find rules that indirectly allow empty string. Using the Bellman-Ford algorithm
     // on the rule reference graph.
@@ -1162,7 +1195,10 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
     return result;
   }
 
-  void FindExplicitEmptyRules(std::unordered_set<int32_t>* empty_rule_id_set) {
+  void FindExplicitEmptyRules(
+      std::unordered_set<int32_t>* empty_rule_id_set,
+      std::unordered_map<std::string, FSMWithStartEnd>& regex_fsm_cache
+  ) {
     for (int i = 0; i < static_cast<int>(base_grammar_->NumRules()); ++i) {
       auto rule = base_grammar_->GetRule(i);
       auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
@@ -1175,13 +1211,15 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
       if (grammar_expr.type == GrammarExprType::kRegex) {
         // A regex rule allows empty iff an end state is in the epsilon closure of the start
         // state of its automaton. Build errors are reported by GrammarFSMBuilder later.
-        auto regex_fsm_result = RegexFSMBuilder::Build(base_grammar_->GetRegexString(grammar_expr));
+        const auto& regex = base_grammar_->GetRegexString(grammar_expr);
+        const bool json_string = base_grammar_->GetRegexIsJSONString(grammar_expr);
+        auto regex_fsm_result = GetOrBuildRegexFSM(regex, json_string, regex_fsm_cache);
         if (regex_fsm_result.IsOk()) {
-          auto regex_fsm = std::move(regex_fsm_result).Unwrap();
-          std::unordered_set<int> start_closure{regex_fsm.GetStart()};
-          regex_fsm.GetFsm().GetEpsilonClosure(&start_closure);
+          const auto* regex_fsm = std::move(regex_fsm_result).Unwrap();
+          std::unordered_set<int> start_closure{regex_fsm->GetStart()};
+          regex_fsm->GetFsm().GetEpsilonClosure(&start_closure);
           if (std::any_of(start_closure.begin(), start_closure.end(), [&](int state) {
-                return regex_fsm.IsEndState(state);
+                return regex_fsm->IsEndState(state);
               })) {
             empty_rule_id_set->insert(i);
           }
@@ -1303,16 +1341,25 @@ class GrammarFSMBuilderImpl {
   const static uint32_t kMin4BytesUnicode = 0xF0808080;
   const static uint32_t kMax4BytesUnicode = 0xF7BFBFBF;
 
-  explicit GrammarFSMBuilderImpl(FSM& target_fsm, const std::string* rule_name = nullptr)
-      : target_fsm_(target_fsm), rule_name_(rule_name) {}
+  using RegexFSMCache = std::unordered_map<std::string, FSMWithStartEnd>;
 
-  static void Apply(Grammar* grammar) {
+  explicit GrammarFSMBuilderImpl(
+      FSM& target_fsm,
+      const std::string* rule_name = nullptr,
+      RegexFSMCache* regex_fsm_cache = nullptr
+  )
+      : target_fsm_(target_fsm), rule_name_(rule_name), regex_fsm_cache_(regex_fsm_cache) {}
+
+  static void Apply(Grammar* grammar, RegexFSMCache* supplied_regex_fsm_cache = nullptr) {
     FSM complete_fsm;
     std::vector<std::optional<FSMWithStartEndWithSize>> per_rule_fsms((*grammar)->NumRules());
     std::vector<int> state_mapping;
+    RegexFSMCache local_regex_fsm_cache;
+    RegexFSMCache* regex_fsm_cache =
+        supplied_regex_fsm_cache != nullptr ? supplied_regex_fsm_cache : &local_regex_fsm_cache;
 
     for (int i = 0; i < (*grammar)->NumRules(); ++i) {
-      auto rule_fsm = BuildRuleFSM(*grammar, i);
+      auto rule_fsm = BuildRuleFSM(*grammar, i, regex_fsm_cache);
       per_rule_fsms[i] = rule_fsm.AddToCompleteFSM(&complete_fsm, &state_mapping);
     }
 
@@ -1364,9 +1411,14 @@ class GrammarFSMBuilderImpl {
   );
 
  private:
-  static FSMWithStartEnd BuildRuleFSM(const Grammar& grammar, int rule_id);
+  static FSMWithStartEnd BuildRuleFSM(
+      const Grammar& grammar, int rule_id, RegexFSMCache* regex_fsm_cache = nullptr
+  );
   static FSMWithStartEnd BuildExpressionFSM(
-      const GrammarExpr& expr, const Grammar& grammar, const std::string* rule_name = nullptr
+      const GrammarExpr& expr,
+      const Grammar& grammar,
+      const std::string* rule_name = nullptr,
+      RegexFSMCache* regex_fsm_cache = nullptr
   );
   void BuildExpression(
       const GrammarExpr& expr,
@@ -1415,11 +1467,13 @@ class GrammarFSMBuilderImpl {
   );
   void AddCharacterClassTransitions(const GrammarExpr& expr, int start_state, int end_state);
   void BuildNegativeCharacterClass(const GrammarExpr& expr, int start_state, int end_state);
-  void AppendFSM(FSMWithStartEnd fsm, int start_state, std::vector<int32_t>* end_states);
+  void AppendFSM(FSMWithStartEnd&& fsm, int start_state, std::vector<int32_t>* end_states);
+  void AppendFSM(const FSMWithStartEnd& fsm, int start_state, std::vector<int32_t>* end_states);
   void AddCharacterRange(int from, int to, uint32_t min, uint32_t max);
 
   FSM& target_fsm_;
   const std::string* rule_name_;
+  RegexFSMCache* regex_fsm_cache_;
 };
 
 // This function will add a range [min, max] of characters to the FSM, and the length
@@ -1712,18 +1766,25 @@ void GrammarFSMBuilderImpl::BuildCharacterClassStar(
   end_states->push_back(start_state);
 }
 
-FSMWithStartEnd GrammarFSMBuilderImpl::BuildRuleFSM(const Grammar& grammar, int rule_id) {
+FSMWithStartEnd GrammarFSMBuilderImpl::BuildRuleFSM(
+    const Grammar& grammar, int rule_id, RegexFSMCache* regex_fsm_cache
+) {
   const auto& rule = grammar->GetRule(rule_id);
-  return BuildExpressionFSM(grammar->GetGrammarExpr(rule.body_expr_id), grammar, &rule.name);
+  return BuildExpressionFSM(
+      grammar->GetGrammarExpr(rule.body_expr_id), grammar, &rule.name, regex_fsm_cache
+  );
 }
 
 FSMWithStartEnd GrammarFSMBuilderImpl::BuildExpressionFSM(
-    const GrammarExpr& expr, const Grammar& grammar, const std::string* rule_name
+    const GrammarExpr& expr,
+    const Grammar& grammar,
+    const std::string* rule_name,
+    RegexFSMCache* regex_fsm_cache
 ) {
   FSM result_fsm;
   int start_state = result_fsm.AddState();
   std::vector<int32_t> end_states;
-  GrammarFSMBuilderImpl builder(result_fsm, rule_name);
+  GrammarFSMBuilderImpl builder(result_fsm, rule_name, regex_fsm_cache);
   builder.BuildExpression(expr, grammar, start_state, &end_states);
   FSMWithStartEnd result(result_fsm, start_state, std::move(end_states));
   if (expr.type != ExprType::kTagDispatch && expr.type != ExprType::kTokenTagDispatch) {
@@ -1999,7 +2060,7 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Choices(
 }
 
 void GrammarFSMBuilderImpl::AppendFSM(
-    FSMWithStartEnd fsm, int start_state, std::vector<int32_t>* end_states
+    FSMWithStartEnd&& fsm, int start_state, std::vector<int32_t>* end_states
 ) {
   const bool target_is_empty = target_fsm_.NumStates() == 1 && start_state == 0 &&
                                target_fsm_.GetEdges(0).empty() &&
@@ -2010,6 +2071,12 @@ void GrammarFSMBuilderImpl::AppendFSM(
     return;
   }
 
+  AppendFSM(static_cast<const FSMWithStartEnd&>(fsm), start_state, end_states);
+}
+
+void GrammarFSMBuilderImpl::AppendFSM(
+    const FSMWithStartEnd& fsm, int start_state, std::vector<int32_t>* end_states
+) {
   std::vector<int> state_mapping;
   target_fsm_.AddFSM(fsm.GetFsm(), &state_mapping);
   target_fsm_.AddEpsilonEdge(start_state, state_mapping[fsm.GetStart()]);
@@ -2023,6 +2090,21 @@ void GrammarFSMBuilderImpl::AppendFSM(
 void GrammarFSMBuilderImpl::BuildRegex(
     const std::string& regex, bool json_string, int start_state, std::vector<int32_t>* end_states
 ) {
+  if (regex_fsm_cache_ != nullptr) {
+    auto regex_fsm_result = GetOrBuildRegexFSM(regex, json_string, *regex_fsm_cache_);
+    if (regex_fsm_result.IsErr()) {
+      auto error = std::move(regex_fsm_result).UnwrapErr();
+      if (rule_name_ != nullptr) {
+        XGRAMMAR_LOG(FATAL) << "Failed to build the automaton for rule " << *rule_name_
+                            << " with regex " << regex << ": " << error.what();
+      }
+      XGRAMMAR_LOG(FATAL) << "Failed to build the automaton for regex " << regex << ": "
+                          << error.what();
+    }
+    AppendFSM(*std::move(regex_fsm_result).Unwrap(), start_state, end_states);
+    return;
+  }
+
   auto build_result = json_string ? RegexFSMBuilder::BuildWithForbiddenChars(
                                         regex, GrammarFSMBuilder::JSONStringForbiddenChars()
                                     )
@@ -2993,10 +3075,11 @@ class GrammarOptimizerImpl {
     result = LazyBodyFlattenerImpl().Apply(result);
     result = DeadCodeEliminator::Apply(result);
     result = LookaheadAssertionAnalyzer::Apply(result);
-    result->allow_empty_rule_ids = AllowEmptyRuleAnalyzer::Apply(result);
+    GrammarFSMBuilderImpl::RegexFSMCache regex_fsm_cache;
+    result->allow_empty_rule_ids = AllowEmptyRuleAnalyzerImpl().Apply(result, regex_fsm_cache);
     ValidateLazyRules(result);
     RepetitionNormalizer::Apply(&result);
-    GrammarFSMBuilder::Apply(&result);
+    GrammarFSMBuilderImpl::Apply(&result, &regex_fsm_cache);
     result->optimized = true;
     return result;
   }

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1459,7 +1459,14 @@ class GrammarFSMBuilderImpl {
       int start_state,
       std::vector<int32_t>* end_states
   );
-  void BuildChoices(
+  // Returns whether the specialized choice builder handled the whole expression.
+  bool BuildChoices(
+      const GrammarExpr& expr,
+      const Grammar& grammar,
+      int start_state,
+      std::vector<int32_t>* end_states
+  );
+  bool BuildByteStringRuleRefChoices(
       const GrammarExpr& expr,
       const Grammar& grammar,
       int start_state,
@@ -1785,11 +1792,18 @@ FSMWithStartEnd GrammarFSMBuilderImpl::BuildExpressionFSM(
   int start_state = result_fsm.AddState();
   std::vector<int32_t> end_states;
   GrammarFSMBuilderImpl builder(result_fsm, rule_name, regex_fsm_cache);
-  builder.BuildExpression(expr, grammar, start_state, &end_states);
+  bool skip_equivalent_state_merge = false;
+  if (expr.type == ExprType::kChoices) {
+    skip_equivalent_state_merge = builder.BuildChoices(expr, grammar, start_state, &end_states);
+  } else {
+    builder.BuildExpression(expr, grammar, start_state, &end_states);
+  }
   FSMWithStartEnd result(result_fsm, start_state, std::move(end_states));
   if (expr.type != ExprType::kTagDispatch && expr.type != ExprType::kTokenTagDispatch) {
     result = result.SimplifyEpsilon();
-    result = result.MergeEquivalentStates();
+    if (!skip_equivalent_state_merge) {
+      result = result.MergeEquivalentStates();
+    }
   }
   return result;
 }
@@ -1880,8 +1894,10 @@ void GrammarFSMBuilderImpl::BuildExpression(
       return BuildExcludeToken(expr, start_state, end_states);
     case ExprType::kSequence:
       return BuildSequence(expr, grammar, start_state, end_states);
-    case ExprType::kChoices:
-      return BuildChoices(expr, grammar, start_state, end_states);
+    case ExprType::kChoices: {
+      BuildChoices(expr, grammar, start_state, end_states);
+      return;
+    }
     case ExprType::kRegex:
       return BuildRegex(
           grammar->GetRegexString(expr),
@@ -1997,7 +2013,7 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Sequence(
   return FSMWithStartEnd(result_fsm, start_state, std::move(end_states));
 }
 
-void GrammarFSMBuilderImpl::BuildChoices(
+bool GrammarFSMBuilderImpl::BuildChoices(
     const GrammarExpr& expr,
     const Grammar& grammar,
     int start_state,
@@ -2020,7 +2036,7 @@ void GrammarFSMBuilderImpl::BuildChoices(
 
   if (non_empty_choice_count == 0) {
     end_states->push_back(start_state);
-    return;
+    return false;
   }
 
   if (non_empty_choice_count == 1 && !nullable) {
@@ -2028,10 +2044,14 @@ void GrammarFSMBuilderImpl::BuildChoices(
       const auto& choice_expr = grammar->GetGrammarExpr(choice_id);
       if (choice_expr.type != ExprType::kEmptyStr) {
         BuildExpression(choice_expr, grammar, start_state, end_states);
-        return;
+        return false;
       }
     }
     XGRAMMAR_UNREACHABLE();
+  }
+
+  if (!nullable && BuildByteStringRuleRefChoices(expr, grammar, start_state, end_states)) {
+    return true;
   }
 
   std::vector<int32_t> branch_end_states;
@@ -2051,6 +2071,79 @@ void GrammarFSMBuilderImpl::BuildChoices(
     target_fsm_.AddEpsilonEdge(start_state, nullable_branch_state);
     end_states->push_back(nullable_branch_state);
   }
+  return false;
+}
+
+bool GrammarFSMBuilderImpl::BuildByteStringRuleRefChoices(
+    const GrammarExpr& expr,
+    const Grammar& grammar,
+    int start_state,
+    std::vector<int32_t>* end_states
+) {
+  struct Branch {
+    std::string prefix;
+    int32_t rule_id;
+    std::string suffix;
+  };
+
+  std::vector<Branch> branches;
+  branches.reserve(expr.size());
+  std::vector<std::string> prefixes;
+  prefixes.reserve(expr.size());
+  for (int32_t choice_id : expr) {
+    const auto& sequence = grammar->GetGrammarExpr(choice_id);
+    if (sequence.type != ExprType::kSequence || sequence.size() != 3) {
+      return false;
+    }
+    const auto& prefix = grammar->GetGrammarExpr(sequence[0]);
+    const auto& rule_ref = grammar->GetGrammarExpr(sequence[1]);
+    const auto& suffix = grammar->GetGrammarExpr(sequence[2]);
+    if (prefix.type != ExprType::kByteString || rule_ref.type != ExprType::kRuleRef ||
+        suffix.type != ExprType::kByteString) {
+      return false;
+    }
+
+    Branch branch;
+    branch.prefix.reserve(prefix.size());
+    for (int32_t byte : prefix) {
+      branch.prefix.push_back(static_cast<char>(static_cast<uint8_t>(byte)));
+    }
+    branch.rule_id = rule_ref[0];
+    branch.suffix.reserve(suffix.size());
+    for (int32_t byte : suffix) {
+      branch.suffix.push_back(static_cast<char>(static_cast<uint8_t>(byte)));
+    }
+    prefixes.push_back(branch.prefix);
+    branches.push_back(std::move(branch));
+  }
+
+  std::vector<int32_t> prefix_end_states;
+  auto trie = TrieFSMBuilder::Build(prefixes, {}, &prefix_end_states, true, false);
+  XGRAMMAR_DCHECK(trie.has_value());
+
+  std::vector<int> state_mapping;
+  target_fsm_.AddFSM(trie->GetFsm(), &state_mapping);
+  target_fsm_.AddEpsilonEdge(start_state, state_mapping[trie->GetStart()]);
+
+  std::unordered_map<std::string, int32_t> suffix_start_states;
+  suffix_start_states.reserve(branches.size());
+  end_states->clear();
+  for (int index = 0; index < static_cast<int>(branches.size()); ++index) {
+    const auto& branch = branches[index];
+    auto [it, inserted] = suffix_start_states.emplace(branch.suffix, -1);
+    if (inserted) {
+      int32_t current_state = target_fsm_.AddState();
+      it->second = current_state;
+      for (uint8_t byte : branch.suffix) {
+        int32_t next_state = target_fsm_.AddState();
+        target_fsm_.AddEdge(current_state, next_state, byte, byte);
+        current_state = next_state;
+      }
+      end_states->push_back(current_state);
+    }
+    target_fsm_.AddRuleEdge(state_mapping[prefix_end_states[index]], it->second, branch.rule_id);
+  }
+  return true;
 }
 
 std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Choices(

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -7,25 +7,20 @@
 
 #include <xgrammar/xgrammar.h>
 
-#include <array>
 #include <bitset>
 #include <cstdint>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <queue>
 #include <set>
 #include <stack>
 #include <string>
-#include <tuple>
 #include <vector>
 
-#include "compiled_grammar_impl.h"
 #include "fsm.h"
 #include "fsm_builder.h"
 #include "grammar_builder.h"
 #include "grammar_impl.h"
-#include "support/container.h"
 #include "support/encoding.h"
 #include "support/logging.h"
 #include "xgrammar/grammar.h"
@@ -3883,204 +3878,6 @@ std::optional<uint64_t> GrammarFSMHasherImpl::HashSequence(
   }
   return hash_result;
 }
-
-class RuleLevelCache::Impl {
- public:
-  using NodeKey = std::tuple<
-      uint64_t /*The hash value of the FSM*/,
-      int32_t /* The normalized node id*/,
-      int32_t /*The number of states*/,
-      int32_t /* The number of edges*/>;
-  using NodeType = std::pair<NodeKey, AdaptiveTokenMask>;
-
-  explicit Impl(size_t max_cache_memory_size) : max_cache_memory_size_(max_cache_memory_size) {}
-
-  std::optional<AdaptiveTokenMask> GetCache(
-      const uint64_t& fsm_hash,
-      int32_t fsm_new_node_id,
-      const int32_t& state_cnt,
-      const int32_t edge_cnt
-  );
-
-  bool AddCache(
-      const uint64_t& fsm_hash,
-      int32_t fsm_new_node_id,
-      const int32_t& state_cnt,
-      const int32_t edge_cnt,
-      const AdaptiveTokenMask& token_mask
-  );
-
-  bool AddCache(
-      const uint64_t& fsm_hash,
-      int32_t fsm_new_node_id,
-      const int32_t& state_cnt,
-      const int32_t edge_cnt,
-      AdaptiveTokenMask&& token_mask
-  );
-
-  void ClearCache();
-
-  friend size_t MemorySize(const Impl* impl) {
-    int64_t total = 0;
-    for (const auto& shard : impl->shards_) {
-      total += shard.current_cache_memory_size;
-    }
-    return total;
-  }
-
-  size_t GetMaxSize() const { return max_cache_memory_size_; }
-
- private:
-  /*!
-   * \brief The cache is sharded to reduce lock contention: the token mask cache generation
-   * queries and inserts from all compilation threads, and a single global mutex would serialize
-   * them (large grammars issue millions of cache operations).
-   */
-  static constexpr size_t kNumShards = 16;
-
-  struct Shard {
-    std::mutex mutex;
-    int64_t current_cache_memory_size = 0;
-    // The cache map: (fsm_hash, node_id, ...) -> index in cache_list
-    List<NodeType> cache_list;
-    std::unordered_map<NodeKey, int> cache;
-  };
-
-  Shard& GetShard(const NodeKey& key) {
-    return shards_[HashCombine(std::get<0>(key), std::get<1>(key)) % kNumShards];
-  }
-
-  /*! \brief The memory budget of one shard. Eviction is performed per shard. */
-  size_t ShardMaxSize() const {
-    return max_cache_memory_size_ == kUnlimitedSize ? kUnlimitedSize
-                                                    : max_cache_memory_size_ / kNumShards;
-  }
-
-  const size_t max_cache_memory_size_;
-  std::array<Shard, kNumShards> shards_;
-};
-
-std::optional<AdaptiveTokenMask> RuleLevelCache::GetCache(
-    const uint64_t& fsm_hash,
-    int32_t fsm_new_node_id,
-    const int32_t& state_cnt,
-    const int32_t edge_cnt
-) {
-  return pimpl_->GetCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
-}
-
-bool RuleLevelCache::AddCache(
-    const uint64_t& fsm_hash,
-    int32_t fsm_new_node_id,
-    const int32_t& state_cnt,
-    const int32_t edge_cnt,
-    const AdaptiveTokenMask& token_mask
-) {
-  return pimpl_->AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, token_mask);
-}
-
-bool RuleLevelCache::AddCache(
-    const uint64_t& fsm_hash,
-    int32_t fsm_new_node_id,
-    const int32_t& state_cnt,
-    const int32_t edge_cnt,
-    AdaptiveTokenMask&& token_mask
-) {
-  return pimpl_->AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, std::move(token_mask));
-}
-
-void RuleLevelCache::ClearCache() { pimpl_->ClearCache(); }
-
-size_t RuleLevelCache::GetMaxSize() const { return pimpl_->GetMaxSize(); }
-
-std::optional<AdaptiveTokenMask> RuleLevelCache::Impl::GetCache(
-    const uint64_t& fsm_hash,
-    int32_t fsm_new_node_id,
-    const int32_t& state_cnt,
-    const int32_t edge_cnt
-) {
-  // Find in the cache.
-  NodeKey key = std::make_tuple(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
-  Shard& shard = GetShard(key);
-  std::lock_guard<std::mutex> lock(shard.mutex);
-  auto it = shard.cache.find(key);
-  if (it == shard.cache.end()) {
-    return std::nullopt;
-  }
-
-  // Move the node to the back of the list.
-  shard.cache_list.MoveBack(it->second);
-  return List<NodeType>::iterator(it->second, shard.cache_list)->second;
-}
-
-bool RuleLevelCache::Impl::AddCache(
-    const uint64_t& fsm_hash,
-    int32_t fsm_new_node_id,
-    const int32_t& state_cnt,
-    const int32_t edge_cnt,
-    const AdaptiveTokenMask& token_mask
-) {
-  return AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, AdaptiveTokenMask(token_mask));
-}
-
-bool RuleLevelCache::Impl::AddCache(
-    const uint64_t& fsm_hash,
-    int32_t fsm_new_node_id,
-    const int32_t& state_cnt,
-    const int32_t edge_cnt,
-    AdaptiveTokenMask&& token_mask
-) {
-  // Check if we can add to the cache.
-  NodeKey key = std::make_tuple(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
-  Shard& shard = GetShard(key);
-  const size_t shard_max_size = ShardMaxSize();
-  std::lock_guard<std::mutex> lock(shard.mutex);
-  if (shard_max_size != kUnlimitedSize && MemorySize(token_mask) > shard_max_size) {
-    // The token mask is too large to be cached.
-    return false;
-  }
-  if (shard.cache.find(key) != shard.cache.end()) {
-    // Already exists.
-    return false;
-  }
-
-  // Evict old entries if needed.
-  if (shard_max_size != kUnlimitedSize) {
-    size_t new_item_size = MemorySize(token_mask);
-    while ((shard.current_cache_memory_size) > static_cast<int64_t>(shard_max_size - new_item_size)
-    ) {
-      auto oldest_it = shard.cache_list.begin();
-      if (oldest_it == shard.cache_list.end()) {
-        // This should not happen if the size of the new item is smaller than
-        // the shard budget, but this is a safeguard.
-        break;
-      }
-      shard.current_cache_memory_size -= MemorySize(oldest_it->second);
-      shard.cache.erase(oldest_it->first);
-      shard.cache_list.Erase(oldest_it);
-    }
-  }
-
-  // Add to the cache.
-  auto new_it = shard.cache_list.PushBack(NodeType(key, std::move(token_mask)));
-  shard.current_cache_memory_size += MemorySize(new_it->second);
-  shard.cache[key] = new_it.Index();
-  return true;
-}
-
-RuleLevelCache::RuleLevelCache(size_t max_cache_memory_size)
-    : pimpl_(std::make_shared<Impl>(max_cache_memory_size)) {}
-
-void RuleLevelCache::Impl::ClearCache() {
-  for (auto& shard : shards_) {
-    std::lock_guard<std::mutex> lock(shard.mutex);
-    shard.cache_list.Clear();
-    shard.cache.clear();
-    shard.current_cache_memory_size = 0;
-  }
-}
-
-size_t MemorySize(const RuleLevelCache& manager) { return MemorySize(manager.ImplPtr()); }
 
 /*************************** Forward grammar constructors to their impl ***************************/
 

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -3351,6 +3351,16 @@ class GrammarFSMHasherImpl {
   uint64_t HashFsm(int fsm_index);
 
   /*!
+   * \brief Add a non-rule edge to an FSM hash using its semantic payload.
+   */
+  uint64_t HashNonRuleEdge(
+      uint64_t hash_result,
+      int32_t current_new_state_id,
+      const FSMEdge& edge,
+      int32_t target_new_state_id
+  ) const;
+
+  /*!
    * \brief Find a simple cycle in the reference graph, And hash the
    * fsms in the simple cycle.
    */
@@ -3572,6 +3582,32 @@ void GrammarFSMHasherImpl::Apply(Grammar* grammar) {
   }
 }
 
+uint64_t GrammarFSMHasherImpl::HashNonRuleEdge(
+    uint64_t hash_result,
+    int32_t current_new_state_id,
+    const FSMEdge& edge,
+    int32_t target_new_state_id
+) const {
+  hash_result = HashCombine(hash_result, current_new_state_id, static_cast<int32_t>(edge.min));
+  if (edge.IsToken()) {
+    const auto token_edge = grammar_->ImplPtr()->complete_fsm.GetTokenEdgeInfo(edge.GetAuxIndex());
+    hash_result = HashCombine(hash_result, token_edge.Count());
+    for (int32_t index = 0; index < token_edge.Count(); ++index) {
+      hash_result = HashCombine(hash_result, token_edge.TokenIds()[index]);
+    }
+  } else if (edge.IsExcludeToken()) {
+    const auto exclude_token_edge =
+        grammar_->ImplPtr()->complete_fsm.GetExcludeTokenEdgeInfo(edge.GetAuxIndex());
+    hash_result = HashCombine(hash_result, exclude_token_edge.Count());
+    for (int32_t index = 0; index < exclude_token_edge.Count(); ++index) {
+      hash_result = HashCombine(hash_result, exclude_token_edge.TokenIds()[index]);
+    }
+  } else {
+    hash_result = HashCombine(hash_result, static_cast<int32_t>(edge.max));
+  }
+  return HashCombine(hash_result, target_new_state_id);
+}
+
 std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index) {
   uint64_t hash_result = 0;
   XGRAMMAR_DCHECK(fsm_index >= 0 && fsm_index < (*grammar_)->NumRules())
@@ -3668,13 +3704,7 @@ std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index)
       if (edge.IsRuleRef() || edge.IsRepeatRef()) {
         continue;
       }
-      hash_result = HashCombine(
-          hash_result,
-          current_new_state_id,
-          static_cast<int32_t>(edge.min),
-          static_cast<int32_t>(edge.max),
-          target_new_id
-      );
+      hash_result = HashNonRuleEdge(hash_result, current_new_state_id, edge, target_new_id);
     }
   }
   std::vector<std::pair<int32_t, int32_t>> new_id_mapping;
@@ -3695,7 +3725,7 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
   std::map<int32_t, int32_t> original_state_id_to_new_id;
   original_state_id_to_new_id[fsm.GetStart()] = 0;
   std::queue<int32_t> bfs_queue;
-  std::set<std::pair<int32_t, int32_t>> hash_and_target;
+  std::set<std::pair<uint64_t, int32_t>> hash_and_target;
   bfs_queue.push(fsm.GetStart());
 
   // Perform a bfs to hash all the edges.
@@ -3746,7 +3776,7 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
           XGRAMMAR_CHECK(grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].has_value());
           uint64_t base_hash = grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].value();
           uint64_t repeat_hash = HashCombine(base_hash, info.Lower(), info.Upper());
-          hash_and_target.insert({static_cast<int32_t>(repeat_hash), edge.target});
+          hash_and_target.insert({repeat_hash, edge.target});
         }
       }
     }
@@ -3773,13 +3803,7 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
       if (edge.IsRuleRef() || edge.IsRepeatRef()) {
         continue;
       }
-      hash_result = HashCombine(
-          hash_result,
-          current_new_state_id,
-          static_cast<int32_t>(edge.min),
-          static_cast<int32_t>(edge.max),
-          target_new_id
-      );
+      hash_result = HashNonRuleEdge(hash_result, current_new_state_id, edge, target_new_id);
     }
   }
   std::vector<std::pair<int32_t, int32_t>> new_id_mapping;

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -14,7 +14,6 @@
 #include <cstdint>
 #include <string>
 
-#include "compiled_grammar_impl.h"
 #include "grammar_builder.h"
 #include "grammar_impl.h"
 #include "support/utils.h"
@@ -458,46 +457,6 @@ class GrammarFSMHasher {
  public:
   static void Apply(Grammar* grammar);
   static std::optional<uint64_t> HashSequence(const Grammar& grammar, int32_t sequence_id);
-};
-
-/*!
- * \brief Store the crossing cache for different grammars.
- * \param max_cache_size The maximum size of the cache numbers.
- * \details LRU algorithm is implemented.
- */
-class RuleLevelCache {
- public:
-  static const size_t kUnlimitedSize = static_cast<size_t>(-1);
-
-  std::optional<AdaptiveTokenMask> GetCache(
-      const uint64_t& fsm_hash,
-      int32_t fsm_new_node_id,
-      const int32_t& state_cnt,
-      const int32_t edge_cnt
-  );
-  bool AddCache(
-      const uint64_t& fsm_hash,
-      int32_t fsm_new_node_id,
-      const int32_t& state_cnt,
-      const int32_t edge_cnt,
-      const AdaptiveTokenMask& token_mask
-  );
-  bool AddCache(
-      const uint64_t& fsm_hash,
-      int32_t fsm_new_node_id,
-      const int32_t& state_cnt,
-      const int32_t edge_cnt,
-      AdaptiveTokenMask&& token_mask
-  );
-  RuleLevelCache(size_t max_cache_memory_size = kUnlimitedSize);
-
-  void ClearCache();
-
-  size_t GetMaxSize() const;
-
-  friend size_t MemorySize(const RuleLevelCache& manager);
-
-  XGRAMMAR_DEFINE_PIMPL_METHODS(RuleLevelCache);
 };
 
 }  // namespace xgrammar

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -438,7 +438,7 @@ class RepetitionRangeExpander {
  */
 class GrammarOptimizer {
  public:
-  static Grammar Apply(const Grammar& grammar);
+  static Grammar Apply(const Grammar& grammar, bool expand_repetition_ranges = true);
 };
 
 /*!

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -790,26 +790,24 @@ GrammarMatcher::Impl::FindRepeatedCharacterClass(const ParserState& state) const
     if (completed_rule_id != state.rule_id || parent.rule_id < 0) {
       continue;
     }
-    for (const auto& edge : grammar_->complete_fsm.GetEdges(parent.element_id)) {
-      if (!edge.IsRepeatRef()) {
-        continue;
-      }
-      const auto repeat = grammar_->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
-      if (repeat.RuleId() != state.rule_id) {
-        continue;
-      }
-      const int32_t remaining =
-          repeat.Upper() == -1 ? max_token_characters : repeat.Upper() - parent.repeat_count;
-      if (remaining > 0) {
-        const bool upper_bound_is_stable =
-            repeat.Upper() == -1 || remaining >= max_token_characters;
-        return RepeatedCharacterClassState{
-            sequence[0],
-            upper_bound_is_stable ? -1 : std::min(remaining, max_token_characters),
-            parent,
-            repeat.Lower()
-        };
-      }
+    const auto& edges = grammar_->complete_fsm.GetEdges(parent.element_id);
+    if (edges.size() != 1 || !edges[0].IsRepeatRef()) {
+      continue;
+    }
+    const auto repeat = grammar_->complete_fsm.GetRepeatEdgeInfo(edges[0].GetAuxIndex());
+    if (repeat.RuleId() != state.rule_id) {
+      continue;
+    }
+    const int32_t remaining =
+        repeat.Upper() == -1 ? max_token_characters : repeat.Upper() - parent.repeat_count;
+    if (remaining > 0) {
+      const bool upper_bound_is_stable = repeat.Upper() == -1 || remaining >= max_token_characters;
+      return RepeatedCharacterClassState{
+          sequence[0],
+          upper_bound_is_stable ? -1 : std::min(remaining, max_token_characters),
+          parent,
+          repeat.Lower()
+      };
     }
   }
   return std::nullopt;

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -742,12 +742,6 @@ class GrammarMatcher::Impl : public EarleyParser {
   DynamicBitset tmp_accepted_bitset_;
   std::vector<int32_t> tmp_rejected_indices_;
   std::vector<int32_t> tmp_rejected_indices_delta_;
-  struct RepeatMaskCacheEntry {
-    RepeatTokenMaskKey key;
-    bool parser_completed;
-    DynamicBitset mask;
-  };
-  std::optional<RepeatMaskCacheEntry> repeat_mask_cache_;
 };
 
 std::optional<ParserState> GrammarMatcher::Impl::FindRepeatParent(const ParserState& state) const {
@@ -1880,26 +1874,8 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
   }
 
   std::optional<ParserState> single_repeat_parent;
-  std::optional<RepeatTokenMaskKey> repeat_mask_key;
   if (latest_states.size() == 1) {
     single_repeat_parent = FindRepeatParent(latest_states[0]);
-    if (single_repeat_parent.has_value()) {
-      repeat_mask_key = compiled_grammar_->token_mask_cache.GetRepeatTokenMaskKey(
-          latest_states[0], *single_repeat_parent, grammar_, tokenizer_info_
-      );
-      if (repeat_mask_cache_.has_value() && repeat_mask_cache_->key == *repeat_mask_key &&
-          repeat_mask_cache_->parser_completed == IsCompleted()) {
-        DynamicBitset output(
-            tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr)
-        );
-        output = repeat_mask_cache_->mask;
-        if (debug_print) {
-          XGRAMMAR_LOG(INFO) << "Filled bitmask: "
-                             << PrintBitmask(bitmask_data_ptr, tokenizer_info_);
-        }
-        return;
-      }
-    }
   }
 
   std::vector<std::pair<ParserState, const AdaptiveTokenMask*>> latest_states_with_masks;
@@ -1936,15 +1912,6 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
       SetTokenBitmask(
           bitmask_data_ptr, tmp_accepted_bitset_, tmp_rejected_indices_, IsCompleted(), false
       );
-      if (repeat_mask_key.has_value()) {
-        DynamicBitset output(
-            tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr)
-        );
-        DynamicBitset owned_mask(tokenizer_info_.GetVocabSize());
-        owned_mask = output;
-        repeat_mask_cache_ =
-            RepeatMaskCacheEntry{*repeat_mask_key, IsCompleted(), std::move(owned_mask)};
-      }
       if (debug_print) {
         XGRAMMAR_LOG(INFO) << "Filled bitmask: " << PrintBitmask(bitmask_data_ptr, tokenizer_info_);
       }

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -538,23 +538,7 @@ class GrammarMatcher::Impl : public EarleyParser {
  private:
   using StoreType = AdaptiveTokenMask::StoreType;
 
-  struct RepeatMaskCacheKey {
-    ParserState state;
-    int32_t parent_node_id;
-    int32_t lower_bound_distance;
-    int32_t upper_bound_distance;
-
-    bool operator==(const RepeatMaskCacheKey& other) const {
-      return StateEqualForCache()(state, other.state) && parent_node_id == other.parent_node_id &&
-             lower_bound_distance == other.lower_bound_distance &&
-             upper_bound_distance == other.upper_bound_distance;
-    }
-  };
-
   std::optional<ParserState> FindRepeatParent(const ParserState& state) const;
-
-  RepeatMaskCacheKey GetRepeatMaskCacheKey(const ParserState& state, const ParserState& parent)
-      const;
 
   /*!
    * \brief If is_uncertain_saved is true, find the next token in uncertain_indices. Otherwise,
@@ -759,7 +743,7 @@ class GrammarMatcher::Impl : public EarleyParser {
   std::vector<int32_t> tmp_rejected_indices_;
   std::vector<int32_t> tmp_rejected_indices_delta_;
   struct RepeatMaskCacheEntry {
-    RepeatMaskCacheKey key;
+    RepeatTokenMaskKey key;
     bool parser_completed;
     DynamicBitset mask;
   };
@@ -767,8 +751,8 @@ class GrammarMatcher::Impl : public EarleyParser {
 };
 
 std::optional<ParserState> GrammarMatcher::Impl::FindRepeatParent(const ParserState& state) const {
-  if (!compiled_grammar_->token_mask_cache.IsDynamic() || state.rule_id < 0 ||
-      !features_->IsRuleContextIndependent(state.rule_id) || state.rule_start_pos < 0 ||
+  if (state.rule_id < 0 || !features_->IsRuleContextIndependent(state.rule_id) ||
+      state.rule_start_pos < 0 ||
       state.rule_start_pos >= static_cast<int32_t>(rule_id_to_completable_states_.size())) {
     return std::nullopt;
   }
@@ -782,10 +766,12 @@ std::optional<ParserState> GrammarMatcher::Impl::FindRepeatParent(const ParserSt
     if (parent.rule_id < 0) {
       return std::nullopt;
     }
-    const auto& edges = grammar_->complete_fsm.GetEdges(parent.element_id);
-    if (edges.size() != 1 || !edges[0].IsRepeatRef()) {
+    if (!(features_->fsm_state_flags[parent.element_id] &
+          EarleyParserFeatures::kFsmStateRepeatSource)) {
       return std::nullopt;
     }
+    const auto& edges = grammar_->complete_fsm.GetEdges(parent.element_id);
+    XGRAMMAR_DCHECK(edges.size() == 1 && edges[0].IsRepeatRef());
     const auto repeat_info = grammar_->complete_fsm.GetRepeatEdgeInfo(edges[0].GetAuxIndex());
     if (repeat_info.RuleId() != state.rule_id) {
       return std::nullopt;
@@ -796,25 +782,6 @@ std::optional<ParserState> GrammarMatcher::Impl::FindRepeatParent(const ParserSt
     repeat_parent = parent;
   }
   return repeat_parent;
-}
-
-GrammarMatcher::Impl::RepeatMaskCacheKey GrammarMatcher::Impl::GetRepeatMaskCacheKey(
-    const ParserState& state, const ParserState& parent
-) const {
-  const auto& parent_edges = grammar_->complete_fsm.GetEdges(parent.element_id);
-  const auto repeat_info = grammar_->complete_fsm.GetRepeatEdgeInfo(parent_edges[0].GetAuxIndex());
-  const int32_t far_distance = tokenizer_info_.ImplPtr()->GetMaxTokenBytes() + 1;
-  const auto normalize_distance = [far_distance](int64_t distance) {
-    return static_cast<int32_t>(std::min<int64_t>(std::max<int64_t>(distance, 0), far_distance));
-  };
-  return RepeatMaskCacheKey{
-      state,
-      parent.element_id,
-      normalize_distance(static_cast<int64_t>(repeat_info.Lower()) - parent.repeat_count),
-      repeat_info.Upper() == -1
-          ? -1
-          : normalize_distance(static_cast<int64_t>(repeat_info.Upper()) - parent.repeat_count)
-  };
 }
 
 class BatchGrammarMatcher::Impl {
@@ -1913,11 +1880,13 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
   }
 
   std::optional<ParserState> single_repeat_parent;
-  std::optional<RepeatMaskCacheKey> repeat_mask_key;
+  std::optional<RepeatTokenMaskKey> repeat_mask_key;
   if (latest_states.size() == 1) {
     single_repeat_parent = FindRepeatParent(latest_states[0]);
     if (single_repeat_parent.has_value()) {
-      repeat_mask_key = GetRepeatMaskCacheKey(latest_states[0], *single_repeat_parent);
+      repeat_mask_key = compiled_grammar_->token_mask_cache.GetRepeatTokenMaskKey(
+          latest_states[0], *single_repeat_parent, grammar_, tokenizer_info_
+      );
       if (repeat_mask_cache_.has_value() && repeat_mask_cache_->key == *repeat_mask_key &&
           repeat_mask_cache_->parser_completed == IsCompleted()) {
         DynamicBitset output(

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -524,6 +524,7 @@ class GrammarMatcher::Impl : public EarleyParser {
     temporary_input_bytes_.clear();
     accepted_bytes_.clear();
     row_byte_end_.assign(1, 0);
+    repeat_mask_cache_.clear();
     EarleyParser::Reset();
   }
 
@@ -542,9 +543,15 @@ class GrammarMatcher::Impl : public EarleyParser {
     int32_t character_class_expression_id;
     // -1 means the upper bound cannot affect the current token.
     int32_t character_limit;
+    ParserState parent;
+    int32_t lower;
   };
 
   std::optional<RepeatedCharacterClassState> FindRepeatedCharacterClass(const ParserState& state
+  ) const;
+
+  std::optional<std::vector<int32_t>> GetStableRepeatedCharacterClassMaskKey(
+      const std::vector<ParserState>& states
   ) const;
 
   /*!
@@ -749,6 +756,11 @@ class GrammarMatcher::Impl : public EarleyParser {
   DynamicBitset tmp_accepted_bitset_;
   std::vector<int32_t> tmp_rejected_indices_;
   std::vector<int32_t> tmp_rejected_indices_delta_;
+  struct RepeatMaskCacheEntry {
+    std::vector<int32_t> key;
+    DynamicBitset mask;
+  };
+  std::vector<RepeatMaskCacheEntry> repeat_mask_cache_;
 };
 
 std::optional<GrammarMatcher::Impl::RepeatedCharacterClassState>
@@ -792,12 +804,70 @@ GrammarMatcher::Impl::FindRepeatedCharacterClass(const ParserState& state) const
         const bool upper_bound_is_stable =
             repeat.Upper() == -1 || remaining >= max_token_characters;
         return RepeatedCharacterClassState{
-            sequence[0], upper_bound_is_stable ? -1 : std::min(remaining, max_token_characters)
+            sequence[0],
+            upper_bound_is_stable ? -1 : std::min(remaining, max_token_characters),
+            parent,
+            repeat.Lower()
         };
       }
     }
   }
   return std::nullopt;
+}
+
+std::optional<std::vector<int32_t>> GrammarMatcher::Impl::GetStableRepeatedCharacterClassMaskKey(
+    const std::vector<ParserState>& states
+) const {
+  if (!compiled_grammar_->token_mask_cache.IsDynamic()) {
+    return std::nullopt;
+  }
+  std::vector<int32_t> key;
+  key.reserve(states.size() * 12 + 2);
+  key.push_back(static_cast<int32_t>(states.size()));
+  key.push_back(IsCompleted());
+  bool found_repeat = false;
+  for (const auto& state : states) {
+    if (!features_->IsRuleContextIndependent(state.rule_id)) {
+      return std::nullopt;
+    }
+    const auto repeated_character_class = FindRepeatedCharacterClass(state);
+    if (repeated_character_class.has_value() && repeated_character_class->character_limit == -1 &&
+        repeated_character_class->parent.repeat_count >= repeated_character_class->lower) {
+      const auto& parent = repeated_character_class->parent;
+      found_repeat = true;
+      key.insert(
+          key.end(),
+          {1,
+           state.rule_id,
+           state.sequence_id,
+           state.element_id,
+           state.sub_element_id,
+           state.partial_codepoint,
+           parent.rule_id,
+           parent.sequence_id,
+           parent.element_id,
+           parent.rule_start_pos,
+           parent.sub_element_id,
+           parent.partial_codepoint}
+      );
+    } else {
+      key.insert(
+          key.end(),
+          {0,
+           state.rule_id,
+           state.sequence_id,
+           state.element_id,
+           state.rule_start_pos,
+           state.budget_deadline,
+           state.sub_element_id,
+           state.repeat_count,
+           state.partial_codepoint,
+           state.active_temperature_rule_id,
+           state.char_budget_deadline}
+      );
+    }
+  }
+  return found_repeat ? std::optional<std::vector<int32_t>>(std::move(key)) : std::nullopt;
 }
 
 class BatchGrammarMatcher::Impl {
@@ -1880,6 +1950,22 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
     latest_states.push_back(state);
   }
 
+  const auto repeat_mask_key = GetStableRepeatedCharacterClassMaskKey(latest_states);
+  if (repeat_mask_key.has_value()) {
+    const auto cached = std::find_if(
+        repeat_mask_cache_.begin(),
+        repeat_mask_cache_.end(),
+        [&](const RepeatMaskCacheEntry& entry) { return entry.key == *repeat_mask_key; }
+    );
+    if (cached != repeat_mask_cache_.end()) {
+      DynamicBitset output(
+          tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr)
+      );
+      output = cached->mask;
+      return;
+    }
+  }
+
   // We check all the latest states of the earley parser, and check all the masks of the leaf
   // states. The final accepted token set is the union of the accepted token sets of all leaf
   // states. The final rejected token set is the intersection of the rejected token sets of all leaf
@@ -2081,6 +2167,15 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
   SetTokenBitmask(
       bitmask_data_ptr, tmp_accepted_bitset_, tmp_rejected_indices_, can_reach_end, false
   );
+  constexpr size_t kMaxRepeatMaskCacheEntries = 32;
+  if (repeat_mask_key.has_value() && repeat_mask_cache_.size() < kMaxRepeatMaskCacheEntries) {
+    DynamicBitset output(
+        tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr)
+    );
+    DynamicBitset owned_mask(tokenizer_info_.GetVocabSize());
+    owned_mask = output;
+    repeat_mask_cache_.push_back(RepeatMaskCacheEntry{*repeat_mask_key, std::move(owned_mask)});
+  }
   if (debug_print) {
     XGRAMMAR_LOG(INFO) << "Filled bitmask: " << PrintBitmask(bitmask_data_ptr, tokenizer_info_);
   }
@@ -2186,6 +2281,7 @@ void GrammarMatcher::Impl::Rollback(int num_tokens) {
   temporary_input_start_row_ = -1;
   temporary_input_bytes_.clear();
   budget_body_match_cache_.clear();
+  repeat_mask_cache_.clear();
 }
 
 std::vector<std::pair<std::string, std::string>> GrammarMatcher::Impl::GetCaptures(bool deduplicate

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -889,7 +889,8 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
   const auto latest_row = scanable_state_history_[scanable_state_history_.size() - 1];
   std::vector<ParserState> latest_states(latest_row.begin(), latest_row.end());
   std::vector<ParserState> force_completed_states;
-  std::unordered_set<int64_t> force_completed_occurrences;
+  std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
+      force_completed_occurrences;
 
   tmp_states_visited_in_queue_.Clear();
   tmp_states_to_be_added_.clear();
@@ -904,9 +905,7 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
     if (!CanForceCompleteWithoutMarker(state, false)) {
       continue;
     }
-    int64_t occurrence =
-        (static_cast<int64_t>(state.rule_id) << 32) | static_cast<uint32_t>(state.rule_start_pos);
-    if (force_completed_occurrences.insert(occurrence).second) {
+    if (force_completed_occurrences.insert(state).second) {
       force_completed_states.push_back(state);
     }
   }
@@ -976,7 +975,8 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
     previous_capture_events = CopyLastCaptureRow();
   }
   std::vector<ParserState> force_completed_states;
-  std::unordered_set<int64_t> force_completed_occurrences;
+  std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
+      force_completed_occurrences;
 
   tmp_states_visited_in_queue_.Clear();
   tmp_states_to_be_added_.clear();
@@ -991,9 +991,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
     if (!CanForceCompleteWithoutMarker(state, true)) {
       continue;
     }
-    int64_t occurrence =
-        (static_cast<int64_t>(state.rule_id) << 32) | static_cast<uint32_t>(state.rule_start_pos);
-    if (force_completed_occurrences.insert(occurrence).second) {
+    if (force_completed_occurrences.insert(state).second) {
       force_completed_states.push_back(state);
     }
   }

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -887,16 +887,14 @@ bool GrammarMatcher::Impl::CanForceCompleteWithoutMarker(
 }
 
 bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
-  XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
+  XGRAMMAR_DCHECK(tmp_pending_states_.empty());
   const auto latest_row = scanable_state_history_[scanable_state_history_.size() - 1];
   std::vector<ParserState> latest_states(latest_row.begin(), latest_row.end());
   std::vector<ParserState> force_completed_states;
   std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
       force_completed_occurrences;
 
-  tmp_states_visited_in_queue_.Clear();
-  tmp_states_to_be_added_.clear();
-  tmp_completed_lazy_occurrences_.clear();
+  ClearTemporaryContainers();
   tmp_accept_stop_token_ = IsCompleted();
 
   for (const auto& state : latest_states) {
@@ -915,17 +913,7 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
   for (const auto& state : force_completed_states) {
     Complete(state, debug_print, /*marker_present=*/false);
   }
-  while (!tmp_process_state_queue_.empty()) {
-    const auto state = std::move(tmp_process_state_queue_.front());
-    tmp_process_state_queue_.pop();
-    auto [scanable, completable] = Predict(state, debug_print);
-    if (completable) {
-      Complete(state, debug_print);
-    }
-    if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
-    }
-  }
+  ExpandPendingStates(debug_print);
   if (!tmp_completed_lazy_occurrences_.empty()) {
     RemoveCommittedLazyStates();
   }
@@ -933,7 +921,7 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
   bool any_expired = false;
   bool any_alive = false;
   for (const auto& state : tmp_states_to_be_added_) {
-    if (IsExpiredState(state)) {
+    if (IsExpiredState(*state)) {
       any_expired = true;
     } else {
       any_alive = true;
@@ -947,7 +935,7 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
         std::remove_if(
             tmp_states_to_be_added_.begin(),
             tmp_states_to_be_added_.end(),
-            [&](const ParserState& state) { return IsExpiredState(state); }
+            [&](const ParserState* state) { return IsExpiredState(*state); }
         ),
         tmp_states_to_be_added_.end()
     );
@@ -955,16 +943,18 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
 
   bool viable = tmp_accept_stop_token_ || !tmp_states_to_be_added_.empty();
   if (!viable) {
+    ClearTemporaryContainers();
     return false;
   }
   scanable_state_history_.PopBack(1);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
   is_completed_.back() = tmp_accept_stop_token_;
+  ClearTemporaryContainers();
   return true;
 }
 
 bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
-  XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
+  XGRAMMAR_DCHECK(tmp_pending_states_.empty());
   const auto latest_row = scanable_state_history_[scanable_state_history_.size() - 1];
   std::vector<ParserState> latest_states(latest_row.begin(), latest_row.end());
   auto previous_completable_row = rule_id_to_completable_states_.Back();
@@ -980,9 +970,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
   std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
       force_completed_occurrences;
 
-  tmp_states_visited_in_queue_.Clear();
-  tmp_states_to_be_added_.clear();
-  tmp_completed_lazy_occurrences_.clear();
+  ClearTemporaryContainers();
   tmp_accept_stop_token_ = IsCompleted();
 
   for (const auto& state : latest_states) {
@@ -1001,17 +989,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
   for (const auto& state : force_completed_states) {
     Complete(state, debug_print, /*marker_present=*/false);
   }
-  while (!tmp_process_state_queue_.empty()) {
-    const auto state = std::move(tmp_process_state_queue_.front());
-    tmp_process_state_queue_.pop();
-    auto [scanable, completable] = Predict(state, debug_print);
-    if (completable) {
-      Complete(state, debug_print);
-    }
-    if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
-    }
-  }
+  ExpandPendingStates(debug_print);
   if (!tmp_completed_lazy_occurrences_.empty()) {
     RemoveCommittedLazyStates();
   }
@@ -1019,7 +997,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
   bool any_expired = false;
   bool any_alive = false;
   for (const auto& state : tmp_states_to_be_added_) {
-    if (IsCharExpiredState(state)) {
+    if (IsCharExpiredState(*state)) {
       any_expired = true;
     } else {
       any_alive = true;
@@ -1030,7 +1008,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
         std::remove_if(
             tmp_states_to_be_added_.begin(),
             tmp_states_to_be_added_.end(),
-            [&](const ParserState& state) { return IsCharExpiredState(state); }
+            [&](const ParserState* state) { return IsCharExpiredState(*state); }
         ),
         tmp_states_to_be_added_.end()
     );
@@ -1044,11 +1022,13 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(previous_capture_events);
     }
+    ClearTemporaryContainers();
     return false;
   }
   scanable_state_history_.PopBack(1);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
   is_completed_.back() = tmp_accept_stop_token_;
+  ClearTemporaryContainers();
   return true;
 }
 

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -1832,7 +1832,6 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
 ) {
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
   const auto& subtree_range = tokenizer_info_.GetTrieSubtreeNodesRange();
-  const auto& adaptive_token_mask_cache = compiled_grammar_->adaptive_token_mask_cache;
   // We need to have a copy, because scanable_state_history_ will be modified during the
   // FillNextTokenBitmask process, which can lead to undefined behavior.
   std::vector<ParserState> latest_states;
@@ -1858,13 +1857,11 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
                        << ", num of states=" << latest_states.size();
   }
 
-  std::vector<std::pair<ParserState, decltype(adaptive_token_mask_cache.cbegin())>>
-      latest_states_with_masks;
+  std::vector<std::pair<ParserState, const AdaptiveTokenMask*>> latest_states_with_masks;
 
   for (const auto& state : latest_states) {
-    auto adaptive_token_mask_it = adaptive_token_mask_cache.find(state);
-    XGRAMMAR_CHECK(adaptive_token_mask_it != adaptive_token_mask_cache.end()) << state;
-    const auto& adaptive_token_mask = adaptive_token_mask_it->second;
+    const AdaptiveTokenMask& adaptive_token_mask =
+        compiled_grammar_->GetAdaptiveTokenMask(state, state.rule_id == grammar_->GetRootRuleId());
     if (state.char_budget_deadline >= 0) {
       int32_t remaining_chars = state.char_budget_deadline - GetCurrentCharIndex();
       if (remaining_chars <= tokenizer_info_.ImplPtr()->GetMaxTokenChars()) {
@@ -1872,7 +1869,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
         continue;
       }
     }
-    latest_states_with_masks.push_back(std::make_pair(state, adaptive_token_mask_it));
+    latest_states_with_masks.emplace_back(state, &adaptive_token_mask);
     if (adaptive_token_mask.store_type == StoreType::kAcceptedBitset) {
       tmp_accepted_bitset_ |= adaptive_token_mask.accepted_bitset;
     } else if (adaptive_token_mask.store_type == StoreType::kAccepted) {
@@ -1882,8 +1879,8 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
     }
   }
 
-  for (const auto& [state, adaptive_token_mask_it] : latest_states_with_masks) {
-    const auto& adaptive_token_mask = adaptive_token_mask_it->second;
+  for (const auto& [state, adaptive_token_mask_ptr] : latest_states_with_masks) {
+    const auto& adaptive_token_mask = *adaptive_token_mask_ptr;
 
     // For each ParserState, we will check every uncertain token and put them into the accepted or
     // rejected list.

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -466,7 +466,9 @@ class GrammarMatcher::Impl : public EarleyParser {
       int max_rollback_tokens = -1,
       std::optional<float> default_temperature = std::nullopt
   )
-      : EarleyParser(compiled_grammar->grammar),
+      : EarleyParser(
+            compiled_grammar->grammar, std::nullopt, &compiled_grammar->earley_parser_features
+        ),
         compiled_grammar_(compiled_grammar),
         tokenizer_info_(compiled_grammar->tokenizer_info),
         stop_token_ids_(override_stop_tokens.value_or(tokenizer_info_.GetStopTokenIds())),
@@ -475,7 +477,7 @@ class GrammarMatcher::Impl : public EarleyParser {
         tmp_accepted_bitset_(tokenizer_info_.GetVocabSize()) {
     XGRAMMAR_CHECK(!override_stop_tokens.has_value() || !override_stop_tokens->empty())
         << "The override_stop_tokens should not be empty";
-    if (has_budget_rules_ || has_char_budget_rules_) {
+    if (features_->has_budget_rules || features_->has_char_budget_rules) {
       for (int32_t rule_id = 0; rule_id < grammar_->NumRules(); ++rule_id) {
         const auto& rule = grammar_->GetRule(rule_id);
         if (rule.max_tokens < 0 && rule.max_chars < 0) {
@@ -594,7 +596,7 @@ class GrammarMatcher::Impl : public EarleyParser {
   class CaptureRecordingGuard {
    public:
     explicit CaptureRecordingGuard(Impl* impl) : impl_(impl) {
-      if (impl_->capture_tracking_) {
+      if (impl_->features_->capture_tracking) {
         impl_->capture_recording_ = true;
       }
     }
@@ -624,7 +626,7 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   /*! \brief Whether byte offsets are needed for captures or budgeted suffix/stop rules. */
   bool ShouldTrackAcceptedBytes() const {
-    return IsCaptureTrackingEnabled() || has_budget_marker_rules_;
+    return features_->capture_tracking || has_budget_marker_rules_;
   }
 
   /*! \brief Whether the bytes consumed by this expired suffix/stop occurrence form a complete
@@ -971,7 +973,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
       previous_completable_row.data + previous_completable_row.data_len
   );
   std::vector<CaptureEvent> previous_capture_events;
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     previous_capture_events = CopyLastCaptureRow();
   }
   std::vector<ParserState> force_completed_states;
@@ -1038,7 +1040,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
   if (!viable) {
     rule_id_to_completable_states_.PopBack(1);
     rule_id_to_completable_states_.PushBack(previous_completable_states);
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(previous_capture_events);
     }
@@ -1072,7 +1074,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcementToFixedPoint(bool debu
 }
 
 bool GrammarMatcher::Impl::AdvanceWithCharacterBudget(uint8_t byte, bool debug_print) {
-  if (!has_char_budget_rules_ || !StartsUTF8Codepoint(byte)) {
+  if (!features_->has_char_budget_rules || !StartsUTF8Codepoint(byte)) {
     return Advance(byte, debug_print);
   }
 
@@ -1095,7 +1097,7 @@ bool GrammarMatcher::Impl::AdvanceWithCharacterBudget(uint8_t byte, bool debug_p
       previous_completable_row.data + previous_completable_row.data_len
   );
   std::vector<CaptureEvent> previous_capture_events;
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     previous_capture_events = CopyLastCaptureRow();
   }
 
@@ -1110,7 +1112,7 @@ bool GrammarMatcher::Impl::AdvanceWithCharacterBudget(uint8_t byte, bool debug_p
     rule_id_to_completable_states_.PopBack(1);
     rule_id_to_completable_states_.PushBack(previous_completable_states);
     is_completed_.back() = previous_completed;
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(previous_capture_events);
     }
@@ -1123,7 +1125,7 @@ bool GrammarMatcher::Impl::AdvanceAtomicTokenWithCharacterBudget(
 ) {
   bool has_expired_state = false;
   bool crosses_budget = false;
-  if (has_char_budget_rules_ && token_char_count > 0) {
+  if (features_->has_char_budget_rules && token_char_count > 0) {
     for (const auto& state : scanable_state_history_[scanable_state_history_.size() - 1]) {
       has_expired_state = has_expired_state || IsCharExpiredState(state);
       crosses_budget =
@@ -1145,7 +1147,7 @@ bool GrammarMatcher::Impl::AdvanceAtomicTokenWithCharacterBudget(
         previous_completable_row.data + previous_completable_row.data_len
     );
     previous_completed = IsCompleted();
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       previous_capture_events = CopyLastCaptureRow();
     }
     enforced = ApplyCharacterBudgetEnforcementToFixedPoint(debug_print);
@@ -1161,7 +1163,7 @@ bool GrammarMatcher::Impl::AdvanceAtomicTokenWithCharacterBudget(
     rule_id_to_completable_states_.PopBack(1);
     rule_id_to_completable_states_.PushBack(previous_completable_states);
     is_completed_.back() = previous_completed;
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(previous_capture_events);
     }
@@ -1259,7 +1261,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   // The token extends a derivation past its budget iff expired states are allowed to scan
   // (no enforcement) while some exist.
   bool consumed_past_deadline = false;
-  if (has_budget_rules_ && !enforce_budget) {
+  if (features_->has_budget_rules && !enforce_budget) {
     const auto& row = scanable_state_history_[scanable_state_history_.size() - 1];
     for (const auto& state : row) {
       if (IsExpiredState(state)) {
@@ -1290,7 +1292,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
 
   const auto& token = tokenizer_info_.GetDecodedVocab()[token_id];
   int32_t token_char_count = 0;
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     for (uint8_t byte : token) {
       token_char_count += StartsUTF8Codepoint(byte);
     }
@@ -1301,7 +1303,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   std::vector<std::pair<int32_t, ParserState>> completable_before_token;
   std::vector<CaptureEvent> capture_row_before_token;
   bool completed_before_token = false;
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     states_before_token = GetLatestScanableStates();
     auto completable_row_before_token = rule_id_to_completable_states_.Back();
     completable_before_token.assign(
@@ -1312,7 +1314,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     completed_before_token = is_completed_.back();
   }
   auto restore_row_before_token = [&]() {
-    if (!has_char_budget_rules_) {
+    if (!features_->has_char_budget_rules) {
       return;
     }
     scanable_state_history_.PopBack(1);
@@ -1320,7 +1322,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     rule_id_to_completable_states_.PopBack(1);
     rule_id_to_completable_states_.PushBack(completable_before_token);
     is_completed_.back() = completed_before_token;
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(capture_row_before_token);
     }
@@ -1332,7 +1334,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   std::vector<CaptureEvent> atomic_capture_row;
   bool atomic_completed = false;
   bool atomic_success =
-      has_char_budget_rules_
+      features_->has_char_budget_rules
           ? AdvanceAtomicTokenWithCharacterBudget(token_id, token_char_count, debug_print)
           : AdvanceAtomicToken(token_id, debug_print);
   if (atomic_success) {
@@ -1347,7 +1349,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
 
   // Phase 2: Try byte-by-byte path (from the same original state)
   record_char_budget_relaxation_ = true;
-  bool track_temporary_input = has_char_budget_rules_ && has_budget_marker_rules_;
+  bool track_temporary_input = features_->has_char_budget_rules && has_budget_marker_rules_;
   if (track_temporary_input) {
     temporary_input_start_row_ = scanable_state_history_.size() - 1;
     temporary_input_bytes_.clear();
@@ -1355,7 +1357,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   int pos = 0;
   bool byte_path_success = true;
   for (auto char_value : token) {
-    bool accepted = has_char_budget_rules_
+    bool accepted = features_->has_char_budget_rules
                         ? AdvanceWithCharacterBudget(static_cast<uint8_t>(char_value), debug_print)
                         : Advance(static_cast<uint8_t>(char_value), debug_print);
     if (!accepted) {
@@ -1390,7 +1392,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     restore_row_before_token();
     char_budget_relaxed_ = false;
     bool accepted =
-        has_char_budget_rules_
+        features_->has_char_budget_rules
             ? AdvanceAtomicTokenWithCharacterBudget(token_id, token_char_count, debug_print)
             : AdvanceAtomicToken(token_id, debug_print);
     XGRAMMAR_DCHECK(accepted);
@@ -1503,7 +1505,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   if (debug_print) {
     XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<" << EscapeString(token) << "> accepted.";
   }
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     // Close exhausted occurrences at the token boundary, including after zero-byte atomic tokens.
     ApplyCharacterBudgetEnforcementToFixedPoint(debug_print);
   }
@@ -1535,7 +1537,7 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
   std::vector<std::pair<int32_t, ParserState>> completable_before_input;
   std::vector<CaptureEvent> capture_row_before_input;
   bool completed_before_input = false;
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     states_before_input = GetLatestScanableStates();
     auto completable_row_before_input = rule_id_to_completable_states_.Back();
     completable_before_input.assign(
@@ -1545,14 +1547,14 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
     capture_row_before_input = CopyLastCaptureRow();
     completed_before_input = is_completed_.back();
   }
-  bool track_temporary_input = has_char_budget_rules_ && has_budget_marker_rules_;
+  bool track_temporary_input = features_->has_char_budget_rules && has_budget_marker_rules_;
   if (track_temporary_input) {
     temporary_input_start_row_ = scanable_state_history_.size() - 1;
     temporary_input_bytes_.clear();
   }
   int accepted_cnt = 0;
   for (auto char_value : input_str) {
-    bool accepted = has_char_budget_rules_
+    bool accepted = features_->has_char_budget_rules
                         ? AdvanceWithCharacterBudget(static_cast<uint8_t>(char_value), debug_print)
                         : Advance(static_cast<uint8_t>(char_value), debug_print);
     if (!accepted) {
@@ -1561,13 +1563,13 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
                            << "position " << accepted_cnt << ", char " << EscapeString(char_value);
       }
       PopLastStates(accepted_cnt);
-      if (has_char_budget_rules_) {
+      if (features_->has_char_budget_rules) {
         scanable_state_history_.PopBack(1);
         scanable_state_history_.PushBack(states_before_input);
         rule_id_to_completable_states_.PopBack(1);
         rule_id_to_completable_states_.PushBack(completable_before_input);
         is_completed_.back() = completed_before_input;
-        if (capture_tracking_) {
+        if (features_->capture_tracking) {
           capture_event_history_.PopBack(1);
           capture_event_history_.PushBack(capture_row_before_input);
         }
@@ -1593,7 +1595,7 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
   if (ShouldTrackAcceptedBytes()) {
     AppendPerByteRows(input_str);
   }
-  if (has_char_budget_rules_ && !input_str.empty()) {
+  if (features_->has_char_budget_rules && !input_str.empty()) {
     // Leave the parser at the enforced boundary even when no later input is supplied.
     ApplyCharacterBudgetEnforcementToFixedPoint(debug_print);
   }
@@ -1649,7 +1651,7 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
   int32_t* bitmask_data_ptr =
       CheckAndGetBitmaskPtr(*next_token_bitmask, tokenizer_info_.GetVocabSize(), index);
   current_token_index_ = static_cast<int32_t>(token_length_history.size());
-  if (has_budget_rules_) {
+  if (features_->has_budget_rules) {
     const auto& row = scanable_state_history_[scanable_state_history_.size() - 1];
     bool any_expired = false;
     bool any_alive = false;
@@ -1859,7 +1861,11 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
 
   for (const auto& state : latest_states) {
     const AdaptiveTokenMask& adaptive_token_mask = compiled_grammar_->token_mask_cache.Get(
-        state, state.rule_id == grammar_->GetRootRuleId(), grammar_, tokenizer_info_
+        state,
+        state.rule_id == grammar_->GetRootRuleId(),
+        grammar_,
+        tokenizer_info_,
+        compiled_grammar_->earley_parser_features
     );
     if (state.char_budget_deadline >= 0) {
       int32_t remaining_chars = state.char_budget_deadline - GetCurrentCharIndex();
@@ -1894,12 +1900,12 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
 
     // Examine only the current one ParserState
     std::optional<Impl> atomic_trial_base;
-    if (has_char_budget_rules_ && !adaptive_token_mask.uncertain_indices.empty()) {
+    if (features_->has_char_budget_rules && !adaptive_token_mask.uncertain_indices.empty()) {
       atomic_trial_base.emplace(*this);
       atomic_trial_base->capture_recording_ = false;
     }
     PushOneStateToCheck(state);
-    bool track_temporary_input = has_char_budget_rules_ && has_budget_marker_rules_;
+    bool track_temporary_input = features_->has_char_budget_rules && has_budget_marker_rules_;
     int32_t saved_temporary_input_start_row = -1;
     std::string saved_temporary_input_bytes;
     if (track_temporary_input) {
@@ -1932,7 +1938,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
       }
 
       const auto& cur_token = sorted_decoded_vocab[cur_token_idx].second;
-      bool accepted = !cur_token.empty() || !has_char_budget_rules_;
+      bool accepted = !cur_token.empty() || !features_->has_char_budget_rules;
 
       // Step 2.1. Find the longest common prefix with the accepted part of the previous token.
       // We can reuse the previous matched size to avoid unnecessary matching.
@@ -1957,7 +1963,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
       // Step 2.2. Find if the current token is accepted or rejected.
       if (accepted) {
         for (int j = prev_matched_size; j < static_cast<int>(cur_token.size()); ++j) {
-          bool byte_accepted = has_char_budget_rules_
+          bool byte_accepted = features_->has_char_budget_rules
                                    ? AdvanceWithCharacterBudget(static_cast<uint8_t>(cur_token[j]))
                                    : Advance(static_cast<uint8_t>(cur_token[j]));
           if (!byte_accepted) {
@@ -1972,7 +1978,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
         }
       }
 
-      if (!accepted && has_char_budget_rules_) {
+      if (!accepted && features_->has_char_budget_rules) {
         int32_t token_char_count = 0;
         for (uint8_t byte : cur_token) {
           token_char_count += StartsUTF8Codepoint(byte);
@@ -2133,7 +2139,7 @@ void GrammarMatcher::Impl::Rollback(int num_tokens) {
 std::vector<std::pair<std::string, std::string>> GrammarMatcher::Impl::GetCaptures(bool deduplicate
 ) const {
   std::vector<std::pair<std::string, std::string>> result;
-  if (!IsCaptureTrackingEnabled()) {
+  if (!features_->capture_tracking) {
     return result;
   }
   XGRAMMAR_DCHECK(capture_event_history_.size() == static_cast<int32_t>(row_byte_end_.size()))

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -524,7 +524,6 @@ class GrammarMatcher::Impl : public EarleyParser {
     temporary_input_bytes_.clear();
     accepted_bytes_.clear();
     row_byte_end_.assign(1, 0);
-    repeat_mask_cache_.clear();
     EarleyParser::Reset();
   }
 
@@ -539,20 +538,23 @@ class GrammarMatcher::Impl : public EarleyParser {
  private:
   using StoreType = AdaptiveTokenMask::StoreType;
 
-  struct RepeatedCharacterClassState {
-    int32_t character_class_expression_id;
-    // -1 means the upper bound cannot affect the current token.
-    int32_t character_limit;
-    ParserState parent;
-    int32_t lower;
+  struct RepeatMaskCacheKey {
+    ParserState state;
+    int32_t parent_node_id;
+    int32_t lower_bound_distance;
+    int32_t upper_bound_distance;
+
+    bool operator==(const RepeatMaskCacheKey& other) const {
+      return StateEqualForCache()(state, other.state) && parent_node_id == other.parent_node_id &&
+             lower_bound_distance == other.lower_bound_distance &&
+             upper_bound_distance == other.upper_bound_distance;
+    }
   };
 
-  std::optional<RepeatedCharacterClassState> FindRepeatedCharacterClass(const ParserState& state
-  ) const;
+  std::optional<ParserState> FindRepeatParent(const ParserState& state) const;
 
-  std::optional<std::vector<int32_t>> GetStableRepeatedCharacterClassMaskKey(
-      const std::vector<ParserState>& states
-  ) const;
+  RepeatMaskCacheKey GetRepeatMaskCacheKey(const ParserState& state, const ParserState& parent)
+      const;
 
   /*!
    * \brief If is_uncertain_saved is true, find the next token in uncertain_indices. Otherwise,
@@ -757,115 +759,62 @@ class GrammarMatcher::Impl : public EarleyParser {
   std::vector<int32_t> tmp_rejected_indices_;
   std::vector<int32_t> tmp_rejected_indices_delta_;
   struct RepeatMaskCacheEntry {
-    std::vector<int32_t> key;
+    RepeatMaskCacheKey key;
+    bool parser_completed;
     DynamicBitset mask;
   };
-  std::vector<RepeatMaskCacheEntry> repeat_mask_cache_;
+  std::optional<RepeatMaskCacheEntry> repeat_mask_cache_;
 };
 
-std::optional<GrammarMatcher::Impl::RepeatedCharacterClassState>
-GrammarMatcher::Impl::FindRepeatedCharacterClass(const ParserState& state) const {
-  using GrammarExprType = Grammar::Impl::GrammarExprType;
+std::optional<ParserState> GrammarMatcher::Impl::FindRepeatParent(const ParserState& state) const {
   if (!compiled_grammar_->token_mask_cache.IsDynamic() || state.rule_id < 0 ||
-      state.sub_element_id != 0 || !features_->IsRuleContextIndependent(state.rule_id) ||
-      state.partial_codepoint != 0 || state.rule_start_pos < 0 ||
-      state.rule_start_pos >= static_cast<int32_t>(rule_id_to_completable_states_.size()) ||
-      state.element_id != grammar_->per_rule_fsms[state.rule_id]->GetFsm().GetStart()) {
+      !features_->IsRuleContextIndependent(state.rule_id) || state.rule_start_pos < 0 ||
+      state.rule_start_pos >= static_cast<int32_t>(rule_id_to_completable_states_.size())) {
     return std::nullopt;
   }
 
-  const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(state.rule_id).body_expr_id);
-  if (body.type != GrammarExprType::kChoices || body.size() != 1) {
-    return std::nullopt;
-  }
-  const auto& sequence = grammar_->GetGrammarExpr(body[0]);
-  if (sequence.type != GrammarExprType::kSequence || sequence.size() != 1 ||
-      grammar_->GetGrammarExpr(sequence[0]).type != GrammarExprType::kCharacterClass) {
-    return std::nullopt;
-  }
-
-  const int32_t max_token_characters = tokenizer_info_.ImplPtr()->GetMaxTokenChars();
+  std::optional<ParserState> repeat_parent;
   for (const auto& [completed_rule_id, parent] :
        rule_id_to_completable_states_[state.rule_start_pos]) {
-    if (completed_rule_id != state.rule_id || parent.rule_id < 0) {
+    if (completed_rule_id != state.rule_id || !IsCompletionCompatibleWithParent(state, parent)) {
       continue;
+    }
+    if (parent.rule_id < 0) {
+      return std::nullopt;
     }
     const auto& edges = grammar_->complete_fsm.GetEdges(parent.element_id);
     if (edges.size() != 1 || !edges[0].IsRepeatRef()) {
-      continue;
-    }
-    const auto repeat = grammar_->complete_fsm.GetRepeatEdgeInfo(edges[0].GetAuxIndex());
-    if (repeat.RuleId() != state.rule_id) {
-      continue;
-    }
-    const int32_t remaining =
-        repeat.Upper() == -1 ? max_token_characters : repeat.Upper() - parent.repeat_count;
-    if (remaining > 0) {
-      const bool upper_bound_is_stable = repeat.Upper() == -1 || remaining >= max_token_characters;
-      return RepeatedCharacterClassState{
-          sequence[0],
-          upper_bound_is_stable ? -1 : std::min(remaining, max_token_characters),
-          parent,
-          repeat.Lower()
-      };
-    }
-  }
-  return std::nullopt;
-}
-
-std::optional<std::vector<int32_t>> GrammarMatcher::Impl::GetStableRepeatedCharacterClassMaskKey(
-    const std::vector<ParserState>& states
-) const {
-  if (!compiled_grammar_->token_mask_cache.IsDynamic()) {
-    return std::nullopt;
-  }
-  std::vector<int32_t> key;
-  key.reserve(states.size() * 12 + 2);
-  key.push_back(static_cast<int32_t>(states.size()));
-  key.push_back(IsCompleted());
-  bool found_repeat = false;
-  for (const auto& state : states) {
-    if (!features_->IsRuleContextIndependent(state.rule_id)) {
       return std::nullopt;
     }
-    const auto repeated_character_class = FindRepeatedCharacterClass(state);
-    if (repeated_character_class.has_value() && repeated_character_class->character_limit == -1 &&
-        repeated_character_class->parent.repeat_count >= repeated_character_class->lower) {
-      const auto& parent = repeated_character_class->parent;
-      found_repeat = true;
-      key.insert(
-          key.end(),
-          {1,
-           state.rule_id,
-           state.sequence_id,
-           state.element_id,
-           state.sub_element_id,
-           state.partial_codepoint,
-           parent.rule_id,
-           parent.sequence_id,
-           parent.element_id,
-           parent.rule_start_pos,
-           parent.sub_element_id,
-           parent.partial_codepoint}
-      );
-    } else {
-      key.insert(
-          key.end(),
-          {0,
-           state.rule_id,
-           state.sequence_id,
-           state.element_id,
-           state.rule_start_pos,
-           state.budget_deadline,
-           state.sub_element_id,
-           state.repeat_count,
-           state.partial_codepoint,
-           state.active_temperature_rule_id,
-           state.char_budget_deadline}
-      );
+    const auto repeat_info = grammar_->complete_fsm.GetRepeatEdgeInfo(edges[0].GetAuxIndex());
+    if (repeat_info.RuleId() != state.rule_id) {
+      return std::nullopt;
     }
+    if (repeat_parent.has_value() && !StateEqualForParsing()(*repeat_parent, parent)) {
+      return std::nullopt;
+    }
+    repeat_parent = parent;
   }
-  return found_repeat ? std::optional<std::vector<int32_t>>(std::move(key)) : std::nullopt;
+  return repeat_parent;
+}
+
+GrammarMatcher::Impl::RepeatMaskCacheKey GrammarMatcher::Impl::GetRepeatMaskCacheKey(
+    const ParserState& state, const ParserState& parent
+) const {
+  const auto& parent_edges = grammar_->complete_fsm.GetEdges(parent.element_id);
+  const auto repeat_info = grammar_->complete_fsm.GetRepeatEdgeInfo(parent_edges[0].GetAuxIndex());
+  const int32_t far_distance = tokenizer_info_.ImplPtr()->GetMaxTokenBytes() + 1;
+  const auto normalize_distance = [far_distance](int64_t distance) {
+    return static_cast<int32_t>(std::min<int64_t>(std::max<int64_t>(distance, 0), far_distance));
+  };
+  return RepeatMaskCacheKey{
+      state,
+      parent.element_id,
+      normalize_distance(static_cast<int64_t>(repeat_info.Lower()) - parent.repeat_count),
+      repeat_info.Upper() == -1
+          ? -1
+          : normalize_distance(static_cast<int64_t>(repeat_info.Upper()) - parent.repeat_count)
+  };
 }
 
 class BatchGrammarMatcher::Impl {
@@ -1948,22 +1897,6 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
     latest_states.push_back(state);
   }
 
-  const auto repeat_mask_key = GetStableRepeatedCharacterClassMaskKey(latest_states);
-  if (repeat_mask_key.has_value()) {
-    const auto cached = std::find_if(
-        repeat_mask_cache_.begin(),
-        repeat_mask_cache_.end(),
-        [&](const RepeatMaskCacheEntry& entry) { return entry.key == *repeat_mask_key; }
-    );
-    if (cached != repeat_mask_cache_.end()) {
-      DynamicBitset output(
-          tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr)
-      );
-      output = cached->mask;
-      return;
-    }
-  }
-
   // We check all the latest states of the earley parser, and check all the masks of the leaf
   // states. The final accepted token set is the union of the accepted token sets of all leaf
   // states. The final rejected token set is the intersection of the rejected token sets of all leaf
@@ -1979,27 +1912,40 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
                        << ", num of states=" << latest_states.size();
   }
 
+  std::optional<ParserState> single_repeat_parent;
+  std::optional<RepeatMaskCacheKey> repeat_mask_key;
+  if (latest_states.size() == 1) {
+    single_repeat_parent = FindRepeatParent(latest_states[0]);
+    if (single_repeat_parent.has_value()) {
+      repeat_mask_key = GetRepeatMaskCacheKey(latest_states[0], *single_repeat_parent);
+      if (repeat_mask_cache_.has_value() && repeat_mask_cache_->key == *repeat_mask_key &&
+          repeat_mask_cache_->parser_completed == IsCompleted()) {
+        DynamicBitset output(
+            tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr)
+        );
+        output = repeat_mask_cache_->mask;
+        if (debug_print) {
+          XGRAMMAR_LOG(INFO) << "Filled bitmask: "
+                             << PrintBitmask(bitmask_data_ptr, tokenizer_info_);
+        }
+        return;
+      }
+    }
+  }
+
   std::vector<std::pair<ParserState, const AdaptiveTokenMask*>> latest_states_with_masks;
 
   for (const auto& state : latest_states) {
-    const auto repeated_character_class = FindRepeatedCharacterClass(state);
-    const RepeatedCharacterClassTokenMask* repeated_character_class_token_mask =
-        repeated_character_class.has_value()
-            ? &compiled_grammar_->GetRepeatedCharacterClassTokenMask(
-                  repeated_character_class->character_class_expression_id,
-                  repeated_character_class->character_limit
-              )
-            : nullptr;
-    const AdaptiveTokenMask& adaptive_token_mask =
-        repeated_character_class_token_mask != nullptr
-            ? repeated_character_class_token_mask->adaptive_token_mask
-            : compiled_grammar_->token_mask_cache.Get(
-                  state,
-                  state.rule_id == grammar_->GetRootRuleId(),
-                  grammar_,
-                  tokenizer_info_,
-                  compiled_grammar_->earley_parser_features
-              );
+    const auto repeat_parent =
+        latest_states.size() == 1 ? single_repeat_parent : FindRepeatParent(state);
+    const AdaptiveTokenMask& adaptive_token_mask = compiled_grammar_->token_mask_cache.Get(
+        state,
+        repeat_parent.has_value() ? false : state.rule_id == grammar_->GetRootRuleId(),
+        grammar_,
+        tokenizer_info_,
+        compiled_grammar_->earley_parser_features,
+        repeat_parent.has_value() ? &*repeat_parent : nullptr
+    );
     if (state.char_budget_deadline >= 0) {
       int32_t remaining_chars = state.char_budget_deadline - GetCurrentCharIndex();
       if (remaining_chars <= tokenizer_info_.ImplPtr()->GetMaxTokenChars()) {
@@ -2007,7 +1953,6 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
         continue;
       }
     }
-    latest_states_with_masks.emplace_back(state, &adaptive_token_mask);
     if (adaptive_token_mask.store_type == StoreType::kAcceptedBitset) {
       tmp_accepted_bitset_ |= adaptive_token_mask.accepted_bitset;
     } else if (adaptive_token_mask.store_type == StoreType::kAccepted) {
@@ -2015,9 +1960,28 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
         tmp_accepted_bitset_.Set(sorted_decoded_vocab[idx].first, true);
       }
     }
-    if (repeated_character_class_token_mask != nullptr) {
-      tmp_accepted_bitset_ |= repeated_character_class_token_mask->accepted_prefix_tokens;
+    if (latest_states.size() == 1 && adaptive_token_mask.uncertain_indices.empty()) {
+      if (adaptive_token_mask.store_type == StoreType::kRejected) {
+        IntsetIntersection(&tmp_rejected_indices_, adaptive_token_mask.rejected_indices);
+      }
+      SetTokenBitmask(
+          bitmask_data_ptr, tmp_accepted_bitset_, tmp_rejected_indices_, IsCompleted(), false
+      );
+      if (repeat_mask_key.has_value()) {
+        DynamicBitset output(
+            tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr)
+        );
+        DynamicBitset owned_mask(tokenizer_info_.GetVocabSize());
+        owned_mask = output;
+        repeat_mask_cache_ =
+            RepeatMaskCacheEntry{*repeat_mask_key, IsCompleted(), std::move(owned_mask)};
+      }
+      if (debug_print) {
+        XGRAMMAR_LOG(INFO) << "Filled bitmask: " << PrintBitmask(bitmask_data_ptr, tokenizer_info_);
+      }
+      return;
     }
+    latest_states_with_masks.emplace_back(state, &adaptive_token_mask);
   }
 
   for (const auto& [state, adaptive_token_mask_ptr] : latest_states_with_masks) {
@@ -2025,6 +1989,12 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
 
     // For each ParserState, we will check every uncertain token and put them into the accepted or
     // rejected list.
+    if (adaptive_token_mask.uncertain_indices.empty()) {
+      if (adaptive_token_mask.store_type == StoreType::kRejected) {
+        IntsetIntersection(&tmp_rejected_indices_, adaptive_token_mask.rejected_indices);
+      }
+      continue;
+    }
 
     // Step 2. Update the accepted tokens in accepted_indices_delta, or the rejected tokens in
     // rejected_indices_delta.
@@ -2165,15 +2135,6 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
   SetTokenBitmask(
       bitmask_data_ptr, tmp_accepted_bitset_, tmp_rejected_indices_, can_reach_end, false
   );
-  constexpr size_t kMaxRepeatMaskCacheEntries = 32;
-  if (repeat_mask_key.has_value() && repeat_mask_cache_.size() < kMaxRepeatMaskCacheEntries) {
-    DynamicBitset output(
-        tokenizer_info_.GetVocabSize(), reinterpret_cast<uint32_t*>(bitmask_data_ptr)
-    );
-    DynamicBitset owned_mask(tokenizer_info_.GetVocabSize());
-    owned_mask = output;
-    repeat_mask_cache_.push_back(RepeatMaskCacheEntry{*repeat_mask_key, std::move(owned_mask)});
-  }
   if (debug_print) {
     XGRAMMAR_LOG(INFO) << "Filled bitmask: " << PrintBitmask(bitmask_data_ptr, tokenizer_info_);
   }
@@ -2279,7 +2240,6 @@ void GrammarMatcher::Impl::Rollback(int num_tokens) {
   temporary_input_start_row_ = -1;
   temporary_input_bytes_.clear();
   budget_body_match_cache_.clear();
-  repeat_mask_cache_.clear();
 }
 
 std::vector<std::pair<std::string, std::string>> GrammarMatcher::Impl::GetCaptures(bool deduplicate

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -538,6 +538,15 @@ class GrammarMatcher::Impl : public EarleyParser {
  private:
   using StoreType = AdaptiveTokenMask::StoreType;
 
+  struct RepeatedCharacterClassState {
+    int32_t character_class_expression_id;
+    // -1 means the upper bound cannot affect the current token.
+    int32_t character_limit;
+  };
+
+  std::optional<RepeatedCharacterClassState> FindRepeatedCharacterClass(const ParserState& state
+  ) const;
+
   /*!
    * \brief If is_uncertain_saved is true, find the next token in uncertain_indices. Otherwise,
    * find the next token that is set to true in uncertain_tokens_bitset.
@@ -741,6 +750,55 @@ class GrammarMatcher::Impl : public EarleyParser {
   std::vector<int32_t> tmp_rejected_indices_;
   std::vector<int32_t> tmp_rejected_indices_delta_;
 };
+
+std::optional<GrammarMatcher::Impl::RepeatedCharacterClassState>
+GrammarMatcher::Impl::FindRepeatedCharacterClass(const ParserState& state) const {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  if (!compiled_grammar_->token_mask_cache.IsDynamic() || state.rule_id < 0 ||
+      state.sub_element_id != 0 || !features_->IsRuleContextIndependent(state.rule_id) ||
+      state.partial_codepoint != 0 || state.rule_start_pos < 0 ||
+      state.rule_start_pos >= static_cast<int32_t>(rule_id_to_completable_states_.size()) ||
+      state.element_id != grammar_->per_rule_fsms[state.rule_id]->GetFsm().GetStart()) {
+    return std::nullopt;
+  }
+
+  const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(state.rule_id).body_expr_id);
+  if (body.type != GrammarExprType::kChoices || body.size() != 1) {
+    return std::nullopt;
+  }
+  const auto& sequence = grammar_->GetGrammarExpr(body[0]);
+  if (sequence.type != GrammarExprType::kSequence || sequence.size() != 1 ||
+      grammar_->GetGrammarExpr(sequence[0]).type != GrammarExprType::kCharacterClass) {
+    return std::nullopt;
+  }
+
+  const int32_t max_token_characters = tokenizer_info_.ImplPtr()->GetMaxTokenChars();
+  for (const auto& [completed_rule_id, parent] :
+       rule_id_to_completable_states_[state.rule_start_pos]) {
+    if (completed_rule_id != state.rule_id || parent.rule_id < 0) {
+      continue;
+    }
+    for (const auto& edge : grammar_->complete_fsm.GetEdges(parent.element_id)) {
+      if (!edge.IsRepeatRef()) {
+        continue;
+      }
+      const auto repeat = grammar_->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
+      if (repeat.RuleId() != state.rule_id) {
+        continue;
+      }
+      const int32_t remaining =
+          repeat.Upper() == -1 ? max_token_characters : repeat.Upper() - parent.repeat_count;
+      if (remaining > 0) {
+        const bool upper_bound_is_stable =
+            repeat.Upper() == -1 || remaining >= max_token_characters;
+        return RepeatedCharacterClassState{
+            sequence[0], upper_bound_is_stable ? -1 : std::min(remaining, max_token_characters)
+        };
+      }
+    }
+  }
+  return std::nullopt;
+}
 
 class BatchGrammarMatcher::Impl {
  public:
@@ -1840,13 +1898,24 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
   std::vector<std::pair<ParserState, const AdaptiveTokenMask*>> latest_states_with_masks;
 
   for (const auto& state : latest_states) {
-    const AdaptiveTokenMask& adaptive_token_mask = compiled_grammar_->token_mask_cache.Get(
-        state,
-        state.rule_id == grammar_->GetRootRuleId(),
-        grammar_,
-        tokenizer_info_,
-        compiled_grammar_->earley_parser_features
-    );
+    const auto repeated_character_class = FindRepeatedCharacterClass(state);
+    const RepeatedCharacterClassTokenMask* repeated_character_class_token_mask =
+        repeated_character_class.has_value()
+            ? &compiled_grammar_->GetRepeatedCharacterClassTokenMask(
+                  repeated_character_class->character_class_expression_id,
+                  repeated_character_class->character_limit
+              )
+            : nullptr;
+    const AdaptiveTokenMask& adaptive_token_mask =
+        repeated_character_class_token_mask != nullptr
+            ? repeated_character_class_token_mask->adaptive_token_mask
+            : compiled_grammar_->token_mask_cache.Get(
+                  state,
+                  state.rule_id == grammar_->GetRootRuleId(),
+                  grammar_,
+                  tokenizer_info_,
+                  compiled_grammar_->earley_parser_features
+              );
     if (state.char_budget_deadline >= 0) {
       int32_t remaining_chars = state.char_budget_deadline - GetCurrentCharIndex();
       if (remaining_chars <= tokenizer_info_.ImplPtr()->GetMaxTokenChars()) {
@@ -1861,6 +1930,9 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
       for (auto idx : adaptive_token_mask.accepted_indices) {
         tmp_accepted_bitset_.Set(sorted_decoded_vocab[idx].first, true);
       }
+    }
+    if (repeated_character_class_token_mask != nullptr) {
+      tmp_accepted_bitset_ |= repeated_character_class_token_mask->accepted_prefix_tokens;
     }
   }
 

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -1860,8 +1860,9 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
   std::vector<std::pair<ParserState, const AdaptiveTokenMask*>> latest_states_with_masks;
 
   for (const auto& state : latest_states) {
-    const AdaptiveTokenMask& adaptive_token_mask =
-        compiled_grammar_->GetAdaptiveTokenMask(state, state.rule_id == grammar_->GetRootRuleId());
+    const AdaptiveTokenMask& adaptive_token_mask = compiled_grammar_->token_mask_cache.Get(
+        state, state.rule_id == grammar_->GetRootRuleId(), grammar_, tokenizer_info_
+    );
     if (state.char_budget_deadline >= 0) {
       int32_t remaining_chars = state.char_budget_deadline - GetCurrentCharIndex();
       if (remaining_chars <= tokenizer_info_.ImplPtr()->GetMaxTokenChars()) {

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -93,12 +93,11 @@ picojson::value ConstStringFormat::ToJSON() const {
 picojson::value JSONSchemaFormat::ToJSON() const {
   picojson::object obj;
   obj["type"] = picojson::value(type);
-  picojson::value schema_val;
-  if (picojson::parse(schema_val, json_schema).empty()) {
-    obj["json_schema"] = schema_val;
-  } else {
-    obj["json_schema"] = picojson::value(json_schema);
-  }
+  // Embed the schema text as a string. ToJSON is only consumed by the converter's
+  // deduplication fingerprint, so reparsing the schema into a JSON value is unnecessary
+  // and would cost a full JSON parse of potentially large schemas at every fingerprinted
+  // ancestor format.
+  obj["json_schema"] = picojson::value(json_schema);
   obj["style"] = picojson::value(style);
   obj["any_order"] = picojson::value(any_order);
   if (max_whitespace_cnt.has_value()) {
@@ -1759,6 +1758,11 @@ class StructuralTagGrammarConverter {
    * \note This method uses serialization to deduplicate identical formats.
    */
   Result<int, ISTError> Visit(const Format& format);
+
+  /*!
+   * \brief Dispatch a Format to the matching VisitSub overload, without fingerprinting.
+   */
+  Result<int, ISTError> VisitDispatch(const Format& format);
   Result<int, ISTError> VisitSub(const ConstStringFormat& format);
   Result<int, ISTError> VisitSub(const JSONSchemaFormat& format);
   Result<int, ISTError> VisitSub(const AnyTextFormat& format);
@@ -1804,7 +1808,10 @@ bool StructuralTagGrammarConverter::IsPrefix(
 Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(const StructuralTag& structural_tag
 ) {
   StructuralTagGrammarConverter converter;
-  auto result = converter.Visit(structural_tag.format);
+  // The root format is visited exactly once, so fingerprinting the entire format tree cannot
+  // produce a cache hit. Dispatch directly; nested formats still go through Visit() and retain
+  // deduplication.
+  auto result = converter.VisitDispatch(structural_tag.format);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }
@@ -1821,6 +1828,12 @@ Grammar StructuralTagGrammarConverter::AddRootRuleAndGetGrammar(int ref_rule_id)
   return grammar_builder_.Get(root_rule_id);
 }
 
+Result<int, ISTError> StructuralTagGrammarConverter::VisitDispatch(const Format& format) {
+  return std::visit(
+      [&](const auto& arg) -> Result<int, ISTError> { return VisitSub(arg); }, format
+  );
+}
+
 Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format) {
   std::string fingerprint = FormatToJSONValue(format).serialize();
 
@@ -1831,8 +1844,7 @@ Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format)
   }
 
   // Process the format and cache the result
-  auto result =
-      std::visit([&](auto&& arg) -> Result<int, ISTError> { return VisitSub(arg); }, format);
+  auto result = VisitDispatch(format);
   if (result.IsOk()) {
     int rule_id = std::move(result).Unwrap();
     serialization_to_rule_id_[fingerprint] = rule_id;

--- a/cpp/support/compact_2d_array.h
+++ b/cpp/support/compact_2d_array.h
@@ -190,6 +190,13 @@ class Compact2DArray {
   int32_t PushBack(const std::vector<DataType>& new_data);
 
   /*!
+   * \brief Insert a row by copying elements referenced by stable pointers.
+   * \param new_data Pointers to the elements to be inserted.
+   * \return The index of the newly inserted row.
+   */
+  int32_t PushBackIndirect(const std::vector<const DataType*>& new_data);
+
+  /*!
    * \brief Insert a new row of data into the Compact2DArray from a Row struct.
    * \param row The Row struct containing the data to be inserted.
    * \return The index of the newly inserted row.
@@ -345,6 +352,18 @@ template <typename DataType>
 inline int32_t Compact2DArray<DataType>::PushBack(const std::vector<DataType>& new_data) {
   CheckCanAppendData(new_data.size());
   data_.insert(data_.end(), new_data.begin(), new_data.end());
+  indptr_.push_back(static_cast<int32_t>(data_.size()));
+  return static_cast<int32_t>(indptr_.size()) - 2;
+}
+
+template <typename DataType>
+inline int32_t Compact2DArray<DataType>::PushBackIndirect(
+    const std::vector<const DataType*>& new_data
+) {
+  CheckCanAppendData(new_data.size());
+  for (const DataType* element : new_data) {
+    data_.push_back(*element);
+  }
   indptr_.push_back(static_cast<int32_t>(data_.size()));
   return static_cast<int32_t>(indptr_.size()) - 2;
 }

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v16";
+  static constexpr const char kXGrammarSerializeVersion[] = "v17";
 };
 
 /*!

--- a/cpp/support/logging.h
+++ b/cpp/support/logging.h
@@ -218,6 +218,9 @@ class LogMessage {
 #define XGRAMMAR_ICHECK(x) \
   if (!(x)) LogFatal(__FILE__, __LINE__).stream() << "Internal check failed: (" #x << ") is false: "
 
+/*! \brief Whether internal checks are enabled for this build. */
+inline constexpr bool kInternalChecksEnabled = XGRAMMAR_ENABLE_INTERNAL_CHECK != 0;
+
 /*!
  * \brief Check if the condition is true. Used to guarantee some internal conditions in the code.
  * \note This check is only enabled in debug mode. In release mode, it will be disabled for

--- a/cpp/support/utils.h
+++ b/cpp/support/utils.h
@@ -107,7 +107,7 @@ struct hash<std::tuple<Args...>> {
 template <typename T>
 struct hash<std::vector<T>> {
   size_t operator()(const std::vector<T>& vec) const {
-    uint32_t seed = 0;
+    uint64_t seed = 0;
     for (const auto& item : vec) {
       xgrammar::HashCombineBinary(seed, std::hash<T>{}(item));
     }

--- a/cpp/tokenizer_info.cc
+++ b/cpp/tokenizer_info.cc
@@ -326,16 +326,20 @@ TokenizerInfo::Impl::Impl(
 
 void TokenizerInfo::Impl::BuildTokenCharData() {
   token_char_counts_.assign(sorted_decoded_vocab_.size(), 0);
-  int32_t max_chars = 0;
+  int32_t maximum_characters = 0;
+  int32_t maximum_bytes = 0;
   for (int32_t index = 0; index < static_cast<int32_t>(sorted_decoded_vocab_.size()); ++index) {
     int32_t count = 0;
-    for (uint8_t byte : sorted_decoded_vocab_[index].second) {
+    const auto& token = sorted_decoded_vocab_[index].second;
+    for (uint8_t byte : token) {
       count += (byte & 0xC0) != 0x80;
     }
     token_char_counts_[index] = count;
-    max_chars = std::max(max_chars, count);
+    maximum_characters = std::max(maximum_characters, count);
+    maximum_bytes = std::max(maximum_bytes, static_cast<int32_t>(token.size()));
   }
-  max_token_chars_ = max_chars;
+  max_token_chars_ = maximum_characters;
+  max_token_bytes_ = maximum_bytes;
 }
 
 const std::vector<int32_t>& TokenizerInfo::Impl::GetTokenCharCounts() const {

--- a/cpp/tokenizer_info_impl.h
+++ b/cpp/tokenizer_info_impl.h
@@ -41,6 +41,7 @@ class TokenizerInfo::Impl {
   }
   const std::vector<int32_t>& GetTokenCharCounts() const;
   int32_t GetMaxTokenChars() const;
+  int32_t GetMaxTokenBytes() const { return max_token_bytes_; }
   void BuildTokenCharData();
 
   std::string DumpMetadata() const;
@@ -84,6 +85,8 @@ class TokenizerInfo::Impl {
   std::vector<int32_t> token_id_to_sorted_vocab_index_;
   /*! \brief Unicode codepoint counts for the sorted decoded vocabulary. */
   int32_t max_token_chars_ = 0;
+  /*! \brief Maximum decoded token length in bytes. */
+  int32_t max_token_bytes_ = 0;
   std::vector<int32_t> token_char_counts_;
 
   /*!

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -205,6 +205,21 @@ class GrammarCompilerObj : public ffi::Object {
             max_memory_bytes
         ) {}
 
+  GrammarCompilerObj(
+      ffi::ObjectRef tokenizer_ref,
+      int64_t max_threads,
+      bool cache_enabled,
+      int64_t max_memory_bytes,
+      bool enable_dynamic_compilation
+  )
+      : value(
+            tokenizer_ref.as<TokenizerInfoObj>()->value,
+            static_cast<int>(max_threads),
+            cache_enabled,
+            max_memory_bytes,
+            enable_dynamic_compilation
+        ) {}
+
   static constexpr bool _type_mutable = true;
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL(
       "xgrammar.tvm_ffi_binding.GrammarCompiler", GrammarCompilerObj, ffi::Object
@@ -502,9 +517,17 @@ TVM_FFI_STATIC_INIT_BLOCK() {
         XGRAMMAR_FFI_TRY_END();
       });
 
-  // GrammarCompiler: init(tokenizer_info, max_threads, cache_enabled, max_memory_bytes)
+  // Keep the existing initializer and expose dynamic compilation separately.
   refl::ObjectDef<GrammarCompilerObj>()
       .def(refl::init<O, int64_t, bool, int64_t>())
+      .def_static(
+          "create_with_dynamic_compilation",
+          [](O tokenizer_ref, int64_t max_threads, bool cache_enabled, int64_t max_memory_bytes) {
+            return ffi::ObjectRef(ffi::make_object<GrammarCompilerObj>(
+                tokenizer_ref, max_threads, cache_enabled, max_memory_bytes, true
+            ));
+          }
+      )
       .def(
           "compile_json_schema",
           [](GrammarCompilerObj* o,

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -196,19 +196,6 @@ class GrammarCompilerObj : public ffi::Object {
       ffi::ObjectRef tokenizer_ref,
       int64_t max_threads,
       bool cache_enabled,
-      int64_t max_memory_bytes
-  )
-      : value(
-            tokenizer_ref.as<TokenizerInfoObj>()->value,
-            static_cast<int>(max_threads),
-            cache_enabled,
-            max_memory_bytes
-        ) {}
-
-  GrammarCompilerObj(
-      ffi::ObjectRef tokenizer_ref,
-      int64_t max_threads,
-      bool cache_enabled,
       int64_t max_memory_bytes,
       bool enable_dynamic_compilation
   )
@@ -517,17 +504,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
         XGRAMMAR_FFI_TRY_END();
       });
 
-  // Keep the existing initializer and expose dynamic compilation separately.
+  // GrammarCompiler: init(tokenizer_info, max_threads, cache_enabled, max_memory_bytes,
+  //                       enable_dynamic_compilation)
   refl::ObjectDef<GrammarCompilerObj>()
-      .def(refl::init<O, int64_t, bool, int64_t>())
-      .def_static(
-          "create_with_dynamic_compilation",
-          [](O tokenizer_ref, int64_t max_threads, bool cache_enabled, int64_t max_memory_bytes) {
-            return ffi::ObjectRef(ffi::make_object<GrammarCompilerObj>(
-                tokenizer_ref, max_threads, cache_enabled, max_memory_bytes, true
-            ));
-          }
-      )
+      .def(refl::init<O, int64_t, bool, int64_t, bool>())
       .def(
           "compile_json_schema",
           [](GrammarCompilerObj* o,

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -71,6 +71,22 @@ class GrammarCompiler {
       int64_t max_memory_bytes = -1  // unlimited
   );
 
+  /*!
+   * \brief Construct a compiler with configurable token mask generation.
+   * \param tokenizer_info The tokenizer info.
+   * \param max_threads The maximum number of threads to use for compiling grammars.
+   * \param cache_enabled Whether to enable the cache.
+   * \param max_memory_bytes The maximum memory usage in bytes.
+   * \param enable_dynamic_compilation Whether to generate token masks on first use.
+   */
+  GrammarCompiler(
+      const TokenizerInfo& tokenizer_info,
+      int max_threads,
+      bool cache_enabled,
+      int64_t max_memory_bytes,
+      bool enable_dynamic_compilation
+  );
+
   /*! \brief Get the compiled grammar for a JSON schema string. */
   CompiledGrammar CompileJSONSchema(
       const std::string& schema,

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -63,28 +63,14 @@ class GrammarCompiler {
    * \param max_threads The maximum number of threads to use for compiling grammars.
    * \param cache_enabled Whether to enable the cache.
    * \param max_memory_bytes The maximum memory usage in bytes.
+   * \param enable_dynamic_compilation Whether to generate token masks on first use.
    */
   GrammarCompiler(
       const TokenizerInfo& tokenizer_info,
       int max_threads = 8,
       bool cache_enabled = true,
-      int64_t max_memory_bytes = -1  // unlimited
-  );
-
-  /*!
-   * \brief Construct a compiler with configurable token mask generation.
-   * \param tokenizer_info The tokenizer info.
-   * \param max_threads The maximum number of threads to use for compiling grammars.
-   * \param cache_enabled Whether to enable the cache.
-   * \param max_memory_bytes The maximum memory usage in bytes.
-   * \param enable_dynamic_compilation Whether to generate token masks on first use.
-   */
-  GrammarCompiler(
-      const TokenizerInfo& tokenizer_info,
-      int max_threads,
-      bool cache_enabled,
-      int64_t max_memory_bytes,
-      bool enable_dynamic_compilation
+      int64_t max_memory_bytes = -1,  // unlimited
+      bool enable_dynamic_compilation = false
   );
 
   /*! \brief Get the compiled grammar for a JSON schema string. */

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -110,6 +110,7 @@ class GrammarCompiler(XGRObject):
         max_threads: int = 8,
         cache_enabled: bool = True,
         cache_limit_bytes: int = -1,
+        enable_dynamic_compilation: bool = False,
     ):
         """Construct the compiler.
 
@@ -127,6 +128,9 @@ class GrammarCompiler(XGRObject):
         cache_limit_bytes : int, default: -1
             The maximum memory usage for the cache in the specified unit.
             Note that the actual memory usage may slightly exceed this value.
+
+        enable_dynamic_compilation : bool, default: False
+            Whether to generate token masks when they are first needed.
         """
         if not isinstance(tokenizer_info, TokenizerInfo):
             raise ValueError(
@@ -134,11 +138,18 @@ class GrammarCompiler(XGRObject):
                 "to GrammarCompiler."
             )
 
-        self._init_handle(
-            _core.GrammarCompiler(
-                tokenizer_info._handle, max_threads, cache_enabled, cache_limit_bytes
+        if enable_dynamic_compilation:
+            self._init_handle(
+                _core.GrammarCompiler.create_with_dynamic_compilation(
+                    tokenizer_info._handle, max_threads, cache_enabled, cache_limit_bytes
+                )
             )
-        )
+        else:
+            self._init_handle(
+                _core.GrammarCompiler(
+                    tokenizer_info._handle, max_threads, cache_enabled, cache_limit_bytes
+                )
+            )
 
     def compile_json_schema(
         self,

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -138,18 +138,15 @@ class GrammarCompiler(XGRObject):
                 "to GrammarCompiler."
             )
 
-        if enable_dynamic_compilation:
-            self._init_handle(
-                _core.GrammarCompiler.create_with_dynamic_compilation(
-                    tokenizer_info._handle, max_threads, cache_enabled, cache_limit_bytes
-                )
+        self._init_handle(
+            _core.GrammarCompiler(
+                tokenizer_info._handle,
+                max_threads,
+                cache_enabled,
+                cache_limit_bytes,
+                enable_dynamic_compilation,
             )
-        else:
-            self._init_handle(
-                _core.GrammarCompiler(
-                    tokenizer_info._handle, max_threads, cache_enabled, cache_limit_bytes
-                )
-            )
+        )
 
     def compile_json_schema(
         self,

--- a/tests/cpp/test_earley_parser.cc
+++ b/tests/cpp/test_earley_parser.cc
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+#include "earley_parser.h"
+#include "grammar_functor.h"
+
+TEST(RepeatDetectorTest, PreservesStatesAcrossSetTransitionAndResetsCopies) {
+  xgrammar::RepeatDetector detector(2);
+  const xgrammar::ParserState first_state(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+  const xgrammar::ParserState second_state(11, 12, 13, 14, 15, 16, 17, 18, 19, 20);
+  const xgrammar::ParserState third_state(21, 22, 23, 24, 25, 26, 27, 28, 29, 30);
+
+  const xgrammar::ParserState* stored_first = detector.InsertIfAbsent(first_state);
+  const xgrammar::ParserState* stored_second = detector.InsertIfAbsent(second_state);
+  ASSERT_NE(stored_first, nullptr);
+  ASSERT_NE(stored_second, nullptr);
+  EXPECT_EQ(detector.InsertIfAbsent(first_state), nullptr);
+
+  const xgrammar::ParserState* stored_third = detector.InsertIfAbsent(third_state);
+  ASSERT_NE(stored_third, nullptr);
+  EXPECT_TRUE(xgrammar::StateEqualForParsing()(*stored_first, first_state));
+  EXPECT_TRUE(xgrammar::StateEqualForParsing()(*stored_second, second_state));
+  EXPECT_TRUE(xgrammar::StateEqualForParsing()(*stored_third, third_state));
+
+  xgrammar::RepeatDetector copied_detector(detector);
+  EXPECT_NE(copied_detector.InsertIfAbsent(first_state), nullptr);
+
+  detector.Clear();
+  EXPECT_NE(detector.InsertIfAbsent(first_state), nullptr);
+}
+
+TEST(EarleyParserTest, HandlesMoreThanFiftyStatesAcrossCopyFailureAndReset) {
+  constexpr int32_t branch_count = 64;
+  std::string grammar_text = "root ::= ";
+  for (int32_t branch_index = 0; branch_index < branch_count; ++branch_index) {
+    if (branch_index != 0) {
+      grammar_text += " | ";
+    }
+    grammar_text += "branch_" + std::to_string(branch_index);
+  }
+  for (int32_t branch_index = 0; branch_index < branch_count; ++branch_index) {
+    std::string suffix;
+    suffix += static_cast<char>('A' + branch_index / 26);
+    suffix += static_cast<char>('a' + branch_index % 26);
+    grammar_text += "\nbranch_" + std::to_string(branch_index) + " ::= prefix_" +
+                    std::to_string(branch_index) + " \"" + suffix + "\"";
+    grammar_text += "\nprefix_" + std::to_string(branch_index) + " ::= \"a\"";
+  }
+
+  xgrammar::Grammar grammar =
+      xgrammar::GrammarOptimizer::Apply(xgrammar::Grammar::FromEBNF(grammar_text));
+  xgrammar::EarleyParser parser(grammar);
+  ASSERT_GT(parser.GetLatestScanableStates().size(), 50);
+
+  xgrammar::EarleyParser copied_parser(parser);
+  EXPECT_FALSE(parser.Advance('!'));
+  EXPECT_FALSE(copied_parser.Advance('!'));
+
+  for (char character : std::string("aCl")) {
+    ASSERT_TRUE(parser.Advance(static_cast<uint8_t>(character)));
+    ASSERT_TRUE(copied_parser.Advance(static_cast<uint8_t>(character)));
+    if (character == 'a') {
+      EXPECT_GT(parser.GetLatestScanableStates().size(), 50);
+      EXPECT_GT(copied_parser.GetLatestScanableStates().size(), 50);
+    }
+  }
+  EXPECT_TRUE(parser.IsCompleted());
+  EXPECT_TRUE(copied_parser.IsCompleted());
+
+  parser.Reset();
+  for (char character : std::string("aAa")) {
+    ASSERT_TRUE(parser.Advance(static_cast<uint8_t>(character)));
+  }
+  EXPECT_TRUE(parser.IsCompleted());
+}

--- a/tests/cpp/test_fsm.cc
+++ b/tests/cpp/test_fsm.cc
@@ -493,6 +493,54 @@ TEST(XGrammarFSMTest, MergingNodesTest) {
   EXPECT_EQ(fsm_wse.GetFsm().NumStates(), 5);
 }
 
+TEST(XGrammarFSMTest, RepeatEdgeInvariantValidation) {
+  FSM valid_fsm(2);
+  valid_fsm.AddRepeatEdge(0, 1, 0, 1, 2);
+  EXPECT_NO_THROW(valid_fsm.ValidateRepeatEdgeInvariant());
+
+  FSM invalid_fsm = valid_fsm.Copy();
+  invalid_fsm.GetEdges(0).emplace_back('a', 'a', 1);
+  EXPECT_THROW(invalid_fsm.ValidateRepeatEdgeInvariant(), LogFatalError);
+}
+
+TEST(XGrammarFSMTest, InternalRepeatEdgeValidationCallSites) {
+  if constexpr (!kInternalChecksEnabled) {
+    GTEST_SKIP() << "Internal checks are disabled.";
+  }
+
+  FSM add_normal_edge_fsm(3);
+  add_normal_edge_fsm.AddRepeatEdge(0, 1, 0, 1, 2);
+  EXPECT_THROW(add_normal_edge_fsm.AddEdge(0, 2, 'a', 'a'), LogFatalError);
+
+  FSM add_repeat_edge_fsm(3);
+  add_repeat_edge_fsm.AddEdge(0, 1, 'a', 'a');
+  EXPECT_THROW(add_repeat_edge_fsm.AddRepeatEdge(0, 2, 0, 1, 2), LogFatalError);
+
+  std::vector<std::vector<FSMEdge>> edges(3);
+  edges[0].emplace_back(FSMEdge::EdgeType::kRepeatRef, 0, 1);
+  edges[0].emplace_back('a', 'a', 2);
+  std::vector<int32_t> edge_aux_data{0, 1, 2};
+  EXPECT_THROW(FSM(edges, edge_aux_data), LogFatalError);
+
+  auto make_invalid_fsm = []() {
+    FSMWithStartEnd fsm;
+    for (int i = 0; i < 3; ++i) {
+      fsm.AddState();
+    }
+    fsm.SetStartState(0);
+    fsm.AddEndState(2);
+    fsm.GetFsm().AddRepeatEdge(0, 1, 0, 1, 2);
+    fsm.GetFsm().GetEdges(0).emplace_back('a', 'a', 2);
+    return fsm;
+  };
+
+  auto simplify_fsm = make_invalid_fsm();
+  EXPECT_THROW(simplify_fsm.SimplifyEpsilon(), LogFatalError);
+
+  auto merge_fsm = make_invalid_fsm();
+  EXPECT_THROW(merge_fsm.MergeEquivalentStates(), LogFatalError);
+}
+
 TEST(XGrammarFSMTest, MergeEquivalentStatesNoCrossRuleChaining) {
   FSMWithStartEnd fsm_wse;
   for (int i = 0; i < 7; ++i) {

--- a/tests/cpp/test_grammar_fsm_hasher.cc
+++ b/tests/cpp/test_grammar_fsm_hasher.cc
@@ -1,0 +1,70 @@
+/**
+ * \file tests/cpp/test_grammar_fsm_hasher.cc
+ * \brief Regression tests for canonical grammar FSM hashing.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "grammar_functor.h"
+#include "grammar_impl.h"
+#include "xgrammar/grammar.h"
+
+using namespace xgrammar;
+
+namespace {
+
+int32_t FindRule(const Grammar& grammar, const std::string& name) {
+  for (int32_t rule_id = 0; rule_id < grammar->NumRules(); ++rule_id) {
+    if (grammar->GetRule(rule_id).name == name) {
+      return rule_id;
+    }
+  }
+  return -1;
+}
+
+int CountRuleEdges(const CompactFSMWithStartEnd& fsm) {
+  int result = 0;
+  for (int32_t state = 0; state < fsm.NumStates(); ++state) {
+    for (const auto& edge : fsm.GetFsm().GetEdges(state)) {
+      result += edge.IsRuleRef();
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+TEST(XGrammarFSMHasherTest, RuleEdgeScratchIsScopedToEachState) {
+  auto grammar = Grammar::FromEBNF(R"(
+root ::= left | right
+left ::= ref "x" | "a" ref "y"
+right ::= "a" ref "y" | ref "x"
+ref ::= "z"
+)");
+  GrammarFSMBuilder::Apply(&grammar);
+  GrammarFSMHasher::Apply(&grammar);
+
+  const int32_t left = FindRule(grammar, "left");
+  const int32_t right = FindRule(grammar, "right");
+  ASSERT_GE(left, 0);
+  ASSERT_GE(right, 0);
+  ASSERT_TRUE(grammar->per_rule_fsms[left].has_value());
+  ASSERT_TRUE(grammar->per_rule_fsms[right].has_value());
+  EXPECT_GE(CountRuleEdges(grammar->per_rule_fsms[left]->GetFsm()), 2);
+  EXPECT_GE(CountRuleEdges(grammar->per_rule_fsms[right]->GetFsm()), 2);
+
+  ASSERT_TRUE(grammar->per_rule_fsm_hashes[left].has_value());
+  ASSERT_TRUE(grammar->per_rule_fsm_hashes[right].has_value());
+  EXPECT_EQ(grammar->per_rule_fsm_hashes[left], grammar->per_rule_fsm_hashes[right]);
+
+  const auto first_hashes = grammar->per_rule_fsm_hashes;
+  const auto first_state_ids = grammar->per_rule_fsm_new_state_ids;
+  GrammarFSMHasher::Apply(&grammar);
+  EXPECT_EQ(grammar->per_rule_fsm_hashes, first_hashes);
+  EXPECT_EQ(grammar->per_rule_fsm_new_state_ids, first_state_ids);
+}

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -6,6 +6,7 @@ import torch
 
 import xgrammar as xgr
 from xgrammar.base import _core
+from xgrammar.testing import bitmask_to_bool_mask
 
 VOCABULARY = [chr(value) for value in range(32, 127)] + ["Ada", "hello", "42", "<call>"]
 
@@ -322,3 +323,36 @@ def test_rule_mask_sharing_distinguishes_lookahead_expression_boundaries(
 
     assert not torch.equal(first_mask, expected_mask)
     torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_shared_parser_features_preserve_budget_and_capture_behavior():
+    tokenizer_info = xgr.TokenizerInfo(["ab ", "cd", " ", "</t>", "1", "<t>", "x"])
+    grammar = xgr.Grammar.from_lark(
+        'start: r "<t>"\nr[max_tokens=3, capture]: TEXT\nTEXT: /(\\n|.)*/',
+        tokenizer_info=tokenizer_info,
+    )
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(grammar)
+    for _ in range(4):
+        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        assert all(matcher.accept_token(token_id) for token_id in [0, 1, 2])
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        assert matcher.fill_next_token_bitmask(bitmask)
+        assert bitmask_to_bool_mask(bitmask, tokenizer_info.vocab_size).nonzero().tolist() == [
+            [0, 5]
+        ]
+        assert matcher.accept_token(5)
+        assert matcher.is_terminated()
+        assert matcher.get_captures() == [("r", b"ab cd ")]
+
+    grammar = xgr.Grammar.from_lark(
+        'start[capture="outer"]: r "z"\n' 'r[max_chars=2, capture="inner", suffix="!"]: /[a-z]*/'
+    )
+    compiled = xgr.GrammarCompiler(xgr.TokenizerInfo([])).compile_grammar(grammar)
+    for _ in range(4):
+        for value, expected_captures in [
+            ("a!z", [("inner", b"a"), ("outer", b"a!z")]),
+            ("abz", [("inner", b"ab"), ("outer", b"abz")]),
+        ]:
+            matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+            assert matcher.accept_string(value) and matcher.is_terminated()
+            assert matcher.get_captures() == expected_captures

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -77,12 +77,17 @@ def _compile_structural_tag(compiler: xgr.GrammarCompiler) -> xgr.CompiledGramma
     )
 
 
+def _compile_repeated_character_class(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_grammar("root ::= [a-z]{1,}")
+
+
 CASES = [
     (_compile_ebnf, "hello!"),
     (_compile_json_schema, '{"name":"Ada","scores":[1,2]}'),
     (_compile_regex, "Ada42"),
     (_compile_builtin_json, '{"name":"Ada"}'),
     (_compile_structural_tag, "prefix<call>X"),
+    (_compile_repeated_character_class, "hello"),
 ]
 
 
@@ -98,7 +103,14 @@ def test_native_constructor_takes_dynamic_compilation_flag():
 @pytest.mark.parametrize(
     "compile_grammar,input_string",
     CASES,
-    ids=["ebnf", "json-schema", "regex", "builtin-json", "structural-tag"],
+    ids=[
+        "ebnf",
+        "json-schema",
+        "regex",
+        "builtin-json",
+        "structural-tag",
+        "repeated-character-class",
+    ],
 )
 def test_dynamic_compilation_matches_eager_masks(compile_grammar, input_string):
     tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
@@ -229,8 +241,9 @@ def test_dynamic_tag_dispatch_slicing_uses_rule_level_cache():
     [
         (_compile_json_schema, '{"name":"Ada","scores":[1,2]}'),
         (_compile_structural_tag, "prefix<call>X"),
+        (_compile_repeated_character_class, "hello"),
     ],
-    ids=["json-schema", "structural-tag"],
+    ids=["json-schema", "structural-tag", "repeated-character-class"],
 )
 def test_concurrent_dynamic_mask_generation(compile_grammar, input_string):
     tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
@@ -696,3 +709,99 @@ def test_rule_mask_sharing_distinguishes_repeat_bounds():
 
     assert not torch.equal(first_mask, expected_mask)
     torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "grammar",
+    [r"root ::= [^\u0000]{1,}", r"root ::= [\u0000-\U0010FFFF]{1,}", r"root ::= [a-ca-b]{1,}"],
+    ids=["negative", "positive", "overlapping-ranges"],
+)
+def test_repeated_character_class_masks_follow_fsm_semantics(grammar):
+    vocabulary = [b"\xc0\x80", b"\xc0", b"\xed\xa0\x80", b"\xf5\x80\x80\x80", "a", "\x00"]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    eager = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=False
+    ).compile_grammar(grammar)
+    dynamic = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    ).compile_grammar(grammar)
+
+    def initial_mask(compiled_grammar):
+        matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        xgr.reset_token_bitmask(bitmask)
+        assert matcher.fill_next_token_bitmask(bitmask)
+        return bitmask_to_bool_mask(bitmask, tokenizer_info.vocab_size)
+
+    torch.testing.assert_close(initial_mask(dynamic), initial_mask(eager), rtol=0, atol=0)
+    for token_id in range(tokenizer_info.vocab_size):
+        eager_matcher = xgr.GrammarMatcher(eager, terminate_without_stop_token=True)
+        dynamic_matcher = xgr.GrammarMatcher(dynamic, terminate_without_stop_token=True)
+        assert dynamic_matcher.accept_token(token_id) == eager_matcher.accept_token(token_id)
+
+
+@pytest.mark.parametrize("operation", ["rollback", "reset", "fork"])
+def test_repeated_character_class_masks_do_not_leak_across_state_changes(operation):
+    tokenizer_info = xgr.TokenizerInfo(["p", "q", "a", "x", "y"], stop_token_ids=[])
+    compiled = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    ).compile_grammar('root ::= "p" repeated "x" | "q" repeated "y"\nrepeated ::= [a]{1,}')
+
+    def next_token_ids(matcher):
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        xgr.reset_token_bitmask(bitmask)
+        assert matcher.fill_next_token_bitmask(bitmask)
+        return set(
+            bitmask_to_bool_mask(bitmask, tokenizer_info.vocab_size)[0].nonzero().flatten().tolist()
+        )
+
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    assert matcher.accept_token(0)
+    assert matcher.accept_token(2)
+    assert next_token_ids(matcher) == {2, 3}
+
+    if operation == "rollback":
+        matcher.rollback(2)
+    elif operation == "reset":
+        matcher.reset()
+    else:
+        matcher = matcher.fork()
+        matcher.rollback(2)
+
+    assert matcher.accept_token(1)
+    assert matcher.accept_token(2)
+    assert next_token_ids(matcher) == {2, 4}
+
+
+def test_repeated_character_class_masks_are_shared_by_compiled_grammar():
+    tokenizer_info = xgr.TokenizerInfo(["a", "ab", "b", "x"], stop_token_ids=[])
+    compiled = _compile_repeated_character_class(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+
+    initial_size = compiled.memory_size_bytes
+    _mask_trace(compiled, "a")
+    populated_size = compiled.memory_size_bytes
+    assert populated_size > initial_size
+    _mask_trace(compiled, "b")
+    assert compiled.memory_size_bytes == populated_size
+
+
+def test_serialization_rebuilds_repeated_character_class_masks():
+    tokenizer_info = xgr.TokenizerInfo(["a", "ab", "b", "x"], stop_token_ids=[])
+    grammar = "root ::= [a-z]{1,3}"
+    dynamic = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    ).compile_grammar(grammar)
+    eager = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=False
+    ).compile_grammar(grammar)
+    restored = xgr.CompiledGrammar.deserialize_json(dynamic.serialize_json(), tokenizer_info)
+
+    expected = _mask_trace(eager, "ab")
+    actual = _mask_trace(restored, "ab")
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+        assert actual_apply == expected_apply
+        expected_tokens = bitmask_to_bool_mask(expected_mask, tokenizer_info.vocab_size)
+        actual_tokens = bitmask_to_bool_mask(actual_mask, tokenizer_info.vocab_size)
+        torch.testing.assert_close(actual_tokens, expected_tokens, rtol=0, atol=0)

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -642,19 +642,45 @@ def test_preserved_repetition_ranges_survive_serialization():
     dynamic = xgr.GrammarCompiler(
         tokenizer_info, max_threads=1, enable_dynamic_compilation=True
     ).compile_grammar(grammar)
-    restored = xgr.CompiledGrammar.deserialize_json(dynamic.serialize_json(), tokenizer_info)
+    for compiled in [eager, dynamic]:
+        restored = xgr.CompiledGrammar.deserialize_json(compiled.serialize_json(), tokenizer_info)
+        for value in ["aax", "aaay"]:
+            expected = _mask_trace(eager, value)
+            actual = _mask_trace(restored, value)
+            for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(
+                expected, actual
+            ):
+                assert actual_apply == expected_apply
+                torch.testing.assert_close(
+                    bitmask_to_bool_mask(actual_mask, tokenizer_info.vocab_size),
+                    bitmask_to_bool_mask(expected_mask, tokenizer_info.vocab_size),
+                    rtol=0,
+                    atol=0,
+                )
 
-    for value in ["aax", "aaay"]:
-        expected = _mask_trace(eager, value)
-        actual = _mask_trace(restored, value)
-        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
-            assert actual_apply == expected_apply
-            torch.testing.assert_close(
-                bitmask_to_bool_mask(actual_mask, tokenizer_info.vocab_size),
-                bitmask_to_bool_mask(expected_mask, tokenizer_info.vocab_size),
-                rtol=0,
-                atol=0,
-            )
+
+@pytest.mark.parametrize("max_threads", [1, 4])
+def test_eager_repetition_phase_masks_match_token_acceptance(max_threads):
+    vocabulary = ["a", "aa", "aaaa", "az", "aaz", "aaaaaz", "z", "x"]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    compiled = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=max_threads, enable_dynamic_compilation=False
+    ).compile_grammar('root ::= unit{100,110} "z"\nunit ::= "a"')
+
+    for repeat_count in [0, 94, 95, 99, 100, 104, 105, 108, 109]:
+        prefix = "a" * repeat_count
+        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        assert matcher.accept_string(prefix)
+        actual = _next_token_mask(matcher, tokenizer_info.vocab_size)
+
+        expected = []
+        for token_id in range(tokenizer_info.vocab_size):
+            trial_matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+            assert trial_matcher.accept_string(prefix)
+            expected.append(trial_matcher.accept_token(token_id))
+        torch.testing.assert_close(
+            actual, torch.tensor(expected, dtype=torch.bool).reshape(1, -1), rtol=0, atol=0
+        )
 
 
 def test_preserved_repetition_ranges_survive_rollback():

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -740,6 +740,74 @@ def test_repeated_character_class_masks_follow_fsm_semantics(grammar):
         assert dynamic_matcher.accept_token(token_id) == eager_matcher.accept_token(token_id)
 
 
+@pytest.mark.parametrize(
+    ("grammar", "accepted_input"),
+    [
+        ('root ::= unit{1,5} "z"\nunit ::= "ab"', "ababz"),
+        ('root ::= unit{1,5} "z"\nunit ::= "ab" | "c"', "abcabz"),
+        ('root ::= unit{1,5} "z"\nunit ::= "" | "ab"', "ababz"),
+        ('root ::= unit{1,5} "z"\nunit ::= "é"', "ééz"),
+        ('root ::= unit{1,} | "(" root ")"\nunit ::= "a"', "(a)"),
+    ],
+    ids=["byte-string", "choice", "nullable", "multibyte", "recursive-root"],
+)
+def test_repeated_subrule_masks_match_eager(grammar, accepted_input):
+    vocabulary = [
+        "a",
+        "b",
+        "c",
+        "z",
+        "ab",
+        "abab",
+        "ababz",
+        "abcabz",
+        "é",
+        "éé",
+        "ééz",
+        "x",
+        "(",
+        ")",
+        "a)",
+        "(a)",
+    ]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    eager = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=False
+    ).compile_grammar(grammar)
+    dynamic = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    ).compile_grammar(grammar)
+
+    expected = _mask_trace(eager, accepted_input)
+    actual = _mask_trace(dynamic, accepted_input)
+    assert dynamic.memory_size_bytes > 0
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+        assert actual_apply == expected_apply
+        expected_tokens = bitmask_to_bool_mask(expected_mask, tokenizer_info.vocab_size)
+        actual_tokens = bitmask_to_bool_mask(actual_mask, tokenizer_info.vocab_size)
+        torch.testing.assert_close(actual_tokens, expected_tokens, rtol=0, atol=0)
+
+    for token_id in range(tokenizer_info.vocab_size):
+        eager_matcher = xgr.GrammarMatcher(eager, terminate_without_stop_token=True)
+        dynamic_matcher = xgr.GrammarMatcher(dynamic, terminate_without_stop_token=True)
+        assert dynamic_matcher.accept_token(token_id) == eager_matcher.accept_token(token_id)
+
+
+def test_large_finite_nullable_repeat_skips_redundant_empty_matches():
+    tokenizer_info = xgr.TokenizerInfo(["z", "ab", "ababz", "x"], stop_token_ids=[])
+    compiled = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    ).compile_grammar('root ::= unit{0,1000000} "z"\nunit ::= "" | "ab"')
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+
+    assert _next_token_mask(matcher, tokenizer_info.vocab_size)[0].tolist() == [
+        True,
+        True,
+        True,
+        False,
+    ]
+
+
 @pytest.mark.parametrize("operation", ["rollback", "reset", "fork"])
 def test_repeated_character_class_masks_do_not_leak_across_state_changes(operation):
     tokenizer_info = xgr.TokenizerInfo(["p", "q", "a", "x", "y"], stop_token_ids=[])

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -1,3 +1,4 @@
+import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
@@ -173,6 +174,54 @@ def test_serialization_roundtrips_dynamic_tag_dispatch():
     for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
         assert actual_apply == expected_apply
         torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_dynamic_tag_dispatch_slicing_uses_rule_level_cache():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    cache_limit = 64 * 1024
+    compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=True,
+        cache_limit_bytes=cache_limit,
+        enable_dynamic_compilation=True,
+    )
+
+    def dispatch(value, trigger="<call>"):
+        return {
+            "type": "structural_tag",
+            "format": {
+                "type": "dispatch",
+                "rules": [[trigger, {"type": "const_string", "value": value}]],
+                "loop": False,
+                "excludes": [],
+            },
+        }
+
+    def compile_dispatch(value, trigger="<call>"):
+        return compiler.compile_structural_tag(dispatch(value, trigger))
+
+    first = compile_dispatch("X")
+    size_before_first_use = compiler.get_cache_size_bytes()
+    _mask_trace(first, "prefix<call>X")
+    size_after_first_use = compiler.get_cache_size_bytes()
+    assert size_before_first_use < size_after_first_use <= cache_limit
+
+    second = compiler.compile_structural_tag(json.dumps(dispatch("X"), indent=2))
+    size_before_second_use = compiler.get_cache_size_bytes()
+    _mask_trace(second, "prefix<call>X")
+    assert compiler.get_cache_size_bytes() == size_before_second_use
+
+    distinct_patterns = [compile_dispatch("X", trigger=f"<call{index}>") for index in range(32)]
+    for compiled_grammar in distinct_patterns:
+        matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        matcher.fill_next_token_bitmask(bitmask)
+    size_after_distinct_patterns = compiler.get_cache_size_bytes()
+    assert 0 < size_after_distinct_patterns <= cache_limit
+
+    compiler.clear_cache()
+    assert compiler.get_cache_size_bytes() == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -23,6 +23,12 @@ def _mask_trace(compiled_grammar: xgr.CompiledGrammar, input_string: str):
     return trace
 
 
+def _next_token_mask(matcher: xgr.GrammarMatcher, vocabulary_size: int) -> torch.Tensor:
+    bitmask = xgr.allocate_token_bitmask(1, vocabulary_size)
+    matcher.fill_next_token_bitmask(bitmask)
+    return bitmask_to_bool_mask(bitmask, vocabulary_size)
+
+
 def _compile_ebnf(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
     return compiler.compile_grammar(
         """
@@ -356,3 +362,61 @@ def test_shared_parser_features_preserve_budget_and_capture_behavior():
             matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
             assert matcher.accept_string(value) and matcher.is_terminated()
             assert matcher.get_captures() == expected_captures
+
+
+def test_reusable_parser_worklists_survive_reset_fork_failure_and_rollback():
+    vocabulary = ["a", "b", "c", "d", "ab", "bc", "abc", "cd", "x", b"\xff"]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    compiled_grammar = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    ).compile_grammar('root ::= [a-c]{0,8} "d"')
+    token_identifiers = {token: vocabulary.index(token) for token in ["a", "b", "c", "d", "x"]}
+
+    def fresh_mask(prefix):
+        fresh_matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+        assert all(fresh_matcher.accept_token(token_identifier) for token_identifier in prefix)
+        return _next_token_mask(fresh_matcher, tokenizer_info.vocab_size)
+
+    matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+    for _ in range(32):
+        matcher.reset()
+        prefix = []
+        for token in ["a", "b"]:
+            expected_mask = fresh_mask(prefix)
+            torch.testing.assert_close(
+                _next_token_mask(matcher, tokenizer_info.vocab_size), expected_mask, rtol=0, atol=0
+            )
+            torch.testing.assert_close(
+                _next_token_mask(matcher, tokenizer_info.vocab_size), expected_mask, rtol=0, atol=0
+            )
+            assert matcher.accept_token(token_identifiers[token])
+            prefix.append(token_identifiers[token])
+
+        forked_matcher = matcher.fork()
+        torch.testing.assert_close(
+            _next_token_mask(forked_matcher, tokenizer_info.vocab_size),
+            fresh_mask(prefix),
+            rtol=0,
+            atol=0,
+        )
+        assert forked_matcher.accept_token(token_identifiers["c"])
+        assert forked_matcher.accept_token(token_identifiers["d"])
+        assert forked_matcher.is_terminated()
+
+        mask_before_failure = _next_token_mask(matcher, tokenizer_info.vocab_size)
+        assert not matcher.accept_token(token_identifiers["x"])
+        torch.testing.assert_close(
+            _next_token_mask(matcher, tokenizer_info.vocab_size),
+            mask_before_failure,
+            rtol=0,
+            atol=0,
+        )
+
+        matcher.rollback(1)
+        prefix.pop()
+        torch.testing.assert_close(
+            _next_token_mask(matcher, tokenizer_info.vocab_size), fresh_mask(prefix), rtol=0, atol=0
+        )
+        assert matcher.accept_token(token_identifiers["c"])
+        assert matcher.accept_token(token_identifiers["d"])
+        assert matcher.is_terminated()

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -834,6 +834,62 @@ def test_large_finite_nullable_repeat_skips_redundant_empty_matches():
     ]
 
 
+@pytest.mark.parametrize(
+    ("grammar", "accepted_input"),
+    [
+        ('root ::= "L" wrapper "x"\nwrapper ::= unit{1,4} "z"\nunit ::= "ab"', "Lababzx"),
+        (
+            'root ::= "L" wrapper "x" | "R" wrapper "y"\nwrapper ::= unit{1,4} "z"\nunit ::= "ab"',
+            "Rababzy",
+        ),
+        ('root ::= unit{1,4} "z"\nunit ::= "ab"', "ababz"),
+        ('root ::= "L" wrapper "x"\nwrapper ::= unit{0,4} "z"\nunit ::= "" | "ab"', "Labzx"),
+    ],
+    ids=["exact-lookahead", "branching-lookahead", "root-parent", "nullable-unit"],
+)
+def test_repeat_parent_lookahead_masks_stay_exact(grammar, accepted_input):
+    # Repeat masks apply the parent rule's lookahead assertion to tokens crossing the parent's
+    # completion point. Verify every mask bit against real per-token acceptance so a wrong
+    # lookahead-based rejection or acceptance cannot slip through.
+    vocabulary = [
+        "a",
+        "b",
+        "z",
+        "x",
+        "y",
+        "ab",
+        "abab",
+        "abz",
+        "abzx",
+        "abzxx",
+        "abzy",
+        "zx",
+        "zz",
+        "L",
+        "R",
+    ]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    for enable_dynamic_compilation in (False, True):
+        compiled = xgr.GrammarCompiler(
+            tokenizer_info, max_threads=1, enable_dynamic_compilation=enable_dynamic_compilation
+        ).compile_grammar(grammar)
+        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        for consumed_length, char in enumerate(accepted_input):
+            xgr.reset_token_bitmask(bitmask)
+            assert matcher.fill_next_token_bitmask(bitmask)
+            allowed = bitmask_to_bool_mask(bitmask, tokenizer_info.vocab_size)[0]
+            for token_id in range(tokenizer_info.vocab_size):
+                probe = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+                if consumed_length > 0:
+                    assert probe.accept_string(accepted_input[:consumed_length])
+                assert allowed[token_id].item() == probe.accept_token(token_id), (
+                    f"token {vocabulary[token_id]!r} after "
+                    f"{accepted_input[:consumed_length]!r} (dynamic={enable_dynamic_compilation})"
+                )
+            assert matcher.accept_string(char)
+
+
 @pytest.mark.parametrize("operation", ["rollback", "reset", "fork"])
 def test_repeated_character_class_masks_do_not_leak_across_state_changes(operation):
     tokenizer_info = xgr.TokenizerInfo(["p", "q", "a", "x", "y"], stop_token_ids=[])

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -1,0 +1,192 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import torch
+
+import xgrammar as xgr
+from xgrammar.base import _core
+
+VOCABULARY = [chr(value) for value in range(32, 127)] + ["Ada", "hello", "42", "<call>"]
+
+
+def _mask_trace(compiled_grammar: xgr.CompiledGrammar, input_string: str):
+    matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+    bitmask = xgr.allocate_token_bitmask(1, compiled_grammar.tokenizer_info.vocab_size)
+    trace = []
+    for char in input_string:
+        xgr.reset_token_bitmask(bitmask)
+        trace.append((matcher.fill_next_token_bitmask(bitmask), bitmask.clone()))
+        assert matcher.accept_string(char)
+    assert matcher.is_terminated()
+    return trace
+
+
+def _compile_ebnf(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_grammar(
+        """
+root ::= greeting punctuation
+greeting ::= "hello" | "hi"
+punctuation ::= "!" | "?"
+"""
+    )
+
+
+def _compile_json_schema(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_json_schema(
+        {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "scores": {"type": "array", "items": {"type": "integer"}},
+            },
+            "required": ["name", "scores"],
+            "additionalProperties": False,
+        },
+        any_whitespace=True,
+    )
+
+
+def _compile_regex(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_regex(r"[A-Z][a-z]{2}[0-9]+")
+
+
+def _compile_builtin_json(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_builtin_json_grammar()
+
+
+def _compile_structural_tag(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_structural_tag(
+        {
+            "type": "structural_tag",
+            "format": {
+                "type": "dispatch",
+                "rules": [["<call>", {"type": "const_string", "value": "X"}]],
+                "loop": False,
+                "excludes": [],
+            },
+        }
+    )
+
+
+CASES = [
+    (_compile_ebnf, "hello!"),
+    (_compile_json_schema, '{"name":"Ada","scores":[1,2]}'),
+    (_compile_regex, "Ada42"),
+    (_compile_builtin_json, '{"name":"Ada"}'),
+    (_compile_structural_tag, "prefix<call>X"),
+]
+
+
+def test_existing_native_constructor_remains_available():
+    tokenizer_info = xgr.TokenizerInfo(["a"], stop_token_ids=[])
+    compiler = _core.GrammarCompiler(tokenizer_info._handle, 1, True, -1)
+    compiler.compile_builtin_json_grammar()
+
+
+@pytest.mark.parametrize(
+    "compile_grammar,input_string",
+    CASES,
+    ids=["ebnf", "json-schema", "regex", "builtin-json", "structural-tag"],
+)
+def test_dynamic_compilation_matches_eager_masks(compile_grammar, input_string):
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    eager = compile_grammar(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+    dynamic = compile_grammar(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+
+    expected = _mask_trace(eager, input_string)
+    actual = _mask_trace(dynamic, input_string)
+    assert len(actual) == len(expected)
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+        assert actual_apply == expected_apply
+        torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_dynamic_masks_are_cached():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic = _compile_builtin_json(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    eager = _compile_builtin_json(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+
+    initial_size = dynamic.memory_size_bytes
+    assert initial_size < eager.memory_size_bytes
+    _mask_trace(dynamic, '{"name":"Ada"}')
+    populated_size = dynamic.memory_size_bytes
+    assert populated_size > initial_size
+    _mask_trace(dynamic, '{"name":"Ada"}')
+    assert dynamic.memory_size_bytes == populated_size
+
+
+def test_serialization_materializes_dynamic_masks():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic = _compile_ebnf(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    initial_size = dynamic.memory_size_bytes
+
+    restored = xgr.CompiledGrammar.deserialize_json(dynamic.serialize_json(), tokenizer_info)
+    assert dynamic.memory_size_bytes > initial_size
+    for input_string in ["hello!", "hi?"]:
+        expected = _mask_trace(dynamic, input_string)
+        actual = _mask_trace(restored, input_string)
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+            assert actual_apply == expected_apply
+            torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_concurrent_dynamic_mask_generation():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic = _compile_json_schema(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    input_string = '{"name":"Ada","scores":[1,2]}'
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        traces = list(executor.map(lambda _: _mask_trace(dynamic, input_string), range(32)))
+
+    expected = traces[0]
+    for actual in traces[1:]:
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+            assert actual_apply == expected_apply
+            torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_limited_compiler_cache_does_not_retain_growing_grammar():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    cache_limit = 64 * 1024
+    compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=True,
+        cache_limit_bytes=cache_limit,
+        enable_dynamic_compilation=True,
+    )
+    dynamic = _compile_builtin_json(compiler)
+    assert compiler.get_cache_size_bytes() == 0
+
+    barrier = threading.Barrier(9)
+
+    def generate_masks():
+        barrier.wait()
+        return _mask_trace(dynamic, '{"name":"Ada"}')
+
+    def read_cache_sizes():
+        barrier.wait()
+        return [compiler.get_cache_size_bytes() for _ in range(100)]
+
+    with ThreadPoolExecutor(max_workers=9) as executor:
+        mask_futures = [executor.submit(generate_masks) for _ in range(8)]
+        size_future = executor.submit(read_cache_sizes)
+        for future in mask_futures:
+            future.result()
+        observed_sizes = size_future.result()
+
+    assert all(0 <= size <= cache_limit for size in observed_sizes)
+    assert 0 <= compiler.get_cache_size_bytes() <= cache_limit

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -280,3 +280,45 @@ def test_rule_mask_sharing_distinguishes_token_edge_payloads(enable_dynamic_comp
 
     assert not torch.equal(first_mask, expected_mask)
     torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("enable_dynamic_compilation", [False, True], ids=["eager", "dynamic"])
+def test_rule_mask_sharing_distinguishes_lookahead_expression_boundaries(
+    enable_dynamic_compilation,
+):
+    vocabulary = ["p", "qac", "qa\x01\x01aabb", "q"] + [f"invalid-{index}" for index in range(28)]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    cached_compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=True,
+        enable_dynamic_compilation=enable_dynamic_compilation,
+    )
+    uncached_compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=False,
+        enable_dynamic_compilation=enable_dynamic_compilation,
+    )
+
+    byte_string_suffix = r'"a\u0001\u0001aabb"'
+    character_class_suffix = '"a" [^ab]'
+
+    def grammar(suffix):
+        return f'root ::= "p" target {suffix}\ntarget ::= [q] (= {suffix})'
+
+    def mask_after_prefix(compiler, grammar_source):
+        compiled_grammar = compiler.compile_grammar(grammar_source)
+        matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+        assert matcher.accept_token(0)
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        xgr.reset_token_bitmask(bitmask)
+        assert matcher.fill_next_token_bitmask(bitmask)
+        return bitmask
+
+    first_mask = mask_after_prefix(cached_compiler, grammar(byte_string_suffix))
+    actual_mask = mask_after_prefix(cached_compiler, grammar(character_class_suffix))
+    expected_mask = mask_after_prefix(uncached_compiler, grammar(character_class_suffix))
+
+    assert not torch.equal(first_mask, expected_mask)
+    torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -469,3 +469,230 @@ def test_reusable_parser_worklists_survive_reset_fork_failure_and_rollback():
         assert matcher.accept_token(token_identifiers["c"])
         assert matcher.accept_token(token_identifiers["d"])
         assert matcher.is_terminated()
+
+
+@pytest.mark.parametrize(
+    "repeat_range,value",
+    [
+        ("{0}", ""),
+        ("{1}", "a"),
+        ("{0,1}", ""),
+        ("{1,3}", "ab"),
+        ("{63,65}", "a" * 64),
+        ("{127,129}", "a" * 128),
+        ("{255,257}", "a" * 256),
+        ("{2,}", "abc"),
+    ],
+)
+def test_preserved_repetition_ranges_match_eager_masks(repeat_range: str, value: str):
+    vocabulary = [">", "<", "a", "aa", "ab", "abc", "b", "ba", "c", b"\xc3", b"\xff"]
+    grammar = f'root ::= ">" [a-z]{repeat_range} "<"'
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    eager = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=False
+    ).compile_grammar(grammar)
+    dynamic = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    ).compile_grammar(grammar)
+    expected = _mask_trace(eager, ">" + value + "<")
+    actual = _mask_trace(dynamic, ">" + value + "<")
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+        assert actual_apply == expected_apply
+        expected_tokens = bitmask_to_bool_mask(expected_mask, tokenizer_info.vocab_size)
+        actual_tokens = bitmask_to_bool_mask(actual_mask, tokenizer_info.vocab_size)
+        torch.testing.assert_close(actual_tokens, expected_tokens, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("enable_dynamic_compilation", [False, True], ids=["eager", "dynamic"])
+@pytest.mark.parametrize(
+    "repeat_range,accepted_values,rejected_values",
+    [
+        ("{0}", [""], ["a"]),
+        ("{0,2}", ["", "aa"], ["aaa"]),
+        ("{1,3}", ["a", "aaa"], ["", "aaaa"]),
+        ("{2,}", ["aa", "aaaa"], ["", "a"]),
+    ],
+)
+def test_preserved_repetition_ranges_enforce_bounds(
+    enable_dynamic_compilation, repeat_range, accepted_values, rejected_values
+):
+    tokenizer_info = xgr.TokenizerInfo([], stop_token_ids=[])
+    compiled = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=enable_dynamic_compilation
+    ).compile_grammar(f'root ::= unit{repeat_range}\nunit ::= "a"')
+
+    for value in accepted_values:
+        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        assert matcher.accept_string(value)
+        assert matcher.is_terminated()
+    for value in rejected_values:
+        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        assert not (matcher.accept_string(value) and matcher.is_terminated())
+
+
+@pytest.mark.parametrize(
+    "grammar,accepted_values,rejected_values",
+    [
+        ('root ::= unit{1} "x" | unit{1} "y"\nunit ::= "a"', ["ax", "ay"], []),
+        ('root ::= unit{1} "x" | unit{2} "y"\nunit ::= "a"', ["ax", "aay"], ["aax", "ay"]),
+    ],
+    ids=["same-bounds", "different-bounds"],
+)
+def test_preserved_repetition_ranges_keep_shared_repeat_edges(
+    grammar, accepted_values, rejected_values
+):
+    tokenizer_info = xgr.TokenizerInfo(["a", "x", "y"], stop_token_ids=[])
+    eager = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=False
+    ).compile_grammar(grammar)
+    dynamic = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    ).compile_grammar(grammar)
+
+    for value in accepted_values:
+        expected = _mask_trace(eager, value)
+        actual = _mask_trace(dynamic, value)
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+            assert actual_apply == expected_apply
+            expected_tokens = bitmask_to_bool_mask(expected_mask, tokenizer_info.vocab_size)
+            actual_tokens = bitmask_to_bool_mask(actual_mask, tokenizer_info.vocab_size)
+            torch.testing.assert_close(actual_tokens, expected_tokens, rtol=0, atol=0)
+
+    for value in rejected_values:
+        for compiled_grammar in [eager, dynamic]:
+            matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+            assert not (matcher.accept_string(value) and matcher.is_terminated())
+
+
+@pytest.mark.parametrize(
+    "grammar,accepted_values,rejected_values",
+    [
+        ('root ::= unit{2} "x" | "y"\nunit ::= "a"', ["aax", "y"], ["ay", "ax", "aay"]),
+        (
+            'root ::= a{1,2} | b{2,3}\na ::= "a"\nb ::= "b"',
+            ["a", "aa", "bb", "bbb"],
+            ["b", "ab", "ba", "aaa", "bbbb"],
+        ),
+        (
+            'root ::= pair{2,3} "x"\npair ::= unit{1,2}\nunit ::= "a"',
+            ["aax", "aaax", "aaaax", "aaaaax", "aaaaaax"],
+            ["x", "ax", "aaaaaaax"],
+        ),
+        (
+            'root ::= unit{2,3} "x"\nunit ::= "" | "a"',
+            ["x", "ax", "aax", "aaax"],
+            ["a", "aaaax", "xx"],
+        ),
+        ('root ::= unit{2,} "x"\nunit ::= "" | "a"', ["x", "ax", "aax", "aaaaax"], ["a", "xx"]),
+    ],
+    ids=[
+        "repeat-and-literal",
+        "different-repeated-rules",
+        "nested-repeats",
+        "bounded-nullable-repeat",
+        "unbounded-nullable-repeat",
+    ],
+)
+def test_preserved_repetition_ranges_keep_repeat_branches_isolated(
+    grammar, accepted_values, rejected_values
+):
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "x", "y"], stop_token_ids=[])
+    eager = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=False
+    ).compile_grammar(grammar)
+    dynamic = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    ).compile_grammar(grammar)
+
+    for value in accepted_values:
+        expected = _mask_trace(eager, value)
+        actual = _mask_trace(dynamic, value)
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+            assert actual_apply == expected_apply
+            expected_tokens = bitmask_to_bool_mask(expected_mask, tokenizer_info.vocab_size)
+            actual_tokens = bitmask_to_bool_mask(actual_mask, tokenizer_info.vocab_size)
+            torch.testing.assert_close(actual_tokens, expected_tokens, rtol=0, atol=0)
+
+    for value in rejected_values:
+        eager_matcher = xgr.GrammarMatcher(eager, terminate_without_stop_token=True)
+        dynamic_matcher = xgr.GrammarMatcher(dynamic, terminate_without_stop_token=True)
+        assert not (eager_matcher.accept_string(value) and eager_matcher.is_terminated())
+        assert not (dynamic_matcher.accept_string(value) and dynamic_matcher.is_terminated())
+
+
+def test_preserved_repetition_ranges_survive_serialization():
+    grammar = 'root ::= unit{2} "x" | unit{3} "y"\nunit ::= "a"'
+    tokenizer_info = xgr.TokenizerInfo(["a", "x", "y"], stop_token_ids=[])
+    eager = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=False
+    ).compile_grammar(grammar)
+    dynamic = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    ).compile_grammar(grammar)
+    restored = xgr.CompiledGrammar.deserialize_json(dynamic.serialize_json(), tokenizer_info)
+
+    for value in ["aax", "aaay"]:
+        expected = _mask_trace(eager, value)
+        actual = _mask_trace(restored, value)
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+            assert actual_apply == expected_apply
+            torch.testing.assert_close(
+                bitmask_to_bool_mask(actual_mask, tokenizer_info.vocab_size),
+                bitmask_to_bool_mask(expected_mask, tokenizer_info.vocab_size),
+                rtol=0,
+                atol=0,
+            )
+
+
+def test_preserved_repetition_ranges_survive_rollback():
+    tokenizer_info = xgr.TokenizerInfo(["a", "x"], stop_token_ids=[])
+    compiled_grammar = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    ).compile_grammar('root ::= unit{1,3} "x"\nunit ::= "a"')
+
+    def mask_after_one_a(matcher):
+        assert matcher.accept_token(0)
+        return _next_token_mask(matcher, tokenizer_info.vocab_size)
+
+    matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+    expected = mask_after_one_a(
+        xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+    )
+    assert matcher.accept_token(0)
+    assert matcher.accept_token(0)
+    matcher.rollback(1)
+    torch.testing.assert_close(
+        _next_token_mask(matcher, tokenizer_info.vocab_size), expected, rtol=0, atol=0
+    )
+
+
+def test_rule_mask_sharing_distinguishes_repeat_bounds():
+    tokenizer_info = xgr.TokenizerInfo(["p", "a", "x", "z"], stop_token_ids=[])
+    cached_compiler = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, cache_enabled=True, enable_dynamic_compilation=True
+    )
+    uncached_compiler = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, cache_enabled=False, enable_dynamic_compilation=True
+    )
+
+    def grammar(repeat_count):
+        return (
+            f'root ::= "p" recursive "z"\n'
+            f'recursive ::= unit{{{repeat_count}}} recursive | "x"\n'
+            'unit ::= "a"'
+        )
+
+    def mask_after_prefix(compiler, grammar_source):
+        matcher = xgr.GrammarMatcher(
+            compiler.compile_grammar(grammar_source), terminate_without_stop_token=True
+        )
+        assert matcher.accept_token(0)
+        assert matcher.accept_token(1)
+        return _next_token_mask(matcher, tokenizer_info.vocab_size)
+
+    first_mask = mask_after_prefix(cached_compiler, grammar(1))
+    actual_mask = mask_after_prefix(cached_compiler, grammar(2))
+    expected_mask = mask_after_prefix(uncached_compiler, grammar(2))
+
+    assert not torch.equal(first_mask, expected_mask)
+    torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -168,12 +168,19 @@ def test_serialization_roundtrips_dynamic_tag_dispatch():
         torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
 
 
-def test_concurrent_dynamic_mask_generation():
+@pytest.mark.parametrize(
+    "compile_grammar,input_string",
+    [
+        (_compile_json_schema, '{"name":"Ada","scores":[1,2]}'),
+        (_compile_structural_tag, "prefix<call>X"),
+    ],
+    ids=["json-schema", "structural-tag"],
+)
+def test_concurrent_dynamic_mask_generation(compile_grammar, input_string):
     tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
-    dynamic = _compile_json_schema(
+    dynamic = compile_grammar(
         xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
     )
-    input_string = '{"name":"Ada","scores":[1,2]}'
 
     with ThreadPoolExecutor(max_workers=8) as executor:
         traces = list(executor.map(lambda _: _mask_trace(dynamic, input_string), range(32)))

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -223,6 +223,28 @@ def test_limited_compiler_cache_records_dynamic_grammar_size_on_insertion():
             future.result()
         observed_sizes = size_future.result()
 
-    assert all(size == insertion_size for size in observed_sizes)
-    assert compiler.get_cache_size_bytes() == insertion_size
+    assert all(insertion_size <= size <= cache_limit for size in observed_sizes)
+    assert insertion_size <= compiler.get_cache_size_bytes() <= cache_limit
     assert _compile_builtin_json(compiler).memory_size_bytes == dynamic.memory_size_bytes
+
+
+def test_rule_mask_sharing_does_not_cross_context_dependent_rules():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic_compiler = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    )
+    eager_compiler = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=False
+    )
+
+    unbounded = dynamic_compiler.compile_grammar('root ::= "a" shared "z"\nshared ::= [x]+')
+    _mask_trace(unbounded, "axxz")
+
+    bounded_grammar = 'root ::= "a" shared "z"\nshared[max_tokens=1] ::= [x]+'
+    dynamic_bounded = dynamic_compiler.compile_grammar(bounded_grammar)
+    eager_bounded = eager_compiler.compile_grammar(bounded_grammar)
+    expected = _mask_trace(eager_bounded, "axz")
+    actual = _mask_trace(dynamic_bounded, "axz")
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+        assert actual_apply == expected_apply
+        torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -248,3 +248,35 @@ def test_rule_mask_sharing_does_not_cross_context_dependent_rules():
     for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
         assert actual_apply == expected_apply
         torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("enable_dynamic_compilation", [False, True], ids=["eager", "dynamic"])
+@pytest.mark.parametrize("edge_name", ["Token", "ExcludeToken"])
+def test_rule_mask_sharing_distinguishes_token_edge_payloads(enable_dynamic_compilation, edge_name):
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c"], stop_token_ids=[])
+    cached_compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=True,
+        enable_dynamic_compilation=enable_dynamic_compilation,
+    )
+    uncached_compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=False,
+        enable_dynamic_compilation=enable_dynamic_compilation,
+    )
+
+    def initial_mask(compiled_grammar):
+        matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        xgr.reset_token_bitmask(bitmask)
+        assert matcher.fill_next_token_bitmask(bitmask)
+        return bitmask
+
+    first_mask = initial_mask(cached_compiler.compile_grammar(f"root ::= {edge_name}(0)"))
+    actual_mask = initial_mask(cached_compiler.compile_grammar(f"root ::= {edge_name}(1)"))
+    expected_mask = initial_mask(uncached_compiler.compile_grammar(f"root ::= {edge_name}(1)"))
+
+    assert not torch.equal(first_mask, expected_mask)
+    torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -78,10 +78,13 @@ CASES = [
 ]
 
 
-def test_existing_native_constructor_remains_available():
+def test_native_constructor_takes_dynamic_compilation_flag():
     tokenizer_info = xgr.TokenizerInfo(["a"], stop_token_ids=[])
-    compiler = _core.GrammarCompiler(tokenizer_info._handle, 1, True, -1)
-    compiler.compile_builtin_json_grammar()
+    for enable_dynamic_compilation in (False, True):
+        compiler = _core.GrammarCompiler(
+            tokenizer_info._handle, 1, True, -1, enable_dynamic_compilation
+        )
+        compiler.compile_builtin_json_grammar()
 
 
 @pytest.mark.parametrize(
@@ -124,21 +127,45 @@ def test_dynamic_masks_are_cached():
     assert dynamic.memory_size_bytes == populated_size
 
 
-def test_serialization_materializes_dynamic_masks():
+def test_serialization_roundtrips_dynamic_mode():
     tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
     dynamic = _compile_ebnf(
         xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
     )
+    eager = _compile_ebnf(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
     initial_size = dynamic.memory_size_bytes
 
     restored = xgr.CompiledGrammar.deserialize_json(dynamic.serialize_json(), tokenizer_info)
-    assert dynamic.memory_size_bytes > initial_size
+    # Serialization does not materialize masks, and the restored grammar is dynamic again.
+    assert dynamic.memory_size_bytes == initial_size
+    restored_initial_size = restored.memory_size_bytes
+    assert restored_initial_size < eager.memory_size_bytes
     for input_string in ["hello!", "hi?"]:
-        expected = _mask_trace(dynamic, input_string)
+        expected = _mask_trace(eager, input_string)
         actual = _mask_trace(restored, input_string)
         for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
             assert actual_apply == expected_apply
             torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+    assert restored.memory_size_bytes > restored_initial_size
+
+
+def test_serialization_roundtrips_dynamic_tag_dispatch():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic = _compile_structural_tag(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    eager = _compile_structural_tag(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+
+    restored = xgr.CompiledGrammar.deserialize_json(dynamic.serialize_json(), tokenizer_info)
+    expected = _mask_trace(eager, "prefix<call>X")
+    actual = _mask_trace(restored, "prefix<call>X")
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+        assert actual_apply == expected_apply
+        torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
 
 
 def test_concurrent_dynamic_mask_generation():

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -192,7 +192,7 @@ def test_concurrent_dynamic_mask_generation(compile_grammar, input_string):
             torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
 
 
-def test_limited_compiler_cache_does_not_retain_growing_grammar():
+def test_limited_compiler_cache_records_dynamic_grammar_size_on_insertion():
     tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
     cache_limit = 64 * 1024
     compiler = xgr.GrammarCompiler(
@@ -203,7 +203,8 @@ def test_limited_compiler_cache_does_not_retain_growing_grammar():
         enable_dynamic_compilation=True,
     )
     dynamic = _compile_builtin_json(compiler)
-    assert compiler.get_cache_size_bytes() == 0
+    insertion_size = compiler.get_cache_size_bytes()
+    assert 0 < insertion_size <= cache_limit
 
     barrier = threading.Barrier(9)
 
@@ -222,5 +223,6 @@ def test_limited_compiler_cache_does_not_retain_growing_grammar():
             future.result()
         observed_sizes = size_future.result()
 
-    assert all(0 <= size <= cache_limit for size in observed_sizes)
-    assert 0 <= compiler.get_cache_size_bytes() <= cache_limit
+    assert all(size == insertion_size for size in observed_sizes)
+    assert compiler.get_cache_size_bytes() == insertion_size
+    assert _compile_builtin_json(compiler).memory_size_bytes == dynamic.memory_size_bytes

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -447,6 +447,32 @@ def _compiled_accepts(compiled_grammar: xgr.CompiledGrammar, input_str: str) -> 
     return matcher.accept_string(input_str) and matcher.is_terminated()
 
 
+def test_repeated_regex_fsm_reuse_preserves_nullable_rules():
+    tokenizer_info = xgr.TokenizerInfo(["!", "a", "aa", "b"], stop_token_ids=[])
+    grammar = xgr.Grammar.from_lark('start: left "!" right\nleft: /a*/\nright: /a*/')
+
+    compiled = xgr.GrammarCompiler(tokenizer_info, max_threads=1).compile_grammar(grammar)
+    for value in ["!", "a!", "!a", "aa!aa"]:
+        assert _compiled_accepts(compiled, value)
+    for value in ["", "aa", "!!", "b!"]:
+        assert not _compiled_accepts(compiled, value)
+
+
+def test_regex_fsm_cache_distinguishes_json_string_mode():
+    tokenizer_info = xgr.TokenizerInfo([])
+    grammar = xgr.Grammar.from_ebnf(
+        'root ::= plain "!" plain json "!" json\n'
+        'plain ::= Regex(".")\n'
+        'json ::= Regex(".", json_string=true)'
+    )
+
+    compiled = xgr.GrammarCompiler(tokenizer_info, max_threads=1).compile_grammar(grammar)
+    for value in ['"!ab!c', "\\!ab!c", "a!bc!d"]:
+        assert _compiled_accepts(compiled, value)
+    for value in ['a!a"!b', "a!a\\!b", "a!ab!\n"]:
+        assert not _compiled_accepts(compiled, value)
+
+
 def _mask_trace(compiled_grammar: xgr.CompiledGrammar, input_str: str):
     matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
     bitmask = xgr.allocate_token_bitmask(1, compiled_grammar.tokenizer_info.vocab_size)

--- a/tests/python/test_grammar_fsm_builder.py
+++ b/tests/python/test_grammar_fsm_builder.py
@@ -181,6 +181,31 @@ def test_recursive_rule_ref_in_sequence():
     assert not _matcher_accepts(matcher, "())")
 
 
+def test_large_byte_prefix_rule_ref_suffix_choices():
+    prefixes = ["a" * length for length in range(1, 65)]
+    alternatives = []
+    for index, prefix in enumerate(prefixes):
+        suffix = "!" if index % 2 == 0 else "?"
+        alternatives.append(f'"{prefix}" body "{suffix}"')
+    grammar = "root ::= " + " | ".join(alternatives) + "\nbody ::= [0-9]"
+    matcher = _make_string_matcher(grammar)
+
+    for index, prefix in enumerate(prefixes):
+        suffix = "!" if index % 2 == 0 else "?"
+        assert _matcher_accepts(matcher, prefix + "7" + suffix)
+        assert not _matcher_accepts(matcher, prefix + "7" + ("?" if suffix == "!" else "!"))
+        assert not _matcher_accepts(matcher, prefix + suffix)
+
+
+def test_nested_byte_prefix_rule_ref_suffix_choices_merge_outer_fsm():
+    grammar = _ebnf_to_grammar_no_normalization(
+        'root ::= ("a" body "x" | "ab" body "x") ("cd" | "ed")\nbody ::= [0-9]'
+    )
+    grammar = GrammarFunctor.fsm_builder(grammar)
+
+    assert "Rule 0: root, FSM: CompactFSM(num_states=9" in _print_grammar_fsms(grammar)
+
+
 # --- Empty sequence ---
 
 

--- a/tests/python/test_grammar_fsm_builder.py
+++ b/tests/python/test_grammar_fsm_builder.py
@@ -409,31 +409,16 @@ fsm_structure_cases = [
         'root ::= "a" item{2,5} "b"\nitem ::= [0-9]',
         _fsm_snapshot(
             r"""
-            Rule 0: root, FSM: CompactFSM(num_states=16, start=2, end=[3], edges=[
-            0: [Rule(4)->1]
-            1: ['b'->3]
-            2: ['a'->0]
-            3: []
+            Rule 0: root, FSM: CompactFSM(num_states=7, start=1, end=[4], edges=[
+            0: ['b'->4]
+            1: ['a'->2]
+            2: [Eps->3]
+            3: [Repeat(rule=1, min=2, max=5)->0]
+            4: []
             ])
-            Rule 1: root_1, FSM: CompactFSM(num_states=16, start=4, end=[4, 6], edges=[
-            4: [[0-9]->5]
-            5: [Rule(2)->6]
+            Rule 1: item, FSM: CompactFSM(num_states=7, start=5, end=[6], edges=[
+            5: [[0-9]->6]
             6: []
-            ])
-            Rule 2: root_2, FSM: CompactFSM(num_states=16, start=7, end=[7, 9], edges=[
-            7: [[0-9]->8]
-            8: [Rule(3)->9]
-            9: []
-            ])
-            Rule 3: root_3, FSM: CompactFSM(num_states=16, start=10, end=[10, 11], edges=[
-            10: [[0-9]->11]
-            11: []
-            ])
-            Rule 4: root_4, FSM: CompactFSM(num_states=16, start=14, end=[15], edges=[
-            12: [[0-9]->13]
-            13: [Rule(1)->15]
-            14: [[0-9]->12]
-            15: []
             ])
             """
         ),
@@ -443,27 +428,15 @@ fsm_structure_cases = [
         'root ::= item{3,}\nitem ::= "ab" [xy]',
         _fsm_snapshot(
             r"""
-            Rule 0: root, FSM: CompactFSM(num_states=14, start=0, end=[1], edges=[
-            0: [Rule(3)->1]
+            Rule 0: root, FSM: CompactFSM(num_states=6, start=0, end=[1], edges=[
+            0: [Repeat(rule=1, min=3, max=-1)->1]
             1: []
             ])
-            Rule 1: item, FSM: CompactFSM(num_states=14, start=3, end=[5], edges=[
+            Rule 1: item, FSM: CompactFSM(num_states=6, start=3, end=[5], edges=[
             2: ['x'->5, 'y'->5]
             3: ['a'->4]
             4: ['b'->2]
             5: []
-            ])
-            Rule 2: root_1, FSM: CompactFSM(num_states=14, start=6, end=[6, 8], edges=[
-            6: [Rule(1)->7]
-            7: [Rule(2)->8]
-            8: []
-            ])
-            Rule 3: root_2, FSM: CompactFSM(num_states=14, start=12, end=[13], edges=[
-            9: [Rule(1)->10]
-            10: [Rule(1)->11]
-            11: [Rule(2)->13]
-            12: [Rule(1)->9]
-            13: []
             ])
             """
         ),
@@ -622,13 +595,13 @@ fsm_structure_cases = [
         'root ::= a b c\na ::= "x" [0-9]*\nb ::= a "y" | [^xyz]\nc ::= b{1,3} "end"',
         _fsm_snapshot(
             r"""
-            Rule 0: root, FSM: CompactFSM(num_states=23, start=2, end=[3], edges=[
+            Rule 0: root, FSM: CompactFSM(num_states=15, start=2, end=[3], edges=[
             0: [Rule(1)->1, [0-9]->0]
             1: [Rule(2)->3]
             2: ['x'->0]
             3: []
             ])
-            Rule 1: b, FSM: CompactFSM(num_states=23, start=7, end=[5], edges=[
+            Rule 1: b, FSM: CompactFSM(num_states=15, start=7, end=[5], edges=[
             4: [[\x80-\xbf]->6]
             5: []
             6: [[\x80-\xbf]->5]
@@ -636,26 +609,12 @@ fsm_structure_cases = [
             8: [[0-9]->8, 'y'->5]
             9: [[\x80-\xbf]->4]
             ])
-            Rule 2: c, FSM: CompactFSM(num_states=23, start=11, end=[14], edges=[
+            Rule 2: c, FSM: CompactFSM(num_states=15, start=11, end=[14], edges=[
             10: ['e'->12]
-            11: [Rule(5)->10]
+            11: [Repeat(rule=1, min=1, max=3)->10]
             12: ['n'->13]
             13: ['d'->14]
             14: []
-            ])
-            Rule 3: c_1, FSM: CompactFSM(num_states=23, start=15, end=[15, 17], edges=[
-            15: [Rule(1)->16]
-            16: [Rule(4)->17]
-            17: []
-            ])
-            Rule 4: c_2, FSM: CompactFSM(num_states=23, start=18, end=[18, 19], edges=[
-            18: [Rule(1)->19]
-            19: []
-            ])
-            Rule 5: c_3, FSM: CompactFSM(num_states=23, start=21, end=[22], edges=[
-            20: [Rule(3)->22]
-            21: [Rule(1)->20]
-            22: []
             ])
             """
         ),

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -185,6 +185,23 @@ def test_structural_tag_compiler():
     assert str(compiled_grammar.grammar) == expected_grammar_test_structural_tag_after_optimization
 
 
+def test_structural_tag_overlapping_branch_prefixes():
+    tags = [
+        xgr.StructuralTagItem(
+            begin="<call>a", schema={"type": "string", "const": "one"}, end="</call>"
+        ),
+        xgr.StructuralTagItem(
+            begin="<call>ab", schema={"type": "string", "const": "two"}, end="</call>"
+        ),
+    ]
+    grammar = xgr.Grammar.from_structural_tag(tags, ["<call>"])
+
+    assert _is_grammar_accept_string(grammar, '<call>a"one"</call>')
+    assert _is_grammar_accept_string(grammar, '<call>ab"two"</call>')
+    assert not _is_grammar_accept_string(grammar, '<call>a"two"</call>')
+    assert not _is_grammar_accept_string(grammar, '<call>ab"one"</call>')
+
+
 @pytest.mark.hf_token_required
 def test_structural_tag_mask_gen():
     # Define schemas for the test

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -1358,6 +1358,7 @@ def test_lark_budget_reset_and_fork() -> None:
     matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
     for token_id in [5, 0, 0]:
         assert matcher.accept_token(token_id)
+    assert _allowed_token_ids(matcher, MAX_TOKENS_TOKENIZER) == [3]
     forked = matcher.fork()
     assert _allowed_token_ids(forked, MAX_TOKENS_TOKENIZER) == [3]
     matcher.reset()

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -1416,6 +1416,29 @@ def test_lark_budget_shared_subrule() -> None:
     assert matcher.is_completed()
 
 
+def test_lark_budget_shared_subrule_keeps_parent_contexts_separate() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["p", "a", "b", "X", "Y"])
+    compiled = _compile_lark(
+        """
+        start: tight "X" | loose "Y"
+        tight[max_tokens=2]: shared
+        loose: shared
+        shared: "p" sub
+        sub: /[ab]+/
+        """,
+        tokenizer_info,
+    )
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+
+    assert matcher.accept_token(0)
+    assert matcher.accept_token(1)
+    assert 2 in _allowed_token_ids(matcher, tokenizer_info)
+    assert matcher.accept_token(2)
+    assert _allowed_token_ids(matcher, tokenizer_info) == [1, 2, 4]
+    assert not matcher.accept_token(3)
+    assert matcher.accept_token(4) and matcher.is_terminated()
+
+
 def test_lark_budget_round_trip_and_cache() -> None:
     grammar = xgr.Grammar.from_lark(BUDGET_GRAMMAR, tokenizer_info=MAX_TOKENS_TOKENIZER)
     ebnf = str(grammar)

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -264,6 +264,8 @@ def test_max_chars_rollback_reset_and_fork() -> None:
 
     assert matcher.accept_token(1)
     assert _allowed_token_ids(matcher, tokenizer_info) == [2]
+    enforced_fork = matcher.fork()
+    assert _allowed_token_ids(enforced_fork, tokenizer_info) == [2]
     matcher.rollback(1)
     assert 0 in _allowed_token_ids(matcher, tokenizer_info)
 

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -273,6 +273,27 @@ def test_max_chars_rollback_reset_and_fork() -> None:
     assert 0 in _allowed_token_ids(matcher, tokenizer_info)
 
 
+def test_max_chars_shared_subrule_keeps_parent_contexts_separate() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "X", "Y"])
+    compiled = _compile(
+        """
+        start: tight "X" | loose "Y"
+        tight[max_chars=1]: sub
+        loose: sub
+        sub: /[ab]+/
+        """,
+        tokenizer_info,
+    )
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+
+    assert matcher.accept_token(0)
+    assert 1 in _allowed_token_ids(matcher, tokenizer_info)
+    assert matcher.accept_token(1)
+    assert _allowed_token_ids(matcher, tokenizer_info) == [0, 1, 3]
+    assert not matcher.accept_token(2)
+    assert matcher.accept_token(3) and matcher.is_terminated()
+
+
 def test_max_chars_atomic_token_is_best_effort() -> None:
     tokenizer_info = xgr.TokenizerInfo(["<|wide|>", "!"])
     compiled = _compile('start: value "!"\nvalue[max_chars=1]: <|wide|>', tokenizer_info)

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -267,6 +267,7 @@ def test_serialize_compiled_grammar():
         "earley_parser_features": {
             "fsm_state_flags": [19, 19, 27, 21, 19, 9, 19, 21, 9],
             "rule_is_nullable": [1, 0],
+            "rule_is_context_independent": [1, 1],
             "has_budget_rules": False,
             "has_char_budget_rules": False,
             "capture_tracking": False,

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -270,6 +270,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
+        "dynamic": False,
         "__VERSION__": "v16",
     }
 

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -264,6 +264,14 @@ def test_serialize_compiled_grammar():
             # fmt: on
             "optimized": True,
         },
+        "earley_parser_features": {
+            "fsm_state_flags": [19, 19, 27, 21, 19, 9, 19, 21, 9],
+            "rule_is_nullable": [1, 0],
+            "has_budget_rules": False,
+            "has_char_budget_rules": False,
+            "capture_tracking": False,
+            "has_hidden_capture_rules": False,
+        },
         "tokenizer_metadata": {
             "vocab_type": 1,
             "vocab_size": 10,
@@ -298,6 +306,16 @@ def test_serialize_compiled_grammar_roundtrip():
     recovered_compiled_grammar = xgr.CompiledGrammar.deserialize_json(serialized, tokenizer_info)
     serialized_new = recovered_compiled_grammar.serialize_json()
     assert serialized == serialized_new
+
+
+def test_deserialize_compiled_grammar_requires_earley_parser_features():
+    """Test that compiled grammar deserialization requires parser features."""
+    original_compiled_grammar, tokenizer_info = construct_compiled_grammar()
+    serialized_object = json.loads(original_compiled_grammar.serialize_json())
+    serialized_object.pop("earley_parser_features")
+
+    with pytest.raises(xgr.DeserializeFormatError, match="earley_parser_features"):
+        xgr.CompiledGrammar.deserialize_json(json.dumps(serialized_object), tokenizer_info)
 
 
 def test_serialize_compiled_grammar_functional():

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -44,7 +44,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v16"
+    assert xgr.get_serialization_version() == "v17"
 
 
 def test_serialize_grammar():
@@ -68,7 +68,7 @@ def test_serialize_grammar():
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v16",
+        "__VERSION__": "v17",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -92,14 +92,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v16",
+        "__VERSION__": "v17",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v16"
+    expected_json["__VERSION__"] = "v17"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -151,7 +151,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v16"}'
+        '"__VERSION__":"v17"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -280,7 +280,8 @@ def test_serialize_compiled_grammar():
             "stop_token_ids": [0, 1],
         },
         "dynamic": False,
-        "__VERSION__": "v16",
+        "repeat_token_mask_cache": [],
+        "__VERSION__": "v17",
     }
 
     class AdaptiveTokenMask(BaseModel):

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -4196,6 +4196,22 @@ def test_structural_tag_per_tag_whitespace_independent():
     assert not _is_grammar_accept_string(g, a(5) + b(5))
 
 
+def test_structural_tag_identical_json_schema_formats_reuse_safely():
+    content = JSONSchemaFormat(json_schema=_WS_SCHEMA, style="json")
+    stag = StructuralTag(
+        format=SequenceFormat(
+            elements=[
+                TagFormat(begin="<a>", content=content, end="</a>"),
+                TagFormat(begin="<b>", content=content, end="</b>"),
+            ]
+        )
+    )
+    grammar = xgr.Grammar.from_structural_tag(stag)
+
+    assert _is_grammar_accept_string(grammar, '<a>{"a": 1}</a><b>{"a": 2}</b>')
+    assert not _is_grammar_accept_string(grammar, '<a>{"a": 1}</a><b>{"a": "x"}</b>')
+
+
 def test_structural_tag_max_whitespace_cnt_compile_cache():
     # The per-tag setting is part of the serialized tag JSON (the cache key), so no collision.
     compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]), cache_enabled=True)

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -1,8 +1,10 @@
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pytest
+import torch
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
@@ -89,6 +91,78 @@ def check_stag_with_instance(
     assert accepted == is_accepted
     if PROFILER_ON:
         profiler.profile_stag(structural_tag_format, instance)
+
+
+def test_tag_dispatch_slicing_cache_isolated_and_concurrent():
+    vocabulary = [chr(value) for value in range(32, 127)] + [
+        "<alpha>",
+        "x<alpha>",
+        "<guard>",
+        "x<guard>",
+    ]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+
+    def compile_dispatch(compiler, trigger, exclude, value):
+        return compiler.compile_structural_tag(
+            {
+                "type": "structural_tag",
+                "format": {
+                    "type": "dispatch",
+                    "rules": [[trigger, {"type": "const_string", "value": value}]],
+                    "loop": False,
+                    "excludes": [exclude],
+                },
+            }
+        )
+
+    def mask_trace(compiled_grammar, input_string):
+        matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        trace = []
+        for char in input_string:
+            xgr.reset_token_bitmask(bitmask)
+            trace.append((matcher.fill_next_token_bitmask(bitmask), bitmask.clone()))
+            assert matcher.accept_string(char)
+        assert matcher.is_terminated()
+        return trace
+
+    specs = [
+        (
+            ("<alpha>", "<guard>", f"X{index}")
+            if index % 2 == 0
+            else ("<guard>", "<alpha>", f"X{index}")
+        )
+        for index in range(16)
+    ]
+    shared_compiler = xgr.GrammarCompiler(tokenizer_info, max_threads=1, cache_enabled=True)
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        shared_results = list(
+            executor.map(lambda spec: compile_dispatch(shared_compiler, *spec), specs)
+        )
+
+    fresh_results = {
+        spec: compile_dispatch(
+            xgr.GrammarCompiler(tokenizer_info, max_threads=1, cache_enabled=False), *spec
+        )
+        for spec in specs
+    }
+    for spec, shared_result in zip(specs, shared_results):
+        input_string = "prefix" + spec[0] + spec[2]
+        expected = mask_trace(fresh_results[spec], input_string)
+        actual = mask_trace(shared_result, input_string)
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+            assert actual_apply == expected_apply
+            torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+    shared_compiler.clear_cache()
+    for spec, fresh_result in fresh_results.items():
+        rebuilt = compile_dispatch(shared_compiler, *spec)
+        input_string = "prefix" + spec[0] + spec[2]
+        expected = mask_trace(fresh_result, input_string)
+        actual = mask_trace(rebuilt, input_string)
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+            assert actual_apply == expected_apply
+            torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
 
 
 const_string_stag_grammar = [


### PR DESCRIPTION
## Summary
- Stacked on [Ubospica/xgrammar#17](https://github.com/Ubospica/xgrammar/pull/17), extending its phase-aware repeated-subrule mask cache to eager compilation.
- Preserve repetition ranges during eager optimization and precompute one mask for every cache-distinct phase within the maximum-token-byte horizon.
- Serialize eager repeat-context masks, share the repeat key with the matcher fast path, and update the serialization version and FSM snapshots.

## Performance
A 32k-vocabulary, single-thread microbenchmark used seven alternating runs against PR #17:
- Large finite range: compile time decreased 26%, memory decreased 76%, and serialized size decreased 80%; mask/accept time increased by 0.003 ms per workload (9%).
- Large nullable range: compile time decreased 67%, memory decreased 85%, serialized size decreased 99%, and mask/accept time decreased 99%.
- Small finite and unbounded ranges: runtime stayed within 3%; compile-time changes were below 0.3 ms and memory increased by 7-12%.
- Accepted-token counts matched in every run.

## Test plan
- `cmake --build /tmp/pr17-eager-build -j 16`
- `pytest tests/python/test_dynamic_compilation.py -q` (66 passed)
- `pytest tests/python/test_serialization.py -q` (15 passed)
- `pytest tests/python/test_grammar_fsm_builder.py tests/python/test_token_edge.py -q` (99 passed)
- `pre-commit run --files <changed files>`

## Stacking
This PR intentionally includes the commits from the dependent PR. It can be rebased onto upstream `main` after that dependency is finalized.