### PR TITLE
Add minimal on-demand token mask generation

### DIFF
--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -168,7 +168,13 @@ picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl) {
   auto result = picojson::object{};
   result["grammar"] = AutoSerializeJSONValue(impl.grammar);
   result["tokenizer_metadata"] = impl.tokenizer_info->DumpMetadataValue();
-  result["adaptive_token_mask_cache"] = AutoSerializeJSONValue(impl.adaptive_token_mask_cache);
+  // In dynamic mode, serialize an empty mask cache; masks are generated on first use again
+  // after deserialization.
+  result["dynamic"] = picojson::value(impl.token_mask_cache.dynamic_);
+  result["adaptive_token_mask_cache"] = AutoSerializeJSONValue(
+      impl.token_mask_cache.dynamic_ ? decltype(impl.token_mask_cache.masks_){}
+                                     : impl.token_mask_cache.masks_
+  );
   return picojson::value(result);
 }
 
@@ -199,14 +205,21 @@ std::optional<SerializationError> DeserializeJSONValue(
   if (object.find("adaptive_token_mask_cache") == object.end()) {
     return ConstructDeserializeError("Expect a 'adaptive_token_mask_cache' field", type_name);
   }
-  AutoDeserializeJSONValue(&(impl->adaptive_token_mask_cache), object["adaptive_token_mask_cache"]);
+  AutoDeserializeJSONValue(&(impl->token_mask_cache.masks_), object["adaptive_token_mask_cache"]);
+  const auto dynamic_it = object.find("dynamic");
+  if (dynamic_it != object.end() && !dynamic_it->second.is<bool>()) {
+    return ConstructDeserializeError("Expect a boolean 'dynamic' field", type_name);
+  }
+  if (dynamic_it != object.end() && dynamic_it->second.get<bool>()) {
+    impl->token_mask_cache.dynamic_ = true;
+  }
   return std::nullopt;
 }
 
 /************** CompiledGrammar **************/
 
 std::size_t MemorySize(const CompiledGrammar::Impl& impl) {
-  return MemorySize(impl.grammar) + MemorySize(impl.adaptive_token_mask_cache);
+  return MemorySize(impl.grammar) + MemorySize(impl.token_mask_cache);
 }
 
 std::size_t CompiledGrammar::MemorySizeBytes() const { return MemorySize(*pimpl_); }

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -100,6 +101,83 @@ XGRAMMAR_MEMBER_TABLE(
 );
 
 /*!
+ * \brief Manages the adaptive token masks of a compiled grammar. In eager mode (the default),
+ * all masks are precomputed at compile time. In dynamic mode, masks are generated and cached on
+ * first use.
+ */
+class TokenMaskCache {
+ public:
+  /*! \brief Construct an eager cache. Only for deserialization. */
+  TokenMaskCache() = default;
+
+  /*!
+   * \brief Construct the cache with the mask generation mode.
+   * \param dynamic Whether missing token masks should be generated on first use.
+   */
+  explicit TokenMaskCache(bool dynamic) : dynamic_(dynamic) {}
+
+  /*! \brief Whether missing token masks should be generated on first use. */
+  bool IsDynamic() const { return dynamic_; }
+
+  /*! \brief Insert a precomputed mask during eager compilation. Not thread-safe; the compiler
+   * synchronizes concurrent insertions itself. */
+  void Insert(const ParserState& state, AdaptiveTokenMask mask) { masks_[state] = std::move(mask); }
+
+  /*! \brief Return the mask for the state. In dynamic mode, generate and cache it on miss. */
+  const AdaptiveTokenMask& Get(
+      const ParserState& state,
+      bool is_root_rule,
+      const Grammar& grammar,
+      const TokenizerInfo& tokenizer_info
+  );
+
+ private:
+  /*! \brief Return the tag-dispatch bitset for a rule, computing and caching it on first use. */
+  const DynamicBitset* GetTagDispatchSecondSlicingBitset(
+      int32_t rule_id, const Grammar& grammar, const TokenizerInfo& tokenizer_info
+  );
+
+  /*! \brief Whether missing token masks should be generated on first use. */
+  bool dynamic_{false};
+
+  /*! \brief Mapping from the parser state to the adaptive token mask. */
+  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache> masks_;
+
+  /*! \brief Tag-dispatch data computed on first use in dynamic mode. */
+  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset_;
+
+  /*! \brief Protects on-demand token mask lookup and insertion. */
+  mutable std::mutex mutex_;
+
+  friend struct member_trait<TokenMaskCache>;
+  friend picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl);
+  friend std::optional<SerializationError> DeserializeJSONValue(
+      CompiledGrammar::Impl* impl,
+      const picojson::value& json_value,
+      const TokenizerInfo& tokenizer_info
+  );
+
+  friend std::size_t MemorySize(const TokenMaskCache& token_mask_cache) {
+    std::lock_guard<std::mutex> lock(token_mask_cache.mutex_);
+    return MemorySize(token_mask_cache.masks_) +
+           MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_);
+  }
+};
+
+/*!
+ * \brief Compute the bitset of tokens that are definitely accepted since the second character
+ * for a tag-dispatch rule.
+ */
+DynamicBitset ComputeTagDispatchSecondSlicingBitset(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info, int32_t rule_id
+);
+
+/*! \brief Compute the second-slicing bitsets for all tag-dispatch rules. */
+std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitsets(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info
+);
+
+/*!
  * \brief All information that we need to match tokens in the tokenizer to the specified grammar.
  * It is the result of preprocessing.
  * \sa xgrammar::GrammarMatcher
@@ -112,12 +190,14 @@ class CompiledGrammar::Impl {
   /*! \brief The tokenizer information. */
   TokenizerInfo tokenizer_info{NullObj{}};
 
-  /*! \brief Default constructor. */
+  /*! \brief Default constructor. Only for deserialization. */
   Impl() = default;
 
-  /*! \brief Mapping from the parser state to the adaptive token mask. */
-  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache>
-      adaptive_token_mask_cache;
+  /*! \brief Construct with the token mask generation mode. \sa TokenMaskCache */
+  explicit Impl(bool enable_dynamic_compilation) : token_mask_cache(enable_dynamic_compilation) {}
+
+  /*! \brief The adaptive token masks, precomputed or generated on first use. */
+  TokenMaskCache token_mask_cache;
 
   Grammar GetGrammar() const { return grammar; }
 
@@ -133,14 +213,16 @@ class CompiledGrammar::Impl {
   friend std::size_t MemorySize(const Impl& impl);
 };
 
+XGRAMMAR_MEMBER_TABLE(TokenMaskCache, "adaptive_token_mask_cache", &TokenMaskCache::masks_);
+
 XGRAMMAR_MEMBER_TABLE(
     CompiledGrammar::Impl,
     "grammar",
     &CompiledGrammar::Impl::grammar,
     "tokenizer_info",
     &CompiledGrammar::Impl::tokenizer_info,
-    "adaptive_token_mask_cache",
-    &CompiledGrammar::Impl::adaptive_token_mask_cache
+    "token_mask_cache",
+    &CompiledGrammar::Impl::token_mask_cache
 );
 
 }  // namespace xgrammar

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -41,28 +41,30 @@ std::vector<CaptureOccurrence> EarleyParser::CollectStopCaptureTargets(const Par
   // materialization time cannot distinguish an actual captured ancestor from an unrelated
   // Earley branch that happens to cover the same input.
   std::vector<CaptureOccurrence> targets;
-  std::vector<CaptureOccurrence> pending{{state.rule_id, state.rule_start_pos}};
-  std::unordered_set<int64_t> visited;
+  std::vector<ParserState> pending{state};
+  std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
+      visited;
   while (!pending.empty()) {
-    CaptureOccurrence occurrence = pending.back();
+    ParserState completion = pending.back();
     pending.pop_back();
-    int64_t occurrence_key = (static_cast<int64_t>(occurrence.rule_id) << 32) |
-                             static_cast<uint32_t>(occurrence.start_pos);
-    if (!visited.insert(occurrence_key).second) {
+    if (!visited.insert(completion).second) {
       continue;
     }
-    if (RuleHasCapture(occurrence.rule_id)) {
+    CaptureOccurrence occurrence{completion.rule_id, completion.rule_start_pos};
+    if (RuleHasCapture(completion.rule_id) &&
+        std::find(targets.begin(), targets.end(), occurrence) == targets.end()) {
       targets.push_back(occurrence);
     }
-    if (occurrence.start_pos == ParserState::kNoPrevInputPos) {
+    if (completion.rule_start_pos == ParserState::kNoPrevInputPos) {
       continue;
     }
-    const auto& parent_states = rule_id_to_completable_states_[occurrence.start_pos];
+    const auto& parent_states = rule_id_to_completable_states_[completion.rule_start_pos];
     for (const auto& [ref_rule_id, parent_state] : parent_states) {
-      if (ref_rule_id != occurrence.rule_id || parent_state.rule_id < 0) {
+      if (ref_rule_id != completion.rule_id || parent_state.rule_id < 0 ||
+          !IsCompletionCompatibleWithParent(completion, parent_state)) {
         continue;
       }
-      pending.push_back({parent_state.rule_id, parent_state.rule_start_pos});
+      pending.push_back(parent_state);
     }
   }
   return targets;
@@ -150,7 +152,7 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
   // Check all the possible parent states.
   const auto& parent_states_map = rule_id_to_completable_states_[state.rule_start_pos];
   for (const auto& [ref_id, parent_state] : parent_states_map) {
-    if (ref_id != state.rule_id) {
+    if (ref_id != state.rule_id || !IsCompletionCompatibleWithParent(state, parent_state)) {
       continue;
     }
     XGRAMMAR_DCHECK(
@@ -633,7 +635,10 @@ void EarleyParser::ExpandNextRuleRefElement(
       const auto& parent_states_map = rule_id_to_completable_states_[state.rule_start_pos];
       std::vector<std::pair<int32_t, ParserState>> to_added_states;
       for (const auto& parent_state_iter : parent_states_map) {
-        if (parent_state_iter.first != state.rule_id) continue;
+        if (parent_state_iter.first != state.rule_id ||
+            !IsCompletionCompatibleWithParent(state, parent_state_iter.second)) {
+          continue;
+        }
         const auto& parent_state = parent_state_iter.second;
         if (!in_vec(parent_state)) {
           to_added_states.push_back({ref_rule_id, parent_state});
@@ -770,7 +775,10 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
         const auto& parent_states_map = rule_id_to_completable_states_[state.rule_start_pos];
         std::vector<std::pair<int32_t, ParserState>> to_added_states;
         for (const auto& parent_state_iter : parent_states_map) {
-          if (parent_state_iter.first != state.rule_id) continue;
+          if (parent_state_iter.first != state.rule_id ||
+              !IsCompletionCompatibleWithParent(state, parent_state_iter.second)) {
+            continue;
+          }
           const auto& parent_state = parent_state_iter.second;
           if (!in_vec(parent_state)) {
             to_added_states.push_back({ref_rule_id, parent_state});

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -271,6 +271,22 @@ class RepeatDetector {
   void Clear();
 };
 
+struct StateEqualForCompletionContext {
+  bool operator()(const ParserState& left, const ParserState& right) const {
+    return left.rule_id == right.rule_id && left.rule_start_pos == right.rule_start_pos &&
+           left.budget_deadline == right.budget_deadline &&
+           left.char_budget_deadline == right.char_budget_deadline;
+  }
+};
+
+struct StateHashForCompletionContext {
+  size_t operator()(const ParserState& state) const {
+    return HashCombine(
+        state.rule_id, state.rule_start_pos, state.budget_deadline, state.char_budget_deadline
+    );
+  }
+};
+
 /*! \brief A concrete occurrence of a captured rule in an Earley parent chain. */
 struct CaptureOccurrence {
   /*! \brief The id of the captured rule. */
@@ -441,6 +457,18 @@ class EarleyParser {
                            ? std::numeric_limits<int32_t>::max()
                            : current_char_index + own;
     return parent_deadline >= 0 ? std::min(deadline, parent_deadline) : deadline;
+  }
+
+  /*! \brief Whether completion under equal or tighter deadlines can advance the parent. */
+  static bool IsCompletionCompatibleWithParent(
+      const ParserState& completed_state, const ParserState& parent_state
+  ) {
+    return (parent_state.budget_deadline < 0 ||
+            (completed_state.budget_deadline >= 0 &&
+             completed_state.budget_deadline <= parent_state.budget_deadline)) &&
+           (parent_state.char_budget_deadline < 0 ||
+            (completed_state.char_budget_deadline >= 0 &&
+             completed_state.char_budget_deadline <= parent_state.char_budget_deadline));
   }
 
   /*! \brief Whether the state's derivation may not consume another Unicode codepoint. */

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -42,24 +42,24 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   GrammarMatcherForTokenMaskCache(
       const Grammar& grammar,
       const ParserState& init_state,
-      const std::unordered_map<int32_t, DynamicBitset>&
-          tag_dispatch_rule_id_to_second_slicing_bitset,
+      const DynamicBitset* tag_dispatch_second_slicing_bitset,
       const TokenizerInfo& tokenizer_info,
-      std::optional<RuleLevelCache>& rule_level_cache
+      std::optional<RuleLevelCache>& rule_level_cache,
+      bool is_root_rule
   )
       : EarleyParser(grammar, init_state),
         init_rule_id_(init_state.rule_id),
         initial_state_(init_state),
-        tag_dispatch_rule_id_to_second_slicing_bitset_(tag_dispatch_rule_id_to_second_slicing_bitset
-        ),
+        is_root_rule_(is_root_rule),
+        tag_dispatch_second_slicing_bitset_(tag_dispatch_second_slicing_bitset),
         tokenizer_info_(tokenizer_info),
-        rule_level_cache_(rule_level_cache) {}
+        rule_level_cache_(rule_level_cache) {
+    XGRAMMAR_DCHECK(is_root_rule == (init_state.rule_id == grammar->GetRootRuleId()));
+  }
   /*!
    * \brief Get the adaptive token mask for the given ParserState.
-   * \param is_root_rule Whether to consider the parent rule. If false, there will be
-   * no uncertain tokens. Useful for the root rule.
    */
-  AdaptiveTokenMask GetAdaptiveTokenMask(bool is_root_rule);
+  AdaptiveTokenMask GetAdaptiveTokenMask();
 
   /*!
    * \brief Get the token mask for the given ParserState.
@@ -116,8 +116,11 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   // The initial state of the parser.
   ParserState initial_state_;
 
+  // Whether the initial rule is the grammar's root rule.
+  bool is_root_rule_;
+
   /*!
-   * \brief This is a mapping from TagDispatch rule id to the bitset used for second slicing.
+   * \brief The bitset used for second slicing when the initial rule is a TagDispatch rule.
    * \note If a rule is a TagDispatch rule, then there will be an AC automaton for its triggers.
    *  Which means that it can accept a lot of tokens. However, it will be slow to check a lot of
    *  tokens. The DynamicBitset here is used to do a second slicing: if a token's substr(1, n - 1)
@@ -125,7 +128,7 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
    *  When we check a token, we first check if its first character can transit to the start state.
    *  If yes, then we check if it is in the bitset. If yes, then we accept it directly.
    */
-  const std::unordered_map<int32_t, DynamicBitset>& tag_dispatch_rule_id_to_second_slicing_bitset_;
+  const DynamicBitset* tag_dispatch_second_slicing_bitset_;
 
   const TokenizerInfo& tokenizer_info_;
 
@@ -534,8 +537,8 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       grammar_->GetGrammarExpr(grammar_->GetRule(init_rule_id_).body_expr_id).type ==
       Grammar::Impl::GrammarExprType::kTagDispatch;
   if (is_tag_dispatch_rule) {
-    XGRAMMAR_DCHECK(tag_dispatch_rule_id_to_second_slicing_bitset_.count(init_rule_id_) > 0);
-    definite_accepted_bitset = &tag_dispatch_rule_id_to_second_slicing_bitset_.at(init_rule_id_);
+    XGRAMMAR_DCHECK(tag_dispatch_second_slicing_bitset_ != nullptr);
+    definite_accepted_bitset = tag_dispatch_second_slicing_bitset_;
   }
 
   const std::string* prev_token = nullptr;
@@ -790,7 +793,7 @@ const std::vector<int32_t>& GrammarMatcherForTokenMaskCache::GetTokenEdgeAccepte
   return tmp_token_edge_accepted_;
 }
 
-AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_root_rule) {
+AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask() {
   tmp_accepted_indices_.clear();
   tmp_rejected_indices_.clear();
   tmp_uncertain_indices_.clear();
@@ -841,7 +844,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     );
     // If the rule doesn't have a lookahead, then it is exactly the same fsm.
     if (crossing_cache.has_value()) {
-      AdaptCacheWithLookahead(&crossing_cache.value(), is_root_rule);
+      AdaptCacheWithLookahead(&crossing_cache.value(), is_root_rule_);
       return std::move(crossing_cache.value());
     }
   }
@@ -858,7 +861,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     rejected_filled = false;
   } else {
     rejected_filled = GetTokenMaskWithFirstCharacterCheck(
-        first_character_mask, is_root_rule, token_edge_accepted
+        first_character_mask, is_root_rule_, token_edge_accepted
     );
   }
 
@@ -882,7 +885,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
         tmp_uncertain_indices_
     );
     if (rule_level_cache_is_available) {
-      if (lookahead_id == -1 && !is_root_rule) {
+      if (lookahead_id == -1 && !is_root_rule_) {
         // If the rule doesn't have a lookahead, then it is exactly the same fsm.
         auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
         rule_level_cache_->AddCache(
@@ -954,7 +957,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     if (rule_level_cache_is_available) {
       // Prepare for cache.
       auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
-      if (lookahead_id == -1 && !is_root_rule) {
+      if (lookahead_id == -1 && !is_root_rule_) {
         // If the rule doesn't have a lookahead, then it is exactly the same fsm.
         rule_level_cache_->AddCache(
             fsm_hash.value(), new_state_id, fsm.GetNodeNum(), fsm.GetEdgeNum(), return_value
@@ -1003,6 +1006,78 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   }
 }
 
+const DynamicBitset* TokenMaskCache::GetTagDispatchSecondSlicingBitset(
+    int32_t rule_id, const Grammar& grammar, const TokenizerInfo& tokenizer_info
+) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto existing = tag_dispatch_rule_id_to_second_slicing_bitset_.find(rule_id);
+    if (existing != tag_dispatch_rule_id_to_second_slicing_bitset_.end()) {
+      return &existing->second;
+    }
+  }
+
+  DynamicBitset bitset = ComputeTagDispatchSecondSlicingBitset(grammar, tokenizer_info, rule_id);
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  return &tag_dispatch_rule_id_to_second_slicing_bitset_.try_emplace(rule_id, std::move(bitset))
+              .first->second;
+}
+
+const AdaptiveTokenMask& TokenMaskCache::Get(
+    const ParserState& state,
+    bool is_root_rule,
+    const Grammar& grammar,
+    const TokenizerInfo& tokenizer_info
+) {
+  if (!dynamic_) {
+    const auto it = masks_.find(state);
+    XGRAMMAR_CHECK(it != masks_.end())
+        << "The token mask cache is incomplete while dynamic compilation is disabled: " << state;
+    return it->second;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto existing = masks_.find(state);
+    if (existing != masks_.end()) {
+      return existing->second;
+    }
+  }
+
+  const DynamicBitset* tag_dispatch_second_slicing_bitset = nullptr;
+  const auto& rule = grammar->GetRule(state.rule_id);
+  if (grammar->GetGrammarExpr(rule.body_expr_id).type ==
+      Grammar::Impl::GrammarExprType::kTagDispatch) {
+    tag_dispatch_second_slicing_bitset =
+        GetTagDispatchSecondSlicingBitset(state.rule_id, grammar, tokenizer_info);
+  }
+
+  // Generate the mask outside the lock so a miss does not block other lookups. Two threads may
+  // generate the same mask concurrently; emplace keeps the first inserted one.
+  const ParserState cache_state(
+      state.rule_id,
+      state.sequence_id,
+      state.element_id,
+      ParserState::kNoPrevInputPos,
+      -1,
+      state.sub_element_id
+  );
+  std::optional<RuleLevelCache> no_rule_level_cache;
+  AdaptiveTokenMask mask = GrammarMatcherForTokenMaskCache(
+                               grammar,
+                               cache_state,
+                               tag_dispatch_second_slicing_bitset,
+                               tokenizer_info,
+                               no_rule_level_cache,
+                               is_root_rule
+  )
+                               .GetAdaptiveTokenMask();
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  return masks_.emplace(cache_state, std::move(mask)).first->second;
+}
+
 /******************* GrammarCompilerNoCache *******************/
 
 /*!
@@ -1013,11 +1088,13 @@ class GrammarCompilerSub {
   GrammarCompilerSub(
       const TokenizerInfo& tokenizer_info,
       int max_threads,
-      std::optional<RuleLevelCache> rule_level_cache
+      std::optional<RuleLevelCache> rule_level_cache,
+      bool enable_dynamic_compilation
   )
       : tokenizer_info_(tokenizer_info),
         max_threads_(max_threads),
-        rule_level_cache_(rule_level_cache) {}
+        rule_level_cache_(rule_level_cache),
+        enable_dynamic_compilation_(enable_dynamic_compilation) {}
 
   CompiledGrammar CompileBuiltinJSONGrammar();
 
@@ -1042,15 +1119,6 @@ class GrammarCompilerSub {
  private:
   /*! \brief The main logic. Compile the grammar with multi-threading. */
   CompiledGrammar MultiThreadCompileGrammar(Grammar grammar);
-  /*! \brief Optimization for TagDispatch.
-   *  \param compiled_grammar_impl the compiled_grammar to be optimized.
-   *  \param tag_dispatch_rule_id_to_second_slicing_bitset Return value. Mapping from the rule_id to
-   * the definite accepted token mask.
-   */
-  void TagDispatchOptimization(
-      std::shared_ptr<CompiledGrammar::Impl> compiled_grammar_impl,
-      std::unordered_map<int32_t, DynamicBitset>* tag_dispatch_rule_id_to_second_slicing_bitset
-  );
 
   /*! \brief The vocabulary associated with this storage class. */
   const TokenizerInfo tokenizer_info_;
@@ -1059,17 +1127,22 @@ class GrammarCompilerSub {
 
   /*! \brief The manager of the rule level cache.*/
   std::optional<RuleLevelCache> rule_level_cache_;
+
+  /*! \brief Whether token masks are generated on first use. */
+  const bool enable_dynamic_compilation_;
 };
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
-  auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
-  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
+  Grammar grammar = GrammarOptimizer::Apply(grammar_unoptimized);
+  auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>(enable_dynamic_compilation_);
+  compiled_grammar_impl->grammar = std::move(grammar);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
-  if (tokenizer_info_.GetVocabSize() == 0) {
+  if (tokenizer_info_.GetVocabSize() == 0 || enable_dynamic_compilation_) {
     return CompiledGrammar(compiled_grammar_impl);
   }
-  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
-  TagDispatchOptimization(compiled_grammar_impl, &tag_dispatch_rule_id_to_second_slicing_bitset);
+
+  auto tag_dispatch_rule_id_to_second_slicing_bitset =
+      ComputeTagDispatchSecondSlicingBitsets(compiled_grammar_impl->grammar, tokenizer_info_);
 
   // If the compiler is cache-enabled, then we hash the grammars for crossing-grammar caching.
   if (rule_level_cache_.has_value()) {
@@ -1092,19 +1165,30 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   }
 
   auto add_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
+    const DynamicBitset* tag_dispatch_second_slicing_bitset = nullptr;
+    const auto tag_dispatch_bitset_it =
+        tag_dispatch_rule_id_to_second_slicing_bitset.find(state.rule_id);
+    if (tag_dispatch_bitset_it != tag_dispatch_rule_id_to_second_slicing_bitset.end()) {
+      tag_dispatch_second_slicing_bitset = &tag_dispatch_bitset_it->second;
+    }
     auto grammar_matcher = GrammarMatcherForTokenMaskCache(
         compiled_grammar_impl->grammar,
         state,
-        tag_dispatch_rule_id_to_second_slicing_bitset,
+        tag_dispatch_second_slicing_bitset,
         tokenizer_info_,
-        rule_level_cache_
+        rule_level_cache_,
+        is_root_rule
     );
-    auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask(is_root_rule);
+    auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask();
     if (max_threads_ > 1) {
       std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex.value());
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
+      compiled_grammar_impl->token_mask_cache.Insert(
+          state, std::move(cur_adaptive_token_mask_cache)
+      );
     } else {
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
+      compiled_grammar_impl->token_mask_cache.Insert(
+          state, std::move(cur_adaptive_token_mask_cache)
+      );
     }
   };
 
@@ -1192,56 +1276,62 @@ CompiledGrammar GrammarCompilerSub::CompileGrammar(
   return MultiThreadCompileGrammar(Grammar::FromEBNF(ebnf_str, root_rule_name));
 }
 
-void GrammarCompilerSub::TagDispatchOptimization(
-    std::shared_ptr<CompiledGrammar::Impl> compiled_grammar_impl,
-    std::unordered_map<int32_t, DynamicBitset>* tag_dispatch_rule_id_to_second_slicing_bitset
+DynamicBitset ComputeTagDispatchSecondSlicingBitset(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info, int32_t rule_id
 ) {
   using GrammarExprType = Grammar::Impl::GrammarExprType;
-  tag_dispatch_rule_id_to_second_slicing_bitset->clear();
-
-  // Optimization for TagDispatch: Precompute the definitely accepted tokens.
-  for (int i = 0; i < compiled_grammar_impl->grammar->NumRules(); i++) {
-    const auto& rule = compiled_grammar_impl->grammar->GetRule(i);
-    const auto& rule_body = compiled_grammar_impl->grammar->GetGrammarExpr(rule.body_expr_id);
-    if (rule_body.type != GrammarExprType::kTagDispatch) {
+  const auto& rule = grammar->GetRule(rule_id);
+  const auto& rule_body = grammar->GetGrammarExpr(rule.body_expr_id);
+  XGRAMMAR_DCHECK(rule_body.type == GrammarExprType::kTagDispatch);
+  Grammar::Impl::TagDispatch tag_dispatch = grammar->GetTagDispatch(rule.body_expr_id);
+  const auto& sorted_decoded_vocab = tokenizer_info.GetSortedDecodedVocab();
+  DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
+  for (int token_index = 0; token_index < static_cast<int32_t>(sorted_decoded_vocab.size());
+       ++token_index) {
+    bool definite_accept_since_second_char = true;
+    const auto& token = sorted_decoded_vocab[token_index].second;
+    if (token.empty()) {
+      definite_accepted_tokens_since_second_char.Set(token_index);
       continue;
     }
-    XGRAMMAR_DCHECK(rule_body.type == GrammarExprType::kTagDispatch);
-    Grammar::Impl::TagDispatch tag_dispatch =
-        compiled_grammar_impl->GetGrammar()->GetTagDispatch(rule.body_expr_id);
-    const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
-    DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
-    for (int j = 0; j < static_cast<int32_t>(sorted_decoded_vocab.size()); j++) {
-      bool definite_accept_since_second_char = true;
-      const auto& token = sorted_decoded_vocab[j].second;
-      if (token.empty()) {
-        definite_accepted_tokens_since_second_char.Set(j);
-        continue;
-      }
 
-      // Check if the token contains any string trigger or exclude string after first char.
-      for (const auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
-        if (token.find(trigger, 1) != std::string::npos) {
+    // Check if the token contains any string trigger or exclude string after first char.
+    for (const auto& tag_rule_pair : tag_dispatch.tag_rule_pairs) {
+      if (token.find(tag_rule_pair.first, 1) != std::string::npos) {
+        definite_accept_since_second_char = false;
+        break;
+      }
+    }
+    if (definite_accept_since_second_char) {
+      for (const auto& exclude : tag_dispatch.excludes) {
+        if (token.find(exclude, 1) != std::string::npos) {
           definite_accept_since_second_char = false;
           break;
         }
       }
-      if (definite_accept_since_second_char) {
-        for (const auto& excl : tag_dispatch.excludes) {
-          if (token.find(excl, 1) != std::string::npos) {
-            definite_accept_since_second_char = false;
-            break;
-          }
-        }
-      }
-
-      if (definite_accept_since_second_char) {
-        definite_accepted_tokens_since_second_char.Set(j);
-      }
     }
-    (*tag_dispatch_rule_id_to_second_slicing_bitset)[i] =
-        definite_accepted_tokens_since_second_char;
+
+    if (definite_accept_since_second_char) {
+      definite_accepted_tokens_since_second_char.Set(token_index);
+    }
   }
+  return definite_accepted_tokens_since_second_char;
+}
+
+std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitsets(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info
+) {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  std::unordered_map<int32_t, DynamicBitset> result;
+  for (int32_t rule_id = 0; rule_id < static_cast<int32_t>(grammar->NumRules()); ++rule_id) {
+    const auto& rule = grammar->GetRule(rule_id);
+    if (grammar->GetGrammarExpr(rule.body_expr_id).type == GrammarExprType::kTagDispatch) {
+      result.emplace(
+          rule_id, ComputeTagDispatchSecondSlicingBitset(grammar, tokenizer_info, rule_id)
+      );
+    }
+  }
+  return result;
 }
 
 /******************* GrammarCompiler::Impl *******************/
@@ -1343,7 +1433,8 @@ class GrammarCompiler::Impl {
       const TokenizerInfo& tokenizer_info,
       int max_threads,
       bool cache_enabled,
-      int64_t max_memory_bytes
+      int64_t max_memory_bytes,
+      bool enable_dynamic_compilation
   )
       : cache_enabled_(cache_enabled),
         rule_level_cache_(
@@ -1355,7 +1446,9 @@ class GrammarCompiler::Impl {
                   )
                 : std::nullopt
         ),
-        no_cache_compiler_(tokenizer_info, max_threads, rule_level_cache_),
+        no_cache_compiler_(
+            tokenizer_info, max_threads, rule_level_cache_, enable_dynamic_compilation
+        ),
         grammar_level_cache_(
             max_memory_bytes == -1 ? static_cast<std::size_t>(-1)
                                    : static_cast<std::size_t>(max_memory_bytes / 3 * 2),
@@ -1539,10 +1632,12 @@ GrammarCompiler::GrammarCompiler(
     const TokenizerInfo& tokenizer_info,
     int max_threads,
     bool cache_enabled,
-    int64_t max_memory_bytes
+    int64_t max_memory_bytes,
+    bool enable_dynamic_compilation
 )
-    : pimpl_(std::make_shared<Impl>(tokenizer_info, max_threads, cache_enabled, max_memory_bytes)) {
-}
+    : pimpl_(std::make_shared<Impl>(
+          tokenizer_info, max_threads, cache_enabled, max_memory_bytes, enable_dynamic_compilation
+      )) {}
 
 CompiledGrammar GrammarCompiler::CompileJSONSchema(
     const std::string& schema,

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -3234,6 +3234,7 @@ std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index)
     bool is_start = current_old_state_id == fsm.GetStart();
     int current_new_state_id = original_state_id_to_new_id[current_old_state_id];
     bfs_queue.pop();
+    hash_and_target.clear();
 
     // Check if the current state is an end state.
     if (fsm.IsEndState(current_old_state_id)) {
@@ -3347,6 +3348,7 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
     int current_old_state_id = bfs_queue.front();
     int current_new_state_id = original_state_id_to_new_id[current_old_state_id];
     bfs_queue.pop();
+    hash_and_target.clear();
 
     // Check if the current state is an end state.
     if (fsm.IsEndState(current_old_state_id)) {

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1147,6 +1147,36 @@ class RuleRefGraphFinder : public GrammarVisitor<std::vector<std::vector<int32_t
   int32_t cur_rule_id_;
 };
 
+static Result<const FSMWithStartEnd*> GetOrBuildRegexFSM(
+    const std::string& regex,
+    bool json_string,
+    std::unordered_map<std::string, FSMWithStartEnd>& regex_fsm_cache,
+    GrammarBuilder* grammar_builder,
+    const std::string& rule_hint
+) {
+  std::string cache_key;
+  cache_key.reserve(regex.size() + 1);
+  cache_key.push_back(static_cast<char>(json_string));
+  cache_key.append(regex);
+
+  auto cached = regex_fsm_cache.find(cache_key);
+  if (cached != regex_fsm_cache.end()) {
+    return ResultOk<const FSMWithStartEnd*>(&cached->second);
+  }
+
+  auto build_result =
+      json_string
+          ? RegexFSMBuilder::BuildWithForbiddenChars(
+                regex, GrammarFSMBuilder::JSONStringForbiddenChars(), grammar_builder, rule_hint
+            )
+          : RegexFSMBuilder::Build(regex, grammar_builder, rule_hint);
+  if (build_result.IsErr()) {
+    return ResultErr(std::move(build_result).UnwrapErr());
+  }
+  cached = regex_fsm_cache.emplace(std::move(cache_key), std::move(build_result).Unwrap()).first;
+  return ResultOk<const FSMWithStartEnd*>(&cached->second);
+}
+
 /*!
  * \brief Analyzes which rules in a grammar can match the empty string.
  */
@@ -1275,17 +1305,26 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
 
 class GrammarFSMBuilderImpl {
  public:
+  using RegexFSMCache = std::unordered_map<std::string, FSMWithStartEnd>;
+
   explicit GrammarFSMBuilderImpl(
       FSM& target_fsm,
       const std::string* rule_name = nullptr,
-      GrammarBuilder* grammar_builder = nullptr
+      GrammarBuilder* grammar_builder = nullptr,
+      RegexFSMCache* regex_fsm_cache = nullptr
   )
-      : target_fsm_(target_fsm), rule_name_(rule_name), grammar_builder_(grammar_builder) {}
+      : target_fsm_(target_fsm),
+        rule_name_(rule_name),
+        grammar_builder_(grammar_builder),
+        regex_fsm_cache_(regex_fsm_cache) {}
 
   static void Apply(Grammar* grammar) {
     FSM complete_fsm;
     std::vector<std::optional<FSMWithStartEndWithSize>> per_rule_fsms;
     std::vector<int> state_mapping;
+    // Reused across all rules of this grammar so identical regexes are converted to an FSM
+    // only once.
+    RegexFSMCache regex_fsm_cache;
 
     // Compiling a kRegex rule may append new rules through this builder: large bounded
     // repetitions in a regex become kRepeatRef edges referencing new rules. NumRules() is
@@ -1293,7 +1332,7 @@ class GrammarFSMBuilderImpl {
     int32_t num_original_rules = (*grammar)->NumRules();
     GrammarBuilder grammar_builder = GrammarBuilder::FromMutableGrammar(grammar);
     for (int i = 0; i < (*grammar)->NumRules(); ++i) {
-      auto rule_fsm = BuildRuleFSM(*grammar, i, &grammar_builder);
+      auto rule_fsm = BuildRuleFSM(*grammar, i, &grammar_builder, &regex_fsm_cache);
       per_rule_fsms.push_back(rule_fsm.AddToCompleteFSM(&complete_fsm, &state_mapping));
     }
 
@@ -1360,13 +1399,17 @@ class GrammarFSMBuilderImpl {
 
  private:
   static FSMWithStartEnd BuildRuleFSM(
-      const Grammar& grammar, int rule_id, GrammarBuilder* grammar_builder = nullptr
+      const Grammar& grammar,
+      int rule_id,
+      GrammarBuilder* grammar_builder = nullptr,
+      RegexFSMCache* regex_fsm_cache = nullptr
   );
   static FSMWithStartEnd BuildExpressionFSM(
       const GrammarExpr& expr,
       const Grammar& grammar,
       const std::string* rule_name = nullptr,
-      GrammarBuilder* grammar_builder = nullptr
+      GrammarBuilder* grammar_builder = nullptr,
+      RegexFSMCache* regex_fsm_cache = nullptr
   );
   void BuildExpression(
       const GrammarExpr& expr,
@@ -1418,13 +1461,16 @@ class GrammarFSMBuilderImpl {
   );
   void AddCharacterClassTransitions(const GrammarExpr& expr, int start_state, int end_state);
   void BuildNegativeCharacterClass(const GrammarExpr& expr, int start_state, int end_state);
-  void AppendFSM(FSMWithStartEnd fsm, int start_state, std::vector<int32_t>* end_states);
+  void AppendFSM(FSMWithStartEnd&& fsm, int start_state, std::vector<int32_t>* end_states);
+  void AppendFSM(const FSMWithStartEnd& fsm, int start_state, std::vector<int32_t>* end_states);
   void AddCharacterRange(int from, int to, uint32_t min, uint32_t max);
 
   FSM& target_fsm_;
   const std::string* rule_name_;
   // If not null, kRegex expressions may add new rules through this builder; see Apply().
   GrammarBuilder* grammar_builder_ = nullptr;
+  // If not null, regex FSMs are looked up in and stored into this cache; see Apply().
+  RegexFSMCache* regex_fsm_cache_ = nullptr;
 };
 
 // This function will add a range [min, max] of unicode characters to the FSM.
@@ -1514,11 +1560,11 @@ void GrammarFSMBuilderImpl::BuildCharacterClassStar(
 }
 
 FSMWithStartEnd GrammarFSMBuilderImpl::BuildRuleFSM(
-    const Grammar& grammar, int rule_id, GrammarBuilder* grammar_builder
+    const Grammar& grammar, int rule_id, GrammarBuilder* grammar_builder, RegexFSMCache* regex_fsm_cache
 ) {
   const auto& rule = grammar->GetRule(rule_id);
   return BuildExpressionFSM(
-      grammar->GetGrammarExpr(rule.body_expr_id), grammar, &rule.name, grammar_builder
+      grammar->GetGrammarExpr(rule.body_expr_id), grammar, &rule.name, grammar_builder, regex_fsm_cache
   );
 }
 
@@ -1526,12 +1572,13 @@ FSMWithStartEnd GrammarFSMBuilderImpl::BuildExpressionFSM(
     const GrammarExpr& expr,
     const Grammar& grammar,
     const std::string* rule_name,
-    GrammarBuilder* grammar_builder
+    GrammarBuilder* grammar_builder,
+    RegexFSMCache* regex_fsm_cache
 ) {
   FSM result_fsm;
   int start_state = result_fsm.AddState();
   std::vector<int32_t> end_states;
-  GrammarFSMBuilderImpl builder(result_fsm, rule_name, grammar_builder);
+  GrammarFSMBuilderImpl builder(result_fsm, rule_name, grammar_builder, regex_fsm_cache);
   builder.BuildExpression(expr, grammar, start_state, &end_states);
   FSMWithStartEnd result(result_fsm, start_state, std::move(end_states));
   if (expr.type != ExprType::kTagDispatch && expr.type != ExprType::kTokenTagDispatch) {
@@ -1809,7 +1856,7 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Choices(
 }
 
 void GrammarFSMBuilderImpl::AppendFSM(
-    FSMWithStartEnd fsm, int start_state, std::vector<int32_t>* end_states
+    FSMWithStartEnd&& fsm, int start_state, std::vector<int32_t>* end_states
 ) {
   const bool target_is_empty = target_fsm_.NumStates() == 1 && start_state == 0 &&
                                target_fsm_.GetEdges(0).empty() &&
@@ -1820,6 +1867,12 @@ void GrammarFSMBuilderImpl::AppendFSM(
     return;
   }
 
+  AppendFSM(static_cast<const FSMWithStartEnd&>(fsm), start_state, end_states);
+}
+
+void GrammarFSMBuilderImpl::AppendFSM(
+    const FSMWithStartEnd& fsm, int start_state, std::vector<int32_t>* end_states
+) {
   std::vector<int> state_mapping;
   target_fsm_.AddFSM(fsm.GetFsm(), &state_mapping);
   target_fsm_.AddEpsilonEdge(start_state, state_mapping[fsm.GetStart()]);
@@ -1834,6 +1887,22 @@ void GrammarFSMBuilderImpl::BuildRegex(
     const std::string& regex, bool json_string, int start_state, std::vector<int32_t>* end_states
 ) {
   const std::string rule_hint = rule_name_ != nullptr ? *rule_name_ : "";
+  if (regex_fsm_cache_ != nullptr) {
+    auto regex_fsm_result =
+        GetOrBuildRegexFSM(regex, json_string, *regex_fsm_cache_, grammar_builder_, rule_hint);
+    if (regex_fsm_result.IsErr()) {
+      auto error = std::move(regex_fsm_result).UnwrapErr();
+      if (rule_name_ != nullptr) {
+        XGRAMMAR_LOG(FATAL) << "Failed to build the automaton for rule " << *rule_name_
+                            << " with regex " << regex << ": " << error.what();
+      }
+      XGRAMMAR_LOG(FATAL) << "Failed to build the automaton for regex " << regex << ": "
+                          << error.what();
+    }
+    AppendFSM(*std::move(regex_fsm_result).Unwrap(), start_state, end_states);
+    return;
+  }
+
   auto build_result =
       json_string
           ? RegexFSMBuilder::BuildWithForbiddenChars(

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1453,7 +1453,14 @@ class GrammarFSMBuilderImpl {
       int start_state,
       std::vector<int32_t>* end_states
   );
-  void BuildChoices(
+  // Returns whether the specialized choice builder handled the whole expression.
+  bool BuildChoices(
+      const GrammarExpr& expr,
+      const Grammar& grammar,
+      int start_state,
+      std::vector<int32_t>* end_states
+  );
+  bool BuildByteStringRuleRefChoices(
       const GrammarExpr& expr,
       const Grammar& grammar,
       int start_state,
@@ -1579,11 +1586,18 @@ FSMWithStartEnd GrammarFSMBuilderImpl::BuildExpressionFSM(
   int start_state = result_fsm.AddState();
   std::vector<int32_t> end_states;
   GrammarFSMBuilderImpl builder(result_fsm, rule_name, grammar_builder, regex_fsm_cache);
-  builder.BuildExpression(expr, grammar, start_state, &end_states);
+  bool skip_equivalent_state_merge = false;
+  if (expr.type == ExprType::kChoices) {
+    skip_equivalent_state_merge = builder.BuildChoices(expr, grammar, start_state, &end_states);
+  } else {
+    builder.BuildExpression(expr, grammar, start_state, &end_states);
+  }
   FSMWithStartEnd result(result_fsm, start_state, std::move(end_states));
   if (expr.type != ExprType::kTagDispatch && expr.type != ExprType::kTokenTagDispatch) {
     result = result.SimplifyEpsilon();
-    result = result.MergeEquivalentStates();
+    if (!skip_equivalent_state_merge) {
+      result = result.MergeEquivalentStates();
+    }
   }
   return result;
 }
@@ -1674,8 +1688,10 @@ void GrammarFSMBuilderImpl::BuildExpression(
       return BuildExcludeToken(expr, start_state, end_states);
     case ExprType::kSequence:
       return BuildSequence(expr, grammar, start_state, end_states);
-    case ExprType::kChoices:
-      return BuildChoices(expr, grammar, start_state, end_states);
+    case ExprType::kChoices: {
+      BuildChoices(expr, grammar, start_state, end_states);
+      return;
+    }
     case ExprType::kRegex:
       return BuildRegex(
           grammar->GetRegexString(expr),
@@ -1793,7 +1809,7 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Sequence(
   return FSMWithStartEnd(result_fsm, start_state, std::move(end_states));
 }
 
-void GrammarFSMBuilderImpl::BuildChoices(
+bool GrammarFSMBuilderImpl::BuildChoices(
     const GrammarExpr& expr,
     const Grammar& grammar,
     int start_state,
@@ -1816,7 +1832,7 @@ void GrammarFSMBuilderImpl::BuildChoices(
 
   if (non_empty_choice_count == 0) {
     end_states->push_back(start_state);
-    return;
+    return false;
   }
 
   if (non_empty_choice_count == 1 && !nullable) {
@@ -1824,10 +1840,14 @@ void GrammarFSMBuilderImpl::BuildChoices(
       const auto& choice_expr = grammar->GetGrammarExpr(choice_id);
       if (choice_expr.type != ExprType::kEmptyStr) {
         BuildExpression(choice_expr, grammar, start_state, end_states);
-        return;
+        return false;
       }
     }
     XGRAMMAR_UNREACHABLE();
+  }
+
+  if (!nullable && BuildByteStringRuleRefChoices(expr, grammar, start_state, end_states)) {
+    return true;
   }
 
   std::vector<int32_t> branch_end_states;
@@ -1847,6 +1867,79 @@ void GrammarFSMBuilderImpl::BuildChoices(
     target_fsm_.AddEpsilonEdge(start_state, nullable_branch_state);
     end_states->push_back(nullable_branch_state);
   }
+  return false;
+}
+
+bool GrammarFSMBuilderImpl::BuildByteStringRuleRefChoices(
+    const GrammarExpr& expr,
+    const Grammar& grammar,
+    int start_state,
+    std::vector<int32_t>* end_states
+) {
+  struct Branch {
+    std::string prefix;
+    int32_t rule_id;
+    std::string suffix;
+  };
+
+  std::vector<Branch> branches;
+  branches.reserve(expr.size());
+  std::vector<std::string> prefixes;
+  prefixes.reserve(expr.size());
+  for (int32_t choice_id : expr) {
+    const auto& sequence = grammar->GetGrammarExpr(choice_id);
+    if (sequence.type != ExprType::kSequence || sequence.size() != 3) {
+      return false;
+    }
+    const auto& prefix = grammar->GetGrammarExpr(sequence[0]);
+    const auto& rule_ref = grammar->GetGrammarExpr(sequence[1]);
+    const auto& suffix = grammar->GetGrammarExpr(sequence[2]);
+    if (prefix.type != ExprType::kByteString || rule_ref.type != ExprType::kRuleRef ||
+        suffix.type != ExprType::kByteString) {
+      return false;
+    }
+
+    Branch branch;
+    branch.prefix.reserve(prefix.size());
+    for (int32_t byte : prefix) {
+      branch.prefix.push_back(static_cast<char>(static_cast<uint8_t>(byte)));
+    }
+    branch.rule_id = rule_ref[0];
+    branch.suffix.reserve(suffix.size());
+    for (int32_t byte : suffix) {
+      branch.suffix.push_back(static_cast<char>(static_cast<uint8_t>(byte)));
+    }
+    prefixes.push_back(branch.prefix);
+    branches.push_back(std::move(branch));
+  }
+
+  std::vector<int32_t> prefix_end_states;
+  auto trie = TrieFSMBuilder::Build(prefixes, {}, &prefix_end_states, true, false);
+  XGRAMMAR_DCHECK(trie.has_value());
+
+  std::vector<int> state_mapping;
+  target_fsm_.AddFSM(trie->GetFsm(), &state_mapping);
+  target_fsm_.AddEpsilonEdge(start_state, state_mapping[trie->GetStart()]);
+
+  std::unordered_map<std::string, int32_t> suffix_start_states;
+  suffix_start_states.reserve(branches.size());
+  end_states->clear();
+  for (int index = 0; index < static_cast<int>(branches.size()); ++index) {
+    const auto& branch = branches[index];
+    auto [it, inserted] = suffix_start_states.emplace(branch.suffix, -1);
+    if (inserted) {
+      int32_t current_state = target_fsm_.AddState();
+      it->second = current_state;
+      for (uint8_t byte : branch.suffix) {
+        int32_t next_state = target_fsm_.AddState();
+        target_fsm_.AddEdge(current_state, next_state, byte, byte);
+        current_state = next_state;
+      }
+      end_states->push_back(current_state);
+    }
+    target_fsm_.AddRuleEdge(state_mapping[prefix_end_states[index]], it->second, branch.rule_id);
+  }
+  return true;
 }
 
 std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Choices(

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -889,7 +889,8 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
   const auto latest_row = scanable_state_history_[scanable_state_history_.size() - 1];
   std::vector<ParserState> latest_states(latest_row.begin(), latest_row.end());
   std::vector<ParserState> force_completed_states;
-  std::unordered_set<int64_t> force_completed_occurrences;
+  std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
+      force_completed_occurrences;
 
   tmp_states_visited_in_queue_.Clear();
   tmp_states_to_be_added_.clear();
@@ -904,9 +905,7 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
     if (!CanForceCompleteWithoutMarker(state, false)) {
       continue;
     }
-    int64_t occurrence =
-        (static_cast<int64_t>(state.rule_id) << 32) | static_cast<uint32_t>(state.rule_start_pos);
-    if (force_completed_occurrences.insert(occurrence).second) {
+    if (force_completed_occurrences.insert(state).second) {
       force_completed_states.push_back(state);
     }
   }
@@ -976,7 +975,8 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
     previous_capture_events = CopyLastCaptureRow();
   }
   std::vector<ParserState> force_completed_states;
-  std::unordered_set<int64_t> force_completed_occurrences;
+  std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
+      force_completed_occurrences;
 
   tmp_states_visited_in_queue_.Clear();
   tmp_states_to_be_added_.clear();
@@ -991,9 +991,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
     if (!CanForceCompleteWithoutMarker(state, true)) {
       continue;
     }
-    int64_t occurrence =
-        (static_cast<int64_t>(state.rule_id) << 32) | static_cast<uint32_t>(state.rule_start_pos);
-    if (force_completed_occurrences.insert(occurrence).second) {
+    if (force_completed_occurrences.insert(state).second) {
       force_completed_states.push_back(state);
     }
   }

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -1830,7 +1830,6 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
 ) {
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
   const auto& subtree_range = tokenizer_info_.GetTrieSubtreeNodesRange();
-  const auto& adaptive_token_mask_cache = compiled_grammar_->adaptive_token_mask_cache;
   // We need to have a copy, because scanable_state_history_ will be modified during the
   // FillNextTokenBitmask process, which can lead to undefined behavior.
   std::vector<ParserState> latest_states;
@@ -1856,13 +1855,12 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
                        << ", num of states=" << latest_states.size();
   }
 
-  std::vector<std::pair<ParserState, decltype(adaptive_token_mask_cache.cbegin())>>
-      latest_states_with_masks;
+  std::vector<std::pair<ParserState, const AdaptiveTokenMask*>> latest_states_with_masks;
 
   for (const auto& state : latest_states) {
-    auto adaptive_token_mask_it = adaptive_token_mask_cache.find(state);
-    XGRAMMAR_CHECK(adaptive_token_mask_it != adaptive_token_mask_cache.end()) << state;
-    const auto& adaptive_token_mask = adaptive_token_mask_it->second;
+    const AdaptiveTokenMask& adaptive_token_mask = compiled_grammar_->token_mask_cache.Get(
+        state, state.rule_id == grammar_->GetRootRuleId(), grammar_, tokenizer_info_
+    );
     if (state.char_budget_deadline >= 0) {
       int32_t remaining_chars = state.char_budget_deadline - GetCurrentCharIndex();
       if (remaining_chars <= tokenizer_info_.ImplPtr()->GetMaxTokenChars()) {
@@ -1870,7 +1868,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
         continue;
       }
     }
-    latest_states_with_masks.push_back(std::make_pair(state, adaptive_token_mask_it));
+    latest_states_with_masks.emplace_back(state, &adaptive_token_mask);
     if (adaptive_token_mask.store_type == StoreType::kAcceptedBitset) {
       tmp_accepted_bitset_ |= adaptive_token_mask.accepted_bitset;
     } else if (adaptive_token_mask.store_type == StoreType::kAccepted) {
@@ -1880,8 +1878,8 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
     }
   }
 
-  for (const auto& [state, adaptive_token_mask_it] : latest_states_with_masks) {
-    const auto& adaptive_token_mask = adaptive_token_mask_it->second;
+  for (const auto& [state, adaptive_token_mask_ptr] : latest_states_with_masks) {
+    const auto& adaptive_token_mask = *adaptive_token_mask_ptr;
 
     // For each ParserState, we will check every uncertain token and put them into the accepted or
     // rejected list.

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2194,6 +2194,16 @@ int32_t JSONSchemaConverter::GenerateFromSpec(
 int32_t JSONSchemaConverter::RegexExpression(
     const std::string& regex, bool json_string, bool force_cfg_expansion
 ) {
+  std::string cache_key;
+  cache_key.reserve(regex.size() + 2);
+  cache_key.push_back(static_cast<char>(json_string));
+  cache_key.push_back(static_cast<char>(force_cfg_expansion));
+  cache_key.append(regex);
+  const auto cached = regex_expr_ids_.find(cache_key);
+  if (cached != regex_expr_ids_.end()) {
+    return cached->second;
+  }
+
   bool can_use_fsm = !force_cfg_expansion;
   if (json_string) {
     can_use_fsm =
@@ -2212,14 +2222,18 @@ int32_t JSONSchemaConverter::RegexExpression(
             return fsm.IsEndState(state);
           });
       if (!language_is_empty) {
-        return builder_.AddRegex(regex, json_string);
+        const int32_t result = builder_.AddRegex(regex, json_string);
+        regex_expr_ids_.emplace(std::move(cache_key), result);
+        return result;
       }
     }
   }
 
   // Keep regex conversion independent. Only the uncommon fallback path converts its existing
   // EBNF result to a subgrammar; the JSON Schema rule graph itself is still built directly.
-  return AddSubGrammar(Grammar::FromEBNF(RegexToEBNF(regex)));
+  const int32_t result = AddSubGrammar(Grammar::FromEBNF(RegexToEBNF(regex)));
+  regex_expr_ids_.emplace(std::move(cache_key), result);
+  return result;
 }
 
 // ==================== Generate Methods ====================

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -476,6 +476,7 @@ class JSONSchemaConverter {
   std::optional<int32_t> empty_expr_id_;
   std::unordered_map<std::string, int32_t> byte_string_expr_ids_;
   std::unordered_map<int32_t, int32_t> rule_ref_expr_ids_;
+  std::unordered_map<std::string, int32_t> regex_expr_ids_;
   std::optional<int32_t> whitespace_expr_id_;
 
   // Helper for integer/number range regex generation

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -93,12 +93,11 @@ picojson::value ConstStringFormat::ToJSON() const {
 picojson::value JSONSchemaFormat::ToJSON() const {
   picojson::object obj;
   obj["type"] = picojson::value(type);
-  picojson::value schema_val;
-  if (picojson::parse(schema_val, json_schema).empty()) {
-    obj["json_schema"] = schema_val;
-  } else {
-    obj["json_schema"] = picojson::value(json_schema);
-  }
+  // Embed the schema text as a string. ToJSON is only consumed by the converter's
+  // deduplication fingerprint, so reparsing the schema into a JSON value is unnecessary
+  // and would cost a full JSON parse of potentially large schemas at every fingerprinted
+  // ancestor format.
+  obj["json_schema"] = picojson::value(json_schema);
   obj["style"] = picojson::value(style);
   obj["any_order"] = picojson::value(any_order);
   if (max_whitespace_cnt.has_value()) {
@@ -1759,6 +1758,11 @@ class StructuralTagGrammarConverter {
    * \note This method uses serialization to deduplicate identical formats.
    */
   Result<int, ISTError> Visit(const Format& format);
+
+  /*!
+   * \brief Dispatch a Format to the matching VisitSub overload, without fingerprinting.
+   */
+  Result<int, ISTError> VisitDispatch(const Format& format);
   Result<int, ISTError> VisitSub(const ConstStringFormat& format);
   Result<int, ISTError> VisitSub(const JSONSchemaFormat& format);
   Result<int, ISTError> VisitSub(const AnyTextFormat& format);
@@ -1804,7 +1808,10 @@ bool StructuralTagGrammarConverter::IsPrefix(
 Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(const StructuralTag& structural_tag
 ) {
   StructuralTagGrammarConverter converter;
-  auto result = converter.Visit(structural_tag.format);
+  // The root format is visited exactly once, so fingerprinting the entire format tree cannot
+  // produce a cache hit. Dispatch directly; nested formats still go through Visit() and retain
+  // deduplication.
+  auto result = converter.VisitDispatch(structural_tag.format);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }
@@ -1821,6 +1828,12 @@ Grammar StructuralTagGrammarConverter::AddRootRuleAndGetGrammar(int ref_rule_id)
   return grammar_builder_.Get(root_rule_id);
 }
 
+Result<int, ISTError> StructuralTagGrammarConverter::VisitDispatch(const Format& format) {
+  return std::visit(
+      [&](const auto& arg) -> Result<int, ISTError> { return VisitSub(arg); }, format
+  );
+}
+
 Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format) {
   std::string fingerprint = FormatToJSONValue(format).serialize();
 
@@ -1831,8 +1844,7 @@ Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format)
   }
 
   // Process the format and cache the result
-  auto result =
-      std::visit([&](auto&& arg) -> Result<int, ISTError> { return VisitSub(arg); }, format);
+  auto result = VisitDispatch(format);
   if (result.IsOk()) {
     int rule_id = std::move(result).Unwrap();
     serialization_to_rule_id_[fingerprint] = rule_id;

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -196,13 +196,15 @@ class GrammarCompilerObj : public ffi::Object {
       ffi::ObjectRef tokenizer_ref,
       int64_t max_threads,
       bool cache_enabled,
-      int64_t max_memory_bytes
+      int64_t max_memory_bytes,
+      bool enable_dynamic_compilation
   )
       : value(
             tokenizer_ref.as<TokenizerInfoObj>()->value,
             static_cast<int>(max_threads),
             cache_enabled,
-            max_memory_bytes
+            max_memory_bytes,
+            enable_dynamic_compilation
         ) {}
 
   static constexpr bool _type_mutable = true;
@@ -502,9 +504,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
         XGRAMMAR_FFI_TRY_END();
       });
 
-  // GrammarCompiler: init(tokenizer_info, max_threads, cache_enabled, max_memory_bytes)
+  // GrammarCompiler: init(tokenizer_info, max_threads, cache_enabled, max_memory_bytes,
+  //                       enable_dynamic_compilation)
   refl::ObjectDef<GrammarCompilerObj>()
-      .def(refl::init<O, int64_t, bool, int64_t>())
+      .def(refl::init<O, int64_t, bool, int64_t, bool>())
       .def(
           "compile_json_schema",
           [](GrammarCompilerObj* o,

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -63,12 +63,14 @@ class GrammarCompiler {
    * \param max_threads The maximum number of threads to use for compiling grammars.
    * \param cache_enabled Whether to enable the cache.
    * \param max_memory_bytes The maximum memory usage in bytes.
+   * \param enable_dynamic_compilation Whether to generate token masks on first use.
    */
   GrammarCompiler(
       const TokenizerInfo& tokenizer_info,
       int max_threads = 8,
       bool cache_enabled = true,
-      int64_t max_memory_bytes = -1  // unlimited
+      int64_t max_memory_bytes = -1,  // unlimited
+      bool enable_dynamic_compilation = false
   );
 
   /*! \brief Get the compiled grammar for a JSON schema string. */

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -110,6 +110,7 @@ class GrammarCompiler(XGRObject):
         max_threads: int = 8,
         cache_enabled: bool = True,
         cache_limit_bytes: int = -1,
+        enable_dynamic_compilation: bool = False,
     ):
         """Construct the compiler.
 
@@ -127,6 +128,9 @@ class GrammarCompiler(XGRObject):
         cache_limit_bytes : int, default: -1
             The maximum memory usage for the cache in the specified unit.
             Note that the actual memory usage may slightly exceed this value.
+
+        enable_dynamic_compilation : bool, default: False
+            Whether to generate token masks when they are first needed.
         """
         if not isinstance(tokenizer_info, TokenizerInfo):
             raise ValueError(
@@ -136,7 +140,11 @@ class GrammarCompiler(XGRObject):
 
         self._init_handle(
             _core.GrammarCompiler(
-                tokenizer_info._handle, max_threads, cache_enabled, cache_limit_bytes
+                tokenizer_info._handle,
+                max_threads,
+                cache_enabled,
+                cache_limit_bytes,
+                enable_dynamic_compilation,
             )
         )
 

--- a/tests/cpp/test_grammar_fsm_hasher.cc
+++ b/tests/cpp/test_grammar_fsm_hasher.cc
@@ -1,0 +1,70 @@
+/**
+ * \file tests/cpp/test_grammar_fsm_hasher.cc
+ * \brief Regression tests for canonical grammar FSM hashing.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "grammar_functor.h"
+#include "grammar_impl.h"
+#include "xgrammar/grammar.h"
+
+using namespace xgrammar;
+
+namespace {
+
+int32_t FindRule(const Grammar& grammar, const std::string& name) {
+  for (int32_t rule_id = 0; rule_id < grammar->NumRules(); ++rule_id) {
+    if (grammar->GetRule(rule_id).name == name) {
+      return rule_id;
+    }
+  }
+  return -1;
+}
+
+int CountRuleEdges(const CompactFSMWithStartEnd& fsm) {
+  int result = 0;
+  for (int32_t state = 0; state < fsm.NumStates(); ++state) {
+    for (const auto& edge : fsm.GetFsm().GetEdges(state)) {
+      result += edge.IsRuleRef();
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+TEST(XGrammarFSMHasherTest, RuleEdgeScratchIsScopedToEachState) {
+  auto grammar = Grammar::FromEBNF(R"(
+root ::= left | right
+left ::= ref "x" | "a" ref "y"
+right ::= "a" ref "y" | ref "x"
+ref ::= "z"
+)");
+  GrammarFSMBuilder::Apply(&grammar);
+  GrammarFSMHasher::Apply(&grammar);
+
+  const int32_t left = FindRule(grammar, "left");
+  const int32_t right = FindRule(grammar, "right");
+  ASSERT_GE(left, 0);
+  ASSERT_GE(right, 0);
+  ASSERT_TRUE(grammar->per_rule_fsms[left].has_value());
+  ASSERT_TRUE(grammar->per_rule_fsms[right].has_value());
+  EXPECT_GE(CountRuleEdges(grammar->per_rule_fsms[left]->GetFsm()), 2);
+  EXPECT_GE(CountRuleEdges(grammar->per_rule_fsms[right]->GetFsm()), 2);
+
+  ASSERT_TRUE(grammar->per_rule_fsm_hashes[left].has_value());
+  ASSERT_TRUE(grammar->per_rule_fsm_hashes[right].has_value());
+  EXPECT_EQ(grammar->per_rule_fsm_hashes[left], grammar->per_rule_fsm_hashes[right]);
+
+  const auto first_hashes = grammar->per_rule_fsm_hashes;
+  const auto first_state_ids = grammar->per_rule_fsm_new_state_ids;
+  GrammarFSMHasher::Apply(&grammar);
+  EXPECT_EQ(grammar->per_rule_fsm_hashes, first_hashes);
+  EXPECT_EQ(grammar->per_rule_fsm_new_state_ids, first_state_ids);
+}

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -1,0 +1,228 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import torch
+
+import xgrammar as xgr
+from xgrammar.base import _core
+
+VOCABULARY = [chr(value) for value in range(32, 127)] + ["Ada", "hello", "42", "<call>"]
+
+
+def _mask_trace(compiled_grammar: xgr.CompiledGrammar, input_string: str):
+    matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+    bitmask = xgr.allocate_token_bitmask(1, compiled_grammar.tokenizer_info.vocab_size)
+    trace = []
+    for char in input_string:
+        xgr.reset_token_bitmask(bitmask)
+        trace.append((matcher.fill_next_token_bitmask(bitmask), bitmask.clone()))
+        assert matcher.accept_string(char)
+    assert matcher.is_terminated()
+    return trace
+
+
+def _compile_ebnf(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_grammar(
+        """
+root ::= greeting punctuation
+greeting ::= "hello" | "hi"
+punctuation ::= "!" | "?"
+"""
+    )
+
+
+def _compile_json_schema(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_json_schema(
+        {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "scores": {"type": "array", "items": {"type": "integer"}},
+            },
+            "required": ["name", "scores"],
+            "additionalProperties": False,
+        },
+        any_whitespace=True,
+    )
+
+
+def _compile_regex(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_regex(r"[A-Z][a-z]{2}[0-9]+")
+
+
+def _compile_builtin_json(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_builtin_json_grammar()
+
+
+def _compile_structural_tag(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_structural_tag(
+        {
+            "type": "structural_tag",
+            "format": {
+                "type": "dispatch",
+                "rules": [["<call>", {"type": "const_string", "value": "X"}]],
+                "loop": False,
+                "excludes": [],
+            },
+        }
+    )
+
+
+CASES = [
+    (_compile_ebnf, "hello!"),
+    (_compile_json_schema, '{"name":"Ada","scores":[1,2]}'),
+    (_compile_regex, "Ada42"),
+    (_compile_builtin_json, '{"name":"Ada"}'),
+    (_compile_structural_tag, "prefix<call>X"),
+]
+
+
+def test_native_constructor_takes_dynamic_compilation_flag():
+    tokenizer_info = xgr.TokenizerInfo(["a"], stop_token_ids=[])
+    for enable_dynamic_compilation in (False, True):
+        compiler = _core.GrammarCompiler(
+            tokenizer_info._handle, 1, True, -1, enable_dynamic_compilation
+        )
+        compiler.compile_builtin_json_grammar()
+
+
+@pytest.mark.parametrize(
+    "compile_grammar,input_string",
+    CASES,
+    ids=["ebnf", "json-schema", "regex", "builtin-json", "structural-tag"],
+)
+def test_dynamic_compilation_matches_eager_masks(compile_grammar, input_string):
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    eager = compile_grammar(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+    dynamic = compile_grammar(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+
+    expected = _mask_trace(eager, input_string)
+    actual = _mask_trace(dynamic, input_string)
+    assert len(actual) == len(expected)
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+        assert actual_apply == expected_apply
+        torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_dynamic_masks_are_cached():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic = _compile_builtin_json(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    eager = _compile_builtin_json(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+
+    initial_size = dynamic.memory_size_bytes
+    assert initial_size < eager.memory_size_bytes
+    _mask_trace(dynamic, '{"name":"Ada"}')
+    populated_size = dynamic.memory_size_bytes
+    assert populated_size > initial_size
+    _mask_trace(dynamic, '{"name":"Ada"}')
+    assert dynamic.memory_size_bytes == populated_size
+
+
+def test_serialization_roundtrips_dynamic_mode():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic = _compile_ebnf(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    eager = _compile_ebnf(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+    initial_size = dynamic.memory_size_bytes
+
+    restored = xgr.CompiledGrammar.deserialize_json(dynamic.serialize_json(), tokenizer_info)
+    # Serialization does not materialize masks, and the restored grammar is dynamic again.
+    assert dynamic.memory_size_bytes == initial_size
+    restored_initial_size = restored.memory_size_bytes
+    assert restored_initial_size < eager.memory_size_bytes
+    for input_string in ["hello!", "hi?"]:
+        expected = _mask_trace(eager, input_string)
+        actual = _mask_trace(restored, input_string)
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+            assert actual_apply == expected_apply
+            torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+    assert restored.memory_size_bytes > restored_initial_size
+
+
+def test_serialization_roundtrips_dynamic_tag_dispatch():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic = _compile_structural_tag(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    eager = _compile_structural_tag(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+
+    restored = xgr.CompiledGrammar.deserialize_json(dynamic.serialize_json(), tokenizer_info)
+    expected = _mask_trace(eager, "prefix<call>X")
+    actual = _mask_trace(restored, "prefix<call>X")
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+        assert actual_apply == expected_apply
+        torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "compile_grammar,input_string",
+    [
+        (_compile_json_schema, '{"name":"Ada","scores":[1,2]}'),
+        (_compile_structural_tag, "prefix<call>X"),
+    ],
+    ids=["json-schema", "structural-tag"],
+)
+def test_concurrent_dynamic_mask_generation(compile_grammar, input_string):
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic = compile_grammar(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        traces = list(executor.map(lambda _: _mask_trace(dynamic, input_string), range(32)))
+
+    expected = traces[0]
+    for actual in traces[1:]:
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+            assert actual_apply == expected_apply
+            torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_limited_compiler_cache_records_dynamic_grammar_size_on_insertion():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    cache_limit = 64 * 1024
+    compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=True,
+        cache_limit_bytes=cache_limit,
+        enable_dynamic_compilation=True,
+    )
+    dynamic = _compile_builtin_json(compiler)
+    insertion_size = compiler.get_cache_size_bytes()
+    assert 0 < insertion_size <= cache_limit
+
+    barrier = threading.Barrier(9)
+
+    def generate_masks():
+        barrier.wait()
+        return _mask_trace(dynamic, '{"name":"Ada"}')
+
+    def read_cache_sizes():
+        barrier.wait()
+        return [compiler.get_cache_size_bytes() for _ in range(100)]
+
+    with ThreadPoolExecutor(max_workers=9) as executor:
+        mask_futures = [executor.submit(generate_masks) for _ in range(8)]
+        size_future = executor.submit(read_cache_sizes)
+        for future in mask_futures:
+            future.result()
+        observed_sizes = size_future.result()
+
+    assert all(size == insertion_size for size in observed_sizes)
+    assert compiler.get_cache_size_bytes() == insertion_size
+    assert _compile_builtin_json(compiler).memory_size_bytes == dynamic.memory_size_bytes

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -447,6 +447,32 @@ def _compiled_accepts(compiled_grammar: xgr.CompiledGrammar, input_str: str) -> 
     return matcher.accept_string(input_str) and matcher.is_terminated()
 
 
+def test_repeated_regex_fsm_reuse_preserves_nullable_rules():
+    tokenizer_info = xgr.TokenizerInfo(["!", "a", "aa", "b"], stop_token_ids=[])
+    grammar = xgr.Grammar.from_lark('start: left "!" right\nleft: /a*/\nright: /a*/')
+
+    compiled = xgr.GrammarCompiler(tokenizer_info, max_threads=1).compile_grammar(grammar)
+    for value in ["!", "a!", "!a", "aa!aa"]:
+        assert _compiled_accepts(compiled, value)
+    for value in ["", "aa", "!!", "b!"]:
+        assert not _compiled_accepts(compiled, value)
+
+
+def test_regex_fsm_cache_distinguishes_json_string_mode():
+    tokenizer_info = xgr.TokenizerInfo([])
+    grammar = xgr.Grammar.from_ebnf(
+        'root ::= plain "!" plain json "!" json\n'
+        'plain ::= Regex(".")\n'
+        'json ::= Regex(".", json_string=true)'
+    )
+
+    compiled = xgr.GrammarCompiler(tokenizer_info, max_threads=1).compile_grammar(grammar)
+    for value in ['"!ab!c', "\\!ab!c", "a!bc!d"]:
+        assert _compiled_accepts(compiled, value)
+    for value in ['a!a"!b', "a!a\\!b", "a!ab!\n"]:
+        assert not _compiled_accepts(compiled, value)
+
+
 def _mask_trace(compiled_grammar: xgr.CompiledGrammar, input_str: str):
     matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
     bitmask = xgr.allocate_token_bitmask(1, compiled_grammar.tokenizer_info.vocab_size)

--- a/tests/python/test_grammar_fsm_builder.py
+++ b/tests/python/test_grammar_fsm_builder.py
@@ -181,6 +181,31 @@ def test_recursive_rule_ref_in_sequence():
     assert not _matcher_accepts(matcher, "())")
 
 
+def test_large_byte_prefix_rule_ref_suffix_choices():
+    prefixes = ["a" * length for length in range(1, 65)]
+    alternatives = []
+    for index, prefix in enumerate(prefixes):
+        suffix = "!" if index % 2 == 0 else "?"
+        alternatives.append(f'"{prefix}" body "{suffix}"')
+    grammar = "root ::= " + " | ".join(alternatives) + "\nbody ::= [0-9]"
+    matcher = _make_string_matcher(grammar)
+
+    for index, prefix in enumerate(prefixes):
+        suffix = "!" if index % 2 == 0 else "?"
+        assert _matcher_accepts(matcher, prefix + "7" + suffix)
+        assert not _matcher_accepts(matcher, prefix + "7" + ("?" if suffix == "!" else "!"))
+        assert not _matcher_accepts(matcher, prefix + suffix)
+
+
+def test_nested_byte_prefix_rule_ref_suffix_choices_merge_outer_fsm():
+    grammar = _ebnf_to_grammar_no_normalization(
+        'root ::= ("a" body "x" | "ab" body "x") ("cd" | "ed")\nbody ::= [0-9]'
+    )
+    grammar = GrammarFunctor.fsm_builder(grammar)
+
+    assert "Rule 0: root, FSM: CompactFSM(num_states=9" in _print_grammar_fsms(grammar)
+
+
 # --- Empty sequence ---
 
 

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -185,6 +185,23 @@ def test_structural_tag_compiler():
     assert str(compiled_grammar.grammar) == expected_grammar_test_structural_tag_after_optimization
 
 
+def test_structural_tag_overlapping_branch_prefixes():
+    tags = [
+        xgr.StructuralTagItem(
+            begin="<call>a", schema={"type": "string", "const": "one"}, end="</call>"
+        ),
+        xgr.StructuralTagItem(
+            begin="<call>ab", schema={"type": "string", "const": "two"}, end="</call>"
+        ),
+    ]
+    grammar = xgr.Grammar.from_structural_tag(tags, ["<call>"])
+
+    assert _is_grammar_accept_string(grammar, '<call>a"one"</call>')
+    assert _is_grammar_accept_string(grammar, '<call>ab"two"</call>')
+    assert not _is_grammar_accept_string(grammar, '<call>a"two"</call>')
+    assert not _is_grammar_accept_string(grammar, '<call>ab"one"</call>')
+
+
 @pytest.mark.hf_token_required
 def test_structural_tag_mask_gen():
     # Define schemas for the test

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -976,6 +976,23 @@ def test_restricted_string():
     )
 
 
+def test_repeated_string_patterns_preserve_each_property():
+    schema = {
+        "type": "object",
+        "properties": {
+            "first": {"type": "string", "pattern": "^[a-f]+$"},
+            "second": {"type": "string", "pattern": "^[a-f]+$"},
+        },
+        "required": ["first", "second"],
+        "additionalProperties": False,
+    }
+
+    check_schema_with_instance(schema, {"first": "ab", "second": "fa"}, any_whitespace=False)
+    check_schema_with_instance(
+        schema, {"first": "ab", "second": "z"}, is_accepted=False, any_whitespace=False
+    )
+
+
 def test_complex_restrictions():
     class RestrictedModel(BaseModel):
         restricted_string: str = Field(..., pattern=r"[^\"]*")

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -1711,6 +1711,29 @@ def test_lark_budget_shared_subrule() -> None:
     assert matcher.is_completed()
 
 
+def test_lark_budget_shared_subrule_keeps_parent_contexts_separate() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["p", "a", "b", "X", "Y"])
+    compiled = _compile_lark(
+        """
+        start: tight "X" | loose "Y"
+        tight[max_tokens=2]: shared
+        loose: shared
+        shared: "p" sub
+        sub: /[ab]+/
+        """,
+        tokenizer_info,
+    )
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+
+    assert matcher.accept_token(0)
+    assert matcher.accept_token(1)
+    assert 2 in _allowed_token_ids(matcher, tokenizer_info)
+    assert matcher.accept_token(2)
+    assert _allowed_token_ids(matcher, tokenizer_info) == [1, 2, 4]
+    assert not matcher.accept_token(3)
+    assert matcher.accept_token(4) and matcher.is_terminated()
+
+
 def test_lark_budget_round_trip_and_cache() -> None:
     grammar = xgr.Grammar.from_lark(BUDGET_GRAMMAR, tokenizer_info=MAX_TOKENS_TOKENIZER)
     ebnf = str(grammar)

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -273,6 +273,27 @@ def test_max_chars_rollback_reset_and_fork() -> None:
     assert 0 in _allowed_token_ids(matcher, tokenizer_info)
 
 
+def test_max_chars_shared_subrule_keeps_parent_contexts_separate() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "X", "Y"])
+    compiled = _compile(
+        """
+        start: tight "X" | loose "Y"
+        tight[max_chars=1]: sub
+        loose: sub
+        sub: /[ab]+/
+        """,
+        tokenizer_info,
+    )
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+
+    assert matcher.accept_token(0)
+    assert 1 in _allowed_token_ids(matcher, tokenizer_info)
+    assert matcher.accept_token(1)
+    assert _allowed_token_ids(matcher, tokenizer_info) == [0, 1, 3]
+    assert not matcher.accept_token(2)
+    assert matcher.accept_token(3) and matcher.is_terminated()
+
+
 def test_max_chars_atomic_token_is_best_effort() -> None:
     tokenizer_info = xgr.TokenizerInfo(["<|wide|>", "!"])
     compiled = _compile('start: value "!"\nvalue[max_chars=1]: <|wide|>', tokenizer_info)

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -270,6 +270,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
+        "dynamic": False,
         "__VERSION__": "v16",
     }
 

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -4196,6 +4196,22 @@ def test_structural_tag_per_tag_whitespace_independent():
     assert not _is_grammar_accept_string(g, a(5) + b(5))
 
 
+def test_structural_tag_identical_json_schema_formats_reuse_safely():
+    content = JSONSchemaFormat(json_schema=_WS_SCHEMA, style="json")
+    stag = StructuralTag(
+        format=SequenceFormat(
+            elements=[
+                TagFormat(begin="<a>", content=content, end="</a>"),
+                TagFormat(begin="<b>", content=content, end="</b>"),
+            ]
+        )
+    )
+    grammar = xgr.Grammar.from_structural_tag(stag)
+
+    assert _is_grammar_accept_string(grammar, '<a>{"a": 1}</a><b>{"a": 2}</b>')
+    assert not _is_grammar_accept_string(grammar, '<a>{"a": 1}</a><b>{"a": "x"}</b>')
+
+
 def test_structural_tag_max_whitespace_cnt_compile_cache():
     # The per-tag setting is part of the serialized tag JSON (the cache key), so no collision.
     compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]), cache_enabled=True)


### PR DESCRIPTION
## Summary

- Add opt-in on-demand token mask generation.
- Generate and cache exact masks on first use.
- Preserve eager behavior for serialization and the default compiler path.
- Share immutable cache state safely across matchers.

This is the minimal functional base of the on-demand compilation work. The default path stays eager compilation; nothing changes unless dynamic compilation is requested.

## Stacking

- Base is `main`, so the diff currently also shows the six independent PRs #809, #810, #811, #812, #813, #814 that this branch is built on. The change specific to this PR is the last commit (`Add minimal on-demand token mask generation`). I will rebase as the predecessors merge.
- The measurements below compare this branch against its immediate base (main plus those six PRs): Before = eager compilation, After = this branch with dynamic compilation enabled.

## Correctness

- Full valid-vocabulary token-mask sweep across four workloads (structural tag large/small on the `Qwen/Qwen3-4B-Instruct-2507` vocabulary, JSON Schema large/small on the `unsloth/Meta-Llama-3.1-8B-Instruct` vocabulary), comparing dynamic mode against the eager base: 0 allowed-set differences.
- Local: C++ suite passed; `test_dynamic_compilation.py` + `test_serialization.py` 25 passed.

## Performance

Measured on Modal (AMD EPYC 9V33X, 16 physical cores), 5 rounds, median of same-round ratios (>1x is faster). Before = base with eager compilation, After = this branch with dynamic compilation enabled:

| Workload | Compile | Mask | End-to-end |
|---|---:|---:|---:|
| Structural tag large | 2.081x | 0.021x | 1.024x |
| Structural tag small | 11.100x | 0.017x | 0.573x |
| JSON Schema large | 2.538x | 0.142x | 1.993x |
| JSON Schema small | 21.084x | 0.027x | 0.090x |

Dynamic mode moves work from compile to first mask use by design, so mask means regress while compile improves. On its own the mode is end-to-end profitable for compile-dominated workloads (JSON Schema large: 1.993x) and unprofitable for mask-dominated ones (JSON Schema small: 0.090x); the follow-up PRs in this series recover mask cost. The default eager path is unaffected.
