### PR TITLE
Reuse JSON Schema regex expressions

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2194,6 +2194,16 @@ int32_t JSONSchemaConverter::GenerateFromSpec(
 int32_t JSONSchemaConverter::RegexExpression(
     const std::string& regex, bool json_string, bool force_cfg_expansion
 ) {
+  std::string cache_key;
+  cache_key.reserve(regex.size() + 2);
+  cache_key.push_back(static_cast<char>(json_string));
+  cache_key.push_back(static_cast<char>(force_cfg_expansion));
+  cache_key.append(regex);
+  const auto cached = regex_expr_ids_.find(cache_key);
+  if (cached != regex_expr_ids_.end()) {
+    return cached->second;
+  }
+
   bool can_use_fsm = !force_cfg_expansion;
   if (json_string) {
     can_use_fsm =
@@ -2212,14 +2222,18 @@ int32_t JSONSchemaConverter::RegexExpression(
             return fsm.IsEndState(state);
           });
       if (!language_is_empty) {
-        return builder_.AddRegex(regex, json_string);
+        const int32_t result = builder_.AddRegex(regex, json_string);
+        regex_expr_ids_.emplace(std::move(cache_key), result);
+        return result;
       }
     }
   }
 
   // Keep regex conversion independent. Only the uncommon fallback path converts its existing
   // EBNF result to a subgrammar; the JSON Schema rule graph itself is still built directly.
-  return AddSubGrammar(Grammar::FromEBNF(RegexToEBNF(regex)));
+  const int32_t result = AddSubGrammar(Grammar::FromEBNF(RegexToEBNF(regex)));
+  regex_expr_ids_.emplace(std::move(cache_key), result);
+  return result;
 }
 
 // ==================== Generate Methods ====================

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -476,6 +476,7 @@ class JSONSchemaConverter {
   std::optional<int32_t> empty_expr_id_;
   std::unordered_map<std::string, int32_t> byte_string_expr_ids_;
   std::unordered_map<int32_t, int32_t> rule_ref_expr_ids_;
+  std::unordered_map<std::string, int32_t> regex_expr_ids_;
   std::optional<int32_t> whitespace_expr_id_;
 
   // Helper for integer/number range regex generation

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -976,6 +976,23 @@ def test_restricted_string():
     )
 
 
+def test_repeated_string_patterns_preserve_each_property():
+    schema = {
+        "type": "object",
+        "properties": {
+            "first": {"type": "string", "pattern": "^[a-f]+$"},
+            "second": {"type": "string", "pattern": "^[a-f]+$"},
+        },
+        "required": ["first", "second"],
+        "additionalProperties": False,
+    }
+
+    check_schema_with_instance(schema, {"first": "ab", "second": "fa"}, any_whitespace=False)
+    check_schema_with_instance(
+        schema, {"first": "ab", "second": "z"}, is_accepted=False, any_whitespace=False
+    )
+
+
 def test_complex_restrictions():
     class RestrictedModel(BaseModel):
         restricted_string: str = Field(..., pattern=r"[^\"]*")


### PR DESCRIPTION
## Summary

- Reuse equivalent regex expressions emitted by JSON Schema conversion.
- Avoid rebuilding the same number, string, and helper regex fragments.
- Keep the converter output unchanged.

## Review scope

This is a self-contained change and is based directly on main (`1819601e`). It removes duplicated regex construction during JSON Schema conversion; the effect scales with how many identical fragments a schema repeats.

## Correctness

- Full valid-vocabulary token-mask sweep across four workloads (structural tag large/small on the `Qwen/Qwen3-4B-Instruct-2507` vocabulary, JSON Schema large/small on the `unsloth/Meta-Llama-3.1-8B-Instruct` vocabulary): 0 allowed-set differences versus main.
- One small JSON Schema record (`Github_hard---o9823.json`) hits a pre-existing `per_rule_fsm_hashes` check failure on unmodified main; it fails identically before and after this change and is excluded from comparisons.
- Local: C++ suite 67/67 passed; `test_json_schema_converter.py` 519 passed.

## Performance

Measured on Modal (AMD EPYC 9V33X, 16 physical cores), 5 rounds, per-round before/after wheel pairs, median of same-round ratios (>1x is faster):

| Workload | Compile | End-to-end | 5-round e2e range |
|---|---:|---:|---:|
| Structural tag large | 1.050x | 1.049x | 0.998–1.206x |
| Structural tag small | 0.989x | 0.988x | 0.924–0.994x |
| JSON Schema large | 1.065x | 1.064x | 0.761–1.155x |
| JSON Schema small | 1.010x | 1.006x | 0.989–1.016x |

Medians lean positive on the JSON Schema and structural tag large workloads but stay within the same-version control noise bounds measured in the same container, so no standalone speedup claim is made from this run.
