### PR TITLE
Reuse regex FSMs during grammar optimization

### DIFF
--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1147,6 +1147,36 @@ class RuleRefGraphFinder : public GrammarVisitor<std::vector<std::vector<int32_t
   int32_t cur_rule_id_;
 };
 
+static Result<const FSMWithStartEnd*> GetOrBuildRegexFSM(
+    const std::string& regex,
+    bool json_string,
+    std::unordered_map<std::string, FSMWithStartEnd>& regex_fsm_cache,
+    GrammarBuilder* grammar_builder,
+    const std::string& rule_hint
+) {
+  std::string cache_key;
+  cache_key.reserve(regex.size() + 1);
+  cache_key.push_back(static_cast<char>(json_string));
+  cache_key.append(regex);
+
+  auto cached = regex_fsm_cache.find(cache_key);
+  if (cached != regex_fsm_cache.end()) {
+    return ResultOk<const FSMWithStartEnd*>(&cached->second);
+  }
+
+  auto build_result =
+      json_string
+          ? RegexFSMBuilder::BuildWithForbiddenChars(
+                regex, GrammarFSMBuilder::JSONStringForbiddenChars(), grammar_builder, rule_hint
+            )
+          : RegexFSMBuilder::Build(regex, grammar_builder, rule_hint);
+  if (build_result.IsErr()) {
+    return ResultErr(std::move(build_result).UnwrapErr());
+  }
+  cached = regex_fsm_cache.emplace(std::move(cache_key), std::move(build_result).Unwrap()).first;
+  return ResultOk<const FSMWithStartEnd*>(&cached->second);
+}
+
 /*!
  * \brief Analyzes which rules in a grammar can match the empty string.
  */
@@ -1275,17 +1305,26 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
 
 class GrammarFSMBuilderImpl {
  public:
+  using RegexFSMCache = std::unordered_map<std::string, FSMWithStartEnd>;
+
   explicit GrammarFSMBuilderImpl(
       FSM& target_fsm,
       const std::string* rule_name = nullptr,
-      GrammarBuilder* grammar_builder = nullptr
+      GrammarBuilder* grammar_builder = nullptr,
+      RegexFSMCache* regex_fsm_cache = nullptr
   )
-      : target_fsm_(target_fsm), rule_name_(rule_name), grammar_builder_(grammar_builder) {}
+      : target_fsm_(target_fsm),
+        rule_name_(rule_name),
+        grammar_builder_(grammar_builder),
+        regex_fsm_cache_(regex_fsm_cache) {}
 
   static void Apply(Grammar* grammar) {
     FSM complete_fsm;
     std::vector<std::optional<FSMWithStartEndWithSize>> per_rule_fsms;
     std::vector<int> state_mapping;
+    // Reused across all rules of this grammar so identical regexes are converted to an FSM
+    // only once.
+    RegexFSMCache regex_fsm_cache;
 
     // Compiling a kRegex rule may append new rules through this builder: large bounded
     // repetitions in a regex become kRepeatRef edges referencing new rules. NumRules() is
@@ -1293,7 +1332,7 @@ class GrammarFSMBuilderImpl {
     int32_t num_original_rules = (*grammar)->NumRules();
     GrammarBuilder grammar_builder = GrammarBuilder::FromMutableGrammar(grammar);
     for (int i = 0; i < (*grammar)->NumRules(); ++i) {
-      auto rule_fsm = BuildRuleFSM(*grammar, i, &grammar_builder);
+      auto rule_fsm = BuildRuleFSM(*grammar, i, &grammar_builder, &regex_fsm_cache);
       per_rule_fsms.push_back(rule_fsm.AddToCompleteFSM(&complete_fsm, &state_mapping));
     }
 
@@ -1360,13 +1399,17 @@ class GrammarFSMBuilderImpl {
 
  private:
   static FSMWithStartEnd BuildRuleFSM(
-      const Grammar& grammar, int rule_id, GrammarBuilder* grammar_builder = nullptr
+      const Grammar& grammar,
+      int rule_id,
+      GrammarBuilder* grammar_builder = nullptr,
+      RegexFSMCache* regex_fsm_cache = nullptr
   );
   static FSMWithStartEnd BuildExpressionFSM(
       const GrammarExpr& expr,
       const Grammar& grammar,
       const std::string* rule_name = nullptr,
-      GrammarBuilder* grammar_builder = nullptr
+      GrammarBuilder* grammar_builder = nullptr,
+      RegexFSMCache* regex_fsm_cache = nullptr
   );
   void BuildExpression(
       const GrammarExpr& expr,
@@ -1418,13 +1461,16 @@ class GrammarFSMBuilderImpl {
   );
   void AddCharacterClassTransitions(const GrammarExpr& expr, int start_state, int end_state);
   void BuildNegativeCharacterClass(const GrammarExpr& expr, int start_state, int end_state);
-  void AppendFSM(FSMWithStartEnd fsm, int start_state, std::vector<int32_t>* end_states);
+  void AppendFSM(FSMWithStartEnd&& fsm, int start_state, std::vector<int32_t>* end_states);
+  void AppendFSM(const FSMWithStartEnd& fsm, int start_state, std::vector<int32_t>* end_states);
   void AddCharacterRange(int from, int to, uint32_t min, uint32_t max);
 
   FSM& target_fsm_;
   const std::string* rule_name_;
   // If not null, kRegex expressions may add new rules through this builder; see Apply().
   GrammarBuilder* grammar_builder_ = nullptr;
+  // If not null, regex FSMs are looked up in and stored into this cache; see Apply().
+  RegexFSMCache* regex_fsm_cache_ = nullptr;
 };
 
 // This function will add a range [min, max] of unicode characters to the FSM.
@@ -1514,11 +1560,11 @@ void GrammarFSMBuilderImpl::BuildCharacterClassStar(
 }
 
 FSMWithStartEnd GrammarFSMBuilderImpl::BuildRuleFSM(
-    const Grammar& grammar, int rule_id, GrammarBuilder* grammar_builder
+    const Grammar& grammar, int rule_id, GrammarBuilder* grammar_builder, RegexFSMCache* regex_fsm_cache
 ) {
   const auto& rule = grammar->GetRule(rule_id);
   return BuildExpressionFSM(
-      grammar->GetGrammarExpr(rule.body_expr_id), grammar, &rule.name, grammar_builder
+      grammar->GetGrammarExpr(rule.body_expr_id), grammar, &rule.name, grammar_builder, regex_fsm_cache
   );
 }
 
@@ -1526,12 +1572,13 @@ FSMWithStartEnd GrammarFSMBuilderImpl::BuildExpressionFSM(
     const GrammarExpr& expr,
     const Grammar& grammar,
     const std::string* rule_name,
-    GrammarBuilder* grammar_builder
+    GrammarBuilder* grammar_builder,
+    RegexFSMCache* regex_fsm_cache
 ) {
   FSM result_fsm;
   int start_state = result_fsm.AddState();
   std::vector<int32_t> end_states;
-  GrammarFSMBuilderImpl builder(result_fsm, rule_name, grammar_builder);
+  GrammarFSMBuilderImpl builder(result_fsm, rule_name, grammar_builder, regex_fsm_cache);
   builder.BuildExpression(expr, grammar, start_state, &end_states);
   FSMWithStartEnd result(result_fsm, start_state, std::move(end_states));
   if (expr.type != ExprType::kTagDispatch && expr.type != ExprType::kTokenTagDispatch) {
@@ -1809,7 +1856,7 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Choices(
 }
 
 void GrammarFSMBuilderImpl::AppendFSM(
-    FSMWithStartEnd fsm, int start_state, std::vector<int32_t>* end_states
+    FSMWithStartEnd&& fsm, int start_state, std::vector<int32_t>* end_states
 ) {
   const bool target_is_empty = target_fsm_.NumStates() == 1 && start_state == 0 &&
                                target_fsm_.GetEdges(0).empty() &&
@@ -1820,6 +1867,12 @@ void GrammarFSMBuilderImpl::AppendFSM(
     return;
   }
 
+  AppendFSM(static_cast<const FSMWithStartEnd&>(fsm), start_state, end_states);
+}
+
+void GrammarFSMBuilderImpl::AppendFSM(
+    const FSMWithStartEnd& fsm, int start_state, std::vector<int32_t>* end_states
+) {
   std::vector<int> state_mapping;
   target_fsm_.AddFSM(fsm.GetFsm(), &state_mapping);
   target_fsm_.AddEpsilonEdge(start_state, state_mapping[fsm.GetStart()]);
@@ -1834,6 +1887,22 @@ void GrammarFSMBuilderImpl::BuildRegex(
     const std::string& regex, bool json_string, int start_state, std::vector<int32_t>* end_states
 ) {
   const std::string rule_hint = rule_name_ != nullptr ? *rule_name_ : "";
+  if (regex_fsm_cache_ != nullptr) {
+    auto regex_fsm_result =
+        GetOrBuildRegexFSM(regex, json_string, *regex_fsm_cache_, grammar_builder_, rule_hint);
+    if (regex_fsm_result.IsErr()) {
+      auto error = std::move(regex_fsm_result).UnwrapErr();
+      if (rule_name_ != nullptr) {
+        XGRAMMAR_LOG(FATAL) << "Failed to build the automaton for rule " << *rule_name_
+                            << " with regex " << regex << ": " << error.what();
+      }
+      XGRAMMAR_LOG(FATAL) << "Failed to build the automaton for regex " << regex << ": "
+                          << error.what();
+    }
+    AppendFSM(*std::move(regex_fsm_result).Unwrap(), start_state, end_states);
+    return;
+  }
+
   auto build_result =
       json_string
           ? RegexFSMBuilder::BuildWithForbiddenChars(

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -447,6 +447,32 @@ def _compiled_accepts(compiled_grammar: xgr.CompiledGrammar, input_str: str) -> 
     return matcher.accept_string(input_str) and matcher.is_terminated()
 
 
+def test_repeated_regex_fsm_reuse_preserves_nullable_rules():
+    tokenizer_info = xgr.TokenizerInfo(["!", "a", "aa", "b"], stop_token_ids=[])
+    grammar = xgr.Grammar.from_lark('start: left "!" right\nleft: /a*/\nright: /a*/')
+
+    compiled = xgr.GrammarCompiler(tokenizer_info, max_threads=1).compile_grammar(grammar)
+    for value in ["!", "a!", "!a", "aa!aa"]:
+        assert _compiled_accepts(compiled, value)
+    for value in ["", "aa", "!!", "b!"]:
+        assert not _compiled_accepts(compiled, value)
+
+
+def test_regex_fsm_cache_distinguishes_json_string_mode():
+    tokenizer_info = xgr.TokenizerInfo([])
+    grammar = xgr.Grammar.from_ebnf(
+        'root ::= plain "!" plain json "!" json\n'
+        'plain ::= Regex(".")\n'
+        'json ::= Regex(".", json_string=true)'
+    )
+
+    compiled = xgr.GrammarCompiler(tokenizer_info, max_threads=1).compile_grammar(grammar)
+    for value in ['"!ab!c', "\\!ab!c", "a!bc!d"]:
+        assert _compiled_accepts(compiled, value)
+    for value in ['a!a"!b', "a!a\\!b", "a!ab!\n"]:
+        assert not _compiled_accepts(compiled, value)
+
+
 def _mask_trace(compiled_grammar: xgr.CompiledGrammar, input_str: str):
     matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
     bitmask = xgr.allocate_token_bitmask(1, compiled_grammar.tokenizer_info.vocab_size)


### PR DESCRIPTION
## Summary

- Reuse regex FSMs while optimizing grammar expressions.
- Preserve the existing optimizer behavior while avoiding repeated regex-to-FSM construction.
- Add focused cache-equivalence coverage.

## Review scope

This is a self-contained change and is based directly on main (`1819601e`). It targets compile cost for grammars that repeat the same regex fragments; the four benchmark workloads below exercise that pattern only lightly.

## Correctness

- Full valid-vocabulary token-mask sweep across four workloads (structural tag large/small on the `Qwen/Qwen3-4B-Instruct-2507` vocabulary, JSON Schema large/small on the `unsloth/Meta-Llama-3.1-8B-Instruct` vocabulary): 0 allowed-set differences versus main.
- One small JSON Schema record (`Github_hard---o9823.json`) hits a pre-existing `per_rule_fsm_hashes` check failure on unmodified main; it fails identically before and after this change and is excluded from comparisons.
- Local: C++ suite 67/67 passed; `test_grammar_compiler.py` 13 passed (including the new cache-equivalence tests).

## Performance

Measured on Modal (AMD EPYC 9V33X, 16 physical cores), 5 rounds, per-round before/after wheel pairs, median of same-round ratios (>1x is faster):

| Workload | Compile | End-to-end | 5-round e2e range |
|---|---:|---:|---:|
| Structural tag large | 0.965x | 0.965x | 0.953–1.131x |
| Structural tag small | 0.986x | 0.986x | 0.964–1.054x |
| JSON Schema large | 1.011x | 1.011x | 0.941–1.138x |
| JSON Schema small | 1.005x | 1.011x | 0.984–1.013x |

On these workloads the change is performance-neutral (all values within the same-version control noise bounds measured in the same container). The benefit is bounded to compile time of grammars with many repeated regex fragments.
