### PR TITLE
feat: add EXAONE 4.0 structural tag

### DIFF
--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -23,7 +23,7 @@ Use it when you need to constrain the model to output in a fixed pattern such as
 
 ### Parameters
 
-- **model** (`str`): The structural-tag style. Valid values are `"llama"`, `"qwen_3"`, `"qwen_3_5"`, `"qwen_3_coder"`, `"kimi"`, `"kimi_k3"`, `"deepseek_r1"`, `"deepseek_v3_1"`, `"harmony"`, `"deepseek_v3_2"`, `"minimax"`, `"glm_4_7"`, `"deepseek_v4"`, `"cohere"`.
+- **model** (`str`): The structural-tag style. Valid values are `"llama"`, `"qwen_3"`, `"qwen_3_5"`, `"qwen_3_coder"`, `"kimi"`, `"kimi_k3"`, `"deepseek_r1"`, `"deepseek_v3_1"`, `"harmony"`, `"deepseek_v3_2"`, `"minimax"`, `"glm_4_7"`, `"deepseek_v4"`, `"cohere"`, `"exaone"`.
 - **tools** (`List[ToolParam | dict]`, optional): Function and builtin tools available to the model. The list can contain two kinds of tools:
   - **Function tools** use the OpenAI Chat Completions shape:
     ```json

--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -205,6 +205,7 @@ The `model` argument of `get_model_structural_tag` accepts the style names below
 | `"glm_4_7"` | GLM-5, GLM-4.7 |
 | `"deepseek_v4"` | DeepSeek-V4 |
 | `"cohere"` | Cohere Command models using XML tool calls |
+| `"exaone"` | EXAONE-4.0-32B, EXAONE-4.0-1.2B |
 
 ## Extending with custom models
 

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -2345,6 +2345,118 @@ def get_cohere_structural_tag(
     return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
 
 
+@register_model_structural_tag("exaone")
+def get_exaone_structural_tag(
+    tools: Optional[List[FunctionToolParam]] = None,
+    builtin_tools: Optional[List[BuiltinToolParam]] = None,
+    tool_choice: Literal["auto", "required", "forced"] = "auto",
+    reasoning: bool = True,
+    any_order: bool = False,
+    exclude_special_tokens: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
+    **kwargs: Any,
+) -> StructuralTag:
+    """Get EXAONE 4.0 style structural tag format.
+
+    Corresponding model key: ``"exaone"``.
+
+    Reference: https://huggingface.co/LGAI-EXAONE/EXAONE-4.0-32B
+
+    Supported models:
+
+    - EXAONE-4.0-32B
+    - EXAONE-4.0-1.2B
+    """
+    TOOL_CALL_BEGIN_PREFIX = '<tool_call>{"name": "'
+    ARGUMENTS_FIELD_PREFIX = '", "arguments": '
+    TOOL_CALL_END = "}</tool_call>"
+    TOOL_CALL_TRIGGER = "<tool_call>"
+    THINK_TAG_END = "</think>"
+    THINK_SUFFIX = "\n\n"
+    THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
+
+    tools = tools or []
+    builtin_tools = builtin_tools or []
+    if tool_choice == "auto":
+        tags = []
+        for tool in tools:
+            function = tool.function
+            parameters = _get_function_parameters(function)
+            name = function.name
+            tags.append(
+                TagFormat(
+                    begin=(TOOL_CALL_BEGIN_PREFIX + name + ARGUMENTS_FIELD_PREFIX),
+                    content=JSONSchemaFormat(
+                        json_schema=parameters,
+                        any_order=any_order,
+                        max_whitespace_cnt=max_whitespace_cnt,
+                    ),
+                    end=TOOL_CALL_END,
+                )
+            )
+
+        if len(tags) > 0:
+            suffix_tag = TriggeredTagsFormat(
+                triggers=[TOOL_CALL_TRIGGER],
+                tags=tags,
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
+            )
+        else:
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS)
+            )
+
+    elif tool_choice == "forced":
+        if not tools:
+            raise ValueError("Forced tool choice must resolve to exactly one tool.")
+        function = tools[0].function
+        suffix_tag = TagFormat(
+            begin=(TOOL_CALL_BEGIN_PREFIX + function.name + ARGUMENTS_FIELD_PREFIX),
+            content=JSONSchemaFormat(
+                json_schema=_get_function_parameters(function),
+                any_order=any_order,
+                max_whitespace_cnt=max_whitespace_cnt,
+            ),
+            end=TOOL_CALL_END,
+        )
+
+    elif tool_choice == "required":
+        tags = []
+        for tool in tools:
+            function = tool.function
+            parameters = _get_function_parameters(function)
+            name = function.name
+            tags.append(
+                TagFormat(
+                    begin=(TOOL_CALL_BEGIN_PREFIX + name + ARGUMENTS_FIELD_PREFIX),
+                    content=JSONSchemaFormat(
+                        json_schema=parameters,
+                        any_order=any_order,
+                        max_whitespace_cnt=max_whitespace_cnt,
+                    ),
+                    end=TOOL_CALL_END,
+                )
+            )
+        assert len(tags) > 0
+        suffix_tag = TriggeredTagsFormat(
+            triggers=[TOOL_CALL_TRIGGER],
+            tags=tags,
+            excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
+            at_least_one=True,
+        )
+
+    if not reasoning:
+        return StructuralTag(format=suffix_tag)
+
+    prefix_tag = SequenceFormat(
+        elements=[
+            TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END),
+            ConstStringFormat(value=THINK_SUFFIX),
+        ]
+    )
+    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+
+
 # Backward-compatible alias
 get_builtin_structural_tag = get_model_structural_tag
 """Alias for :func:`get_model_structural_tag`. Deprecated."""

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -218,6 +218,7 @@ _tools_qwen_3_5_pair = make_tools(["run_sql", "run_py"])
 _tools_harmony_pair = make_tools(["comment_tool", "other_tool"])
 _tools_glm_4_7_pair = make_tools(["search", "alt"])
 _tools_cohere_pair = make_tools(["search", "alt"])
+_tools_exaone_pair = make_tools(["t1", "t2"])
 
 
 # ---------- Test: unknown format type ----------
@@ -1209,6 +1210,7 @@ _EXCLUDE_TOKEN_MODELS = [
     "minimax",
     "glm_4_7",
     "cohere",
+    "exaone",
 ]
 _EXPECTED_EXCLUDE_TOKENS = {"cohere": ["<|START_THINKING|>", "<|END_THINKING|>"]}
 
@@ -1337,6 +1339,8 @@ def test_exclude_special_tokens_passed_to_specific_function():
         ("qwen_3", 'text<tool_call>\n{"name": "t2", "arguments": {"q": "v"}}\n</tool_call>', False),
         ("qwen_3", 'text<tool_call>\n{"name": "t1", "arguments": {"q": "v"}}\n</tool_call>', True),
         ("qwen_3", 'text<tool_call>\n{"name": "t2", "arguments": {"q": "v"}}\n</tool_call>', False),
+        ("exaone", 'text<tool_call>{"name": "t1", "arguments": {"q": "v"}}</tool_call>', True),
+        ("exaone", 'text<tool_call>{"name": "t2", "arguments": {"q": "v"}}</tool_call>', False),
         (
             "harmony",
             '<|channel|>commentary to=functions.t1<|constrain|>json<|message|>{"q": "v"}<|call|>',
@@ -1788,6 +1792,29 @@ _tool_choice_instance_cases = [
         ),
         id="cohere-forced",
     ),
+    pytest.param(
+        "exaone",
+        (
+            {"tools": _tools_exaone_pair, "tool_choice": "required"},
+            ["", '<tool_call>{"name": "t1", "arguments": {"q": "v"}}</tool_call>'],
+            False,
+            [False, True],
+        ),
+        id="exaone-required",
+    ),
+    pytest.param(
+        "exaone",
+        (
+            {"tools": _tools_exaone_pair, "tool_choice": "forced", "forced_function_name": "t1"},
+            [
+                '<tool_call>{"name": "t1", "arguments": {"q": "v"}}</tool_call>',
+                '<tool_call>{"name": "t2", "arguments": {"q": "v"}}</tool_call>',
+            ],
+            False,
+            [True, False],
+        ),
+        id="exaone-forced",
+    ),
 ]
 
 
@@ -2056,6 +2083,12 @@ _REQUIRED_TERMINATION_CASES = [
         "</function>\n</tool_call>\n<tool_call>\n<function=get_time>\n<parameter=timezone>\nUTC\n"
         "</parameter>\n</function>\n</tool_call>",
     ),
+    (
+        "exaone",
+        '<tool_call>{"name": "get_weather", "arguments": {"location": "Beijing"}}</tool_call>',
+        '<tool_call>{"name": "get_weather", "arguments": {"location": "Beijing"}}</tool_call>'
+        '<tool_call>{"name": "get_time", "arguments": {"timezone": "UTC"}}</tool_call>',
+    ),
 ]
 
 
@@ -2103,6 +2136,7 @@ _ANY_ORDER_MODELS = [
     "minimax",
     "glm_4_7",
     "harmony",
+    "exaone",
 ]
 
 

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -109,6 +109,13 @@ MODEL_CONFIGS = [
     # Cohere's official Melody renderer, which is the source of truth for CMD5.
     ("cohere", "MELODY:cmd5", True, {"reasoning": True}),
     ("cohere", "MELODY:cmd5", False, {"reasoning": False}),
+    ("exaone", "LGAI-EXAONE/EXAONE-4.0-1.2B", True, {"skip_think": False, "enable_thinking": True}),
+    (
+        "exaone",
+        "LGAI-EXAONE/EXAONE-4.0-1.2B",
+        False,
+        {"skip_think": True, "enable_thinking": False},
+    ),
 ]
 
 # Models whose renderer cannot produce a turn with an empty reasoning block: the DeepSeek
@@ -149,6 +156,7 @@ EOS_SUFFIXES = {
     "deepseek_v3_2": ["<｜end▁of▁sentence｜>"],
     "deepseek_v4": ["<｜end▁of▁sentence｜>"],
     "cohere": ["<|END_OF_TURN_TOKEN|>"],
+    "exaone": ["[|endofturn|]"],
 }
 
 


### PR DESCRIPTION
## Summary

Adds a new `exaone` built-in structural tag for EXAONE 4.0.

EXAONE 4.0 supports reasoning and tool calling with the following output format:

```text
<think>reasoning text</think>

<tool_call>{"name": "search", "arguments": {"location": "Seoul"}}</tool_call>
```

## Changes

- Add `get_exaone_structural_tag()` in `builtin_structural_tag.py`
- Register `exaone` in test parametrized lists: exclude-token models, tool-choice instance cases, required-termination cases, any-order models
- Add chat-template alignment test cases for EXAONE-4.0-1.2B

## Testing

- All 319 builtin structural tag tests pass
- Verified grammar acceptance against the official EXAONE 4.0 chat template output (reasoning on/off, single/parallel tool calls, auto/required/forced tool_choice)

## Reference

- Model card: https://huggingface.co/LGAI-EXAONE/EXAONE-4.0-32B
- Supported models: EXAONE-4.0-32B, EXAONE-4.0-1.2B
