### PR TITLE
Reuse stable Earley parser worklists

### DIFF
--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -168,7 +168,13 @@ picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl) {
   auto result = picojson::object{};
   result["grammar"] = AutoSerializeJSONValue(impl.grammar);
   result["tokenizer_metadata"] = impl.tokenizer_info->DumpMetadataValue();
-  result["adaptive_token_mask_cache"] = AutoSerializeJSONValue(impl.adaptive_token_mask_cache);
+  // In dynamic mode, serialize an empty mask cache; masks are generated on first use again
+  // after deserialization.
+  result["dynamic"] = picojson::value(impl.token_mask_cache.dynamic_);
+  result["adaptive_token_mask_cache"] = AutoSerializeJSONValue(
+      impl.token_mask_cache.dynamic_ ? decltype(impl.token_mask_cache.masks_){}
+                                     : impl.token_mask_cache.masks_
+  );
   return picojson::value(result);
 }
 
@@ -199,14 +205,21 @@ std::optional<SerializationError> DeserializeJSONValue(
   if (object.find("adaptive_token_mask_cache") == object.end()) {
     return ConstructDeserializeError("Expect a 'adaptive_token_mask_cache' field", type_name);
   }
-  AutoDeserializeJSONValue(&(impl->adaptive_token_mask_cache), object["adaptive_token_mask_cache"]);
+  AutoDeserializeJSONValue(&(impl->token_mask_cache.masks_), object["adaptive_token_mask_cache"]);
+  const auto dynamic_it = object.find("dynamic");
+  if (dynamic_it != object.end() && !dynamic_it->second.is<bool>()) {
+    return ConstructDeserializeError("Expect a boolean 'dynamic' field", type_name);
+  }
+  if (dynamic_it != object.end() && dynamic_it->second.get<bool>()) {
+    impl->token_mask_cache.dynamic_ = true;
+  }
   return std::nullopt;
 }
 
 /************** CompiledGrammar **************/
 
 std::size_t MemorySize(const CompiledGrammar::Impl& impl) {
-  return MemorySize(impl.grammar) + MemorySize(impl.adaptive_token_mask_cache);
+  return MemorySize(impl.grammar) + MemorySize(impl.token_mask_cache);
 }
 
 std::size_t CompiledGrammar::MemorySizeBytes() const { return MemorySize(*pimpl_); }

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -167,6 +167,7 @@ std::string AdaptiveTokenMask::Print(const TokenizerInfo& tokenizer_info) const 
 picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl) {
   auto result = picojson::object{};
   result["grammar"] = AutoSerializeJSONValue(impl.grammar);
+  result["earley_parser_features"] = AutoSerializeJSONValue(impl.earley_parser_features);
   result["tokenizer_metadata"] = impl.tokenizer_info->DumpMetadataValue();
   // In dynamic mode, serialize an empty mask cache; masks are generated on first use again
   // after deserialization.
@@ -192,6 +193,23 @@ std::optional<SerializationError> DeserializeJSONValue(
     return ConstructDeserializeError("Expect a 'grammar' field", type_name);
   }
   AutoDeserializeJSONValue(&(impl->grammar), object["grammar"], type_name);
+  const auto features_it = object.find("earley_parser_features");
+  if (features_it == object.end()) {
+    return ConstructDeserializeError("Expect an 'earley_parser_features' field", type_name);
+  }
+  if (auto error = AutoDeserializeJSONValue(
+          &(impl->earley_parser_features), features_it->second, type_name
+      )) {
+    return error;
+  }
+  if (impl->earley_parser_features.fsm_state_flags.size() !=
+          static_cast<std::size_t>(impl->grammar->complete_fsm.NumStates()) ||
+      impl->earley_parser_features.rule_is_nullable.size() !=
+          static_cast<std::size_t>(impl->grammar->NumRules())) {
+    return ConstructDeserializeError(
+        "Earley parser feature dimensions do not match the grammar", type_name
+    );
+  }
   if (object.find("tokenizer_metadata") == object.end()) {
     return ConstructDeserializeError("Expect a 'tokenizer_metadata' field", type_name);
   }
@@ -219,7 +237,8 @@ std::optional<SerializationError> DeserializeJSONValue(
 /************** CompiledGrammar **************/
 
 std::size_t MemorySize(const CompiledGrammar::Impl& impl) {
-  return MemorySize(impl.grammar) + MemorySize(impl.token_mask_cache);
+  return MemorySize(impl.grammar) + MemorySize(impl.token_mask_cache) +
+         MemorySize(impl.earley_parser_features);
 }
 
 std::size_t CompiledGrammar::MemorySizeBytes() const { return MemorySize(*pimpl_); }

--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -192,7 +192,9 @@ std::optional<SerializationError> DeserializeJSONValue(
   if (object.find("grammar") == object.end()) {
     return ConstructDeserializeError("Expect a 'grammar' field", type_name);
   }
-  AutoDeserializeJSONValue(&(impl->grammar), object["grammar"], type_name);
+  if (auto error = AutoDeserializeJSONValue(&(impl->grammar), object["grammar"], type_name)) {
+    return error;
+  }
   const auto features_it = object.find("earley_parser_features");
   if (features_it == object.end()) {
     return ConstructDeserializeError("Expect an 'earley_parser_features' field", type_name);

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -23,6 +24,8 @@
 #include "xgrammar/exception.h"
 
 namespace xgrammar {
+
+class RuleLevelCache;
 
 /******************* CompiledGrammar Datastructures *******************/
 
@@ -116,6 +119,14 @@ class TokenMaskCache {
    */
   explicit TokenMaskCache(bool dynamic) : dynamic_(dynamic) {}
 
+  /*! \brief Configure cross-grammar rule mask sharing for dynamic generation. */
+  void SetRuleLevelCache(
+      std::shared_ptr<RuleLevelCache> rule_level_cache, std::vector<uint8_t> rule_level_cacheable
+  ) {
+    rule_level_cache_ = std::move(rule_level_cache);
+    rule_level_cacheable_ = std::move(rule_level_cacheable);
+  }
+
   /*! \brief Whether missing token masks should be generated on first use. */
   bool IsDynamic() const { return dynamic_; }
 
@@ -140,6 +151,12 @@ class TokenMaskCache {
   /*! \brief Whether missing token masks should be generated on first use. */
   bool dynamic_{false};
 
+  /*! \brief Rule masks shared by grammars compiled with the same compiler. */
+  std::shared_ptr<RuleLevelCache> rule_level_cache_;
+
+  /*! \brief Whether each rule is independent of runtime parser context. */
+  std::vector<uint8_t> rule_level_cacheable_;
+
   /*! \brief Mapping from the parser state to the adaptive token mask. */
   std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache> masks_;
 
@@ -160,7 +177,8 @@ class TokenMaskCache {
   friend std::size_t MemorySize(const TokenMaskCache& token_mask_cache) {
     std::lock_guard<std::mutex> lock(token_mask_cache.mutex_);
     return MemorySize(token_mask_cache.masks_) +
-           MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_);
+           MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_) +
+           MemorySize(token_mask_cache.rule_level_cacheable_);
   }
 };
 

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -28,6 +29,22 @@ namespace xgrammar {
 class RuleLevelCache;
 
 /******************* CompiledGrammar Datastructures *******************/
+
+XGRAMMAR_MEMBER_TABLE(
+    EarleyParserFeatures,
+    "fsm_state_flags",
+    &EarleyParserFeatures::fsm_state_flags,
+    "rule_is_nullable",
+    &EarleyParserFeatures::rule_is_nullable,
+    "has_budget_rules",
+    &EarleyParserFeatures::has_budget_rules,
+    "has_char_budget_rules",
+    &EarleyParserFeatures::has_char_budget_rules,
+    "capture_tracking",
+    &EarleyParserFeatures::capture_tracking,
+    "has_hidden_capture_rules",
+    &EarleyParserFeatures::has_hidden_capture_rules
+);
 
 /*!
  * \brief Preprocessed information, for a given specific ParserState, divides the token set
@@ -139,7 +156,8 @@ class TokenMaskCache {
       const ParserState& state,
       bool is_root_rule,
       const Grammar& grammar,
-      const TokenizerInfo& tokenizer_info
+      const TokenizerInfo& tokenizer_info,
+      const EarleyParserFeatures& features
   );
 
  private:
@@ -216,6 +234,9 @@ class CompiledGrammar::Impl {
 
   /*! \brief The adaptive token masks, precomputed or generated on first use. */
   TokenMaskCache token_mask_cache;
+
+  /*! \brief Grammar-wide flags and nullable rules shared by Earley parsers. */
+  EarleyParserFeatures earley_parser_features;
 
   Grammar GetGrammar() const { return grammar; }
 

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -100,6 +101,83 @@ XGRAMMAR_MEMBER_TABLE(
 );
 
 /*!
+ * \brief Manages the adaptive token masks of a compiled grammar. In eager mode (the default),
+ * all masks are precomputed at compile time. In dynamic mode, masks are generated and cached on
+ * first use.
+ */
+class TokenMaskCache {
+ public:
+  /*! \brief Construct an eager cache. Only for deserialization. */
+  TokenMaskCache() = default;
+
+  /*!
+   * \brief Construct the cache with the mask generation mode.
+   * \param dynamic Whether missing token masks should be generated on first use.
+   */
+  explicit TokenMaskCache(bool dynamic) : dynamic_(dynamic) {}
+
+  /*! \brief Whether missing token masks should be generated on first use. */
+  bool IsDynamic() const { return dynamic_; }
+
+  /*! \brief Insert a precomputed mask during eager compilation. Not thread-safe; the compiler
+   * synchronizes concurrent insertions itself. */
+  void Insert(const ParserState& state, AdaptiveTokenMask mask) { masks_[state] = std::move(mask); }
+
+  /*! \brief Return the mask for the state. In dynamic mode, generate and cache it on miss. */
+  const AdaptiveTokenMask& Get(
+      const ParserState& state,
+      bool is_root_rule,
+      const Grammar& grammar,
+      const TokenizerInfo& tokenizer_info
+  );
+
+ private:
+  /*! \brief Return the tag-dispatch bitset for a rule, computing and caching it on first use. */
+  const DynamicBitset* GetTagDispatchSecondSlicingBitset(
+      int32_t rule_id, const Grammar& grammar, const TokenizerInfo& tokenizer_info
+  );
+
+  /*! \brief Whether missing token masks should be generated on first use. */
+  bool dynamic_{false};
+
+  /*! \brief Mapping from the parser state to the adaptive token mask. */
+  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache> masks_;
+
+  /*! \brief Tag-dispatch data computed on first use in dynamic mode. */
+  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset_;
+
+  /*! \brief Protects on-demand token mask lookup and insertion. */
+  mutable std::mutex mutex_;
+
+  friend struct member_trait<TokenMaskCache>;
+  friend picojson::value SerializeJSONValue(const CompiledGrammar::Impl& impl);
+  friend std::optional<SerializationError> DeserializeJSONValue(
+      CompiledGrammar::Impl* impl,
+      const picojson::value& json_value,
+      const TokenizerInfo& tokenizer_info
+  );
+
+  friend std::size_t MemorySize(const TokenMaskCache& token_mask_cache) {
+    std::lock_guard<std::mutex> lock(token_mask_cache.mutex_);
+    return MemorySize(token_mask_cache.masks_) +
+           MemorySize(token_mask_cache.tag_dispatch_rule_id_to_second_slicing_bitset_);
+  }
+};
+
+/*!
+ * \brief Compute the bitset of tokens that are definitely accepted since the second character
+ * for a tag-dispatch rule.
+ */
+DynamicBitset ComputeTagDispatchSecondSlicingBitset(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info, int32_t rule_id
+);
+
+/*! \brief Compute the second-slicing bitsets for all tag-dispatch rules. */
+std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitsets(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info
+);
+
+/*!
  * \brief All information that we need to match tokens in the tokenizer to the specified grammar.
  * It is the result of preprocessing.
  * \sa xgrammar::GrammarMatcher
@@ -112,12 +190,14 @@ class CompiledGrammar::Impl {
   /*! \brief The tokenizer information. */
   TokenizerInfo tokenizer_info{NullObj{}};
 
-  /*! \brief Default constructor. */
+  /*! \brief Default constructor. Only for deserialization. */
   Impl() = default;
 
-  /*! \brief Mapping from the parser state to the adaptive token mask. */
-  std::unordered_map<ParserState, AdaptiveTokenMask, StateHashForCache, StateEqualForCache>
-      adaptive_token_mask_cache;
+  /*! \brief Construct with the token mask generation mode. \sa TokenMaskCache */
+  explicit Impl(bool enable_dynamic_compilation) : token_mask_cache(enable_dynamic_compilation) {}
+
+  /*! \brief The adaptive token masks, precomputed or generated on first use. */
+  TokenMaskCache token_mask_cache;
 
   Grammar GetGrammar() const { return grammar; }
 
@@ -133,14 +213,16 @@ class CompiledGrammar::Impl {
   friend std::size_t MemorySize(const Impl& impl);
 };
 
+XGRAMMAR_MEMBER_TABLE(TokenMaskCache, "adaptive_token_mask_cache", &TokenMaskCache::masks_);
+
 XGRAMMAR_MEMBER_TABLE(
     CompiledGrammar::Impl,
     "grammar",
     &CompiledGrammar::Impl::grammar,
     "tokenizer_info",
     &CompiledGrammar::Impl::tokenizer_info,
-    "adaptive_token_mask_cache",
-    &CompiledGrammar::Impl::adaptive_token_mask_cache
+    "token_mask_cache",
+    &CompiledGrammar::Impl::token_mask_cache
 );
 
 }  // namespace xgrammar

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -25,6 +25,31 @@ using GrammarExpr = Grammar::Impl::GrammarExpr;
 
 bool EarleyParser::IsCompleted() const { return is_completed_.back(); }
 
+void EarleyParser::ClearTemporaryContainers() {
+  tmp_pending_states_.clear();
+  tmp_states_to_be_added_.clear();
+  tmp_states_visited_in_queue_.Clear();
+  tmp_completed_lazy_occurrences_.clear();
+}
+
+void EarleyParser::ExpandPendingStates(bool debug_print) {
+  size_t process_index = 0;
+  while (process_index < tmp_pending_states_.size()) {
+    const ParserState& state = *tmp_pending_states_[process_index++];
+    if (process_index == tmp_pending_states_.size()) {
+      tmp_pending_states_.clear();
+      process_index = 0;
+    }
+    auto [scanable, completable] = Predict(state, debug_print);
+    if (completable) {
+      Complete(state, debug_print);
+    }
+    if (scanable) {
+      tmp_states_to_be_added_.push_back(&state);
+    }
+  }
+}
+
 bool EarleyParser::CompletionConsumedMarker(const ParserState& state) const {
   const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(state.rule_id).body_expr_id);
   if (body.type != GrammarExprType::kTagDispatch) {
@@ -385,12 +410,10 @@ void EarleyParser::Scan(const ParserState& state, const uint8_t ch) {
 */
 bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   // Initialize the containers.
-  XGRAMMAR_DCHECK(tmp_process_state_queue_.empty())
-      << "The tmp_process_state_queue_ should be empty before the scan.";
-  tmp_states_visited_in_queue_.Clear();
-  tmp_states_to_be_added_.clear();
+  XGRAMMAR_DCHECK(tmp_pending_states_.empty())
+      << "The tmp_pending_states_ should be empty before the scan.";
+  ClearTemporaryContainers();
   tmp_accept_stop_token_ = false;
-  tmp_completed_lazy_occurrences_.clear();
   if (features_->has_char_budget_rules) {
     tmp_char_budget_entered_ = char_budget_entry_history_.back();
     char_count_history_.push_back(GetCurrentCharIndex() + StartsUTF8Codepoint(ch));
@@ -405,10 +428,11 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   }
 
   // Check if the character is accepted.
-  if (tmp_process_state_queue_.empty() && tmp_states_to_be_added_.empty()) {
+  if (tmp_pending_states_.empty() && tmp_states_to_be_added_.empty()) {
     if (features_->has_char_budget_rules) {
       char_count_history_.pop_back();
     }
+    ClearTemporaryContainers();
     return false;
   }
 
@@ -417,34 +441,25 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }
-  while (!tmp_process_state_queue_.empty()) {
-    const auto state = std::move(tmp_process_state_queue_.front());
-    tmp_process_state_queue_.pop();
-    auto [scanable, completable] = Predict(state, debug_print);
-    if (completable) {
-      Complete(state, debug_print);
-    }
-    if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
-    }
-  }
+  ExpandPendingStates(debug_print);
 
   // Check if the grammar is completed, and add the scannable states to the history.
   if (!tmp_completed_lazy_occurrences_.empty()) {
     RemoveCommittedLazyStates();
   }
   is_completed_.push_back(tmp_accept_stop_token_);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
   if (features_->has_char_budget_rules) {
     char_budget_entry_history_.push_back(tmp_char_budget_entered_);
   }
+  ClearTemporaryContainers();
   return true;
 }
 
 void EarleyParser::RemoveCommittedLazyStates() {
-  auto is_committed = [&](const ParserState& state) {
+  auto is_committed = [&](const ParserState* state) {
     for (const auto& [rule_id, rule_start_pos] : tmp_completed_lazy_occurrences_) {
-      if (state.rule_id == rule_id && state.rule_start_pos == rule_start_pos) {
+      if (state->rule_id == rule_id && state->rule_start_pos == rule_start_pos) {
         return true;
       }
     }
@@ -536,35 +551,24 @@ ParserState EarleyParser::RootInitialState() const {
 }
 
 void EarleyParser::PushStateAndExpand(const ParserState& state) {
-  tmp_states_visited_in_queue_.Clear();
+  ClearTemporaryContainers();
   tmp_accept_stop_token_ = false;
-  tmp_states_to_be_added_.clear();
-  tmp_completed_lazy_occurrences_.clear();
   Enqueue(state);
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
   if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }
-  while (!tmp_process_state_queue_.empty()) {
-    const auto state = tmp_process_state_queue_.front();
-    tmp_process_state_queue_.pop();
-    auto [scanable, completable] = Predict(state);
-    if (completable) {
-      Complete(state);
-    }
-    if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
-    }
-  }
+  ExpandPendingStates();
   if (!tmp_completed_lazy_occurrences_.empty()) {
     RemoveCommittedLazyStates();
   }
   is_completed_.push_back(tmp_accept_stop_token_);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
   if (features_->has_char_budget_rules) {
     char_count_history_.push_back(GetCurrentCharIndex());
     char_budget_entry_history_.push_back(tmp_char_budget_entered_);
   }
+  ClearTemporaryContainers();
 }
 
 void EarleyParser::Reset() {
@@ -579,7 +583,7 @@ void EarleyParser::Reset() {
   char_budget_entry_history_.clear();
   tmp_char_budget_entered_ = false;
   capture_recording_ = false;
-  XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
+  XGRAMMAR_DCHECK(tmp_pending_states_.empty());
   PushStateAndExpand(RootInitialState());
 }
 
@@ -876,7 +880,7 @@ void EarleyParser::AdvanceByteString(
       Enqueue(new_state);
       // Assert: In a sequence, the bytestring can't be skipped. So the state can't be repeated.
     } else {
-      tmp_states_to_be_added_.push_back(new_state);
+      EnqueueWithoutProcessing(new_state);
     }
   }
   return;
@@ -951,7 +955,7 @@ void EarleyParser::AdvanceCharacterClass(
         // For positive classes: only continue if some range could match
         bool should_continue = is_negative ? true : could_match;
         if (should_continue) {
-          tmp_states_to_be_added_.push_back(new_state);
+          EnqueueWithoutProcessing(new_state);
         }
       }
     }
@@ -991,7 +995,7 @@ void EarleyParser::AdvanceCharacterClass(
       auto new_state = state;
       new_state.sub_element_id = num_bytes - 1;
       new_state.partial_codepoint = partial;
-      tmp_states_to_be_added_.push_back(new_state);
+      EnqueueWithoutProcessing(new_state);
     }
     return;
   }
@@ -1084,7 +1088,7 @@ void EarleyParser::AdvanceCharacterClassStar(
         // For positive classes: only continue if some range could match
         bool should_continue = is_negative ? true : could_match;
         if (should_continue) {
-          tmp_states_to_be_added_.push_back(new_state);
+          EnqueueWithoutProcessing(new_state);
         }
       }
     }
@@ -1124,7 +1128,7 @@ void EarleyParser::AdvanceCharacterClassStar(
       auto new_state = state;
       new_state.sub_element_id = num_bytes - 1;
       new_state.partial_codepoint = partial;
-      tmp_states_to_be_added_.push_back(new_state);
+      EnqueueWithoutProcessing(new_state);
     }
     return;
   }
@@ -1150,15 +1154,15 @@ void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
     if ((!edge.IsCharRange()) || ch < edge.min || ch > edge.max) {
       continue;
     }
-    auto new_state = state;
-    new_state.element_id = edge.target;
+    ParserState transitioned_state = state;
+    transitioned_state.element_id = edge.target;
     const uint8_t flags = features_->fsm_state_flags[edge.target];
     if (!(flags & EarleyParserFeatures::kFsmStateNonTerminal) &&
         !(flags & EarleyParserFeatures::kFsmStateEnd) &&
         (flags & EarleyParserFeatures::kFsmStateScanable)) {
-      EnqueueWithoutProcessing(std::move(new_state));
+      EnqueueWithoutProcessing(transitioned_state);
     } else {
-      Enqueue(std::move(new_state));
+      Enqueue(transitioned_state);
     }
   }
 }
@@ -1193,12 +1197,10 @@ void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
 bool EarleyParser::AdvanceAtomicToken(
     int32_t token_id, bool debug_print, int32_t token_char_count
 ) {
-  XGRAMMAR_DCHECK(tmp_process_state_queue_.empty())
-      << "The tmp_process_state_queue_ should be empty before AdvanceAtomicToken.";
-  tmp_states_visited_in_queue_.Clear();
-  tmp_states_to_be_added_.clear();
+  XGRAMMAR_DCHECK(tmp_pending_states_.empty())
+      << "The tmp_pending_states_ should be empty before AdvanceAtomicToken.";
+  ClearTemporaryContainers();
   tmp_accept_stop_token_ = false;
-  tmp_completed_lazy_occurrences_.clear();
   if (features_->has_char_budget_rules) {
     tmp_char_budget_entered_ = char_budget_entry_history_.back();
     char_count_history_.push_back(GetCurrentCharIndex() + token_char_count);
@@ -1210,69 +1212,45 @@ bool EarleyParser::AdvanceAtomicToken(
     }
     ScanAtomicToken(state, token_id);
   }
-  if (tmp_process_state_queue_.empty() && tmp_states_to_be_added_.empty()) {
+  if (tmp_pending_states_.empty() && tmp_states_to_be_added_.empty()) {
     if (features_->has_char_budget_rules) {
       char_count_history_.pop_back();
     }
+    ClearTemporaryContainers();
     return false;
   }
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
   if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }
-  while (!tmp_process_state_queue_.empty()) {
-    const auto state = std::move(tmp_process_state_queue_.front());
-    tmp_process_state_queue_.pop();
-    auto [scanable, completable] = Predict(state, debug_print);
-    if (completable) {
-      Complete(state, debug_print);
-    }
-    if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
-    }
-  }
+  ExpandPendingStates(debug_print);
   if (!tmp_completed_lazy_occurrences_.empty()) {
     RemoveCommittedLazyStates();
   }
   is_completed_.push_back(tmp_accept_stop_token_);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
   if (features_->has_char_budget_rules) {
     char_budget_entry_history_.push_back(tmp_char_budget_entered_);
   }
+  ClearTemporaryContainers();
   return true;
 }
 
-bool RepeatDetector::IsVisited(const ParserState& state) const {
-  // If the size is larger than the threshold, then we use the set to check.
-  if (size_ > transition_threshold_) {
-    return visited_set_.find(state) != visited_set_.end();
-  }
-  return std::find_if(
-             visited_vector_.begin(),
-             visited_vector_.begin() + size_,
-             [&state](const ParserState& s) { return StateEqualForParsing()(state, s); }
-         ) != visited_vector_.begin() + size_;
-}
-
-void RepeatDetector::Insert(const ParserState& state) {
-  if (size_ == transition_threshold_) {
-    for (const auto& s : visited_vector_) {
-      visited_set_.insert(s);
+const ParserState* RepeatDetector::InsertInSet(const ParserState& state) {
+  if (!using_set_) {
+    for (const auto& existing : visited_vector_) {
+      visited_set_.insert(existing);
     }
+    using_set_ = true;
   }
-  size_++;
-  if (size_ > transition_threshold_) {
-    visited_set_.insert(state);
-  } else {
-    visited_vector_[size_ - 1] = state;
+  const auto [it, inserted] = visited_set_.insert(state);
+  if (inserted) {
+    ++size_;
+    return &*it;
   }
+  return nullptr;
 }
 
-void RepeatDetector::Clear() {
-  if (size_ > transition_threshold_) {
-    visited_set_.clear();
-  }
-  size_ = 0;
-}
+void RepeatDetector::ClearSet() { visited_set_.clear(); }
 
 }  // namespace xgrammar

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -41,28 +41,30 @@ std::vector<CaptureOccurrence> EarleyParser::CollectStopCaptureTargets(const Par
   // materialization time cannot distinguish an actual captured ancestor from an unrelated
   // Earley branch that happens to cover the same input.
   std::vector<CaptureOccurrence> targets;
-  std::vector<CaptureOccurrence> pending{{state.rule_id, state.rule_start_pos}};
-  std::unordered_set<int64_t> visited;
+  std::vector<ParserState> pending{state};
+  std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
+      visited;
   while (!pending.empty()) {
-    CaptureOccurrence occurrence = pending.back();
+    ParserState completion = pending.back();
     pending.pop_back();
-    int64_t occurrence_key = (static_cast<int64_t>(occurrence.rule_id) << 32) |
-                             static_cast<uint32_t>(occurrence.start_pos);
-    if (!visited.insert(occurrence_key).second) {
+    if (!visited.insert(completion).second) {
       continue;
     }
-    if (RuleHasCapture(occurrence.rule_id)) {
+    CaptureOccurrence occurrence{completion.rule_id, completion.rule_start_pos};
+    if (RuleHasCapture(completion.rule_id) &&
+        std::find(targets.begin(), targets.end(), occurrence) == targets.end()) {
       targets.push_back(occurrence);
     }
-    if (occurrence.start_pos == ParserState::kNoPrevInputPos) {
+    if (completion.rule_start_pos == ParserState::kNoPrevInputPos) {
       continue;
     }
-    const auto& parent_states = rule_id_to_completable_states_[occurrence.start_pos];
+    const auto& parent_states = rule_id_to_completable_states_[completion.rule_start_pos];
     for (const auto& [ref_rule_id, parent_state] : parent_states) {
-      if (ref_rule_id != occurrence.rule_id || parent_state.rule_id < 0) {
+      if (ref_rule_id != completion.rule_id || parent_state.rule_id < 0 ||
+          !IsCompletionCompatibleWithParent(completion, parent_state)) {
         continue;
       }
-      pending.push_back({parent_state.rule_id, parent_state.rule_start_pos});
+      pending.push_back(parent_state);
     }
   }
   return targets;
@@ -150,7 +152,7 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
   // Check all the possible parent states.
   const auto& parent_states_map = rule_id_to_completable_states_[state.rule_start_pos];
   for (const auto& [ref_id, parent_state] : parent_states_map) {
-    if (ref_id != state.rule_id) {
+    if (ref_id != state.rule_id || !IsCompletionCompatibleWithParent(state, parent_state)) {
       continue;
     }
     XGRAMMAR_DCHECK(
@@ -633,7 +635,10 @@ void EarleyParser::ExpandNextRuleRefElement(
       const auto& parent_states_map = rule_id_to_completable_states_[state.rule_start_pos];
       std::vector<std::pair<int32_t, ParserState>> to_added_states;
       for (const auto& parent_state_iter : parent_states_map) {
-        if (parent_state_iter.first != state.rule_id) continue;
+        if (parent_state_iter.first != state.rule_id ||
+            !IsCompletionCompatibleWithParent(state, parent_state_iter.second)) {
+          continue;
+        }
         const auto& parent_state = parent_state_iter.second;
         if (!in_vec(parent_state)) {
           to_added_states.push_back({ref_rule_id, parent_state});
@@ -770,7 +775,10 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
         const auto& parent_states_map = rule_id_to_completable_states_[state.rule_start_pos];
         std::vector<std::pair<int32_t, ParserState>> to_added_states;
         for (const auto& parent_state_iter : parent_states_map) {
-          if (parent_state_iter.first != state.rule_id) continue;
+          if (parent_state_iter.first != state.rule_id ||
+              !IsCompletionCompatibleWithParent(state, parent_state_iter.second)) {
+            continue;
+          }
           const auto& parent_state = parent_state_iter.second;
           if (!in_vec(parent_state)) {
             to_added_states.push_back({ref_rule_id, parent_state});

--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -31,8 +31,7 @@ bool EarleyParser::CompletionConsumedMarker(const ParserState& state) const {
     return true;
   }
   XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
-  const auto& fsm = grammar_->per_rule_fsms[state.rule_id]->GetFsm().GetFsm();
-  return fsm.GetEdges(state.element_id).size() == 0;
+  return grammar_->complete_fsm.GetEdges(state.element_id).size() == 0;
 }
 
 std::vector<CaptureOccurrence> EarleyParser::CollectStopCaptureTargets(const ParserState& state
@@ -114,10 +113,10 @@ void EarleyParser::PopLastStates(int32_t cnt) {
   rule_id_to_completable_states_.PopBack(cnt);
   is_completed_.erase(is_completed_.end() - cnt, is_completed_.end());
   scanable_state_history_.PopBack(cnt);
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     capture_event_history_.PopBack(cnt);
   }
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     char_count_history_.erase(char_count_history_.end() - cnt, char_count_history_.end());
     char_budget_entry_history_.erase(
         char_budget_entry_history_.end() - cnt, char_budget_entry_history_.end()
@@ -215,8 +214,7 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
 
     // Check if the parent_state sits on a kRepeatRef edge
     bool handled_as_repeat = false;
-    const auto& parent_fsm = grammar_->per_rule_fsms[parent_state.rule_id].value();
-    for (const auto& edge : parent_fsm.GetFsm().GetFsm().GetEdges(parent_state.element_id)) {
+    for (const auto& edge : grammar_->complete_fsm.GetEdges(parent_state.element_id)) {
       // Because of invariance, a state with a kRepeatRef edge has exactly one outgoing edge.
       if (!edge.IsRepeatRef()) continue;
       auto info = grammar_->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
@@ -265,11 +263,13 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
   // Check if the rule has a corresponding FSM.
   if (state.rule_id != -1) {
     XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
-    const uint8_t flags = GetFsmStateFlags(state.rule_id, state.element_id);
-    if (flags & kFsmStateNonTerminal) {
+    const uint8_t flags = features_->fsm_state_flags[state.element_id];
+    if (flags & EarleyParserFeatures::kFsmStateNonTerminal) {
       ExpandNextRuleRefElementOnFSM(state, debug_print);
     }
-    return std::make_pair(flags & kFsmStateScanable, flags & kFsmStateEnd);
+    return std::make_pair(
+        flags & EarleyParserFeatures::kFsmStateScanable, flags & EarleyParserFeatures::kFsmStateEnd
+    );
   }
   const GrammarExpr& grammar_expr = grammar_->GetGrammarExpr(state.sequence_id);
   XGRAMMAR_DCHECK(
@@ -391,7 +391,7 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   tmp_states_to_be_added_.clear();
   tmp_accept_stop_token_ = false;
   tmp_completed_lazy_occurrences_.clear();
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     tmp_char_budget_entered_ = char_budget_entry_history_.back();
     char_count_history_.push_back(GetCurrentCharIndex() + StartsUTF8Codepoint(ch));
   }
@@ -406,7 +406,7 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
 
   // Check if the character is accepted.
   if (tmp_process_state_queue_.empty() && tmp_states_to_be_added_.empty()) {
-    if (has_char_budget_rules_) {
+    if (features_->has_char_budget_rules) {
       char_count_history_.pop_back();
     }
     return false;
@@ -414,7 +414,7 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
 
   // execute Predict and Complete for all states in the queue until empty.
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }
   while (!tmp_process_state_queue_.empty()) {
@@ -435,7 +435,7 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   }
   is_completed_.push_back(tmp_accept_stop_token_);
   scanable_state_history_.PushBack(tmp_states_to_be_added_);
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     char_budget_entry_history_.push_back(tmp_char_budget_entered_);
   }
   return true;
@@ -456,70 +456,66 @@ void EarleyParser::RemoveCommittedLazyStates() {
   );
 }
 
-EarleyParser::EarleyParser(const Grammar& grammar, std::optional<ParserState> initial_state)
-    : grammar_(grammar),
-      fsm_state_flags_cache_(grammar->NumRules()),
-      rule_is_nullable_(grammar->NumRules(), 0) {
+EarleyParserFeatures::EarleyParserFeatures(const Grammar& grammar)
+    : fsm_state_flags(grammar->complete_fsm.NumStates(), kFsmStateInitialized),
+      rule_is_nullable(grammar->NumRules(), 0) {
+  XGRAMMAR_CHECK(grammar->optimized)
+      << "Cannot build Earley parser features for an unoptimized grammar";
+
+  const auto& complete_fsm_edges = grammar->complete_fsm.GetEdges();
+  for (int32_t state_id = 0; state_id < grammar->complete_fsm.NumStates(); ++state_id) {
+    const auto edges = complete_fsm_edges[state_id];
+    uint8_t& flags = fsm_state_flags[state_id];
+    if (edges.size() != 0) {
+      flags |= kFsmStateHasEdges;
+    }
+    for (const auto& edge : edges) {
+      if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken()) {
+        flags |= kFsmStateScanable;
+      } else if (edge.IsRuleRef() || edge.IsEpsilon() || edge.IsRepeatRef()) {
+        flags |= kFsmStateNonTerminal;
+      }
+    }
+  }
+
+  for (int32_t rule_id = 0; rule_id < grammar->NumRules(); ++rule_id) {
+    const auto& rule = grammar->GetRule(rule_id);
+    const auto& rule_fsm = grammar->per_rule_fsms[rule_id];
+    XGRAMMAR_DCHECK(rule_fsm.has_value());
+    for (int32_t end_state : rule_fsm->GetFsm().GetEnds()) {
+      fsm_state_flags[end_state] |= kFsmStateEnd;
+    }
+    const auto* suffix_stop_info = grammar->GetSuffixStopInfo(rule_id);
+    has_budget_rules = has_budget_rules || rule.max_tokens >= 0;
+    has_char_budget_rules = has_char_budget_rules || rule.max_chars >= 0;
+    capture_tracking =
+        capture_tracking || !rule.capture_name.empty() ||
+        (suffix_stop_info != nullptr && !suffix_stop_info->stop_capture_name.empty());
+    has_hidden_capture_rules =
+        has_hidden_capture_rules ||
+        (suffix_stop_info != nullptr &&
+         (suffix_stop_info->hidden_suffix_bytes > 0 || suffix_stop_info->hidden_stop_bytes > 0));
+  }
+  for (int32_t rule_id : grammar->allow_empty_rule_ids) {
+    rule_is_nullable[rule_id] = true;
+  }
+}
+
+EarleyParser::EarleyParser(
+    const Grammar& grammar,
+    std::optional<ParserState> initial_state,
+    const EarleyParserFeatures* features
+)
+    : grammar_(grammar), features_(features) {
   if (!grammar->optimized) {
     XGRAMMAR_LOG(FATAL) << "The grammar is not optimized. Please optimize the grammar before using "
                            "the Earley parser.";
   }
-  for (int32_t i = 0; i < grammar_->NumRules(); ++i) {
-    has_budget_rules_ = has_budget_rules_ || grammar_->GetRule(i).max_tokens >= 0;
-    has_char_budget_rules_ = has_char_budget_rules_ || grammar_->GetRule(i).max_chars >= 0;
-    if (has_budget_rules_ && has_char_budget_rules_) {
-      break;
-    }
-  }
-  for (int32_t i = 0; i < grammar_->NumRules(); ++i) {
-    const auto& rule = grammar_->GetRule(i);
-    const auto* suffix_stop_info = grammar_->GetSuffixStopInfo(i);
-    capture_tracking_ =
-        capture_tracking_ || !rule.capture_name.empty() ||
-        (suffix_stop_info != nullptr && !suffix_stop_info->stop_capture_name.empty());
-    has_hidden_capture_rules_ =
-        has_hidden_capture_rules_ ||
-        (suffix_stop_info != nullptr &&
-         (suffix_stop_info->hidden_suffix_bytes > 0 || suffix_stop_info->hidden_stop_bytes > 0));
-    if (capture_tracking_ && has_hidden_capture_rules_) {
-      break;
-    }
-  }
-  for (int32_t rule_id : grammar_->allow_empty_rule_ids) {
-    rule_is_nullable_[rule_id] = true;
+  if (features_ == nullptr) {
+    owned_features_ = EarleyParserFeatures(grammar);
+    features_ = &owned_features_;
   }
   PushStateAndExpand(initial_state.has_value() ? *initial_state : RootInitialState());
-}
-
-uint8_t EarleyParser::InitializeFsmStateFlags(int32_t rule_id, int32_t state_id) {
-  XGRAMMAR_DCHECK(grammar_->per_rule_fsms[rule_id].has_value());
-  const auto& fsm = grammar_->per_rule_fsms[rule_id]->GetFsm();
-  auto& flags_cache = fsm_state_flags_cache_[rule_id];
-  if (flags_cache.empty()) {
-    flags_cache.resize(fsm.NumStates());
-  }
-  XGRAMMAR_DCHECK(state_id >= 0 && state_id < static_cast<int32_t>(flags_cache.size()));
-  uint8_t& flags = flags_cache[state_id];
-  if (flags & kFsmStateInitialized) {
-    return flags;
-  }
-
-  flags = kFsmStateInitialized;
-  if (fsm.IsEndState(state_id)) {
-    flags |= kFsmStateEnd;
-  }
-  const auto& edges = fsm.GetFsm().GetEdges(state_id);
-  if (edges.size() != 0) {
-    flags |= kFsmStateHasEdges;
-  }
-  for (const auto& edge : edges) {
-    if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken()) {
-      flags |= kFsmStateScanable;
-    } else if (edge.IsRuleRef() || edge.IsEpsilon() || edge.IsRepeatRef()) {
-      flags |= kFsmStateNonTerminal;
-    }
-  }
-  return flags;
 }
 
 ParserState EarleyParser::RootInitialState() const {
@@ -546,7 +542,7 @@ void EarleyParser::PushStateAndExpand(const ParserState& state) {
   tmp_completed_lazy_occurrences_.clear();
   Enqueue(state);
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }
   while (!tmp_process_state_queue_.empty()) {
@@ -565,7 +561,7 @@ void EarleyParser::PushStateAndExpand(const ParserState& state) {
   }
   is_completed_.push_back(tmp_accept_stop_token_);
   scanable_state_history_.PushBack(tmp_states_to_be_added_);
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     char_count_history_.push_back(GetCurrentCharIndex());
     char_budget_entry_history_.push_back(tmp_char_budget_entered_);
   }
@@ -576,7 +572,7 @@ void EarleyParser::Reset() {
   scanable_state_history_.PopBack(scanable_state_history_.size());
   is_completed_.clear();
   stop_token_is_accepted_ = false;
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     capture_event_history_.PopBack(capture_event_history_.size());
   }
   char_count_history_.clear();
@@ -650,7 +646,7 @@ void EarleyParser::ExpandNextRuleRefElement(
     }
   }
 
-  if (IsRuleNullable(ref_rule_id)) {
+  if (features_->rule_is_nullable[ref_rule_id] != 0) {
     XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kSequence);
     Enqueue(ParserState{
         state.rule_id,
@@ -692,10 +688,8 @@ void EarleyParser::ExpandNextRuleRefElement(
 
 void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool debug_print) {
   XGRAMMAR_DCHECK(state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value());
-  const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
-
   // Add the rule reference pairs, and enqueue the epsilon edges.
-  for (const auto& edge : fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
+  for (const auto& edge : grammar_->complete_fsm.GetEdges(state.element_id)) {
     if (edge.IsEpsilon()) {
       Enqueue(ParserState{
           state.rule_id,
@@ -752,8 +746,9 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
                          << grammar_->GetRule(state.rule_id).name << " predict the new rule "
                          << ref_rule_id << ": " << grammar_->GetRule(ref_rule_id).name << ".";
     }
-    const uint8_t target_flags = GetFsmStateFlags(state.rule_id, target);
-    if (!is_repeat && !(target_flags & kFsmStateHasEdges) && (target_flags & kFsmStateEnd) &&
+    const uint8_t target_flags = features_->fsm_state_flags[target];
+    if (!is_repeat && !(target_flags & EarleyParserFeatures::kFsmStateHasEdges) &&
+        (target_flags & EarleyParserFeatures::kFsmStateEnd) &&
         state.rule_start_pos != static_cast<int32_t>(rule_id_to_completable_states_.size() - 1) &&
         !RuleNeedsCaptureEvent(state.rule_id) && !RuleNeedsCaptureEvent(ref_rule_id)) {
       // It's a right recursion. We can optimize it. The optimization elides the completion of
@@ -827,7 +822,7 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
     }
 
     // Check if the reference rule can be empty.
-    if (!is_repeat && IsRuleNullable(ref_rule_id)) {
+    if (!is_repeat && features_->rule_is_nullable[ref_rule_id] != 0) {
       Enqueue(ParserState{
           state.rule_id,
           state.sequence_id,
@@ -1151,15 +1146,16 @@ void EarleyParser::AdvanceCharacterClassStar(
 
 void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
   XGRAMMAR_DCHECK(state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value());
-  const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
-  for (const auto& edge : current_fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
+  for (const auto& edge : grammar_->complete_fsm.GetEdges(state.element_id)) {
     if ((!edge.IsCharRange()) || ch < edge.min || ch > edge.max) {
       continue;
     }
     auto new_state = state;
     new_state.element_id = edge.target;
-    const uint8_t flags = GetFsmStateFlags(state.rule_id, edge.target);
-    if (!(flags & kFsmStateNonTerminal) && !(flags & kFsmStateEnd) && (flags & kFsmStateScanable)) {
+    const uint8_t flags = features_->fsm_state_flags[edge.target];
+    if (!(flags & EarleyParserFeatures::kFsmStateNonTerminal) &&
+        !(flags & EarleyParserFeatures::kFsmStateEnd) &&
+        (flags & EarleyParserFeatures::kFsmStateScanable)) {
       EnqueueWithoutProcessing(std::move(new_state));
     } else {
       Enqueue(std::move(new_state));
@@ -1171,7 +1167,7 @@ void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
   if (state.rule_id == -1) return;
   XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
   const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
-  for (const auto& edge : current_fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
+  for (const auto& edge : grammar_->complete_fsm.GetEdges(state.element_id)) {
     bool matched = false;
     if (edge.IsToken()) {
       auto info = current_fsm.GetFsm().GetFsm().GetTokenEdgeInfo(edge.GetAuxIndex());
@@ -1183,8 +1179,10 @@ void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
     if (!matched) continue;
     auto new_state = state;
     new_state.element_id = edge.target;
-    const uint8_t flags = GetFsmStateFlags(state.rule_id, edge.target);
-    if (!(flags & kFsmStateNonTerminal) && !(flags & kFsmStateEnd) && (flags & kFsmStateScanable)) {
+    const uint8_t flags = features_->fsm_state_flags[edge.target];
+    if (!(flags & EarleyParserFeatures::kFsmStateNonTerminal) &&
+        !(flags & EarleyParserFeatures::kFsmStateEnd) &&
+        (flags & EarleyParserFeatures::kFsmStateScanable)) {
       EnqueueWithoutProcessing(std::move(new_state));
     } else {
       Enqueue(std::move(new_state));
@@ -1201,7 +1199,7 @@ bool EarleyParser::AdvanceAtomicToken(
   tmp_states_to_be_added_.clear();
   tmp_accept_stop_token_ = false;
   tmp_completed_lazy_occurrences_.clear();
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     tmp_char_budget_entered_ = char_budget_entry_history_.back();
     char_count_history_.push_back(GetCurrentCharIndex() + token_char_count);
   }
@@ -1213,13 +1211,13 @@ bool EarleyParser::AdvanceAtomicToken(
     ScanAtomicToken(state, token_id);
   }
   if (tmp_process_state_queue_.empty() && tmp_states_to_be_added_.empty()) {
-    if (has_char_budget_rules_) {
+    if (features_->has_char_budget_rules) {
       char_count_history_.pop_back();
     }
     return false;
   }
   rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     capture_event_history_.PushBack(std::vector<CaptureEvent>());
   }
   while (!tmp_process_state_queue_.empty()) {
@@ -1238,7 +1236,7 @@ bool EarleyParser::AdvanceAtomicToken(
   }
   is_completed_.push_back(tmp_accept_stop_token_);
   scanable_state_history_.PushBack(tmp_states_to_be_added_);
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     char_budget_entry_history_.push_back(tmp_char_budget_entered_);
   }
   return true;

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -11,7 +11,6 @@
 #include <limits>
 #include <optional>
 #include <ostream>
-#include <queue>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -248,6 +247,11 @@ class RepeatDetector {
   std::unordered_set<ParserState, StateHashForParsing, StateEqualForParsing> visited_set_;
 
   int size_ = 0;
+  bool using_set_ = false;
+
+  const ParserState* InsertInSet(const ParserState& state);
+
+  void ClearSet();
 
  public:
   RepeatDetector(const int transition_threshold = 50)
@@ -255,20 +259,35 @@ class RepeatDetector {
     visited_vector_.resize(transition_threshold_);
   }
 
-  /*!
-   * \brief Check if the element is visited.
-   * \return True if visited, false otherwise.
-   */
-  bool IsVisited(const ParserState& state) const;
+  /*! \brief Copy the detector configuration without copying temporary visited states. */
+  RepeatDetector(const RepeatDetector& other)
+      : transition_threshold_(other.transition_threshold_) {}
 
-  /*!
-   * \brief Add the state into the visited states.
-   * \param state The state to be added.
-   */
-  void Insert(const ParserState& state);
+  /*! \brief Insert a state only if absent and return its stable address, or nullptr. */
+  const ParserState* InsertIfAbsent(const ParserState& state) {
+    if (!using_set_ && size_ < transition_threshold_) {
+      if (visited_vector_.empty()) {
+        visited_vector_.resize(transition_threshold_);
+      }
+      for (int i = 0; i < size_; ++i) {
+        if (StateEqualForParsing()(state, visited_vector_[i])) {
+          return nullptr;
+        }
+      }
+      visited_vector_[size_] = state;
+      return &visited_vector_[size_++];
+    }
+    return InsertInSet(state);
+  }
 
   /*! \brief Reset the detector. */
-  void Clear();
+  void Clear() {
+    if (using_set_) {
+      ClearSet();
+    }
+    size_ = 0;
+    using_set_ = false;
+  }
 };
 
 struct StateEqualForCompletionContext {
@@ -389,13 +408,16 @@ class EarleyParser {
    * \brief A temporary vector only used in Advance, used to add states in the
    * scanable_state_history.
    */
-  std::vector<ParserState> tmp_states_to_be_added_;
+  std::vector<const ParserState*> tmp_states_to_be_added_;
 
-  /*! \brief It's the processing queue of the earley parser. */
-  std::queue<ParserState> tmp_process_state_queue_;
+  /*! \brief Stable pointers to visited states awaiting prediction/completion. */
+  std::vector<const ParserState*> tmp_pending_states_;
 
   /*! \brief The class is used to check if a state has been added into the queue. */
   RepeatDetector tmp_states_visited_in_queue_;
+
+  /*! \brief Clear temporary containers after their state pointers have been consumed. */
+  void ClearTemporaryContainers();
 
   /*! \brief Check if the stop token is accepted. */
   bool stop_token_is_accepted_ = false;
@@ -533,15 +555,6 @@ class EarleyParser {
   void RemoveCommittedLazyStates();
 
   /*!
-   * \brief Check if the state has been added into the queue.
-   * \param state The state to check.
-   * \return True if in the vector, false otherwise.
-   */
-  bool IsStateVisitedInQueue(const ParserState& state) const {
-    return tmp_states_visited_in_queue_.IsVisited(state);
-  }
-
-  /*!
    * \brief The scanning operation of the Earley parser. Put the new states in the queue.
    */
   void Scan(const ParserState& state, const uint8_t ch);
@@ -566,6 +579,9 @@ class EarleyParser {
    * \return Second: If the state is completable, then return true, otherwise return false.
    */
   std::pair<bool, bool> Predict(const ParserState& state, bool debug_print = false);
+
+  /*! \brief Expand pending states through prediction and completion. */
+  void ExpandPendingStates(bool debug_print = false);
 
   /*! \brief The initial state expanded from the root rule of the grammar. */
   ParserState RootInitialState() const;
@@ -659,9 +675,8 @@ class EarleyParser {
    * \details The state is enqueued if it is not visited in the queue.
    */
   void Enqueue(const ParserState& state) {
-    if (!IsStateVisitedInQueue(state)) {
-      tmp_process_state_queue_.push(state);
-      tmp_states_visited_in_queue_.Insert(state);
+    if (const ParserState* inserted = tmp_states_visited_in_queue_.InsertIfAbsent(state)) {
+      tmp_pending_states_.push_back(inserted);
     }
   }
 
@@ -670,9 +685,8 @@ class EarleyParser {
    * \param state The state to be enqueued.
    */
   void EnqueueWithoutProcessing(const ParserState& state) {
-    if (!IsStateVisitedInQueue(state)) {
-      tmp_states_visited_in_queue_.Insert(state);
-      tmp_states_to_be_added_.push_back(state);
+    if (const ParserState* inserted = tmp_states_visited_in_queue_.InsertIfAbsent(state)) {
+      tmp_states_to_be_added_.push_back(inserted);
     }
   }
 

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -271,6 +271,22 @@ class RepeatDetector {
   void Clear();
 };
 
+struct StateEqualForCompletionContext {
+  bool operator()(const ParserState& left, const ParserState& right) const {
+    return left.rule_id == right.rule_id && left.rule_start_pos == right.rule_start_pos &&
+           left.budget_deadline == right.budget_deadline &&
+           left.char_budget_deadline == right.char_budget_deadline;
+  }
+};
+
+struct StateHashForCompletionContext {
+  size_t operator()(const ParserState& state) const {
+    return HashCombine(
+        state.rule_id, state.rule_start_pos, state.budget_deadline, state.char_budget_deadline
+    );
+  }
+};
+
 /*! \brief A concrete occurrence of a captured rule in an Earley parent chain. */
 struct CaptureOccurrence {
   /*! \brief The id of the captured rule. */
@@ -441,6 +457,18 @@ class EarleyParser {
                            ? std::numeric_limits<int32_t>::max()
                            : current_char_index + own;
     return parent_deadline >= 0 ? std::min(deadline, parent_deadline) : deadline;
+  }
+
+  /*! \brief Whether completion under equal or tighter deadlines can advance the parent. */
+  static bool IsCompletionCompatibleWithParent(
+      const ParserState& completed_state, const ParserState& parent_state
+  ) {
+    return (parent_state.budget_deadline < 0 ||
+            (completed_state.budget_deadline >= 0 &&
+             completed_state.budget_deadline <= parent_state.budget_deadline)) &&
+           (parent_state.char_budget_deadline < 0 ||
+            (completed_state.char_budget_deadline >= 0 &&
+             completed_state.char_budget_deadline <= parent_state.char_budget_deadline));
   }
 
   /*! \brief Whether the state's derivation may not consume another Unicode codepoint. */

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -323,6 +323,31 @@ struct CaptureEvent {
   std::vector<CaptureOccurrence> stop_capture_targets;
 };
 
+/*! \brief Immutable grammar-wide features shared by short-lived Earley parsers. */
+struct EarleyParserFeatures {
+  enum FsmStateFlag : uint8_t {
+    kFsmStateInitialized = 1 << 0,
+    kFsmStateScanable = 1 << 1,
+    kFsmStateNonTerminal = 1 << 2,
+    kFsmStateEnd = 1 << 3,
+    kFsmStateHasEdges = 1 << 4,
+  };
+
+  std::vector<uint8_t> fsm_state_flags;
+  std::vector<uint8_t> rule_is_nullable;
+  bool has_budget_rules = false;
+  bool has_char_budget_rules = false;
+  bool capture_tracking = false;
+  bool has_hidden_capture_rules = false;
+
+  EarleyParserFeatures() = default;
+  explicit EarleyParserFeatures(const Grammar& grammar);
+
+  friend std::size_t MemorySize(const EarleyParserFeatures& features) {
+    return MemorySize(features.fsm_state_flags) + MemorySize(features.rule_is_nullable);
+  }
+};
+
 class EarleyParser {
   /*!
    * \brief Here is an article about Earley Parser.
@@ -375,37 +400,11 @@ class EarleyParser {
   /*! \brief Check if the stop token is accepted. */
   bool stop_token_is_accepted_ = false;
 
-  enum FsmStateFlag : uint8_t {
-    kFsmStateInitialized = 1 << 0,
-    kFsmStateScanable = 1 << 1,
-    kFsmStateNonTerminal = 1 << 2,
-    kFsmStateEnd = 1 << 3,
-    kFsmStateHasEdges = 1 << 4,
-  };
+  /*! \brief Parser features built only when the caller does not provide them. */
+  EarleyParserFeatures owned_features_;
 
-  /*! \brief Lazily-computed FSM state properties, indexed by rule id and state id. */
-  std::vector<std::vector<uint8_t>> fsm_state_flags_cache_;
-
-  /*! \brief Whether each rule can match the empty string. */
-  std::vector<uint8_t> rule_is_nullable_;
-
-  /*! \brief Compute and cache properties for a state in a per-rule FSM. */
-  uint8_t InitializeFsmStateFlags(int32_t rule_id, int32_t state_id);
-
-  /*! \brief Return cached properties for a state in a per-rule FSM. */
-  uint8_t GetFsmStateFlags(int32_t rule_id, int32_t state_id) {
-    XGRAMMAR_DCHECK(rule_id >= 0 && rule_id < static_cast<int32_t>(fsm_state_flags_cache_.size()));
-    auto& flags_cache = fsm_state_flags_cache_[rule_id];
-    if (!flags_cache.empty()) {
-      XGRAMMAR_DCHECK(state_id >= 0 && state_id < static_cast<int32_t>(flags_cache.size()));
-      if (flags_cache[state_id] != 0) {
-        return flags_cache[state_id];
-      }
-    }
-    return InitializeFsmStateFlags(rule_id, state_id);
-  }
-
-  bool IsRuleNullable(int32_t rule_id) const { return rule_is_nullable_[rule_id] != 0; }
+  /*! \brief Grammar-wide features used by this parser. */
+  const EarleyParserFeatures* features_;
 
   /*! \brief The index of the LLM token currently being accepted, set by the matcher; -1
    * before any token. budget_deadline values are compared against it. */
@@ -415,14 +414,8 @@ class EarleyParser {
    * the matcher for accepts that follow an enforcing mask computation. */
   bool skip_expired_states_ = false;
 
-  /*! \brief Whether any rule of the grammar has a token budget. */
-  bool has_budget_rules_ = false;
-
   /*! \brief The number of Unicode codepoints accepted at every parser history row. */
   std::vector<int32_t> char_count_history_;
-
-  /*! \brief Whether any rule of the grammar has a character budget. */
-  bool has_char_budget_rules_ = false;
 
   /*! \brief Whether a character-budgeted occurrence was entered since the initial parser row. */
   std::vector<bool> char_budget_entry_history_;
@@ -478,13 +471,6 @@ class EarleyParser {
 
   static bool StartsUTF8Codepoint(uint8_t byte) { return (byte & 0xC0) != 0x80; }
 
-  /*! \brief Whether any rule of the grammar has a capture or stop_capture name. Fixed at
-   * construction. When false, the capture machinery is fully disabled and has no overhead. */
-  bool capture_tracking_ = false;
-
-  /*! \brief Whether the grammar contains suffix/stop spans that may affect captures. */
-  bool has_hidden_capture_rules_ = false;
-
   /*!
    * \brief Whether capture events are currently recorded in Complete(). Only enabled during
    * definitive advances (accepting a token or string), not during speculative exploration
@@ -496,18 +482,19 @@ class EarleyParser {
   /*!
    * \brief The history of capture events. capture_event_history_[i] stores the events recorded
    * when input position i was created. Kept aligned with scanable_state_history_ row-by-row
-   * whenever capture_tracking_ is true, so PopLastStates rolls back events automatically.
+   * whenever capture tracking is enabled, so PopLastStates rolls back events automatically.
    */
   Compact2DArray<CaptureEvent> capture_event_history_;
 
   /*! \brief Returns true if the rule exists and has a capture name. */
   bool RuleHasCapture(int32_t rule_id) const {
-    return capture_tracking_ && rule_id >= 0 && !grammar_->GetRule(rule_id).capture_name.empty();
+    return features_->capture_tracking && rule_id >= 0 &&
+           !grammar_->GetRule(rule_id).capture_name.empty();
   }
 
   /*! \brief Returns true if completing this rule can hide bytes from a capture. */
   bool RuleHasHiddenBytes(int32_t rule_id) const {
-    if (!capture_tracking_ || !has_hidden_capture_rules_ || rule_id < 0) {
+    if (!features_->capture_tracking || !features_->has_hidden_capture_rules || rule_id < 0) {
       return false;
     }
     const auto* suffix_stop_info = grammar_->GetSuffixStopInfo(rule_id);
@@ -695,9 +682,12 @@ class EarleyParser {
    * \param grammar The grammar to be parsed. It must be optimized.
    * \param initial_state The state to start parsing from. If not provided, parsing starts
    * from the root rule of the grammar.
+   * \param features Shared parser features. If not provided, they are built from the grammar.
    */
   explicit EarleyParser(
-      const Grammar& grammar, std::optional<ParserState> initial_state = std::nullopt
+      const Grammar& grammar,
+      std::optional<ParserState> initial_state = std::nullopt,
+      const EarleyParserFeatures* features = nullptr
   );
 
   /*!
@@ -761,10 +751,10 @@ class EarleyParser {
     rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
     is_completed_.push_back(completed);
     scanable_state_history_.PushBack(states);
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       capture_event_history_.PushBack(std::vector<CaptureEvent>());
     }
-    if (has_char_budget_rules_) {
+    if (features_->has_char_budget_rules) {
       char_count_history_.push_back(GetCurrentCharIndex());
       char_budget_entry_history_.push_back(char_budget_entry_history_.back());
     }
@@ -772,7 +762,7 @@ class EarleyParser {
 
   /*! \brief Push a character-count row for a parser row created by the matcher. */
   void PushCharCountRow(int32_t char_count, bool char_budget_entered) {
-    if (!has_char_budget_rules_) {
+    if (!features_->has_char_budget_rules) {
       return;
     }
     char_count_history_.push_back(char_count);
@@ -784,15 +774,12 @@ class EarleyParser {
   }
 
   bool HasEnteredCharBudget() const {
-    return has_char_budget_rules_ && char_budget_entry_history_.back();
+    return features_->has_char_budget_rules && char_budget_entry_history_.back();
   }
-
-  /*! \brief Whether the grammar has any captured rule. */
-  bool IsCaptureTrackingEnabled() const { return capture_tracking_; }
 
   /*! \brief Copy the capture events of the latest input position. */
   std::vector<CaptureEvent> CopyLastCaptureRow() const {
-    if (!capture_tracking_) {
+    if (!features_->capture_tracking) {
       return {};
     }
     auto row = capture_event_history_[capture_event_history_.size() - 1];
@@ -805,7 +792,7 @@ class EarleyParser {
    * capture history aligned with the state history.
    */
   void PushCaptureRow(const std::vector<CaptureEvent>& events) {
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       capture_event_history_.PushBack(events);
     }
   }

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -6,12 +6,16 @@
 #include <xgrammar/compiler.h>
 
 #include <algorithm>
+#include <array>
 #include <bitset>
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -22,6 +26,7 @@
 #include "fsm.h"
 #include "grammar_functor.h"
 #include "grammar_impl.h"
+#include "support/container.h"
 #include "support/dynamic_bitset.h"
 #include "support/int_set.h"
 #include "support/logging.h"
@@ -34,7 +39,293 @@
 
 namespace xgrammar {
 
+/******************* RuleLevelCache *******************/
+
+/*!
+ * \brief Store token masks shared by structurally equivalent rules across grammars.
+ * \details The cache uses least-recently-used eviction.
+ */
+class RuleLevelCache {
+ public:
+  static const size_t kUnlimitedSize = static_cast<size_t>(-1);
+
+  std::optional<AdaptiveTokenMask> GetCache(
+      const uint64_t& fsm_hash,
+      int32_t fsm_new_node_id,
+      const int32_t& state_cnt,
+      const int32_t edge_cnt
+  );
+  bool AddCache(
+      const uint64_t& fsm_hash,
+      int32_t fsm_new_node_id,
+      const int32_t& state_cnt,
+      const int32_t edge_cnt,
+      const AdaptiveTokenMask& token_mask
+  );
+  bool AddCache(
+      const uint64_t& fsm_hash,
+      int32_t fsm_new_node_id,
+      const int32_t& state_cnt,
+      const int32_t edge_cnt,
+      AdaptiveTokenMask&& token_mask
+  );
+  RuleLevelCache(size_t max_cache_memory_size = kUnlimitedSize);
+
+  void ClearCache();
+
+  size_t GetMaxSize() const;
+
+  friend size_t MemorySize(const RuleLevelCache& manager);
+
+  XGRAMMAR_DEFINE_PIMPL_METHODS(RuleLevelCache);
+};
+
+class RuleLevelCache::Impl {
+ public:
+  using NodeKey = std::tuple<
+      uint64_t /*The hash value of the FSM*/,
+      int32_t /* The normalized node id*/,
+      int32_t /*The number of states*/,
+      int32_t /* The number of edges*/>;
+  using NodeType = std::pair<NodeKey, AdaptiveTokenMask>;
+
+  explicit Impl(size_t max_cache_memory_size) : max_cache_memory_size_(max_cache_memory_size) {}
+
+  std::optional<AdaptiveTokenMask> GetCache(
+      const uint64_t& fsm_hash,
+      int32_t fsm_new_node_id,
+      const int32_t& state_cnt,
+      const int32_t edge_cnt
+  );
+
+  bool AddCache(
+      const uint64_t& fsm_hash,
+      int32_t fsm_new_node_id,
+      const int32_t& state_cnt,
+      const int32_t edge_cnt,
+      const AdaptiveTokenMask& token_mask
+  );
+
+  bool AddCache(
+      const uint64_t& fsm_hash,
+      int32_t fsm_new_node_id,
+      const int32_t& state_cnt,
+      const int32_t edge_cnt,
+      AdaptiveTokenMask&& token_mask
+  );
+
+  void ClearCache();
+
+  friend size_t MemorySize(const Impl* impl) {
+    int64_t total = 0;
+    for (const auto& shard : impl->shards_) {
+      std::lock_guard<std::mutex> lock(shard.mutex);
+      total += shard.current_cache_memory_size;
+    }
+    return total;
+  }
+
+  size_t GetMaxSize() const { return max_cache_memory_size_; }
+
+ private:
+  /*!
+   * \brief The cache is sharded to reduce lock contention: the token mask cache generation
+   * queries and inserts from all compilation threads, and a single global mutex would serialize
+   * them (large grammars issue millions of cache operations).
+   */
+  static constexpr size_t kNumShards = 16;
+
+  struct Shard {
+    mutable std::mutex mutex;
+    int64_t current_cache_memory_size = 0;
+    // The cache map: (fsm_hash, node_id, ...) -> index in cache_list
+    List<NodeType> cache_list;
+    std::unordered_map<NodeKey, int> cache;
+  };
+
+  Shard& GetShard(const NodeKey& key) {
+    return shards_[HashCombine(std::get<0>(key), std::get<1>(key)) % kNumShards];
+  }
+
+  /*! \brief The memory budget of one shard. Eviction is performed per shard. */
+  size_t ShardMaxSize() const {
+    return max_cache_memory_size_ == kUnlimitedSize ? kUnlimitedSize
+                                                    : max_cache_memory_size_ / kNumShards;
+  }
+
+  const size_t max_cache_memory_size_;
+  std::array<Shard, kNumShards> shards_;
+};
+
+std::optional<AdaptiveTokenMask> RuleLevelCache::GetCache(
+    const uint64_t& fsm_hash,
+    int32_t fsm_new_node_id,
+    const int32_t& state_cnt,
+    const int32_t edge_cnt
+) {
+  return pimpl_->GetCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
+}
+
+bool RuleLevelCache::AddCache(
+    const uint64_t& fsm_hash,
+    int32_t fsm_new_node_id,
+    const int32_t& state_cnt,
+    const int32_t edge_cnt,
+    const AdaptiveTokenMask& token_mask
+) {
+  return pimpl_->AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, token_mask);
+}
+
+bool RuleLevelCache::AddCache(
+    const uint64_t& fsm_hash,
+    int32_t fsm_new_node_id,
+    const int32_t& state_cnt,
+    const int32_t edge_cnt,
+    AdaptiveTokenMask&& token_mask
+) {
+  return pimpl_->AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, std::move(token_mask));
+}
+
+void RuleLevelCache::ClearCache() { pimpl_->ClearCache(); }
+
+size_t RuleLevelCache::GetMaxSize() const { return pimpl_->GetMaxSize(); }
+
+std::optional<AdaptiveTokenMask> RuleLevelCache::Impl::GetCache(
+    const uint64_t& fsm_hash,
+    int32_t fsm_new_node_id,
+    const int32_t& state_cnt,
+    const int32_t edge_cnt
+) {
+  // Find in the cache.
+  NodeKey key = std::make_tuple(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
+  Shard& shard = GetShard(key);
+  std::lock_guard<std::mutex> lock(shard.mutex);
+  auto it = shard.cache.find(key);
+  if (it == shard.cache.end()) {
+    return std::nullopt;
+  }
+
+  // Move the node to the back of the list.
+  shard.cache_list.MoveBack(it->second);
+  return List<NodeType>::iterator(it->second, shard.cache_list)->second;
+}
+
+bool RuleLevelCache::Impl::AddCache(
+    const uint64_t& fsm_hash,
+    int32_t fsm_new_node_id,
+    const int32_t& state_cnt,
+    const int32_t edge_cnt,
+    const AdaptiveTokenMask& token_mask
+) {
+  return AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, AdaptiveTokenMask(token_mask));
+}
+
+bool RuleLevelCache::Impl::AddCache(
+    const uint64_t& fsm_hash,
+    int32_t fsm_new_node_id,
+    const int32_t& state_cnt,
+    const int32_t edge_cnt,
+    AdaptiveTokenMask&& token_mask
+) {
+  // Check if we can add to the cache.
+  NodeKey key = std::make_tuple(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
+  Shard& shard = GetShard(key);
+  const size_t shard_max_size = ShardMaxSize();
+  std::lock_guard<std::mutex> lock(shard.mutex);
+  if (shard_max_size != kUnlimitedSize && MemorySize(token_mask) > shard_max_size) {
+    // The token mask is too large to be cached.
+    return false;
+  }
+  if (shard.cache.find(key) != shard.cache.end()) {
+    // Already exists.
+    return false;
+  }
+
+  // Evict old entries if needed.
+  if (shard_max_size != kUnlimitedSize) {
+    size_t new_item_size = MemorySize(token_mask);
+    while ((shard.current_cache_memory_size) > static_cast<int64_t>(shard_max_size - new_item_size)
+    ) {
+      auto oldest_it = shard.cache_list.begin();
+      if (oldest_it == shard.cache_list.end()) {
+        // This should not happen if the size of the new item is smaller than
+        // the shard budget, but this is a safeguard.
+        break;
+      }
+      shard.current_cache_memory_size -= MemorySize(oldest_it->second);
+      shard.cache.erase(oldest_it->first);
+      shard.cache_list.Erase(oldest_it);
+    }
+  }
+
+  // Add to the cache.
+  auto new_it = shard.cache_list.PushBack(NodeType(key, std::move(token_mask)));
+  shard.current_cache_memory_size += MemorySize(new_it->second);
+  shard.cache[key] = new_it.Index();
+  return true;
+}
+
+RuleLevelCache::RuleLevelCache(size_t max_cache_memory_size)
+    : pimpl_(std::make_shared<Impl>(max_cache_memory_size)) {}
+
+void RuleLevelCache::Impl::ClearCache() {
+  for (auto& shard : shards_) {
+    std::lock_guard<std::mutex> lock(shard.mutex);
+    shard.cache_list.Clear();
+    shard.cache.clear();
+    shard.current_cache_memory_size = 0;
+  }
+}
+
+size_t MemorySize(const RuleLevelCache& manager) { return MemorySize(manager.ImplPtr()); }
+
 /************** AdaptiveTokenMaskCache Generator **************/
+
+std::vector<uint8_t> GetRuleLevelCacheableRules(const Grammar& grammar) {
+  const int32_t num_rules = grammar->NumRules();
+  std::vector<uint8_t> context_dependent(num_rules, 0);
+  std::vector<std::vector<int32_t>> referenced_rules(num_rules);
+  for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
+    const auto& rule = grammar->GetRule(rule_id);
+    context_dependent[rule_id] = rule.max_tokens >= 0 || rule.max_chars >= 0 || rule.is_lazy ||
+                                 rule.temperature.has_value() ||
+                                 grammar->GetSuffixStopInfo(rule_id) != nullptr;
+    const auto& fsm = grammar->per_rule_fsms[rule_id]->GetFsm();
+    std::unordered_set<int32_t> reachable_states;
+    fsm.GetReachableStates(&reachable_states);
+    for (int32_t state_id : reachable_states) {
+      for (const auto& edge : fsm.GetFsm().GetEdges(state_id)) {
+        if (edge.IsRuleRef()) {
+          referenced_rules[rule_id].push_back(edge.GetRefRuleId());
+        } else if (edge.IsRepeatRef()) {
+          referenced_rules[rule_id].push_back(
+              grammar->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex()).RuleId()
+          );
+        }
+      }
+    }
+  }
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
+      if (!context_dependent[rule_id]) {
+        continue;
+      }
+      for (int32_t referenced_rule_id : referenced_rules[rule_id]) {
+        if (!context_dependent[referenced_rule_id]) {
+          context_dependent[referenced_rule_id] = 1;
+          changed = true;
+        }
+      }
+    }
+  }
+  for (uint8_t& value : context_dependent) {
+    value = !value;
+  }
+  return context_dependent;
+}
 
 /*! \brief The concrete implementation of GrammarMatcherNode. */
 class GrammarMatcherForTokenMaskCache : public EarleyParser {
@@ -1063,13 +1354,18 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
       -1,
       state.sub_element_id
   );
-  std::optional<RuleLevelCache> no_rule_level_cache;
+  std::optional<RuleLevelCache> retained_rule_level_cache;
+  if (rule_level_cache_ != nullptr && state.rule_id >= 0 &&
+      state.rule_id < static_cast<int32_t>(rule_level_cacheable_.size()) &&
+      rule_level_cacheable_[state.rule_id]) {
+    retained_rule_level_cache = *rule_level_cache_;
+  }
   AdaptiveTokenMask mask = GrammarMatcherForTokenMaskCache(
                                grammar,
                                cache_state,
                                tag_dispatch_second_slicing_bitset,
                                tokenizer_info,
-                               no_rule_level_cache,
+                               retained_rule_level_cache,
                                is_root_rule
   )
                                .GetAdaptiveTokenMask();
@@ -1137,17 +1433,27 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>(enable_dynamic_compilation_);
   compiled_grammar_impl->grammar = std::move(grammar);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
-  if (tokenizer_info_.GetVocabSize() == 0 || enable_dynamic_compilation_) {
+  if (tokenizer_info_.GetVocabSize() == 0) {
+    return CompiledGrammar(compiled_grammar_impl);
+  }
+
+  // Rule hashes are needed by both eager and on-demand cross-grammar mask reuse.
+  if (rule_level_cache_.has_value()) {
+    GrammarFSMHasher().Apply(&compiled_grammar_impl->grammar);
+  }
+  if (enable_dynamic_compilation_) {
+    if (rule_level_cache_.has_value()) {
+      compiled_grammar_impl->token_mask_cache.SetRuleLevelCache(
+          std::make_shared<RuleLevelCache>(rule_level_cache_.value()),
+          GetRuleLevelCacheableRules(compiled_grammar_impl->grammar)
+      );
+    }
     return CompiledGrammar(compiled_grammar_impl);
   }
 
   auto tag_dispatch_rule_id_to_second_slicing_bitset =
       ComputeTagDispatchSecondSlicingBitsets(compiled_grammar_impl->grammar, tokenizer_info_);
 
-  // If the compiler is cache-enabled, then we hash the grammars for crossing-grammar caching.
-  if (rule_level_cache_.has_value()) {
-    GrammarFSMHasher().Apply(&compiled_grammar_impl->grammar);
-  }
   // Step 3. Compute the adaptive token mask cache
   // The token mask cache is computed for these positions in the grammar:
   // 1. All character class or character class star (with last_utf8_bytes=0, 1, 2, 3)

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -336,9 +336,10 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
       const DynamicBitset* tag_dispatch_second_slicing_bitset,
       const TokenizerInfo& tokenizer_info,
       std::optional<RuleLevelCache>& rule_level_cache,
-      bool is_root_rule
+      bool is_root_rule,
+      const EarleyParserFeatures& features
   )
-      : EarleyParser(grammar, init_state),
+      : EarleyParser(grammar, init_state, &features),
         init_rule_id_(init_state.rule_id),
         initial_state_(init_state),
         is_root_rule_(is_root_rule),
@@ -816,7 +817,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
 
   XGRAMMAR_DCHECK(init_rule_id_ != -1 && grammar_->per_rule_fsms[init_rule_id_].has_value());
   auto [speculative_calculation, speculative_mask] = GetSpeculativeCalculation();
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     speculative_calculation = false;
   }
 
@@ -1098,7 +1099,8 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask() {
   tmp_can_reach_end_prefix_or_stack_.push_back(false);
 
   // Try to get the crossing cache.
-  bool rule_level_cache_is_available = !has_char_budget_rules_ && rule_level_cache_.has_value() &&
+  bool rule_level_cache_is_available = !features_->has_char_budget_rules &&
+                                       rule_level_cache_.has_value() &&
                                        grammar_->per_rule_fsm_hashes[init_rule_id_].has_value();
   std::optional<uint64_t> fsm_hash = std::nullopt;
   int32_t new_state_id = -1;
@@ -1159,7 +1161,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask() {
   // Token edges are rechecked at runtime when a character budget is present because accepting
   // one can enter a budgeted rule within the same token.
   if (!token_edge_accepted.empty()) {
-    if (has_char_budget_rules_) {
+    if (features_->has_char_budget_rules) {
       IntsetUnion(&tmp_uncertain_indices_, token_edge_accepted);
     } else {
       IntsetUnion(&tmp_accepted_indices_, token_edge_accepted);
@@ -1319,7 +1321,8 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
     const ParserState& state,
     bool is_root_rule,
     const Grammar& grammar,
-    const TokenizerInfo& tokenizer_info
+    const TokenizerInfo& tokenizer_info,
+    const EarleyParserFeatures& features
 ) {
   if (!dynamic_) {
     const auto it = masks_.find(state);
@@ -1366,7 +1369,8 @@ const AdaptiveTokenMask& TokenMaskCache::Get(
                                tag_dispatch_second_slicing_bitset,
                                tokenizer_info,
                                retained_rule_level_cache,
-                               is_root_rule
+                               is_root_rule,
+                               features
   )
                                .GetAdaptiveTokenMask();
 
@@ -1433,6 +1437,8 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>(enable_dynamic_compilation_);
   compiled_grammar_impl->grammar = std::move(grammar);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
+  compiled_grammar_impl->earley_parser_features =
+      EarleyParserFeatures(compiled_grammar_impl->grammar);
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
   }
@@ -1483,7 +1489,8 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
         tag_dispatch_second_slicing_bitset,
         tokenizer_info_,
         rule_level_cache_,
-        is_root_rule
+        is_root_rule,
+        compiled_grammar_impl->earley_parser_features
     );
     auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask();
     if (max_threads_ > 1) {

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -42,24 +42,24 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   GrammarMatcherForTokenMaskCache(
       const Grammar& grammar,
       const ParserState& init_state,
-      const std::unordered_map<int32_t, DynamicBitset>&
-          tag_dispatch_rule_id_to_second_slicing_bitset,
+      const DynamicBitset* tag_dispatch_second_slicing_bitset,
       const TokenizerInfo& tokenizer_info,
-      std::optional<RuleLevelCache>& rule_level_cache
+      std::optional<RuleLevelCache>& rule_level_cache,
+      bool is_root_rule
   )
       : EarleyParser(grammar, init_state),
         init_rule_id_(init_state.rule_id),
         initial_state_(init_state),
-        tag_dispatch_rule_id_to_second_slicing_bitset_(tag_dispatch_rule_id_to_second_slicing_bitset
-        ),
+        is_root_rule_(is_root_rule),
+        tag_dispatch_second_slicing_bitset_(tag_dispatch_second_slicing_bitset),
         tokenizer_info_(tokenizer_info),
-        rule_level_cache_(rule_level_cache) {}
+        rule_level_cache_(rule_level_cache) {
+    XGRAMMAR_DCHECK(is_root_rule == (init_state.rule_id == grammar->GetRootRuleId()));
+  }
   /*!
    * \brief Get the adaptive token mask for the given ParserState.
-   * \param is_root_rule Whether to consider the parent rule. If false, there will be
-   * no uncertain tokens. Useful for the root rule.
    */
-  AdaptiveTokenMask GetAdaptiveTokenMask(bool is_root_rule);
+  AdaptiveTokenMask GetAdaptiveTokenMask();
 
   /*!
    * \brief Get the token mask for the given ParserState.
@@ -116,8 +116,11 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   // The initial state of the parser.
   ParserState initial_state_;
 
+  // Whether the initial rule is the grammar's root rule.
+  bool is_root_rule_;
+
   /*!
-   * \brief This is a mapping from TagDispatch rule id to the bitset used for second slicing.
+   * \brief The bitset used for second slicing when the initial rule is a TagDispatch rule.
    * \note If a rule is a TagDispatch rule, then there will be an AC automaton for its triggers.
    *  Which means that it can accept a lot of tokens. However, it will be slow to check a lot of
    *  tokens. The DynamicBitset here is used to do a second slicing: if a token's substr(1, n - 1)
@@ -125,7 +128,7 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
    *  When we check a token, we first check if its first character can transit to the start state.
    *  If yes, then we check if it is in the bitset. If yes, then we accept it directly.
    */
-  const std::unordered_map<int32_t, DynamicBitset>& tag_dispatch_rule_id_to_second_slicing_bitset_;
+  const DynamicBitset* tag_dispatch_second_slicing_bitset_;
 
   const TokenizerInfo& tokenizer_info_;
 
@@ -534,8 +537,8 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       grammar_->GetGrammarExpr(grammar_->GetRule(init_rule_id_).body_expr_id).type ==
       Grammar::Impl::GrammarExprType::kTagDispatch;
   if (is_tag_dispatch_rule) {
-    XGRAMMAR_DCHECK(tag_dispatch_rule_id_to_second_slicing_bitset_.count(init_rule_id_) > 0);
-    definite_accepted_bitset = &tag_dispatch_rule_id_to_second_slicing_bitset_.at(init_rule_id_);
+    XGRAMMAR_DCHECK(tag_dispatch_second_slicing_bitset_ != nullptr);
+    definite_accepted_bitset = tag_dispatch_second_slicing_bitset_;
   }
 
   const std::string* prev_token = nullptr;
@@ -790,7 +793,7 @@ const std::vector<int32_t>& GrammarMatcherForTokenMaskCache::GetTokenEdgeAccepte
   return tmp_token_edge_accepted_;
 }
 
-AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_root_rule) {
+AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask() {
   tmp_accepted_indices_.clear();
   tmp_rejected_indices_.clear();
   tmp_uncertain_indices_.clear();
@@ -841,7 +844,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     );
     // If the rule doesn't have a lookahead, then it is exactly the same fsm.
     if (crossing_cache.has_value()) {
-      AdaptCacheWithLookahead(&crossing_cache.value(), is_root_rule);
+      AdaptCacheWithLookahead(&crossing_cache.value(), is_root_rule_);
       return std::move(crossing_cache.value());
     }
   }
@@ -858,7 +861,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     rejected_filled = false;
   } else {
     rejected_filled = GetTokenMaskWithFirstCharacterCheck(
-        first_character_mask, is_root_rule, token_edge_accepted
+        first_character_mask, is_root_rule_, token_edge_accepted
     );
   }
 
@@ -882,7 +885,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
         tmp_uncertain_indices_
     );
     if (rule_level_cache_is_available) {
-      if (lookahead_id == -1 && !is_root_rule) {
+      if (lookahead_id == -1 && !is_root_rule_) {
         // If the rule doesn't have a lookahead, then it is exactly the same fsm.
         auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
         rule_level_cache_->AddCache(
@@ -954,7 +957,7 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     if (rule_level_cache_is_available) {
       // Prepare for cache.
       auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
-      if (lookahead_id == -1 && !is_root_rule) {
+      if (lookahead_id == -1 && !is_root_rule_) {
         // If the rule doesn't have a lookahead, then it is exactly the same fsm.
         rule_level_cache_->AddCache(
             fsm_hash.value(), new_state_id, fsm.GetNodeNum(), fsm.GetEdgeNum(), return_value
@@ -1003,6 +1006,78 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   }
 }
 
+const DynamicBitset* TokenMaskCache::GetTagDispatchSecondSlicingBitset(
+    int32_t rule_id, const Grammar& grammar, const TokenizerInfo& tokenizer_info
+) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto existing = tag_dispatch_rule_id_to_second_slicing_bitset_.find(rule_id);
+    if (existing != tag_dispatch_rule_id_to_second_slicing_bitset_.end()) {
+      return &existing->second;
+    }
+  }
+
+  DynamicBitset bitset = ComputeTagDispatchSecondSlicingBitset(grammar, tokenizer_info, rule_id);
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  return &tag_dispatch_rule_id_to_second_slicing_bitset_.try_emplace(rule_id, std::move(bitset))
+              .first->second;
+}
+
+const AdaptiveTokenMask& TokenMaskCache::Get(
+    const ParserState& state,
+    bool is_root_rule,
+    const Grammar& grammar,
+    const TokenizerInfo& tokenizer_info
+) {
+  if (!dynamic_) {
+    const auto it = masks_.find(state);
+    XGRAMMAR_CHECK(it != masks_.end())
+        << "The token mask cache is incomplete while dynamic compilation is disabled: " << state;
+    return it->second;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto existing = masks_.find(state);
+    if (existing != masks_.end()) {
+      return existing->second;
+    }
+  }
+
+  const DynamicBitset* tag_dispatch_second_slicing_bitset = nullptr;
+  const auto& rule = grammar->GetRule(state.rule_id);
+  if (grammar->GetGrammarExpr(rule.body_expr_id).type ==
+      Grammar::Impl::GrammarExprType::kTagDispatch) {
+    tag_dispatch_second_slicing_bitset =
+        GetTagDispatchSecondSlicingBitset(state.rule_id, grammar, tokenizer_info);
+  }
+
+  // Generate the mask outside the lock so a miss does not block other lookups. Two threads may
+  // generate the same mask concurrently; emplace keeps the first inserted one.
+  const ParserState cache_state(
+      state.rule_id,
+      state.sequence_id,
+      state.element_id,
+      ParserState::kNoPrevInputPos,
+      -1,
+      state.sub_element_id
+  );
+  std::optional<RuleLevelCache> no_rule_level_cache;
+  AdaptiveTokenMask mask = GrammarMatcherForTokenMaskCache(
+                               grammar,
+                               cache_state,
+                               tag_dispatch_second_slicing_bitset,
+                               tokenizer_info,
+                               no_rule_level_cache,
+                               is_root_rule
+  )
+                               .GetAdaptiveTokenMask();
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  return masks_.emplace(cache_state, std::move(mask)).first->second;
+}
+
 /******************* GrammarCompilerNoCache *******************/
 
 /*!
@@ -1013,11 +1088,13 @@ class GrammarCompilerSub {
   GrammarCompilerSub(
       const TokenizerInfo& tokenizer_info,
       int max_threads,
-      std::optional<RuleLevelCache> rule_level_cache
+      std::optional<RuleLevelCache> rule_level_cache,
+      bool enable_dynamic_compilation
   )
       : tokenizer_info_(tokenizer_info),
         max_threads_(max_threads),
-        rule_level_cache_(rule_level_cache) {}
+        rule_level_cache_(rule_level_cache),
+        enable_dynamic_compilation_(enable_dynamic_compilation) {}
 
   CompiledGrammar CompileBuiltinJSONGrammar();
 
@@ -1042,15 +1119,6 @@ class GrammarCompilerSub {
  private:
   /*! \brief The main logic. Compile the grammar with multi-threading. */
   CompiledGrammar MultiThreadCompileGrammar(Grammar grammar);
-  /*! \brief Optimization for TagDispatch.
-   *  \param compiled_grammar_impl the compiled_grammar to be optimized.
-   *  \param tag_dispatch_rule_id_to_second_slicing_bitset Return value. Mapping from the rule_id to
-   * the definite accepted token mask.
-   */
-  void TagDispatchOptimization(
-      std::shared_ptr<CompiledGrammar::Impl> compiled_grammar_impl,
-      std::unordered_map<int32_t, DynamicBitset>* tag_dispatch_rule_id_to_second_slicing_bitset
-  );
 
   /*! \brief The vocabulary associated with this storage class. */
   const TokenizerInfo tokenizer_info_;
@@ -1059,17 +1127,22 @@ class GrammarCompilerSub {
 
   /*! \brief The manager of the rule level cache.*/
   std::optional<RuleLevelCache> rule_level_cache_;
+
+  /*! \brief Whether token masks are generated on first use. */
+  const bool enable_dynamic_compilation_;
 };
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
-  auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
-  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
+  Grammar grammar = GrammarOptimizer::Apply(grammar_unoptimized);
+  auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>(enable_dynamic_compilation_);
+  compiled_grammar_impl->grammar = std::move(grammar);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
-  if (tokenizer_info_.GetVocabSize() == 0) {
+  if (tokenizer_info_.GetVocabSize() == 0 || enable_dynamic_compilation_) {
     return CompiledGrammar(compiled_grammar_impl);
   }
-  std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
-  TagDispatchOptimization(compiled_grammar_impl, &tag_dispatch_rule_id_to_second_slicing_bitset);
+
+  auto tag_dispatch_rule_id_to_second_slicing_bitset =
+      ComputeTagDispatchSecondSlicingBitsets(compiled_grammar_impl->grammar, tokenizer_info_);
 
   // If the compiler is cache-enabled, then we hash the grammars for crossing-grammar caching.
   if (rule_level_cache_.has_value()) {
@@ -1092,19 +1165,30 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   }
 
   auto add_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
+    const DynamicBitset* tag_dispatch_second_slicing_bitset = nullptr;
+    const auto tag_dispatch_bitset_it =
+        tag_dispatch_rule_id_to_second_slicing_bitset.find(state.rule_id);
+    if (tag_dispatch_bitset_it != tag_dispatch_rule_id_to_second_slicing_bitset.end()) {
+      tag_dispatch_second_slicing_bitset = &tag_dispatch_bitset_it->second;
+    }
     auto grammar_matcher = GrammarMatcherForTokenMaskCache(
         compiled_grammar_impl->grammar,
         state,
-        tag_dispatch_rule_id_to_second_slicing_bitset,
+        tag_dispatch_second_slicing_bitset,
         tokenizer_info_,
-        rule_level_cache_
+        rule_level_cache_,
+        is_root_rule
     );
-    auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask(is_root_rule);
+    auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask();
     if (max_threads_ > 1) {
       std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex.value());
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
+      compiled_grammar_impl->token_mask_cache.Insert(
+          state, std::move(cur_adaptive_token_mask_cache)
+      );
     } else {
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
+      compiled_grammar_impl->token_mask_cache.Insert(
+          state, std::move(cur_adaptive_token_mask_cache)
+      );
     }
   };
 
@@ -1192,56 +1276,62 @@ CompiledGrammar GrammarCompilerSub::CompileGrammar(
   return MultiThreadCompileGrammar(Grammar::FromEBNF(ebnf_str, root_rule_name));
 }
 
-void GrammarCompilerSub::TagDispatchOptimization(
-    std::shared_ptr<CompiledGrammar::Impl> compiled_grammar_impl,
-    std::unordered_map<int32_t, DynamicBitset>* tag_dispatch_rule_id_to_second_slicing_bitset
+DynamicBitset ComputeTagDispatchSecondSlicingBitset(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info, int32_t rule_id
 ) {
   using GrammarExprType = Grammar::Impl::GrammarExprType;
-  tag_dispatch_rule_id_to_second_slicing_bitset->clear();
-
-  // Optimization for TagDispatch: Precompute the definitely accepted tokens.
-  for (int i = 0; i < compiled_grammar_impl->grammar->NumRules(); i++) {
-    const auto& rule = compiled_grammar_impl->grammar->GetRule(i);
-    const auto& rule_body = compiled_grammar_impl->grammar->GetGrammarExpr(rule.body_expr_id);
-    if (rule_body.type != GrammarExprType::kTagDispatch) {
+  const auto& rule = grammar->GetRule(rule_id);
+  const auto& rule_body = grammar->GetGrammarExpr(rule.body_expr_id);
+  XGRAMMAR_DCHECK(rule_body.type == GrammarExprType::kTagDispatch);
+  Grammar::Impl::TagDispatch tag_dispatch = grammar->GetTagDispatch(rule.body_expr_id);
+  const auto& sorted_decoded_vocab = tokenizer_info.GetSortedDecodedVocab();
+  DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
+  for (int token_index = 0; token_index < static_cast<int32_t>(sorted_decoded_vocab.size());
+       ++token_index) {
+    bool definite_accept_since_second_char = true;
+    const auto& token = sorted_decoded_vocab[token_index].second;
+    if (token.empty()) {
+      definite_accepted_tokens_since_second_char.Set(token_index);
       continue;
     }
-    XGRAMMAR_DCHECK(rule_body.type == GrammarExprType::kTagDispatch);
-    Grammar::Impl::TagDispatch tag_dispatch =
-        compiled_grammar_impl->GetGrammar()->GetTagDispatch(rule.body_expr_id);
-    const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
-    DynamicBitset definite_accepted_tokens_since_second_char(sorted_decoded_vocab.size());
-    for (int j = 0; j < static_cast<int32_t>(sorted_decoded_vocab.size()); j++) {
-      bool definite_accept_since_second_char = true;
-      const auto& token = sorted_decoded_vocab[j].second;
-      if (token.empty()) {
-        definite_accepted_tokens_since_second_char.Set(j);
-        continue;
-      }
 
-      // Check if the token contains any string trigger or exclude string after first char.
-      for (const auto& [trigger, rule_id] : tag_dispatch.tag_rule_pairs) {
-        if (token.find(trigger, 1) != std::string::npos) {
+    // Check if the token contains any string trigger or exclude string after first char.
+    for (const auto& tag_rule_pair : tag_dispatch.tag_rule_pairs) {
+      if (token.find(tag_rule_pair.first, 1) != std::string::npos) {
+        definite_accept_since_second_char = false;
+        break;
+      }
+    }
+    if (definite_accept_since_second_char) {
+      for (const auto& exclude : tag_dispatch.excludes) {
+        if (token.find(exclude, 1) != std::string::npos) {
           definite_accept_since_second_char = false;
           break;
         }
       }
-      if (definite_accept_since_second_char) {
-        for (const auto& excl : tag_dispatch.excludes) {
-          if (token.find(excl, 1) != std::string::npos) {
-            definite_accept_since_second_char = false;
-            break;
-          }
-        }
-      }
-
-      if (definite_accept_since_second_char) {
-        definite_accepted_tokens_since_second_char.Set(j);
-      }
     }
-    (*tag_dispatch_rule_id_to_second_slicing_bitset)[i] =
-        definite_accepted_tokens_since_second_char;
+
+    if (definite_accept_since_second_char) {
+      definite_accepted_tokens_since_second_char.Set(token_index);
+    }
   }
+  return definite_accepted_tokens_since_second_char;
+}
+
+std::unordered_map<int32_t, DynamicBitset> ComputeTagDispatchSecondSlicingBitsets(
+    const Grammar& grammar, const TokenizerInfo& tokenizer_info
+) {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  std::unordered_map<int32_t, DynamicBitset> result;
+  for (int32_t rule_id = 0; rule_id < static_cast<int32_t>(grammar->NumRules()); ++rule_id) {
+    const auto& rule = grammar->GetRule(rule_id);
+    if (grammar->GetGrammarExpr(rule.body_expr_id).type == GrammarExprType::kTagDispatch) {
+      result.emplace(
+          rule_id, ComputeTagDispatchSecondSlicingBitset(grammar, tokenizer_info, rule_id)
+      );
+    }
+  }
+  return result;
 }
 
 /******************* GrammarCompiler::Impl *******************/
@@ -1343,7 +1433,8 @@ class GrammarCompiler::Impl {
       const TokenizerInfo& tokenizer_info,
       int max_threads,
       bool cache_enabled,
-      int64_t max_memory_bytes
+      int64_t max_memory_bytes,
+      bool enable_dynamic_compilation
   )
       : cache_enabled_(cache_enabled),
         rule_level_cache_(
@@ -1355,7 +1446,9 @@ class GrammarCompiler::Impl {
                   )
                 : std::nullopt
         ),
-        no_cache_compiler_(tokenizer_info, max_threads, rule_level_cache_),
+        no_cache_compiler_(
+            tokenizer_info, max_threads, rule_level_cache_, enable_dynamic_compilation
+        ),
         grammar_level_cache_(
             max_memory_bytes == -1 ? static_cast<std::size_t>(-1)
                                    : static_cast<std::size_t>(max_memory_bytes / 3 * 2),
@@ -1539,10 +1632,12 @@ GrammarCompiler::GrammarCompiler(
     const TokenizerInfo& tokenizer_info,
     int max_threads,
     bool cache_enabled,
-    int64_t max_memory_bytes
+    int64_t max_memory_bytes,
+    bool enable_dynamic_compilation
 )
-    : pimpl_(std::make_shared<Impl>(tokenizer_info, max_threads, cache_enabled, max_memory_bytes)) {
-}
+    : pimpl_(std::make_shared<Impl>(
+          tokenizer_info, max_threads, cache_enabled, max_memory_bytes, enable_dynamic_compilation
+      )) {}
 
 CompiledGrammar GrammarCompiler::CompileJSONSchema(
     const std::string& schema,

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -3234,6 +3234,7 @@ std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index)
     bool is_start = current_old_state_id == fsm.GetStart();
     int current_new_state_id = original_state_id_to_new_id[current_old_state_id];
     bfs_queue.pop();
+    hash_and_target.clear();
 
     // Check if the current state is an end state.
     if (fsm.IsEndState(current_old_state_id)) {
@@ -3347,6 +3348,7 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
     int current_old_state_id = bfs_queue.front();
     int current_new_state_id = original_state_id_to_new_id[current_old_state_id];
     bfs_queue.pop();
+    hash_and_target.clear();
 
     // Check if the current state is an end state.
     if (fsm.IsEndState(current_old_state_id)) {

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1147,6 +1147,36 @@ class RuleRefGraphFinder : public GrammarVisitor<std::vector<std::vector<int32_t
   int32_t cur_rule_id_;
 };
 
+static Result<const FSMWithStartEnd*> GetOrBuildRegexFSM(
+    const std::string& regex,
+    bool json_string,
+    std::unordered_map<std::string, FSMWithStartEnd>& regex_fsm_cache,
+    GrammarBuilder* grammar_builder,
+    const std::string& rule_hint
+) {
+  std::string cache_key;
+  cache_key.reserve(regex.size() + 1);
+  cache_key.push_back(static_cast<char>(json_string));
+  cache_key.append(regex);
+
+  auto cached = regex_fsm_cache.find(cache_key);
+  if (cached != regex_fsm_cache.end()) {
+    return ResultOk<const FSMWithStartEnd*>(&cached->second);
+  }
+
+  auto build_result =
+      json_string
+          ? RegexFSMBuilder::BuildWithForbiddenChars(
+                regex, GrammarFSMBuilder::JSONStringForbiddenChars(), grammar_builder, rule_hint
+            )
+          : RegexFSMBuilder::Build(regex, grammar_builder, rule_hint);
+  if (build_result.IsErr()) {
+    return ResultErr(std::move(build_result).UnwrapErr());
+  }
+  cached = regex_fsm_cache.emplace(std::move(cache_key), std::move(build_result).Unwrap()).first;
+  return ResultOk<const FSMWithStartEnd*>(&cached->second);
+}
+
 /*!
  * \brief Analyzes which rules in a grammar can match the empty string.
  */
@@ -1275,17 +1305,26 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
 
 class GrammarFSMBuilderImpl {
  public:
+  using RegexFSMCache = std::unordered_map<std::string, FSMWithStartEnd>;
+
   explicit GrammarFSMBuilderImpl(
       FSM& target_fsm,
       const std::string* rule_name = nullptr,
-      GrammarBuilder* grammar_builder = nullptr
+      GrammarBuilder* grammar_builder = nullptr,
+      RegexFSMCache* regex_fsm_cache = nullptr
   )
-      : target_fsm_(target_fsm), rule_name_(rule_name), grammar_builder_(grammar_builder) {}
+      : target_fsm_(target_fsm),
+        rule_name_(rule_name),
+        grammar_builder_(grammar_builder),
+        regex_fsm_cache_(regex_fsm_cache) {}
 
   static void Apply(Grammar* grammar) {
     FSM complete_fsm;
     std::vector<std::optional<FSMWithStartEndWithSize>> per_rule_fsms;
     std::vector<int> state_mapping;
+    // Reused across all rules of this grammar so identical regexes are converted to an FSM
+    // only once.
+    RegexFSMCache regex_fsm_cache;
 
     // Compiling a kRegex rule may append new rules through this builder: large bounded
     // repetitions in a regex become kRepeatRef edges referencing new rules. NumRules() is
@@ -1293,7 +1332,7 @@ class GrammarFSMBuilderImpl {
     int32_t num_original_rules = (*grammar)->NumRules();
     GrammarBuilder grammar_builder = GrammarBuilder::FromMutableGrammar(grammar);
     for (int i = 0; i < (*grammar)->NumRules(); ++i) {
-      auto rule_fsm = BuildRuleFSM(*grammar, i, &grammar_builder);
+      auto rule_fsm = BuildRuleFSM(*grammar, i, &grammar_builder, &regex_fsm_cache);
       per_rule_fsms.push_back(rule_fsm.AddToCompleteFSM(&complete_fsm, &state_mapping));
     }
 
@@ -1360,13 +1399,17 @@ class GrammarFSMBuilderImpl {
 
  private:
   static FSMWithStartEnd BuildRuleFSM(
-      const Grammar& grammar, int rule_id, GrammarBuilder* grammar_builder = nullptr
+      const Grammar& grammar,
+      int rule_id,
+      GrammarBuilder* grammar_builder = nullptr,
+      RegexFSMCache* regex_fsm_cache = nullptr
   );
   static FSMWithStartEnd BuildExpressionFSM(
       const GrammarExpr& expr,
       const Grammar& grammar,
       const std::string* rule_name = nullptr,
-      GrammarBuilder* grammar_builder = nullptr
+      GrammarBuilder* grammar_builder = nullptr,
+      RegexFSMCache* regex_fsm_cache = nullptr
   );
   void BuildExpression(
       const GrammarExpr& expr,
@@ -1418,13 +1461,16 @@ class GrammarFSMBuilderImpl {
   );
   void AddCharacterClassTransitions(const GrammarExpr& expr, int start_state, int end_state);
   void BuildNegativeCharacterClass(const GrammarExpr& expr, int start_state, int end_state);
-  void AppendFSM(FSMWithStartEnd fsm, int start_state, std::vector<int32_t>* end_states);
+  void AppendFSM(FSMWithStartEnd&& fsm, int start_state, std::vector<int32_t>* end_states);
+  void AppendFSM(const FSMWithStartEnd& fsm, int start_state, std::vector<int32_t>* end_states);
   void AddCharacterRange(int from, int to, uint32_t min, uint32_t max);
 
   FSM& target_fsm_;
   const std::string* rule_name_;
   // If not null, kRegex expressions may add new rules through this builder; see Apply().
   GrammarBuilder* grammar_builder_ = nullptr;
+  // If not null, regex FSMs are looked up in and stored into this cache; see Apply().
+  RegexFSMCache* regex_fsm_cache_ = nullptr;
 };
 
 // This function will add a range [min, max] of unicode characters to the FSM.
@@ -1514,11 +1560,11 @@ void GrammarFSMBuilderImpl::BuildCharacterClassStar(
 }
 
 FSMWithStartEnd GrammarFSMBuilderImpl::BuildRuleFSM(
-    const Grammar& grammar, int rule_id, GrammarBuilder* grammar_builder
+    const Grammar& grammar, int rule_id, GrammarBuilder* grammar_builder, RegexFSMCache* regex_fsm_cache
 ) {
   const auto& rule = grammar->GetRule(rule_id);
   return BuildExpressionFSM(
-      grammar->GetGrammarExpr(rule.body_expr_id), grammar, &rule.name, grammar_builder
+      grammar->GetGrammarExpr(rule.body_expr_id), grammar, &rule.name, grammar_builder, regex_fsm_cache
   );
 }
 
@@ -1526,12 +1572,13 @@ FSMWithStartEnd GrammarFSMBuilderImpl::BuildExpressionFSM(
     const GrammarExpr& expr,
     const Grammar& grammar,
     const std::string* rule_name,
-    GrammarBuilder* grammar_builder
+    GrammarBuilder* grammar_builder,
+    RegexFSMCache* regex_fsm_cache
 ) {
   FSM result_fsm;
   int start_state = result_fsm.AddState();
   std::vector<int32_t> end_states;
-  GrammarFSMBuilderImpl builder(result_fsm, rule_name, grammar_builder);
+  GrammarFSMBuilderImpl builder(result_fsm, rule_name, grammar_builder, regex_fsm_cache);
   builder.BuildExpression(expr, grammar, start_state, &end_states);
   FSMWithStartEnd result(result_fsm, start_state, std::move(end_states));
   if (expr.type != ExprType::kTagDispatch && expr.type != ExprType::kTokenTagDispatch) {
@@ -1809,7 +1856,7 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Choices(
 }
 
 void GrammarFSMBuilderImpl::AppendFSM(
-    FSMWithStartEnd fsm, int start_state, std::vector<int32_t>* end_states
+    FSMWithStartEnd&& fsm, int start_state, std::vector<int32_t>* end_states
 ) {
   const bool target_is_empty = target_fsm_.NumStates() == 1 && start_state == 0 &&
                                target_fsm_.GetEdges(0).empty() &&
@@ -1820,6 +1867,12 @@ void GrammarFSMBuilderImpl::AppendFSM(
     return;
   }
 
+  AppendFSM(static_cast<const FSMWithStartEnd&>(fsm), start_state, end_states);
+}
+
+void GrammarFSMBuilderImpl::AppendFSM(
+    const FSMWithStartEnd& fsm, int start_state, std::vector<int32_t>* end_states
+) {
   std::vector<int> state_mapping;
   target_fsm_.AddFSM(fsm.GetFsm(), &state_mapping);
   target_fsm_.AddEpsilonEdge(start_state, state_mapping[fsm.GetStart()]);
@@ -1834,6 +1887,22 @@ void GrammarFSMBuilderImpl::BuildRegex(
     const std::string& regex, bool json_string, int start_state, std::vector<int32_t>* end_states
 ) {
   const std::string rule_hint = rule_name_ != nullptr ? *rule_name_ : "";
+  if (regex_fsm_cache_ != nullptr) {
+    auto regex_fsm_result =
+        GetOrBuildRegexFSM(regex, json_string, *regex_fsm_cache_, grammar_builder_, rule_hint);
+    if (regex_fsm_result.IsErr()) {
+      auto error = std::move(regex_fsm_result).UnwrapErr();
+      if (rule_name_ != nullptr) {
+        XGRAMMAR_LOG(FATAL) << "Failed to build the automaton for rule " << *rule_name_
+                            << " with regex " << regex << ": " << error.what();
+      }
+      XGRAMMAR_LOG(FATAL) << "Failed to build the automaton for regex " << regex << ": "
+                          << error.what();
+    }
+    AppendFSM(*std::move(regex_fsm_result).Unwrap(), start_state, end_states);
+    return;
+  }
+
   auto build_result =
       json_string
           ? RegexFSMBuilder::BuildWithForbiddenChars(

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -7,20 +7,16 @@
 
 #include <xgrammar/xgrammar.h>
 
-#include <array>
 #include <bitset>
 #include <cstdint>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <queue>
 #include <set>
 #include <stack>
 #include <string>
-#include <tuple>
 #include <vector>
 
-#include "compiled_grammar_impl.h"
 #include "fsm.h"
 #include "fsm_builder.h"
 #include "grammar_builder.h"
@@ -3158,6 +3154,16 @@ class GrammarFSMHasherImpl {
   uint64_t HashFsm(int fsm_index);
 
   /*!
+   * \brief Add a non-rule edge to an FSM hash using its semantic payload.
+   */
+  uint64_t HashNonRuleEdge(
+      uint64_t hash_result,
+      int32_t current_new_state_id,
+      const FSMEdge& edge,
+      int32_t target_new_state_id
+  ) const;
+
+  /*!
    * \brief Find a simple cycle in the reference graph, And hash the
    * fsms in the simple cycle.
    */
@@ -3379,6 +3385,32 @@ void GrammarFSMHasherImpl::Apply(Grammar* grammar) {
   }
 }
 
+uint64_t GrammarFSMHasherImpl::HashNonRuleEdge(
+    uint64_t hash_result,
+    int32_t current_new_state_id,
+    const FSMEdge& edge,
+    int32_t target_new_state_id
+) const {
+  hash_result = HashCombine(hash_result, current_new_state_id, static_cast<int32_t>(edge.min));
+  if (edge.IsToken()) {
+    const auto token_edge = grammar_->ImplPtr()->complete_fsm.GetTokenEdgeInfo(edge.GetAuxIndex());
+    hash_result = HashCombine(hash_result, token_edge.Count());
+    for (int32_t index = 0; index < token_edge.Count(); ++index) {
+      hash_result = HashCombine(hash_result, token_edge.TokenIds()[index]);
+    }
+  } else if (edge.IsExcludeToken()) {
+    const auto exclude_token_edge =
+        grammar_->ImplPtr()->complete_fsm.GetExcludeTokenEdgeInfo(edge.GetAuxIndex());
+    hash_result = HashCombine(hash_result, exclude_token_edge.Count());
+    for (int32_t index = 0; index < exclude_token_edge.Count(); ++index) {
+      hash_result = HashCombine(hash_result, exclude_token_edge.TokenIds()[index]);
+    }
+  } else {
+    hash_result = HashCombine(hash_result, static_cast<int32_t>(edge.max));
+  }
+  return HashCombine(hash_result, target_new_state_id);
+}
+
 std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index) {
   uint64_t hash_result = 0;
   XGRAMMAR_DCHECK(fsm_index >= 0 && fsm_index < (*grammar_)->NumRules())
@@ -3475,13 +3507,7 @@ std::pair<bool, uint64_t> GrammarFSMHasherImpl::IsPartialHashable(int fsm_index)
       if (edge.IsRuleRef() || edge.IsRepeatRef()) {
         continue;
       }
-      hash_result = HashCombine(
-          hash_result,
-          current_new_state_id,
-          static_cast<int32_t>(edge.min),
-          static_cast<int32_t>(edge.max),
-          target_new_id
-      );
+      hash_result = HashNonRuleEdge(hash_result, current_new_state_id, edge, target_new_id);
     }
   }
   std::vector<std::pair<int32_t, int32_t>> new_id_mapping;
@@ -3502,7 +3528,7 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
   std::map<int32_t, int32_t> original_state_id_to_new_id;
   original_state_id_to_new_id[fsm.GetStart()] = 0;
   std::queue<int32_t> bfs_queue;
-  std::set<std::pair<int32_t, int32_t>> hash_and_target;
+  std::set<std::pair<uint64_t, int32_t>> hash_and_target;
   bfs_queue.push(fsm.GetStart());
 
   // Perform a bfs to hash all the edges.
@@ -3553,7 +3579,7 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
           XGRAMMAR_CHECK(grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].has_value());
           uint64_t base_hash = grammar_->ImplPtr()->per_rule_fsm_hashes[ref_rule_id].value();
           uint64_t repeat_hash = HashCombine(base_hash, info.Lower(), info.Upper());
-          hash_and_target.insert({static_cast<int32_t>(repeat_hash), edge.target});
+          hash_and_target.insert({repeat_hash, edge.target});
         }
       }
     }
@@ -3580,13 +3606,7 @@ uint64_t GrammarFSMHasherImpl::HashFsm(int fsm_index) {
       if (edge.IsRuleRef() || edge.IsRepeatRef()) {
         continue;
       }
-      hash_result = HashCombine(
-          hash_result,
-          current_new_state_id,
-          static_cast<int32_t>(edge.min),
-          static_cast<int32_t>(edge.max),
-          target_new_id
-      );
+      hash_result = HashNonRuleEdge(hash_result, current_new_state_id, edge, target_new_id);
     }
   }
   std::vector<std::pair<int32_t, int32_t>> new_id_mapping;
@@ -3667,204 +3687,6 @@ std::optional<uint64_t> GrammarFSMHasherImpl::HashSequence(
   }
   return hash_result;
 }
-
-class RuleLevelCache::Impl {
- public:
-  using NodeKey = std::tuple<
-      uint64_t /*The hash value of the FSM*/,
-      int32_t /* The normalized node id*/,
-      int32_t /*The number of states*/,
-      int32_t /* The number of edges*/>;
-  using NodeType = std::pair<NodeKey, AdaptiveTokenMask>;
-
-  explicit Impl(size_t max_cache_memory_size) : max_cache_memory_size_(max_cache_memory_size) {}
-
-  std::optional<AdaptiveTokenMask> GetCache(
-      const uint64_t& fsm_hash,
-      int32_t fsm_new_node_id,
-      const int32_t& state_cnt,
-      const int32_t edge_cnt
-  );
-
-  bool AddCache(
-      const uint64_t& fsm_hash,
-      int32_t fsm_new_node_id,
-      const int32_t& state_cnt,
-      const int32_t edge_cnt,
-      const AdaptiveTokenMask& token_mask
-  );
-
-  bool AddCache(
-      const uint64_t& fsm_hash,
-      int32_t fsm_new_node_id,
-      const int32_t& state_cnt,
-      const int32_t edge_cnt,
-      AdaptiveTokenMask&& token_mask
-  );
-
-  void ClearCache();
-
-  friend size_t MemorySize(const Impl* impl) {
-    int64_t total = 0;
-    for (const auto& shard : impl->shards_) {
-      total += shard.current_cache_memory_size;
-    }
-    return total;
-  }
-
-  size_t GetMaxSize() const { return max_cache_memory_size_; }
-
- private:
-  /*!
-   * \brief The cache is sharded to reduce lock contention: the token mask cache generation
-   * queries and inserts from all compilation threads, and a single global mutex would serialize
-   * them (large grammars issue millions of cache operations).
-   */
-  static constexpr size_t kNumShards = 16;
-
-  struct Shard {
-    std::mutex mutex;
-    int64_t current_cache_memory_size = 0;
-    // The cache map: (fsm_hash, node_id, ...) -> index in cache_list
-    List<NodeType> cache_list;
-    std::unordered_map<NodeKey, int> cache;
-  };
-
-  Shard& GetShard(const NodeKey& key) {
-    return shards_[HashCombine(std::get<0>(key), std::get<1>(key)) % kNumShards];
-  }
-
-  /*! \brief The memory budget of one shard. Eviction is performed per shard. */
-  size_t ShardMaxSize() const {
-    return max_cache_memory_size_ == kUnlimitedSize ? kUnlimitedSize
-                                                    : max_cache_memory_size_ / kNumShards;
-  }
-
-  const size_t max_cache_memory_size_;
-  std::array<Shard, kNumShards> shards_;
-};
-
-std::optional<AdaptiveTokenMask> RuleLevelCache::GetCache(
-    const uint64_t& fsm_hash,
-    int32_t fsm_new_node_id,
-    const int32_t& state_cnt,
-    const int32_t edge_cnt
-) {
-  return pimpl_->GetCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
-}
-
-bool RuleLevelCache::AddCache(
-    const uint64_t& fsm_hash,
-    int32_t fsm_new_node_id,
-    const int32_t& state_cnt,
-    const int32_t edge_cnt,
-    const AdaptiveTokenMask& token_mask
-) {
-  return pimpl_->AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, token_mask);
-}
-
-bool RuleLevelCache::AddCache(
-    const uint64_t& fsm_hash,
-    int32_t fsm_new_node_id,
-    const int32_t& state_cnt,
-    const int32_t edge_cnt,
-    AdaptiveTokenMask&& token_mask
-) {
-  return pimpl_->AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, std::move(token_mask));
-}
-
-void RuleLevelCache::ClearCache() { pimpl_->ClearCache(); }
-
-size_t RuleLevelCache::GetMaxSize() const { return pimpl_->GetMaxSize(); }
-
-std::optional<AdaptiveTokenMask> RuleLevelCache::Impl::GetCache(
-    const uint64_t& fsm_hash,
-    int32_t fsm_new_node_id,
-    const int32_t& state_cnt,
-    const int32_t edge_cnt
-) {
-  // Find in the cache.
-  NodeKey key = std::make_tuple(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
-  Shard& shard = GetShard(key);
-  std::lock_guard<std::mutex> lock(shard.mutex);
-  auto it = shard.cache.find(key);
-  if (it == shard.cache.end()) {
-    return std::nullopt;
-  }
-
-  // Move the node to the back of the list.
-  shard.cache_list.MoveBack(it->second);
-  return List<NodeType>::iterator(it->second, shard.cache_list)->second;
-}
-
-bool RuleLevelCache::Impl::AddCache(
-    const uint64_t& fsm_hash,
-    int32_t fsm_new_node_id,
-    const int32_t& state_cnt,
-    const int32_t edge_cnt,
-    const AdaptiveTokenMask& token_mask
-) {
-  return AddCache(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt, AdaptiveTokenMask(token_mask));
-}
-
-bool RuleLevelCache::Impl::AddCache(
-    const uint64_t& fsm_hash,
-    int32_t fsm_new_node_id,
-    const int32_t& state_cnt,
-    const int32_t edge_cnt,
-    AdaptiveTokenMask&& token_mask
-) {
-  // Check if we can add to the cache.
-  NodeKey key = std::make_tuple(fsm_hash, fsm_new_node_id, state_cnt, edge_cnt);
-  Shard& shard = GetShard(key);
-  const size_t shard_max_size = ShardMaxSize();
-  std::lock_guard<std::mutex> lock(shard.mutex);
-  if (shard_max_size != kUnlimitedSize && MemorySize(token_mask) > shard_max_size) {
-    // The token mask is too large to be cached.
-    return false;
-  }
-  if (shard.cache.find(key) != shard.cache.end()) {
-    // Already exists.
-    return false;
-  }
-
-  // Evict old entries if needed.
-  if (shard_max_size != kUnlimitedSize) {
-    size_t new_item_size = MemorySize(token_mask);
-    while ((shard.current_cache_memory_size) > static_cast<int64_t>(shard_max_size - new_item_size)
-    ) {
-      auto oldest_it = shard.cache_list.begin();
-      if (oldest_it == shard.cache_list.end()) {
-        // This should not happen if the size of the new item is smaller than
-        // the shard budget, but this is a safeguard.
-        break;
-      }
-      shard.current_cache_memory_size -= MemorySize(oldest_it->second);
-      shard.cache.erase(oldest_it->first);
-      shard.cache_list.Erase(oldest_it);
-    }
-  }
-
-  // Add to the cache.
-  auto new_it = shard.cache_list.PushBack(NodeType(key, std::move(token_mask)));
-  shard.current_cache_memory_size += MemorySize(new_it->second);
-  shard.cache[key] = new_it.Index();
-  return true;
-}
-
-RuleLevelCache::RuleLevelCache(size_t max_cache_memory_size)
-    : pimpl_(std::make_shared<Impl>(max_cache_memory_size)) {}
-
-void RuleLevelCache::Impl::ClearCache() {
-  for (auto& shard : shards_) {
-    std::lock_guard<std::mutex> lock(shard.mutex);
-    shard.cache_list.Clear();
-    shard.cache.clear();
-    shard.current_cache_memory_size = 0;
-  }
-}
-
-size_t MemorySize(const RuleLevelCache& manager) { return MemorySize(manager.ImplPtr()); }
 
 /*************************** Forward grammar constructors to their impl ***************************/
 

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1453,7 +1453,14 @@ class GrammarFSMBuilderImpl {
       int start_state,
       std::vector<int32_t>* end_states
   );
-  void BuildChoices(
+  // Returns whether the specialized choice builder handled the whole expression.
+  bool BuildChoices(
+      const GrammarExpr& expr,
+      const Grammar& grammar,
+      int start_state,
+      std::vector<int32_t>* end_states
+  );
+  bool BuildByteStringRuleRefChoices(
       const GrammarExpr& expr,
       const Grammar& grammar,
       int start_state,
@@ -1579,11 +1586,18 @@ FSMWithStartEnd GrammarFSMBuilderImpl::BuildExpressionFSM(
   int start_state = result_fsm.AddState();
   std::vector<int32_t> end_states;
   GrammarFSMBuilderImpl builder(result_fsm, rule_name, grammar_builder, regex_fsm_cache);
-  builder.BuildExpression(expr, grammar, start_state, &end_states);
+  bool skip_equivalent_state_merge = false;
+  if (expr.type == ExprType::kChoices) {
+    skip_equivalent_state_merge = builder.BuildChoices(expr, grammar, start_state, &end_states);
+  } else {
+    builder.BuildExpression(expr, grammar, start_state, &end_states);
+  }
   FSMWithStartEnd result(result_fsm, start_state, std::move(end_states));
   if (expr.type != ExprType::kTagDispatch && expr.type != ExprType::kTokenTagDispatch) {
     result = result.SimplifyEpsilon();
-    result = result.MergeEquivalentStates();
+    if (!skip_equivalent_state_merge) {
+      result = result.MergeEquivalentStates();
+    }
   }
   return result;
 }
@@ -1674,8 +1688,10 @@ void GrammarFSMBuilderImpl::BuildExpression(
       return BuildExcludeToken(expr, start_state, end_states);
     case ExprType::kSequence:
       return BuildSequence(expr, grammar, start_state, end_states);
-    case ExprType::kChoices:
-      return BuildChoices(expr, grammar, start_state, end_states);
+    case ExprType::kChoices: {
+      BuildChoices(expr, grammar, start_state, end_states);
+      return;
+    }
     case ExprType::kRegex:
       return BuildRegex(
           grammar->GetRegexString(expr),
@@ -1793,7 +1809,7 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Sequence(
   return FSMWithStartEnd(result_fsm, start_state, std::move(end_states));
 }
 
-void GrammarFSMBuilderImpl::BuildChoices(
+bool GrammarFSMBuilderImpl::BuildChoices(
     const GrammarExpr& expr,
     const Grammar& grammar,
     int start_state,
@@ -1816,7 +1832,7 @@ void GrammarFSMBuilderImpl::BuildChoices(
 
   if (non_empty_choice_count == 0) {
     end_states->push_back(start_state);
-    return;
+    return false;
   }
 
   if (non_empty_choice_count == 1 && !nullable) {
@@ -1824,10 +1840,14 @@ void GrammarFSMBuilderImpl::BuildChoices(
       const auto& choice_expr = grammar->GetGrammarExpr(choice_id);
       if (choice_expr.type != ExprType::kEmptyStr) {
         BuildExpression(choice_expr, grammar, start_state, end_states);
-        return;
+        return false;
       }
     }
     XGRAMMAR_UNREACHABLE();
+  }
+
+  if (!nullable && BuildByteStringRuleRefChoices(expr, grammar, start_state, end_states)) {
+    return true;
   }
 
   std::vector<int32_t> branch_end_states;
@@ -1847,6 +1867,79 @@ void GrammarFSMBuilderImpl::BuildChoices(
     target_fsm_.AddEpsilonEdge(start_state, nullable_branch_state);
     end_states->push_back(nullable_branch_state);
   }
+  return false;
+}
+
+bool GrammarFSMBuilderImpl::BuildByteStringRuleRefChoices(
+    const GrammarExpr& expr,
+    const Grammar& grammar,
+    int start_state,
+    std::vector<int32_t>* end_states
+) {
+  struct Branch {
+    std::string prefix;
+    int32_t rule_id;
+    std::string suffix;
+  };
+
+  std::vector<Branch> branches;
+  branches.reserve(expr.size());
+  std::vector<std::string> prefixes;
+  prefixes.reserve(expr.size());
+  for (int32_t choice_id : expr) {
+    const auto& sequence = grammar->GetGrammarExpr(choice_id);
+    if (sequence.type != ExprType::kSequence || sequence.size() != 3) {
+      return false;
+    }
+    const auto& prefix = grammar->GetGrammarExpr(sequence[0]);
+    const auto& rule_ref = grammar->GetGrammarExpr(sequence[1]);
+    const auto& suffix = grammar->GetGrammarExpr(sequence[2]);
+    if (prefix.type != ExprType::kByteString || rule_ref.type != ExprType::kRuleRef ||
+        suffix.type != ExprType::kByteString) {
+      return false;
+    }
+
+    Branch branch;
+    branch.prefix.reserve(prefix.size());
+    for (int32_t byte : prefix) {
+      branch.prefix.push_back(static_cast<char>(static_cast<uint8_t>(byte)));
+    }
+    branch.rule_id = rule_ref[0];
+    branch.suffix.reserve(suffix.size());
+    for (int32_t byte : suffix) {
+      branch.suffix.push_back(static_cast<char>(static_cast<uint8_t>(byte)));
+    }
+    prefixes.push_back(branch.prefix);
+    branches.push_back(std::move(branch));
+  }
+
+  std::vector<int32_t> prefix_end_states;
+  auto trie = TrieFSMBuilder::Build(prefixes, {}, &prefix_end_states, true, false);
+  XGRAMMAR_DCHECK(trie.has_value());
+
+  std::vector<int> state_mapping;
+  target_fsm_.AddFSM(trie->GetFsm(), &state_mapping);
+  target_fsm_.AddEpsilonEdge(start_state, state_mapping[trie->GetStart()]);
+
+  std::unordered_map<std::string, int32_t> suffix_start_states;
+  suffix_start_states.reserve(branches.size());
+  end_states->clear();
+  for (int index = 0; index < static_cast<int>(branches.size()); ++index) {
+    const auto& branch = branches[index];
+    auto [it, inserted] = suffix_start_states.emplace(branch.suffix, -1);
+    if (inserted) {
+      int32_t current_state = target_fsm_.AddState();
+      it->second = current_state;
+      for (uint8_t byte : branch.suffix) {
+        int32_t next_state = target_fsm_.AddState();
+        target_fsm_.AddEdge(current_state, next_state, byte, byte);
+        current_state = next_state;
+      }
+      end_states->push_back(current_state);
+    }
+    target_fsm_.AddRuleEdge(state_mapping[prefix_end_states[index]], it->second, branch.rule_id);
+  }
+  return true;
 }
 
 std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Choices(

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -3629,9 +3629,10 @@ std::optional<uint64_t> GrammarFSMHasherImpl::HashSequence(
   const auto& sequence_expr = grammar->GetGrammarExpr(sequence_id);
   XGRAMMAR_DCHECK(sequence_expr.type == GrammarExprType::kSequence)
       << "GrammarExpr is not a sequence";
+  hash_result = HashCombine(hash_result, sequence_expr.size());
   for (const auto& expr_id : sequence_expr) {
     const auto& expr = grammar->GetGrammarExpr(expr_id);
-    hash_result = HashCombine(hash_result, static_cast<int32_t>(expr.type));
+    hash_result = HashCombine(hash_result, static_cast<int32_t>(expr.type), expr.size());
     switch (expr.type) {
       case (GrammarExprType::kByteString):
       case (GrammarExprType::kCharacterClass):

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -14,7 +14,6 @@
 #include <cstdint>
 #include <string>
 
-#include "compiled_grammar_impl.h"
 #include "grammar_builder.h"
 #include "grammar_impl.h"
 #include "support/utils.h"
@@ -463,46 +462,6 @@ class GrammarFSMHasher {
  public:
   static void Apply(Grammar* grammar);
   static std::optional<uint64_t> HashSequence(const Grammar& grammar, int32_t sequence_id);
-};
-
-/*!
- * \brief Store the crossing cache for different grammars.
- * \param max_cache_size The maximum size of the cache numbers.
- * \details LRU algorithm is implemented.
- */
-class RuleLevelCache {
- public:
-  static const size_t kUnlimitedSize = static_cast<size_t>(-1);
-
-  std::optional<AdaptiveTokenMask> GetCache(
-      const uint64_t& fsm_hash,
-      int32_t fsm_new_node_id,
-      const int32_t& state_cnt,
-      const int32_t edge_cnt
-  );
-  bool AddCache(
-      const uint64_t& fsm_hash,
-      int32_t fsm_new_node_id,
-      const int32_t& state_cnt,
-      const int32_t edge_cnt,
-      const AdaptiveTokenMask& token_mask
-  );
-  bool AddCache(
-      const uint64_t& fsm_hash,
-      int32_t fsm_new_node_id,
-      const int32_t& state_cnt,
-      const int32_t edge_cnt,
-      AdaptiveTokenMask&& token_mask
-  );
-  RuleLevelCache(size_t max_cache_memory_size = kUnlimitedSize);
-
-  void ClearCache();
-
-  size_t GetMaxSize() const;
-
-  friend size_t MemorySize(const RuleLevelCache& manager);
-
-  XGRAMMAR_DEFINE_PIMPL_METHODS(RuleLevelCache);
 };
 
 }  // namespace xgrammar

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -889,7 +889,8 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
   const auto latest_row = scanable_state_history_[scanable_state_history_.size() - 1];
   std::vector<ParserState> latest_states(latest_row.begin(), latest_row.end());
   std::vector<ParserState> force_completed_states;
-  std::unordered_set<int64_t> force_completed_occurrences;
+  std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
+      force_completed_occurrences;
 
   tmp_states_visited_in_queue_.Clear();
   tmp_states_to_be_added_.clear();
@@ -904,9 +905,7 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
     if (!CanForceCompleteWithoutMarker(state, false)) {
       continue;
     }
-    int64_t occurrence =
-        (static_cast<int64_t>(state.rule_id) << 32) | static_cast<uint32_t>(state.rule_start_pos);
-    if (force_completed_occurrences.insert(occurrence).second) {
+    if (force_completed_occurrences.insert(state).second) {
       force_completed_states.push_back(state);
     }
   }
@@ -976,7 +975,8 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
     previous_capture_events = CopyLastCaptureRow();
   }
   std::vector<ParserState> force_completed_states;
-  std::unordered_set<int64_t> force_completed_occurrences;
+  std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
+      force_completed_occurrences;
 
   tmp_states_visited_in_queue_.Clear();
   tmp_states_to_be_added_.clear();
@@ -991,9 +991,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
     if (!CanForceCompleteWithoutMarker(state, true)) {
       continue;
     }
-    int64_t occurrence =
-        (static_cast<int64_t>(state.rule_id) << 32) | static_cast<uint32_t>(state.rule_start_pos);
-    if (force_completed_occurrences.insert(occurrence).second) {
+    if (force_completed_occurrences.insert(state).second) {
       force_completed_states.push_back(state);
     }
   }

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -887,16 +887,14 @@ bool GrammarMatcher::Impl::CanForceCompleteWithoutMarker(
 }
 
 bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
-  XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
+  XGRAMMAR_DCHECK(tmp_pending_states_.empty());
   const auto latest_row = scanable_state_history_[scanable_state_history_.size() - 1];
   std::vector<ParserState> latest_states(latest_row.begin(), latest_row.end());
   std::vector<ParserState> force_completed_states;
   std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
       force_completed_occurrences;
 
-  tmp_states_visited_in_queue_.Clear();
-  tmp_states_to_be_added_.clear();
-  tmp_completed_lazy_occurrences_.clear();
+  ClearTemporaryContainers();
   tmp_accept_stop_token_ = IsCompleted();
 
   for (const auto& state : latest_states) {
@@ -915,17 +913,7 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
   for (const auto& state : force_completed_states) {
     Complete(state, debug_print, /*marker_present=*/false);
   }
-  while (!tmp_process_state_queue_.empty()) {
-    const auto state = std::move(tmp_process_state_queue_.front());
-    tmp_process_state_queue_.pop();
-    auto [scanable, completable] = Predict(state, debug_print);
-    if (completable) {
-      Complete(state, debug_print);
-    }
-    if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
-    }
-  }
+  ExpandPendingStates(debug_print);
   if (!tmp_completed_lazy_occurrences_.empty()) {
     RemoveCommittedLazyStates();
   }
@@ -933,7 +921,7 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
   bool any_expired = false;
   bool any_alive = false;
   for (const auto& state : tmp_states_to_be_added_) {
-    if (IsExpiredState(state)) {
+    if (IsExpiredState(*state)) {
       any_expired = true;
     } else {
       any_alive = true;
@@ -947,7 +935,7 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
         std::remove_if(
             tmp_states_to_be_added_.begin(),
             tmp_states_to_be_added_.end(),
-            [&](const ParserState& state) { return IsExpiredState(state); }
+            [&](const ParserState* state) { return IsExpiredState(*state); }
         ),
         tmp_states_to_be_added_.end()
     );
@@ -955,16 +943,18 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
 
   bool viable = tmp_accept_stop_token_ || !tmp_states_to_be_added_.empty();
   if (!viable) {
+    ClearTemporaryContainers();
     return false;
   }
   scanable_state_history_.PopBack(1);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
   is_completed_.back() = tmp_accept_stop_token_;
+  ClearTemporaryContainers();
   return true;
 }
 
 bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
-  XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
+  XGRAMMAR_DCHECK(tmp_pending_states_.empty());
   const auto latest_row = scanable_state_history_[scanable_state_history_.size() - 1];
   std::vector<ParserState> latest_states(latest_row.begin(), latest_row.end());
   auto previous_completable_row = rule_id_to_completable_states_.Back();
@@ -980,9 +970,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
   std::unordered_set<ParserState, StateHashForCompletionContext, StateEqualForCompletionContext>
       force_completed_occurrences;
 
-  tmp_states_visited_in_queue_.Clear();
-  tmp_states_to_be_added_.clear();
-  tmp_completed_lazy_occurrences_.clear();
+  ClearTemporaryContainers();
   tmp_accept_stop_token_ = IsCompleted();
 
   for (const auto& state : latest_states) {
@@ -1001,17 +989,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
   for (const auto& state : force_completed_states) {
     Complete(state, debug_print, /*marker_present=*/false);
   }
-  while (!tmp_process_state_queue_.empty()) {
-    const auto state = std::move(tmp_process_state_queue_.front());
-    tmp_process_state_queue_.pop();
-    auto [scanable, completable] = Predict(state, debug_print);
-    if (completable) {
-      Complete(state, debug_print);
-    }
-    if (scanable) {
-      tmp_states_to_be_added_.push_back(state);
-    }
-  }
+  ExpandPendingStates(debug_print);
   if (!tmp_completed_lazy_occurrences_.empty()) {
     RemoveCommittedLazyStates();
   }
@@ -1019,7 +997,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
   bool any_expired = false;
   bool any_alive = false;
   for (const auto& state : tmp_states_to_be_added_) {
-    if (IsCharExpiredState(state)) {
+    if (IsCharExpiredState(*state)) {
       any_expired = true;
     } else {
       any_alive = true;
@@ -1030,7 +1008,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
         std::remove_if(
             tmp_states_to_be_added_.begin(),
             tmp_states_to_be_added_.end(),
-            [&](const ParserState& state) { return IsCharExpiredState(state); }
+            [&](const ParserState* state) { return IsCharExpiredState(*state); }
         ),
         tmp_states_to_be_added_.end()
     );
@@ -1044,11 +1022,13 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(previous_capture_events);
     }
+    ClearTemporaryContainers();
     return false;
   }
   scanable_state_history_.PopBack(1);
-  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  scanable_state_history_.PushBackIndirect(tmp_states_to_be_added_);
   is_completed_.back() = tmp_accept_stop_token_;
+  ClearTemporaryContainers();
   return true;
 }
 

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -466,7 +466,9 @@ class GrammarMatcher::Impl : public EarleyParser {
       int max_rollback_tokens = -1,
       std::optional<float> default_temperature = std::nullopt
   )
-      : EarleyParser(compiled_grammar->grammar),
+      : EarleyParser(
+            compiled_grammar->grammar, std::nullopt, &compiled_grammar->earley_parser_features
+        ),
         compiled_grammar_(compiled_grammar),
         tokenizer_info_(compiled_grammar->tokenizer_info),
         stop_token_ids_(override_stop_tokens.value_or(tokenizer_info_.GetStopTokenIds())),
@@ -475,7 +477,7 @@ class GrammarMatcher::Impl : public EarleyParser {
         tmp_accepted_bitset_(tokenizer_info_.GetVocabSize()) {
     XGRAMMAR_CHECK(!override_stop_tokens.has_value() || !override_stop_tokens->empty())
         << "The override_stop_tokens should not be empty";
-    if (has_budget_rules_ || has_char_budget_rules_) {
+    if (features_->has_budget_rules || features_->has_char_budget_rules) {
       for (int32_t rule_id = 0; rule_id < grammar_->NumRules(); ++rule_id) {
         const auto& rule = grammar_->GetRule(rule_id);
         if (rule.max_tokens < 0 && rule.max_chars < 0) {
@@ -594,7 +596,7 @@ class GrammarMatcher::Impl : public EarleyParser {
   class CaptureRecordingGuard {
    public:
     explicit CaptureRecordingGuard(Impl* impl) : impl_(impl) {
-      if (impl_->capture_tracking_) {
+      if (impl_->features_->capture_tracking) {
         impl_->capture_recording_ = true;
       }
     }
@@ -624,7 +626,7 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   /*! \brief Whether byte offsets are needed for captures or budgeted suffix/stop rules. */
   bool ShouldTrackAcceptedBytes() const {
-    return IsCaptureTrackingEnabled() || has_budget_marker_rules_;
+    return features_->capture_tracking || has_budget_marker_rules_;
   }
 
   /*! \brief Whether the bytes consumed by this expired suffix/stop occurrence form a complete
@@ -971,7 +973,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
       previous_completable_row.data + previous_completable_row.data_len
   );
   std::vector<CaptureEvent> previous_capture_events;
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     previous_capture_events = CopyLastCaptureRow();
   }
   std::vector<ParserState> force_completed_states;
@@ -1038,7 +1040,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
   if (!viable) {
     rule_id_to_completable_states_.PopBack(1);
     rule_id_to_completable_states_.PushBack(previous_completable_states);
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(previous_capture_events);
     }
@@ -1072,7 +1074,7 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcementToFixedPoint(bool debu
 }
 
 bool GrammarMatcher::Impl::AdvanceWithCharacterBudget(uint8_t byte, bool debug_print) {
-  if (!has_char_budget_rules_ || !StartsUTF8Codepoint(byte)) {
+  if (!features_->has_char_budget_rules || !StartsUTF8Codepoint(byte)) {
     return Advance(byte, debug_print);
   }
 
@@ -1095,7 +1097,7 @@ bool GrammarMatcher::Impl::AdvanceWithCharacterBudget(uint8_t byte, bool debug_p
       previous_completable_row.data + previous_completable_row.data_len
   );
   std::vector<CaptureEvent> previous_capture_events;
-  if (capture_tracking_) {
+  if (features_->capture_tracking) {
     previous_capture_events = CopyLastCaptureRow();
   }
 
@@ -1110,7 +1112,7 @@ bool GrammarMatcher::Impl::AdvanceWithCharacterBudget(uint8_t byte, bool debug_p
     rule_id_to_completable_states_.PopBack(1);
     rule_id_to_completable_states_.PushBack(previous_completable_states);
     is_completed_.back() = previous_completed;
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(previous_capture_events);
     }
@@ -1123,7 +1125,7 @@ bool GrammarMatcher::Impl::AdvanceAtomicTokenWithCharacterBudget(
 ) {
   bool has_expired_state = false;
   bool crosses_budget = false;
-  if (has_char_budget_rules_ && token_char_count > 0) {
+  if (features_->has_char_budget_rules && token_char_count > 0) {
     for (const auto& state : scanable_state_history_[scanable_state_history_.size() - 1]) {
       has_expired_state = has_expired_state || IsCharExpiredState(state);
       crosses_budget =
@@ -1145,7 +1147,7 @@ bool GrammarMatcher::Impl::AdvanceAtomicTokenWithCharacterBudget(
         previous_completable_row.data + previous_completable_row.data_len
     );
     previous_completed = IsCompleted();
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       previous_capture_events = CopyLastCaptureRow();
     }
     enforced = ApplyCharacterBudgetEnforcementToFixedPoint(debug_print);
@@ -1161,7 +1163,7 @@ bool GrammarMatcher::Impl::AdvanceAtomicTokenWithCharacterBudget(
     rule_id_to_completable_states_.PopBack(1);
     rule_id_to_completable_states_.PushBack(previous_completable_states);
     is_completed_.back() = previous_completed;
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(previous_capture_events);
     }
@@ -1259,7 +1261,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   // The token extends a derivation past its budget iff expired states are allowed to scan
   // (no enforcement) while some exist.
   bool consumed_past_deadline = false;
-  if (has_budget_rules_ && !enforce_budget) {
+  if (features_->has_budget_rules && !enforce_budget) {
     const auto& row = scanable_state_history_[scanable_state_history_.size() - 1];
     for (const auto& state : row) {
       if (IsExpiredState(state)) {
@@ -1290,7 +1292,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
 
   const auto& token = tokenizer_info_.GetDecodedVocab()[token_id];
   int32_t token_char_count = 0;
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     for (uint8_t byte : token) {
       token_char_count += StartsUTF8Codepoint(byte);
     }
@@ -1301,7 +1303,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   std::vector<std::pair<int32_t, ParserState>> completable_before_token;
   std::vector<CaptureEvent> capture_row_before_token;
   bool completed_before_token = false;
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     states_before_token = GetLatestScanableStates();
     auto completable_row_before_token = rule_id_to_completable_states_.Back();
     completable_before_token.assign(
@@ -1312,7 +1314,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     completed_before_token = is_completed_.back();
   }
   auto restore_row_before_token = [&]() {
-    if (!has_char_budget_rules_) {
+    if (!features_->has_char_budget_rules) {
       return;
     }
     scanable_state_history_.PopBack(1);
@@ -1320,7 +1322,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     rule_id_to_completable_states_.PopBack(1);
     rule_id_to_completable_states_.PushBack(completable_before_token);
     is_completed_.back() = completed_before_token;
-    if (capture_tracking_) {
+    if (features_->capture_tracking) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(capture_row_before_token);
     }
@@ -1332,7 +1334,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   std::vector<CaptureEvent> atomic_capture_row;
   bool atomic_completed = false;
   bool atomic_success =
-      has_char_budget_rules_
+      features_->has_char_budget_rules
           ? AdvanceAtomicTokenWithCharacterBudget(token_id, token_char_count, debug_print)
           : AdvanceAtomicToken(token_id, debug_print);
   if (atomic_success) {
@@ -1347,7 +1349,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
 
   // Phase 2: Try byte-by-byte path (from the same original state)
   record_char_budget_relaxation_ = true;
-  bool track_temporary_input = has_char_budget_rules_ && has_budget_marker_rules_;
+  bool track_temporary_input = features_->has_char_budget_rules && has_budget_marker_rules_;
   if (track_temporary_input) {
     temporary_input_start_row_ = scanable_state_history_.size() - 1;
     temporary_input_bytes_.clear();
@@ -1355,7 +1357,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   int pos = 0;
   bool byte_path_success = true;
   for (auto char_value : token) {
-    bool accepted = has_char_budget_rules_
+    bool accepted = features_->has_char_budget_rules
                         ? AdvanceWithCharacterBudget(static_cast<uint8_t>(char_value), debug_print)
                         : Advance(static_cast<uint8_t>(char_value), debug_print);
     if (!accepted) {
@@ -1390,7 +1392,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     restore_row_before_token();
     char_budget_relaxed_ = false;
     bool accepted =
-        has_char_budget_rules_
+        features_->has_char_budget_rules
             ? AdvanceAtomicTokenWithCharacterBudget(token_id, token_char_count, debug_print)
             : AdvanceAtomicToken(token_id, debug_print);
     XGRAMMAR_DCHECK(accepted);
@@ -1503,7 +1505,7 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   if (debug_print) {
     XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<" << EscapeString(token) << "> accepted.";
   }
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     // Close exhausted occurrences at the token boundary, including after zero-byte atomic tokens.
     ApplyCharacterBudgetEnforcementToFixedPoint(debug_print);
   }
@@ -1535,7 +1537,7 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
   std::vector<std::pair<int32_t, ParserState>> completable_before_input;
   std::vector<CaptureEvent> capture_row_before_input;
   bool completed_before_input = false;
-  if (has_char_budget_rules_) {
+  if (features_->has_char_budget_rules) {
     states_before_input = GetLatestScanableStates();
     auto completable_row_before_input = rule_id_to_completable_states_.Back();
     completable_before_input.assign(
@@ -1545,14 +1547,14 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
     capture_row_before_input = CopyLastCaptureRow();
     completed_before_input = is_completed_.back();
   }
-  bool track_temporary_input = has_char_budget_rules_ && has_budget_marker_rules_;
+  bool track_temporary_input = features_->has_char_budget_rules && has_budget_marker_rules_;
   if (track_temporary_input) {
     temporary_input_start_row_ = scanable_state_history_.size() - 1;
     temporary_input_bytes_.clear();
   }
   int accepted_cnt = 0;
   for (auto char_value : input_str) {
-    bool accepted = has_char_budget_rules_
+    bool accepted = features_->has_char_budget_rules
                         ? AdvanceWithCharacterBudget(static_cast<uint8_t>(char_value), debug_print)
                         : Advance(static_cast<uint8_t>(char_value), debug_print);
     if (!accepted) {
@@ -1561,13 +1563,13 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
                            << "position " << accepted_cnt << ", char " << EscapeString(char_value);
       }
       PopLastStates(accepted_cnt);
-      if (has_char_budget_rules_) {
+      if (features_->has_char_budget_rules) {
         scanable_state_history_.PopBack(1);
         scanable_state_history_.PushBack(states_before_input);
         rule_id_to_completable_states_.PopBack(1);
         rule_id_to_completable_states_.PushBack(completable_before_input);
         is_completed_.back() = completed_before_input;
-        if (capture_tracking_) {
+        if (features_->capture_tracking) {
           capture_event_history_.PopBack(1);
           capture_event_history_.PushBack(capture_row_before_input);
         }
@@ -1593,7 +1595,7 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
   if (ShouldTrackAcceptedBytes()) {
     AppendPerByteRows(input_str);
   }
-  if (has_char_budget_rules_ && !input_str.empty()) {
+  if (features_->has_char_budget_rules && !input_str.empty()) {
     // Leave the parser at the enforced boundary even when no later input is supplied.
     ApplyCharacterBudgetEnforcementToFixedPoint(debug_print);
   }
@@ -1649,7 +1651,7 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
   int32_t* bitmask_data_ptr =
       CheckAndGetBitmaskPtr(*next_token_bitmask, tokenizer_info_.GetVocabSize(), index);
   current_token_index_ = static_cast<int32_t>(token_length_history.size());
-  if (has_budget_rules_) {
+  if (features_->has_budget_rules) {
     const auto& row = scanable_state_history_[scanable_state_history_.size() - 1];
     bool any_expired = false;
     bool any_alive = false;
@@ -1859,7 +1861,11 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
 
   for (const auto& state : latest_states) {
     const AdaptiveTokenMask& adaptive_token_mask = compiled_grammar_->token_mask_cache.Get(
-        state, state.rule_id == grammar_->GetRootRuleId(), grammar_, tokenizer_info_
+        state,
+        state.rule_id == grammar_->GetRootRuleId(),
+        grammar_,
+        tokenizer_info_,
+        compiled_grammar_->earley_parser_features
     );
     if (state.char_budget_deadline >= 0) {
       int32_t remaining_chars = state.char_budget_deadline - GetCurrentCharIndex();
@@ -1894,12 +1900,12 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
 
     // Examine only the current one ParserState
     std::optional<Impl> atomic_trial_base;
-    if (has_char_budget_rules_ && !adaptive_token_mask.uncertain_indices.empty()) {
+    if (features_->has_char_budget_rules && !adaptive_token_mask.uncertain_indices.empty()) {
       atomic_trial_base.emplace(*this);
       atomic_trial_base->capture_recording_ = false;
     }
     PushOneStateToCheck(state);
-    bool track_temporary_input = has_char_budget_rules_ && has_budget_marker_rules_;
+    bool track_temporary_input = features_->has_char_budget_rules && has_budget_marker_rules_;
     int32_t saved_temporary_input_start_row = -1;
     std::string saved_temporary_input_bytes;
     if (track_temporary_input) {
@@ -1932,7 +1938,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
       }
 
       const auto& cur_token = sorted_decoded_vocab[cur_token_idx].second;
-      bool accepted = !cur_token.empty() || !has_char_budget_rules_;
+      bool accepted = !cur_token.empty() || !features_->has_char_budget_rules;
 
       // Step 2.1. Find the longest common prefix with the accepted part of the previous token.
       // We can reuse the previous matched size to avoid unnecessary matching.
@@ -1957,7 +1963,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
       // Step 2.2. Find if the current token is accepted or rejected.
       if (accepted) {
         for (int j = prev_matched_size; j < static_cast<int>(cur_token.size()); ++j) {
-          bool byte_accepted = has_char_budget_rules_
+          bool byte_accepted = features_->has_char_budget_rules
                                    ? AdvanceWithCharacterBudget(static_cast<uint8_t>(cur_token[j]))
                                    : Advance(static_cast<uint8_t>(cur_token[j]));
           if (!byte_accepted) {
@@ -1972,7 +1978,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
         }
       }
 
-      if (!accepted && has_char_budget_rules_) {
+      if (!accepted && features_->has_char_budget_rules) {
         int32_t token_char_count = 0;
         for (uint8_t byte : cur_token) {
           token_char_count += StartsUTF8Codepoint(byte);
@@ -2133,7 +2139,7 @@ void GrammarMatcher::Impl::Rollback(int num_tokens) {
 std::vector<std::pair<std::string, std::string>> GrammarMatcher::Impl::GetCaptures(bool deduplicate
 ) const {
   std::vector<std::pair<std::string, std::string>> result;
-  if (!IsCaptureTrackingEnabled()) {
+  if (!features_->capture_tracking) {
     return result;
   }
   XGRAMMAR_DCHECK(capture_event_history_.size() == static_cast<int32_t>(row_byte_end_.size()))

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -1830,7 +1830,6 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
 ) {
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
   const auto& subtree_range = tokenizer_info_.GetTrieSubtreeNodesRange();
-  const auto& adaptive_token_mask_cache = compiled_grammar_->adaptive_token_mask_cache;
   // We need to have a copy, because scanable_state_history_ will be modified during the
   // FillNextTokenBitmask process, which can lead to undefined behavior.
   std::vector<ParserState> latest_states;
@@ -1856,13 +1855,12 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
                        << ", num of states=" << latest_states.size();
   }
 
-  std::vector<std::pair<ParserState, decltype(adaptive_token_mask_cache.cbegin())>>
-      latest_states_with_masks;
+  std::vector<std::pair<ParserState, const AdaptiveTokenMask*>> latest_states_with_masks;
 
   for (const auto& state : latest_states) {
-    auto adaptive_token_mask_it = adaptive_token_mask_cache.find(state);
-    XGRAMMAR_CHECK(adaptive_token_mask_it != adaptive_token_mask_cache.end()) << state;
-    const auto& adaptive_token_mask = adaptive_token_mask_it->second;
+    const AdaptiveTokenMask& adaptive_token_mask = compiled_grammar_->token_mask_cache.Get(
+        state, state.rule_id == grammar_->GetRootRuleId(), grammar_, tokenizer_info_
+    );
     if (state.char_budget_deadline >= 0) {
       int32_t remaining_chars = state.char_budget_deadline - GetCurrentCharIndex();
       if (remaining_chars <= tokenizer_info_.ImplPtr()->GetMaxTokenChars()) {
@@ -1870,7 +1868,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
         continue;
       }
     }
-    latest_states_with_masks.push_back(std::make_pair(state, adaptive_token_mask_it));
+    latest_states_with_masks.emplace_back(state, &adaptive_token_mask);
     if (adaptive_token_mask.store_type == StoreType::kAcceptedBitset) {
       tmp_accepted_bitset_ |= adaptive_token_mask.accepted_bitset;
     } else if (adaptive_token_mask.store_type == StoreType::kAccepted) {
@@ -1880,8 +1878,8 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
     }
   }
 
-  for (const auto& [state, adaptive_token_mask_it] : latest_states_with_masks) {
-    const auto& adaptive_token_mask = adaptive_token_mask_it->second;
+  for (const auto& [state, adaptive_token_mask_ptr] : latest_states_with_masks) {
+    const auto& adaptive_token_mask = *adaptive_token_mask_ptr;
 
     // For each ParserState, we will check every uncertain token and put them into the accepted or
     // rejected list.

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2194,6 +2194,16 @@ int32_t JSONSchemaConverter::GenerateFromSpec(
 int32_t JSONSchemaConverter::RegexExpression(
     const std::string& regex, bool json_string, bool force_cfg_expansion
 ) {
+  std::string cache_key;
+  cache_key.reserve(regex.size() + 2);
+  cache_key.push_back(static_cast<char>(json_string));
+  cache_key.push_back(static_cast<char>(force_cfg_expansion));
+  cache_key.append(regex);
+  const auto cached = regex_expr_ids_.find(cache_key);
+  if (cached != regex_expr_ids_.end()) {
+    return cached->second;
+  }
+
   bool can_use_fsm = !force_cfg_expansion;
   if (json_string) {
     can_use_fsm =
@@ -2212,14 +2222,18 @@ int32_t JSONSchemaConverter::RegexExpression(
             return fsm.IsEndState(state);
           });
       if (!language_is_empty) {
-        return builder_.AddRegex(regex, json_string);
+        const int32_t result = builder_.AddRegex(regex, json_string);
+        regex_expr_ids_.emplace(std::move(cache_key), result);
+        return result;
       }
     }
   }
 
   // Keep regex conversion independent. Only the uncommon fallback path converts its existing
   // EBNF result to a subgrammar; the JSON Schema rule graph itself is still built directly.
-  return AddSubGrammar(Grammar::FromEBNF(RegexToEBNF(regex)));
+  const int32_t result = AddSubGrammar(Grammar::FromEBNF(RegexToEBNF(regex)));
+  regex_expr_ids_.emplace(std::move(cache_key), result);
+  return result;
 }
 
 // ==================== Generate Methods ====================

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -476,6 +476,7 @@ class JSONSchemaConverter {
   std::optional<int32_t> empty_expr_id_;
   std::unordered_map<std::string, int32_t> byte_string_expr_ids_;
   std::unordered_map<int32_t, int32_t> rule_ref_expr_ids_;
+  std::unordered_map<std::string, int32_t> regex_expr_ids_;
   std::optional<int32_t> whitespace_expr_id_;
 
   // Helper for integer/number range regex generation

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -93,12 +93,11 @@ picojson::value ConstStringFormat::ToJSON() const {
 picojson::value JSONSchemaFormat::ToJSON() const {
   picojson::object obj;
   obj["type"] = picojson::value(type);
-  picojson::value schema_val;
-  if (picojson::parse(schema_val, json_schema).empty()) {
-    obj["json_schema"] = schema_val;
-  } else {
-    obj["json_schema"] = picojson::value(json_schema);
-  }
+  // Embed the schema text as a string. ToJSON is only consumed by the converter's
+  // deduplication fingerprint, so reparsing the schema into a JSON value is unnecessary
+  // and would cost a full JSON parse of potentially large schemas at every fingerprinted
+  // ancestor format.
+  obj["json_schema"] = picojson::value(json_schema);
   obj["style"] = picojson::value(style);
   obj["any_order"] = picojson::value(any_order);
   if (max_whitespace_cnt.has_value()) {
@@ -1759,6 +1758,11 @@ class StructuralTagGrammarConverter {
    * \note This method uses serialization to deduplicate identical formats.
    */
   Result<int, ISTError> Visit(const Format& format);
+
+  /*!
+   * \brief Dispatch a Format to the matching VisitSub overload, without fingerprinting.
+   */
+  Result<int, ISTError> VisitDispatch(const Format& format);
   Result<int, ISTError> VisitSub(const ConstStringFormat& format);
   Result<int, ISTError> VisitSub(const JSONSchemaFormat& format);
   Result<int, ISTError> VisitSub(const AnyTextFormat& format);
@@ -1804,7 +1808,10 @@ bool StructuralTagGrammarConverter::IsPrefix(
 Result<Grammar, ISTError> StructuralTagGrammarConverter::Convert(const StructuralTag& structural_tag
 ) {
   StructuralTagGrammarConverter converter;
-  auto result = converter.Visit(structural_tag.format);
+  // The root format is visited exactly once, so fingerprinting the entire format tree cannot
+  // produce a cache hit. Dispatch directly; nested formats still go through Visit() and retain
+  // deduplication.
+  auto result = converter.VisitDispatch(structural_tag.format);
   if (result.IsErr()) {
     return ResultErr(std::move(result).UnwrapErr());
   }
@@ -1821,6 +1828,12 @@ Grammar StructuralTagGrammarConverter::AddRootRuleAndGetGrammar(int ref_rule_id)
   return grammar_builder_.Get(root_rule_id);
 }
 
+Result<int, ISTError> StructuralTagGrammarConverter::VisitDispatch(const Format& format) {
+  return std::visit(
+      [&](const auto& arg) -> Result<int, ISTError> { return VisitSub(arg); }, format
+  );
+}
+
 Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format) {
   std::string fingerprint = FormatToJSONValue(format).serialize();
 
@@ -1831,8 +1844,7 @@ Result<int, ISTError> StructuralTagGrammarConverter::Visit(const Format& format)
   }
 
   // Process the format and cache the result
-  auto result =
-      std::visit([&](auto&& arg) -> Result<int, ISTError> { return VisitSub(arg); }, format);
+  auto result = VisitDispatch(format);
   if (result.IsOk()) {
     int rule_id = std::move(result).Unwrap();
     serialization_to_rule_id_[fingerprint] = rule_id;

--- a/cpp/support/compact_2d_array.h
+++ b/cpp/support/compact_2d_array.h
@@ -190,6 +190,13 @@ class Compact2DArray {
   int32_t PushBack(const std::vector<DataType>& new_data);
 
   /*!
+   * \brief Insert a row by copying elements referenced by stable pointers.
+   * \param new_data Pointers to the elements to be inserted.
+   * \return The index of the newly inserted row.
+   */
+  int32_t PushBackIndirect(const std::vector<const DataType*>& new_data);
+
+  /*!
    * \brief Insert a new row of data into the Compact2DArray from a Row struct.
    * \param row The Row struct containing the data to be inserted.
    * \return The index of the newly inserted row.
@@ -345,6 +352,18 @@ template <typename DataType>
 inline int32_t Compact2DArray<DataType>::PushBack(const std::vector<DataType>& new_data) {
   CheckCanAppendData(new_data.size());
   data_.insert(data_.end(), new_data.begin(), new_data.end());
+  indptr_.push_back(static_cast<int32_t>(data_.size()));
+  return static_cast<int32_t>(indptr_.size()) - 2;
+}
+
+template <typename DataType>
+inline int32_t Compact2DArray<DataType>::PushBackIndirect(
+    const std::vector<const DataType*>& new_data
+) {
+  CheckCanAppendData(new_data.size());
+  for (const DataType* element : new_data) {
+    data_.push_back(*element);
+  }
   indptr_.push_back(static_cast<int32_t>(data_.size()));
   return static_cast<int32_t>(indptr_.size()) - 2;
 }

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -196,13 +196,15 @@ class GrammarCompilerObj : public ffi::Object {
       ffi::ObjectRef tokenizer_ref,
       int64_t max_threads,
       bool cache_enabled,
-      int64_t max_memory_bytes
+      int64_t max_memory_bytes,
+      bool enable_dynamic_compilation
   )
       : value(
             tokenizer_ref.as<TokenizerInfoObj>()->value,
             static_cast<int>(max_threads),
             cache_enabled,
-            max_memory_bytes
+            max_memory_bytes,
+            enable_dynamic_compilation
         ) {}
 
   static constexpr bool _type_mutable = true;
@@ -502,9 +504,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
         XGRAMMAR_FFI_TRY_END();
       });
 
-  // GrammarCompiler: init(tokenizer_info, max_threads, cache_enabled, max_memory_bytes)
+  // GrammarCompiler: init(tokenizer_info, max_threads, cache_enabled, max_memory_bytes,
+  //                       enable_dynamic_compilation)
   refl::ObjectDef<GrammarCompilerObj>()
-      .def(refl::init<O, int64_t, bool, int64_t>())
+      .def(refl::init<O, int64_t, bool, int64_t, bool>())
       .def(
           "compile_json_schema",
           [](GrammarCompilerObj* o,

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -63,12 +63,14 @@ class GrammarCompiler {
    * \param max_threads The maximum number of threads to use for compiling grammars.
    * \param cache_enabled Whether to enable the cache.
    * \param max_memory_bytes The maximum memory usage in bytes.
+   * \param enable_dynamic_compilation Whether to generate token masks on first use.
    */
   GrammarCompiler(
       const TokenizerInfo& tokenizer_info,
       int max_threads = 8,
       bool cache_enabled = true,
-      int64_t max_memory_bytes = -1  // unlimited
+      int64_t max_memory_bytes = -1,  // unlimited
+      bool enable_dynamic_compilation = false
   );
 
   /*! \brief Get the compiled grammar for a JSON schema string. */

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -110,6 +110,7 @@ class GrammarCompiler(XGRObject):
         max_threads: int = 8,
         cache_enabled: bool = True,
         cache_limit_bytes: int = -1,
+        enable_dynamic_compilation: bool = False,
     ):
         """Construct the compiler.
 
@@ -127,6 +128,9 @@ class GrammarCompiler(XGRObject):
         cache_limit_bytes : int, default: -1
             The maximum memory usage for the cache in the specified unit.
             Note that the actual memory usage may slightly exceed this value.
+
+        enable_dynamic_compilation : bool, default: False
+            Whether to generate token masks when they are first needed.
         """
         if not isinstance(tokenizer_info, TokenizerInfo):
             raise ValueError(
@@ -136,7 +140,11 @@ class GrammarCompiler(XGRObject):
 
         self._init_handle(
             _core.GrammarCompiler(
-                tokenizer_info._handle, max_threads, cache_enabled, cache_limit_bytes
+                tokenizer_info._handle,
+                max_threads,
+                cache_enabled,
+                cache_limit_bytes,
+                enable_dynamic_compilation,
             )
         )
 

--- a/tests/cpp/test_earley_parser.cc
+++ b/tests/cpp/test_earley_parser.cc
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+#include "earley_parser.h"
+#include "grammar_functor.h"
+
+TEST(RepeatDetectorTest, PreservesStatesAcrossSetTransitionAndResetsCopies) {
+  xgrammar::RepeatDetector detector(2);
+  const xgrammar::ParserState first_state(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+  const xgrammar::ParserState second_state(11, 12, 13, 14, 15, 16, 17, 18, 19, 20);
+  const xgrammar::ParserState third_state(21, 22, 23, 24, 25, 26, 27, 28, 29, 30);
+
+  const xgrammar::ParserState* stored_first = detector.InsertIfAbsent(first_state);
+  const xgrammar::ParserState* stored_second = detector.InsertIfAbsent(second_state);
+  ASSERT_NE(stored_first, nullptr);
+  ASSERT_NE(stored_second, nullptr);
+  EXPECT_EQ(detector.InsertIfAbsent(first_state), nullptr);
+
+  const xgrammar::ParserState* stored_third = detector.InsertIfAbsent(third_state);
+  ASSERT_NE(stored_third, nullptr);
+  EXPECT_TRUE(xgrammar::StateEqualForParsing()(*stored_first, first_state));
+  EXPECT_TRUE(xgrammar::StateEqualForParsing()(*stored_second, second_state));
+  EXPECT_TRUE(xgrammar::StateEqualForParsing()(*stored_third, third_state));
+
+  xgrammar::RepeatDetector copied_detector(detector);
+  EXPECT_NE(copied_detector.InsertIfAbsent(first_state), nullptr);
+
+  detector.Clear();
+  EXPECT_NE(detector.InsertIfAbsent(first_state), nullptr);
+}
+
+TEST(EarleyParserTest, HandlesMoreThanFiftyStatesAcrossCopyFailureAndReset) {
+  constexpr int32_t branch_count = 64;
+  std::string grammar_text = "root ::= ";
+  for (int32_t branch_index = 0; branch_index < branch_count; ++branch_index) {
+    if (branch_index != 0) {
+      grammar_text += " | ";
+    }
+    grammar_text += "branch_" + std::to_string(branch_index);
+  }
+  for (int32_t branch_index = 0; branch_index < branch_count; ++branch_index) {
+    std::string suffix;
+    suffix += static_cast<char>('A' + branch_index / 26);
+    suffix += static_cast<char>('a' + branch_index % 26);
+    grammar_text += "\nbranch_" + std::to_string(branch_index) + " ::= prefix_" +
+                    std::to_string(branch_index) + " \"" + suffix + "\"";
+    grammar_text += "\nprefix_" + std::to_string(branch_index) + " ::= \"a\"";
+  }
+
+  xgrammar::Grammar grammar =
+      xgrammar::GrammarOptimizer::Apply(xgrammar::Grammar::FromEBNF(grammar_text));
+  xgrammar::EarleyParser parser(grammar);
+  ASSERT_GT(parser.GetLatestScanableStates().size(), 50);
+
+  xgrammar::EarleyParser copied_parser(parser);
+  EXPECT_FALSE(parser.Advance('!'));
+  EXPECT_FALSE(copied_parser.Advance('!'));
+
+  for (char character : std::string("aCl")) {
+    ASSERT_TRUE(parser.Advance(static_cast<uint8_t>(character)));
+    ASSERT_TRUE(copied_parser.Advance(static_cast<uint8_t>(character)));
+    if (character == 'a') {
+      EXPECT_GT(parser.GetLatestScanableStates().size(), 50);
+      EXPECT_GT(copied_parser.GetLatestScanableStates().size(), 50);
+    }
+  }
+  EXPECT_TRUE(parser.IsCompleted());
+  EXPECT_TRUE(copied_parser.IsCompleted());
+
+  parser.Reset();
+  for (char character : std::string("aAa")) {
+    ASSERT_TRUE(parser.Advance(static_cast<uint8_t>(character)));
+  }
+  EXPECT_TRUE(parser.IsCompleted());
+}

--- a/tests/cpp/test_grammar_fsm_hasher.cc
+++ b/tests/cpp/test_grammar_fsm_hasher.cc
@@ -1,0 +1,70 @@
+/**
+ * \file tests/cpp/test_grammar_fsm_hasher.cc
+ * \brief Regression tests for canonical grammar FSM hashing.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "grammar_functor.h"
+#include "grammar_impl.h"
+#include "xgrammar/grammar.h"
+
+using namespace xgrammar;
+
+namespace {
+
+int32_t FindRule(const Grammar& grammar, const std::string& name) {
+  for (int32_t rule_id = 0; rule_id < grammar->NumRules(); ++rule_id) {
+    if (grammar->GetRule(rule_id).name == name) {
+      return rule_id;
+    }
+  }
+  return -1;
+}
+
+int CountRuleEdges(const CompactFSMWithStartEnd& fsm) {
+  int result = 0;
+  for (int32_t state = 0; state < fsm.NumStates(); ++state) {
+    for (const auto& edge : fsm.GetFsm().GetEdges(state)) {
+      result += edge.IsRuleRef();
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+TEST(XGrammarFSMHasherTest, RuleEdgeScratchIsScopedToEachState) {
+  auto grammar = Grammar::FromEBNF(R"(
+root ::= left | right
+left ::= ref "x" | "a" ref "y"
+right ::= "a" ref "y" | ref "x"
+ref ::= "z"
+)");
+  GrammarFSMBuilder::Apply(&grammar);
+  GrammarFSMHasher::Apply(&grammar);
+
+  const int32_t left = FindRule(grammar, "left");
+  const int32_t right = FindRule(grammar, "right");
+  ASSERT_GE(left, 0);
+  ASSERT_GE(right, 0);
+  ASSERT_TRUE(grammar->per_rule_fsms[left].has_value());
+  ASSERT_TRUE(grammar->per_rule_fsms[right].has_value());
+  EXPECT_GE(CountRuleEdges(grammar->per_rule_fsms[left]->GetFsm()), 2);
+  EXPECT_GE(CountRuleEdges(grammar->per_rule_fsms[right]->GetFsm()), 2);
+
+  ASSERT_TRUE(grammar->per_rule_fsm_hashes[left].has_value());
+  ASSERT_TRUE(grammar->per_rule_fsm_hashes[right].has_value());
+  EXPECT_EQ(grammar->per_rule_fsm_hashes[left], grammar->per_rule_fsm_hashes[right]);
+
+  const auto first_hashes = grammar->per_rule_fsm_hashes;
+  const auto first_state_ids = grammar->per_rule_fsm_new_state_ids;
+  GrammarFSMHasher::Apply(&grammar);
+  EXPECT_EQ(grammar->per_rule_fsm_hashes, first_hashes);
+  EXPECT_EQ(grammar->per_rule_fsm_new_state_ids, first_state_ids);
+}

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -6,6 +6,7 @@ import torch
 
 import xgrammar as xgr
 from xgrammar.base import _core
+from xgrammar.testing import bitmask_to_bool_mask
 
 VOCABULARY = [chr(value) for value in range(32, 127)] + ["Ada", "hello", "42", "<call>"]
 
@@ -322,3 +323,36 @@ def test_rule_mask_sharing_distinguishes_lookahead_expression_boundaries(
 
     assert not torch.equal(first_mask, expected_mask)
     torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_shared_parser_features_preserve_budget_and_capture_behavior():
+    tokenizer_info = xgr.TokenizerInfo(["ab ", "cd", " ", "</t>", "1", "<t>", "x"])
+    grammar = xgr.Grammar.from_lark(
+        'start: r "<t>"\nr[max_tokens=3, capture]: TEXT\nTEXT: /(\\n|.)*/',
+        tokenizer_info=tokenizer_info,
+    )
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(grammar)
+    for _ in range(4):
+        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        assert all(matcher.accept_token(token_id) for token_id in [0, 1, 2])
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        assert matcher.fill_next_token_bitmask(bitmask)
+        assert bitmask_to_bool_mask(bitmask, tokenizer_info.vocab_size).nonzero().tolist() == [
+            [0, 5]
+        ]
+        assert matcher.accept_token(5)
+        assert matcher.is_terminated()
+        assert matcher.get_captures() == [("r", b"ab cd ")]
+
+    grammar = xgr.Grammar.from_lark(
+        'start[capture="outer"]: r "z"\n' 'r[max_chars=2, capture="inner", suffix="!"]: /[a-z]*/'
+    )
+    compiled = xgr.GrammarCompiler(xgr.TokenizerInfo([])).compile_grammar(grammar)
+    for _ in range(4):
+        for value, expected_captures in [
+            ("a!z", [("inner", b"a"), ("outer", b"a!z")]),
+            ("abz", [("inner", b"ab"), ("outer", b"abz")]),
+        ]:
+            matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+            assert matcher.accept_string(value) and matcher.is_terminated()
+            assert matcher.get_captures() == expected_captures

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -223,6 +223,60 @@ def test_limited_compiler_cache_records_dynamic_grammar_size_on_insertion():
             future.result()
         observed_sizes = size_future.result()
 
-    assert all(size == insertion_size for size in observed_sizes)
-    assert compiler.get_cache_size_bytes() == insertion_size
+    assert all(insertion_size <= size <= cache_limit for size in observed_sizes)
+    assert insertion_size <= compiler.get_cache_size_bytes() <= cache_limit
     assert _compile_builtin_json(compiler).memory_size_bytes == dynamic.memory_size_bytes
+
+
+def test_rule_mask_sharing_does_not_cross_context_dependent_rules():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic_compiler = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    )
+    eager_compiler = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=False
+    )
+
+    unbounded = dynamic_compiler.compile_grammar('root ::= "a" shared "z"\nshared ::= [x]+')
+    _mask_trace(unbounded, "axxz")
+
+    bounded_grammar = 'root ::= "a" shared "z"\nshared[max_tokens=1] ::= [x]+'
+    dynamic_bounded = dynamic_compiler.compile_grammar(bounded_grammar)
+    eager_bounded = eager_compiler.compile_grammar(bounded_grammar)
+    expected = _mask_trace(eager_bounded, "axz")
+    actual = _mask_trace(dynamic_bounded, "axz")
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+        assert actual_apply == expected_apply
+        torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("enable_dynamic_compilation", [False, True], ids=["eager", "dynamic"])
+@pytest.mark.parametrize("edge_name", ["Token", "ExcludeToken"])
+def test_rule_mask_sharing_distinguishes_token_edge_payloads(enable_dynamic_compilation, edge_name):
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c"], stop_token_ids=[])
+    cached_compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=True,
+        enable_dynamic_compilation=enable_dynamic_compilation,
+    )
+    uncached_compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=False,
+        enable_dynamic_compilation=enable_dynamic_compilation,
+    )
+
+    def initial_mask(compiled_grammar):
+        matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        xgr.reset_token_bitmask(bitmask)
+        assert matcher.fill_next_token_bitmask(bitmask)
+        return bitmask
+
+    first_mask = initial_mask(cached_compiler.compile_grammar(f"root ::= {edge_name}(0)"))
+    actual_mask = initial_mask(cached_compiler.compile_grammar(f"root ::= {edge_name}(1)"))
+    expected_mask = initial_mask(uncached_compiler.compile_grammar(f"root ::= {edge_name}(1)"))
+
+    assert not torch.equal(first_mask, expected_mask)
+    torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -23,6 +23,12 @@ def _mask_trace(compiled_grammar: xgr.CompiledGrammar, input_string: str):
     return trace
 
 
+def _next_token_mask(matcher: xgr.GrammarMatcher, vocabulary_size: int) -> torch.Tensor:
+    bitmask = xgr.allocate_token_bitmask(1, vocabulary_size)
+    matcher.fill_next_token_bitmask(bitmask)
+    return bitmask_to_bool_mask(bitmask, vocabulary_size)
+
+
 def _compile_ebnf(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
     return compiler.compile_grammar(
         """
@@ -356,3 +362,61 @@ def test_shared_parser_features_preserve_budget_and_capture_behavior():
             matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
             assert matcher.accept_string(value) and matcher.is_terminated()
             assert matcher.get_captures() == expected_captures
+
+
+def test_reusable_parser_worklists_survive_reset_fork_failure_and_rollback():
+    vocabulary = ["a", "b", "c", "d", "ab", "bc", "abc", "cd", "x", b"\xff"]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    compiled_grammar = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, enable_dynamic_compilation=True
+    ).compile_grammar('root ::= [a-c]{0,8} "d"')
+    token_identifiers = {token: vocabulary.index(token) for token in ["a", "b", "c", "d", "x"]}
+
+    def fresh_mask(prefix):
+        fresh_matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+        assert all(fresh_matcher.accept_token(token_identifier) for token_identifier in prefix)
+        return _next_token_mask(fresh_matcher, tokenizer_info.vocab_size)
+
+    matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+    for _ in range(32):
+        matcher.reset()
+        prefix = []
+        for token in ["a", "b"]:
+            expected_mask = fresh_mask(prefix)
+            torch.testing.assert_close(
+                _next_token_mask(matcher, tokenizer_info.vocab_size), expected_mask, rtol=0, atol=0
+            )
+            torch.testing.assert_close(
+                _next_token_mask(matcher, tokenizer_info.vocab_size), expected_mask, rtol=0, atol=0
+            )
+            assert matcher.accept_token(token_identifiers[token])
+            prefix.append(token_identifiers[token])
+
+        forked_matcher = matcher.fork()
+        torch.testing.assert_close(
+            _next_token_mask(forked_matcher, tokenizer_info.vocab_size),
+            fresh_mask(prefix),
+            rtol=0,
+            atol=0,
+        )
+        assert forked_matcher.accept_token(token_identifiers["c"])
+        assert forked_matcher.accept_token(token_identifiers["d"])
+        assert forked_matcher.is_terminated()
+
+        mask_before_failure = _next_token_mask(matcher, tokenizer_info.vocab_size)
+        assert not matcher.accept_token(token_identifiers["x"])
+        torch.testing.assert_close(
+            _next_token_mask(matcher, tokenizer_info.vocab_size),
+            mask_before_failure,
+            rtol=0,
+            atol=0,
+        )
+
+        matcher.rollback(1)
+        prefix.pop()
+        torch.testing.assert_close(
+            _next_token_mask(matcher, tokenizer_info.vocab_size), fresh_mask(prefix), rtol=0, atol=0
+        )
+        assert matcher.accept_token(token_identifiers["c"])
+        assert matcher.accept_token(token_identifiers["d"])
+        assert matcher.is_terminated()

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -280,3 +280,45 @@ def test_rule_mask_sharing_distinguishes_token_edge_payloads(enable_dynamic_comp
 
     assert not torch.equal(first_mask, expected_mask)
     torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("enable_dynamic_compilation", [False, True], ids=["eager", "dynamic"])
+def test_rule_mask_sharing_distinguishes_lookahead_expression_boundaries(
+    enable_dynamic_compilation,
+):
+    vocabulary = ["p", "qac", "qa\x01\x01aabb", "q"] + [f"invalid-{index}" for index in range(28)]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    cached_compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=True,
+        enable_dynamic_compilation=enable_dynamic_compilation,
+    )
+    uncached_compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=False,
+        enable_dynamic_compilation=enable_dynamic_compilation,
+    )
+
+    byte_string_suffix = r'"a\u0001\u0001aabb"'
+    character_class_suffix = '"a" [^ab]'
+
+    def grammar(suffix):
+        return f'root ::= "p" target {suffix}\ntarget ::= [q] (= {suffix})'
+
+    def mask_after_prefix(compiler, grammar_source):
+        compiled_grammar = compiler.compile_grammar(grammar_source)
+        matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+        assert matcher.accept_token(0)
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        xgr.reset_token_bitmask(bitmask)
+        assert matcher.fill_next_token_bitmask(bitmask)
+        return bitmask
+
+    first_mask = mask_after_prefix(cached_compiler, grammar(byte_string_suffix))
+    actual_mask = mask_after_prefix(cached_compiler, grammar(character_class_suffix))
+    expected_mask = mask_after_prefix(uncached_compiler, grammar(character_class_suffix))
+
+    assert not torch.equal(first_mask, expected_mask)
+    torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -1,0 +1,228 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import torch
+
+import xgrammar as xgr
+from xgrammar.base import _core
+
+VOCABULARY = [chr(value) for value in range(32, 127)] + ["Ada", "hello", "42", "<call>"]
+
+
+def _mask_trace(compiled_grammar: xgr.CompiledGrammar, input_string: str):
+    matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+    bitmask = xgr.allocate_token_bitmask(1, compiled_grammar.tokenizer_info.vocab_size)
+    trace = []
+    for char in input_string:
+        xgr.reset_token_bitmask(bitmask)
+        trace.append((matcher.fill_next_token_bitmask(bitmask), bitmask.clone()))
+        assert matcher.accept_string(char)
+    assert matcher.is_terminated()
+    return trace
+
+
+def _compile_ebnf(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_grammar(
+        """
+root ::= greeting punctuation
+greeting ::= "hello" | "hi"
+punctuation ::= "!" | "?"
+"""
+    )
+
+
+def _compile_json_schema(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_json_schema(
+        {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "scores": {"type": "array", "items": {"type": "integer"}},
+            },
+            "required": ["name", "scores"],
+            "additionalProperties": False,
+        },
+        any_whitespace=True,
+    )
+
+
+def _compile_regex(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_regex(r"[A-Z][a-z]{2}[0-9]+")
+
+
+def _compile_builtin_json(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_builtin_json_grammar()
+
+
+def _compile_structural_tag(compiler: xgr.GrammarCompiler) -> xgr.CompiledGrammar:
+    return compiler.compile_structural_tag(
+        {
+            "type": "structural_tag",
+            "format": {
+                "type": "dispatch",
+                "rules": [["<call>", {"type": "const_string", "value": "X"}]],
+                "loop": False,
+                "excludes": [],
+            },
+        }
+    )
+
+
+CASES = [
+    (_compile_ebnf, "hello!"),
+    (_compile_json_schema, '{"name":"Ada","scores":[1,2]}'),
+    (_compile_regex, "Ada42"),
+    (_compile_builtin_json, '{"name":"Ada"}'),
+    (_compile_structural_tag, "prefix<call>X"),
+]
+
+
+def test_native_constructor_takes_dynamic_compilation_flag():
+    tokenizer_info = xgr.TokenizerInfo(["a"], stop_token_ids=[])
+    for enable_dynamic_compilation in (False, True):
+        compiler = _core.GrammarCompiler(
+            tokenizer_info._handle, 1, True, -1, enable_dynamic_compilation
+        )
+        compiler.compile_builtin_json_grammar()
+
+
+@pytest.mark.parametrize(
+    "compile_grammar,input_string",
+    CASES,
+    ids=["ebnf", "json-schema", "regex", "builtin-json", "structural-tag"],
+)
+def test_dynamic_compilation_matches_eager_masks(compile_grammar, input_string):
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    eager = compile_grammar(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+    dynamic = compile_grammar(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+
+    expected = _mask_trace(eager, input_string)
+    actual = _mask_trace(dynamic, input_string)
+    assert len(actual) == len(expected)
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+        assert actual_apply == expected_apply
+        torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_dynamic_masks_are_cached():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic = _compile_builtin_json(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    eager = _compile_builtin_json(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+
+    initial_size = dynamic.memory_size_bytes
+    assert initial_size < eager.memory_size_bytes
+    _mask_trace(dynamic, '{"name":"Ada"}')
+    populated_size = dynamic.memory_size_bytes
+    assert populated_size > initial_size
+    _mask_trace(dynamic, '{"name":"Ada"}')
+    assert dynamic.memory_size_bytes == populated_size
+
+
+def test_serialization_roundtrips_dynamic_mode():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic = _compile_ebnf(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    eager = _compile_ebnf(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+    initial_size = dynamic.memory_size_bytes
+
+    restored = xgr.CompiledGrammar.deserialize_json(dynamic.serialize_json(), tokenizer_info)
+    # Serialization does not materialize masks, and the restored grammar is dynamic again.
+    assert dynamic.memory_size_bytes == initial_size
+    restored_initial_size = restored.memory_size_bytes
+    assert restored_initial_size < eager.memory_size_bytes
+    for input_string in ["hello!", "hi?"]:
+        expected = _mask_trace(eager, input_string)
+        actual = _mask_trace(restored, input_string)
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+            assert actual_apply == expected_apply
+            torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+    assert restored.memory_size_bytes > restored_initial_size
+
+
+def test_serialization_roundtrips_dynamic_tag_dispatch():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic = _compile_structural_tag(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+    eager = _compile_structural_tag(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=False)
+    )
+
+    restored = xgr.CompiledGrammar.deserialize_json(dynamic.serialize_json(), tokenizer_info)
+    expected = _mask_trace(eager, "prefix<call>X")
+    actual = _mask_trace(restored, "prefix<call>X")
+    for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+        assert actual_apply == expected_apply
+        torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "compile_grammar,input_string",
+    [
+        (_compile_json_schema, '{"name":"Ada","scores":[1,2]}'),
+        (_compile_structural_tag, "prefix<call>X"),
+    ],
+    ids=["json-schema", "structural-tag"],
+)
+def test_concurrent_dynamic_mask_generation(compile_grammar, input_string):
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    dynamic = compile_grammar(
+        xgr.GrammarCompiler(tokenizer_info, max_threads=1, enable_dynamic_compilation=True)
+    )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        traces = list(executor.map(lambda _: _mask_trace(dynamic, input_string), range(32)))
+
+    expected = traces[0]
+    for actual in traces[1:]:
+        for (expected_apply, expected_mask), (actual_apply, actual_mask) in zip(expected, actual):
+            assert actual_apply == expected_apply
+            torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
+
+
+def test_limited_compiler_cache_records_dynamic_grammar_size_on_insertion():
+    tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
+    cache_limit = 64 * 1024
+    compiler = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=True,
+        cache_limit_bytes=cache_limit,
+        enable_dynamic_compilation=True,
+    )
+    dynamic = _compile_builtin_json(compiler)
+    insertion_size = compiler.get_cache_size_bytes()
+    assert 0 < insertion_size <= cache_limit
+
+    barrier = threading.Barrier(9)
+
+    def generate_masks():
+        barrier.wait()
+        return _mask_trace(dynamic, '{"name":"Ada"}')
+
+    def read_cache_sizes():
+        barrier.wait()
+        return [compiler.get_cache_size_bytes() for _ in range(100)]
+
+    with ThreadPoolExecutor(max_workers=9) as executor:
+        mask_futures = [executor.submit(generate_masks) for _ in range(8)]
+        size_future = executor.submit(read_cache_sizes)
+        for future in mask_futures:
+            future.result()
+        observed_sizes = size_future.result()
+
+    assert all(size == insertion_size for size in observed_sizes)
+    assert compiler.get_cache_size_bytes() == insertion_size
+    assert _compile_builtin_json(compiler).memory_size_bytes == dynamic.memory_size_bytes

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -447,6 +447,32 @@ def _compiled_accepts(compiled_grammar: xgr.CompiledGrammar, input_str: str) -> 
     return matcher.accept_string(input_str) and matcher.is_terminated()
 
 
+def test_repeated_regex_fsm_reuse_preserves_nullable_rules():
+    tokenizer_info = xgr.TokenizerInfo(["!", "a", "aa", "b"], stop_token_ids=[])
+    grammar = xgr.Grammar.from_lark('start: left "!" right\nleft: /a*/\nright: /a*/')
+
+    compiled = xgr.GrammarCompiler(tokenizer_info, max_threads=1).compile_grammar(grammar)
+    for value in ["!", "a!", "!a", "aa!aa"]:
+        assert _compiled_accepts(compiled, value)
+    for value in ["", "aa", "!!", "b!"]:
+        assert not _compiled_accepts(compiled, value)
+
+
+def test_regex_fsm_cache_distinguishes_json_string_mode():
+    tokenizer_info = xgr.TokenizerInfo([])
+    grammar = xgr.Grammar.from_ebnf(
+        'root ::= plain "!" plain json "!" json\n'
+        'plain ::= Regex(".")\n'
+        'json ::= Regex(".", json_string=true)'
+    )
+
+    compiled = xgr.GrammarCompiler(tokenizer_info, max_threads=1).compile_grammar(grammar)
+    for value in ['"!ab!c', "\\!ab!c", "a!bc!d"]:
+        assert _compiled_accepts(compiled, value)
+    for value in ['a!a"!b', "a!a\\!b", "a!ab!\n"]:
+        assert not _compiled_accepts(compiled, value)
+
+
 def _mask_trace(compiled_grammar: xgr.CompiledGrammar, input_str: str):
     matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
     bitmask = xgr.allocate_token_bitmask(1, compiled_grammar.tokenizer_info.vocab_size)

--- a/tests/python/test_grammar_fsm_builder.py
+++ b/tests/python/test_grammar_fsm_builder.py
@@ -181,6 +181,31 @@ def test_recursive_rule_ref_in_sequence():
     assert not _matcher_accepts(matcher, "())")
 
 
+def test_large_byte_prefix_rule_ref_suffix_choices():
+    prefixes = ["a" * length for length in range(1, 65)]
+    alternatives = []
+    for index, prefix in enumerate(prefixes):
+        suffix = "!" if index % 2 == 0 else "?"
+        alternatives.append(f'"{prefix}" body "{suffix}"')
+    grammar = "root ::= " + " | ".join(alternatives) + "\nbody ::= [0-9]"
+    matcher = _make_string_matcher(grammar)
+
+    for index, prefix in enumerate(prefixes):
+        suffix = "!" if index % 2 == 0 else "?"
+        assert _matcher_accepts(matcher, prefix + "7" + suffix)
+        assert not _matcher_accepts(matcher, prefix + "7" + ("?" if suffix == "!" else "!"))
+        assert not _matcher_accepts(matcher, prefix + suffix)
+
+
+def test_nested_byte_prefix_rule_ref_suffix_choices_merge_outer_fsm():
+    grammar = _ebnf_to_grammar_no_normalization(
+        'root ::= ("a" body "x" | "ab" body "x") ("cd" | "ed")\nbody ::= [0-9]'
+    )
+    grammar = GrammarFunctor.fsm_builder(grammar)
+
+    assert "Rule 0: root, FSM: CompactFSM(num_states=9" in _print_grammar_fsms(grammar)
+
+
 # --- Empty sequence ---
 
 

--- a/tests/python/test_grammar_matcher_structural_tag.py
+++ b/tests/python/test_grammar_matcher_structural_tag.py
@@ -185,6 +185,23 @@ def test_structural_tag_compiler():
     assert str(compiled_grammar.grammar) == expected_grammar_test_structural_tag_after_optimization
 
 
+def test_structural_tag_overlapping_branch_prefixes():
+    tags = [
+        xgr.StructuralTagItem(
+            begin="<call>a", schema={"type": "string", "const": "one"}, end="</call>"
+        ),
+        xgr.StructuralTagItem(
+            begin="<call>ab", schema={"type": "string", "const": "two"}, end="</call>"
+        ),
+    ]
+    grammar = xgr.Grammar.from_structural_tag(tags, ["<call>"])
+
+    assert _is_grammar_accept_string(grammar, '<call>a"one"</call>')
+    assert _is_grammar_accept_string(grammar, '<call>ab"two"</call>')
+    assert not _is_grammar_accept_string(grammar, '<call>a"two"</call>')
+    assert not _is_grammar_accept_string(grammar, '<call>ab"one"</call>')
+
+
 @pytest.mark.hf_token_required
 def test_structural_tag_mask_gen():
     # Define schemas for the test

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -976,6 +976,23 @@ def test_restricted_string():
     )
 
 
+def test_repeated_string_patterns_preserve_each_property():
+    schema = {
+        "type": "object",
+        "properties": {
+            "first": {"type": "string", "pattern": "^[a-f]+$"},
+            "second": {"type": "string", "pattern": "^[a-f]+$"},
+        },
+        "required": ["first", "second"],
+        "additionalProperties": False,
+    }
+
+    check_schema_with_instance(schema, {"first": "ab", "second": "fa"}, any_whitespace=False)
+    check_schema_with_instance(
+        schema, {"first": "ab", "second": "z"}, is_accepted=False, any_whitespace=False
+    )
+
+
 def test_complex_restrictions():
     class RestrictedModel(BaseModel):
         restricted_string: str = Field(..., pattern=r"[^\"]*")

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -1711,6 +1711,29 @@ def test_lark_budget_shared_subrule() -> None:
     assert matcher.is_completed()
 
 
+def test_lark_budget_shared_subrule_keeps_parent_contexts_separate() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["p", "a", "b", "X", "Y"])
+    compiled = _compile_lark(
+        """
+        start: tight "X" | loose "Y"
+        tight[max_tokens=2]: shared
+        loose: shared
+        shared: "p" sub
+        sub: /[ab]+/
+        """,
+        tokenizer_info,
+    )
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+
+    assert matcher.accept_token(0)
+    assert matcher.accept_token(1)
+    assert 2 in _allowed_token_ids(matcher, tokenizer_info)
+    assert matcher.accept_token(2)
+    assert _allowed_token_ids(matcher, tokenizer_info) == [1, 2, 4]
+    assert not matcher.accept_token(3)
+    assert matcher.accept_token(4) and matcher.is_terminated()
+
+
 def test_lark_budget_round_trip_and_cache() -> None:
     grammar = xgr.Grammar.from_lark(BUDGET_GRAMMAR, tokenizer_info=MAX_TOKENS_TOKENIZER)
     ebnf = str(grammar)

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -1653,6 +1653,7 @@ def test_lark_budget_reset_and_fork() -> None:
     matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
     for token_id in [5, 0, 0]:
         assert matcher.accept_token(token_id)
+    assert _allowed_token_ids(matcher, MAX_TOKENS_TOKENIZER) == [3]
     forked = matcher.fork()
     assert _allowed_token_ids(forked, MAX_TOKENS_TOKENIZER) == [3]
     matcher.reset()

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -264,6 +264,8 @@ def test_max_chars_rollback_reset_and_fork() -> None:
 
     assert matcher.accept_token(1)
     assert _allowed_token_ids(matcher, tokenizer_info) == [2]
+    enforced_fork = matcher.fork()
+    assert _allowed_token_ids(enforced_fork, tokenizer_info) == [2]
     matcher.rollback(1)
     assert 0 in _allowed_token_ids(matcher, tokenizer_info)
 

--- a/tests/python/test_max_chars.py
+++ b/tests/python/test_max_chars.py
@@ -273,6 +273,27 @@ def test_max_chars_rollback_reset_and_fork() -> None:
     assert 0 in _allowed_token_ids(matcher, tokenizer_info)
 
 
+def test_max_chars_shared_subrule_keeps_parent_contexts_separate() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "X", "Y"])
+    compiled = _compile(
+        """
+        start: tight "X" | loose "Y"
+        tight[max_chars=1]: sub
+        loose: sub
+        sub: /[ab]+/
+        """,
+        tokenizer_info,
+    )
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+
+    assert matcher.accept_token(0)
+    assert 1 in _allowed_token_ids(matcher, tokenizer_info)
+    assert matcher.accept_token(1)
+    assert _allowed_token_ids(matcher, tokenizer_info) == [0, 1, 3]
+    assert not matcher.accept_token(2)
+    assert matcher.accept_token(3) and matcher.is_terminated()
+
+
 def test_max_chars_atomic_token_is_best_effort() -> None:
     tokenizer_info = xgr.TokenizerInfo(["<|wide|>", "!"])
     compiled = _compile('start: value "!"\nvalue[max_chars=1]: <|wide|>', tokenizer_info)

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -270,6 +270,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
+        "dynamic": False,
         "__VERSION__": "v16",
     }
 

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -264,6 +264,14 @@ def test_serialize_compiled_grammar():
             # fmt: on
             "optimized": True,
         },
+        "earley_parser_features": {
+            "fsm_state_flags": [19, 19, 27, 21, 19, 9, 19, 21, 9],
+            "rule_is_nullable": [1, 0],
+            "has_budget_rules": False,
+            "has_char_budget_rules": False,
+            "capture_tracking": False,
+            "has_hidden_capture_rules": False,
+        },
         "tokenizer_metadata": {
             "vocab_type": 1,
             "vocab_size": 10,
@@ -298,6 +306,16 @@ def test_serialize_compiled_grammar_roundtrip():
     recovered_compiled_grammar = xgr.CompiledGrammar.deserialize_json(serialized, tokenizer_info)
     serialized_new = recovered_compiled_grammar.serialize_json()
     assert serialized == serialized_new
+
+
+def test_deserialize_compiled_grammar_requires_earley_parser_features():
+    """Test that compiled grammar deserialization requires parser features."""
+    original_compiled_grammar, tokenizer_info = construct_compiled_grammar()
+    serialized_object = json.loads(original_compiled_grammar.serialize_json())
+    serialized_object.pop("earley_parser_features")
+
+    with pytest.raises(xgr.DeserializeFormatError, match="earley_parser_features"):
+        xgr.CompiledGrammar.deserialize_json(json.dumps(serialized_object), tokenizer_info)
 
 
 def test_serialize_compiled_grammar_functional():

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -4196,6 +4196,22 @@ def test_structural_tag_per_tag_whitespace_independent():
     assert not _is_grammar_accept_string(g, a(5) + b(5))
 
 
+def test_structural_tag_identical_json_schema_formats_reuse_safely():
+    content = JSONSchemaFormat(json_schema=_WS_SCHEMA, style="json")
+    stag = StructuralTag(
+        format=SequenceFormat(
+            elements=[
+                TagFormat(begin="<a>", content=content, end="</a>"),
+                TagFormat(begin="<b>", content=content, end="</b>"),
+            ]
+        )
+    )
+    grammar = xgr.Grammar.from_structural_tag(stag)
+
+    assert _is_grammar_accept_string(grammar, '<a>{"a": 1}</a><b>{"a": 2}</b>')
+    assert not _is_grammar_accept_string(grammar, '<a>{"a": 1}</a><b>{"a": "x"}</b>')
+
+
 def test_structural_tag_max_whitespace_cnt_compile_cache():
     # The per-tag setting is part of the serialized tag JSON (the cache key), so no collision.
     compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]), cache_enabled=True)


### PR DESCRIPTION
## Summary

- Reuse stable Earley completion and scan worklists across byte advances.
- Keep storage capacity while clearing logical contents between rows.
- Avoid repeated temporary-vector allocation in the parser hot path.

Depends on #817 (shared Earley parser feature metadata); the stable worklists use the shared parser metadata introduced there.

## Stacking

- Base is `main`, so the diff currently also shows the predecessor commits (#809–#814, #815, #816, #817). The change specific to this PR is the last commit (`Reuse stable Earley parser worklists`). I will rebase as the predecessors merge.
- The measurements below compare this branch against the #817 branch, both with dynamic compilation enabled.

## Correctness

- Full valid-vocabulary token-mask sweep across four workloads (dynamic mode, before/after): 0 allowed-set differences.
- Local: C++ suite passed; `test_dynamic_compilation.py` + `test_lark.py` + `test_max_chars.py` 424 passed.

## Performance

Measured on Modal (AMD EPYC 9V33X, 16 physical cores), 5 rounds, median of same-round ratios, both sides with dynamic compilation enabled (>1x is faster):

| Workload | Compile | Mask | End-to-end | 5-round e2e range |
|---|---:|---:|---:|---:|
| Structural tag large | 0.973x | 1.041x | 0.986x | 0.831–1.015x |
| Structural tag small | 0.989x | 0.990x | 0.990x | 0.971–0.995x |
| JSON Schema large | 1.000x | 1.132x | 1.011x | 0.932–1.070x |
| JSON Schema small | 1.013x | 1.142x | 1.141x | 1.126–1.162x |

Mask timing on the JSON Schema workloads improves 13–14% (consistent across rounds); the structural tag workloads stay within measurement noise.
