### PR TITLE
fix: check `string="(true|false)"` in DeepSeek XML format

### DIFF
--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -241,7 +241,7 @@ int32_t GrammarBuilder::AddRule(const Rule& rule) {
   EnsureRuleNameMap();
   int32_t id = static_cast<int32_t>(grammar_->rules_.size());
   grammar_->rules_.push_back(rule);
-  XGRAMMAR_CHECK(rule_name_to_id_.count(rule.name) == 0);
+  XGRAMMAR_CHECK(GetRuleId(rule.name) == -1);
   rule_name_to_id_[rule.name] = id;
   return id;
 }
@@ -404,6 +404,12 @@ std::string GrammarBuilder::GetNewRuleName(const std::string& name_hint) {
     ++(*cnt);
   }
   return name_hint + "_" + std::to_string(*cnt);
+}
+
+void GrammarBuilder::ReserveRuleName(const std::string& name) {
+  EnsureRuleNameMap();
+  XGRAMMAR_CHECK(rule_name_to_id_.count(name) == 0) << "Rule name " << name << " is already used.";
+  rule_name_to_id_[name] = -1;
 }
 
 int32_t GrammarBuilder::GetRuleId(const std::string& name) const {

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -266,6 +266,11 @@ class GrammarBuilder {
   std::string GetNewRuleName(const std::string& name_hint);
 
   /*!
+   * \brief Mark the given name as used for GrammarBuilder::GetNewRuleName.
+   */
+  void ReserveRuleName(const std::string& name);
+
+  /*!
    * \brief Get the rule id of the rule with the given name. Return -1 if not found.
    */
   int32_t GetRuleId(const std::string& name) const;

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2492,12 +2492,34 @@ int32_t JSONSchemaConverter::FormatPropertyKey(
 
 int32_t JSONSchemaConverter::FormatProperty(
     const std::string& key,
+    const SchemaSpecPtr& value_spec,
+    const std::string& rule_name,
+    int64_t idx
+) {
+  int32_t value_rule_id = CreateRule(value_spec, rule_name + "_prop_" + std::to_string(idx));
+  return FormatProperty(key, value_rule_id, rule_name, idx, value_spec);
+}
+
+int32_t JSONSchemaConverter::FormatProperty(
+    const std::string& key,
     int32_t value_rule_id,
     const std::string& rule_name,
     int64_t idx,
     const SchemaSpecPtr& schema
 ) {
   return Sequence({FormatPropertyKey(key, schema), colon_expr_id_, RuleRef(value_rule_id)});
+}
+
+int32_t JSONSchemaConverter::FormatOtherProperty(
+    int32_t key_pattern_expr,
+    const SchemaSpecPtr& value_spec,
+    const std::string& rule_name,
+    const std::string& rule_name_suffix
+) {
+  int32_t value_rule_id = CreateRule(value_spec, rule_name + "_" + rule_name_suffix);
+  return FormatOtherProperty(
+      key_pattern_expr, value_rule_id, rule_name, rule_name_suffix, value_spec
+  );
 }
 
 int32_t JSONSchemaConverter::FormatOtherProperty(
@@ -2544,22 +2566,14 @@ int32_t JSONSchemaConverter::GetAnyOrderRuleForProperties(
   std::vector<int32_t> items;
   for (size_t index = 0; index < properties.size(); ++index) {
     const auto& property = properties[index];
-    int32_t value_rule_id =
-        CreateRule(property.schema, rule_name + "_prop_" + std::to_string(index));
-    items.push_back(FormatProperty(property.name, value_rule_id, rule_name, index, property.schema)
-    );
+    items.push_back(FormatProperty(property.name, property.schema, rule_name, index));
   }
   if (additional != nullptr) {
     if (additional_property_override.has_value()) {
       items.push_back(*additional_property_override);
     } else {
-      int32_t value_rule_id = CreateRule(additional, rule_name + "_" + additional_suffix);
       items.push_back(FormatOtherProperty(
-          GetKeyPatternExcluding(properties, rule_name),
-          value_rule_id,
-          rule_name,
-          additional_suffix,
-          /*schema=*/nullptr
+          GetKeyPatternExcluding(properties, rule_name), additional, rule_name, additional_suffix
       ));
     }
   }
@@ -2611,11 +2625,9 @@ int32_t JSONSchemaConverter::GetPartialRuleForProperties(
 
   std::vector<int32_t> property_patterns;
   for (size_t index = 0; index < properties.size(); ++index) {
-    int32_t value_rule_id =
-        CreateRule(properties[index].schema, rule_name + "_prop_" + std::to_string(index));
-    property_patterns.push_back(FormatProperty(
-        properties[index].name, value_rule_id, rule_name, index, properties[index].schema
-    ));
+    property_patterns.push_back(
+        FormatProperty(properties[index].name, properties[index].schema, rule_name, index)
+    );
   }
 
   bool allow_additional = additional != nullptr;
@@ -2625,13 +2637,8 @@ int32_t JSONSchemaConverter::GetPartialRuleForProperties(
       if (additional_property_override.has_value()) {
         additional_pattern = *additional_property_override;
       } else {
-        int32_t value_rule_id = CreateRule(additional, rule_name + "_" + additional_suffix);
         additional_pattern = FormatOtherProperty(
-            GetKeyPatternExcluding(properties, rule_name),
-            value_rule_id,
-            rule_name,
-            additional_suffix,
-            /*schema=*/nullptr
+            GetKeyPatternExcluding(properties, rule_name), additional, rule_name, additional_suffix
         );
       }
     }
@@ -2921,22 +2928,14 @@ int32_t JSONSchemaConverter::GenerateObject(
         int32_t key_rule_id = create_pattern_key_rule(
             pattern_property.pattern, rule_name + "_" + pattern_suffix + "_key"
         );
-        int32_t value_rule_id =
-            CreateRule(pattern_property.schema, rule_name + "_" + pattern_suffix);
         patterns.push_back(FormatOtherProperty(
-            RuleRef(key_rule_id), value_rule_id, rule_name, pattern_suffix, pattern_property.schema
+            RuleRef(key_rule_id), pattern_property.schema, rule_name, pattern_suffix
         ));
       }
       // Merge with existing additionalProperties if present
       if (effective_additional) {
-        int32_t value_rule_id =
-            CreateRule(effective_additional, rule_name + "_" + effective_suffix);
         patterns.push_back(FormatOtherProperty(
-            KeyPatternExpression(),
-            value_rule_id,
-            rule_name,
-            effective_suffix,
-            /*schema=*/nullptr
+            KeyPatternExpression(), effective_additional, rule_name, effective_suffix
         ));
       }
       additional_override = Choice(patterns);
@@ -2949,13 +2948,8 @@ int32_t JSONSchemaConverter::GenerateObject(
       // Only apply when additional properties are allowed - when additionalProperties
       // is false, no extra keys beyond named properties should be permitted.
       int32_t key_rule_id = CreateRule(spec.property_names, rule_name + "_name");
-      int32_t value_rule_id = CreateRule(effective_additional, rule_name + "_" + effective_suffix);
       additional_override = FormatOtherProperty(
-          RuleRef(key_rule_id),
-          value_rule_id,
-          rule_name,
-          /*rule_name_suffix=*/"pn",
-          /*schema=*/nullptr
+          RuleRef(key_rule_id), effective_additional, rule_name, effective_suffix
       );
       effective_suffix = "pn";
     }
@@ -2984,31 +2978,22 @@ int32_t JSONSchemaConverter::GenerateObject(
           int32_t key_rule_id = create_pattern_key_rule(
               pattern_property.pattern, rule_name + "_" + pattern_suffix + "_key"
           );
-          int32_t value_rule_id =
-              CreateRule(pattern_property.schema, rule_name + "_" + pattern_suffix);
           property_choices.push_back(Sequence(
               {beginning_separator,
                FormatOtherProperty(
-                   RuleRef(key_rule_id),
-                   value_rule_id,
-                   rule_name,
-                   pattern_suffix,
-                   pattern_property.schema
+                   RuleRef(key_rule_id), pattern_property.schema, rule_name, pattern_suffix
                )}
           ));
         }
       } else {
         int32_t key_rule_id = CreateRule(spec.property_names, rule_name + "_name");
-        int32_t value_rule_id = builder_.GetRuleId(GetBasicAnyRuleName());
-        XGRAMMAR_DCHECK(value_rule_id != -1);
         property_choices.push_back(Sequence(
             {beginning_separator,
              FormatOtherProperty(
                  RuleRef(key_rule_id),
-                 value_rule_id,
+                 SchemaSpec::Make(AnySpec{}, "{}"),
                  rule_name,
-                 /*rule_name_suffix=*/"pn",
-                 /*schema=*/nullptr
+                 /*rule_name_suffix=*/"pn"
              )}
         ));
       }
@@ -3045,13 +3030,8 @@ int32_t JSONSchemaConverter::GenerateObject(
   } else if (additional_property) {
     // Case 3: no properties defined, additional properties allowed
     if (spec.max_properties != 0) {
-      int32_t value_rule_id = CreateRule(additional_property, rule_name + "_" + additional_suffix);
       int32_t property = FormatOtherProperty(
-          KeyPatternExpression(),
-          value_rule_id,
-          rule_name,
-          additional_suffix,
-          /*schema=*/nullptr
+          KeyPatternExpression(), additional_property, rule_name, additional_suffix
       );
       content = Sequence(
           {NextSeparatorExpression(),
@@ -3121,19 +3101,14 @@ SchemaSpecPtr JSONSchemaConverter::ResolveRefSchema(
   return ref_resolver_(spec.uri, rule_name_hint);
 }
 
-int32_t JSONSchemaConverter::GenerateRef(const RefSpec& spec, const std::string& rule_name) {
-  // First check if we have a direct URI mapping (for circular references)
-  if (uri_to_rule_id_.count(spec.uri)) {
-    return RuleRef(uri_to_rule_id_[spec.uri]);
-  }
-
+std::string JSONSchemaConverter::GetRuleNameHintFromURI(const std::string& uri) {
   // Derive rule name from URI path (like original URIToRule) so that the same
   // $ref always gets the same rule name, and allocate before resolving to prevent
   // dead recursion when the ref target contains a ref back.
   std::string rule_name_hint = "ref";
-  if (spec.uri.size() >= 2 && spec.uri[0] == '#' && spec.uri[1] == '/') {
+  if (uri.size() >= 2 && uri[0] == '#' && uri[1] == '/') {
     std::string new_rule_name_prefix;
-    std::stringstream ss(spec.uri.substr(2));
+    std::stringstream ss(uri.substr(2));
     std::string part;
     while (std::getline(ss, part, '/')) {
       if (!part.empty()) {
@@ -3151,7 +3126,16 @@ int32_t JSONSchemaConverter::GenerateRef(const RefSpec& spec, const std::string&
       rule_name_hint = std::move(new_rule_name_prefix);
     }
   }
+  return rule_name_hint;
+}
 
+int32_t JSONSchemaConverter::GenerateRef(const RefSpec& spec, const std::string& rule_name) {
+  // First check if we have a direct URI mapping (for circular references)
+  if (uri_to_rule_id_.count(spec.uri)) {
+    return RuleRef(uri_to_rule_id_[spec.uri]);
+  }
+
+  std::string rule_name_hint = GetRuleNameHintFromURI(spec.uri);
   int32_t allocated_rule_id = builder_.AddEmptyRuleWithHint(rule_name_hint);
   std::string allocated_rule_name = builder_.GetRule(allocated_rule_id).name;
   uri_to_rule_id_[spec.uri] = allocated_rule_id;
@@ -4177,7 +4161,6 @@ Grammar JSONSchemaToGrammar(
     }
     case JSONFormat::kQwenXML:
     case JSONFormat::kMiniMaxXML:
-    case JSONFormat::kDeepSeekXML:
     case JSONFormat::kGlmXML:
     case JSONFormat::kKimiK3XML: {
       XMLToolCallingConverter converter(
@@ -4187,6 +4170,17 @@ Grammar JSONSchemaToGrammar(
           max_whitespace_cnt,
           std::move(ref_resolver),
           json_format,
+          any_order
+      );
+      return converter.Convert(spec);
+    }
+    case JSONFormat::kDeepSeekXML: {
+      DeepSeekXMLToolCallingConverter converter(
+          indent,
+          std::move(separators),
+          any_whitespace,
+          max_whitespace_cnt,
+          std::move(ref_resolver),
           any_order
       );
       return converter.Convert(spec);
@@ -4270,7 +4264,6 @@ std::string JSONSchemaToEBNF(
     }
     case JSONFormat::kQwenXML:
     case JSONFormat::kMiniMaxXML:
-    case JSONFormat::kDeepSeekXML:
     case JSONFormat::kGlmXML:
     case JSONFormat::kKimiK3XML: {
       XMLToolCallingConverter converter(
@@ -4281,6 +4274,12 @@ std::string JSONSchemaToEBNF(
           ref_resolver,
           json_format,
           any_order
+      );
+      return GrammarNormalizer::Apply(converter.Convert(spec)).ToString();
+    }
+    case JSONFormat::kDeepSeekXML: {
+      DeepSeekXMLToolCallingConverter converter(
+          indent, separators, any_whitespace, max_whitespace_cnt, ref_resolver, any_order
       );
       return GrammarNormalizer::Apply(converter.Convert(spec)).ToString();
     }

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -332,10 +332,26 @@ class JSONSchemaConverter {
   /*! \brief Format a property (key + value). Override for different formats. */
   virtual int32_t FormatProperty(
       const std::string& key,
+      const SchemaSpecPtr& value_spec,
+      const std::string& rule_name,
+      int64_t idx
+  );
+
+  /*! \brief Format a property (key + value). Override for different formats. */
+  virtual int32_t FormatProperty(
+      const std::string& key,
       int32_t value_rule_id,
       const std::string& rule_name,
       int64_t idx,
       const SchemaSpecPtr& schema
+  );
+
+  /*! \brief Format an "other" property (additional/unevaluated). Override for different formats. */
+  virtual int32_t FormatOtherProperty(
+      int32_t key_pattern_expr,
+      const SchemaSpecPtr& value_spec,
+      const std::string& rule_name,
+      const std::string& rule_name_suffix
   );
 
   /*!
@@ -449,6 +465,9 @@ class JSONSchemaConverter {
       int max_properties,
       const std::optional<int32_t>& additional_property_override = std::nullopt
   );
+
+  /*! \brief Helper to create rule name hint from $ref URI. */
+  std::string GetRuleNameHintFromURI(const std::string& uri);
 
   // ==================== Protected members ====================
 

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -55,8 +55,16 @@ std::vector<GrammarBuilder::CharacterClassElement> XMLIdentifierContinuationChar
   return {{'a', 'z'}, {'A', 'Z'}, {'0', '9'}, {'_', '_'}};
 }
 
+constexpr const char* kIntegerCacheKey = "{\"type\":\"integer\"}";
+constexpr const char* kNumberCacheKey = "{\"type\":\"number\"}";
 constexpr const char* kStringCacheKey = "{\"type\":\"string\"}";
+constexpr const char* kBooleanCacheKey = "{\"type\":\"boolean\"}";
+constexpr const char* kNullCacheKey = "{\"type\":\"null\"}";
+constexpr const char* kArrayCacheKey = "{\"type\":\"array\"}";
 constexpr const char* kObjectCacheKey = "{\"type\":\"object\"}";
+
+constexpr int32_t kInvalidExprId = -1;
+constexpr int32_t kInvalidRuleId = -1;
 
 }  // namespace
 
@@ -73,7 +81,7 @@ const std::unordered_map<JSONFormat, XMLToolCallingConverter::XMLWrapper>
          {"<｜DSML｜parameter name=\"",
           "",
           "",
-          // TODO(Linzhang): We do not validate the string's value, and we accept both.
+          // The key suffix is generated in DeepSeekXMLToolCallingConverter.
           "</｜DSML｜parameter>"}},
         {JSONFormat::kGlmXML, {"<arg_key>", "</arg_key>", "<arg_value>", "</arg_value>"}},
         {JSONFormat::kCohereXML, {"<cofl:value", ">", "", "</cofl:value>"}},
@@ -116,13 +124,7 @@ std::string XMLToolCallingConverter::XMLValue(const std::string& json_value) con
 }
 
 int32_t XMLToolCallingConverter::XMLKeySuffix(const std::optional<std::string>& pinned_type) {
-  if (json_format_ == JSONFormat::kDeepSeekXML) {
-    return Sequence(
-        {ByteString("\" string=\""),
-         Choice({ByteString("true"), ByteString("false")}),
-         ByteString("\">")}
-    );
-  }
+  XGRAMMAR_DCHECK(json_format_ != JSONFormat::kDeepSeekXML);
   if (json_format_ == JSONFormat::kKimiK3XML) {
     // A declared property carries exactly the type its value grammar is rendered with, so the
     // parser decodes the value back to the schema's type. Free-form keys have no single schema
@@ -201,24 +203,22 @@ std::optional<std::string> XMLToolCallingConverter::KimiK3TypeAttr(const SchemaS
   );
 }
 
-void XMLToolCallingConverter::AddBasicRules() {
+void XMLToolCallingConverter::AddBasicRules() { AddBasicRules({kXMLString, kXMLAny}); }
+
+void XMLToolCallingConverter::AddBasicRules(const std::vector<std::string>& additional_rule_names) {
   // First add JSON basic rules. These should be in the inner layer of the XML format.
   XGRAMMAR_DCHECK(nested_object_level_ == 0);
   // The nested part, true json format, is at level 2.
   nested_object_level_ = 2;
-  JSONSchemaConverter::AddBasicRules({kXMLString, kXMLAny, kXMLObject, kXMLVariableName});
+  std::vector<std::string> xml_basic_rule_names = additional_rule_names;
+  xml_basic_rule_names.insert(xml_basic_rule_names.end(), {kXMLObject, kXMLVariableName});
+  JSONSchemaConverter::AddBasicRules(xml_basic_rule_names);
 
   auto any_spec = SchemaSpec::Make(AnySpec{}, "{}", kBasicAny);
 
   // The outer part, xml format, is at level 1.
   nested_object_level_ = 1;
-  // Add XML string rule
-  builder_.UpdateRuleBody(kXMLString, TagDispatch(false, {xml_wrapper_.parameter_suffix}));
-  AddCache(kStringCacheKey, builder_.GetRuleId(kXMLString));
-
-  // Add XML any rule
-  builder_.UpdateRuleBody(kXMLAny, GenerateAny(AnySpec{}, kXMLAny));
-  AddCache("{}", builder_.GetRuleId(kXMLAny));
+  AddXMLBasicRulesLevel1();
 
   // Reset the nested object level to 0, which is the root level.
   nested_object_level_ = 0;
@@ -238,6 +238,16 @@ void XMLToolCallingConverter::AddBasicRules() {
            builder_.AddCharacterClassStar({{'a', 'z'}, {'A', 'Z'}, {'0', '9'}, {'_', '_'}})}
       )
   );
+}
+
+void XMLToolCallingConverter::AddXMLBasicRulesLevel1() {
+  // Add XML string rule
+  builder_.UpdateRuleBody(kXMLString, TagDispatch(false, {xml_wrapper_.parameter_suffix}));
+  AddCache(kStringCacheKey, builder_.GetRuleId(kXMLString));
+
+  // Add XML any rule
+  builder_.UpdateRuleBody(kXMLAny, GenerateAny(AnySpec{}, kXMLAny));
+  AddCache("{}", builder_.GetRuleId(kXMLAny));
 }
 
 std::string XMLToolCallingConverter::GetKeyPattern() const {
@@ -465,6 +475,355 @@ std::optional<int32_t> XMLToolCallingConverter::GetCache(const std::string& key)
     return rule_cache_manager_.GetCache(key, true);
   }
   return rule_cache_manager_.GetCache(key, nested_object_level_ > 1);
+}
+
+const std::string DeepSeekXMLToolCallingConverter::kXMLAnyJSON = "xml_any_json";
+
+DeepSeekXMLToolCallingConverter::DeepSeekXMLToolCallingConverter(
+    std::optional<int> indent,
+    std::optional<std::pair<std::string, std::string>> separators,
+    bool any_whitespace,
+    std::optional<int> max_whitespace_cnt,
+    RefResolver ref_resolver,
+    bool any_order
+)
+    : XMLToolCallingConverter(
+          indent,
+          separators,
+          any_whitespace,
+          max_whitespace_cnt,
+          ref_resolver,
+          JSONFormat::kDeepSeekXML,
+          any_order
+      ) {}
+
+void DeepSeekXMLToolCallingConverter::AddBasicRules() {
+  XMLToolCallingConverter::AddBasicRules({kXMLString, kXMLAnyJSON});
+}
+
+void DeepSeekXMLToolCallingConverter::AddXMLBasicRulesLevel1() {
+  // Add XML string rule
+  builder_.UpdateRuleBody(kXMLString, TagDispatch(false, {xml_wrapper_.parameter_suffix}));
+  int32_t xml_string_rule_id = builder_.GetRuleId(kXMLString);
+  AddCache(kStringCacheKey, xml_string_rule_id);
+
+  // Add rules for string branch
+  AddCache("{}", xml_string_rule_id, GenerateMode::kString);
+  AddCache(kStringCacheKey, xml_string_rule_id, GenerateMode::kString);
+
+  // Add rules for JSON branch
+  builder_.UpdateRuleBody(
+      kXMLAnyJSON, GenerateAnyConstrained(AnySpec{}, kXMLAnyJSON, GenerateMode::kJSON)
+  );
+  AddCache("{}", builder_.GetRuleId(kXMLAnyJSON), GenerateMode::kJSON);
+  AddCache(kIntegerCacheKey, builder_.GetRuleId(kBasicInteger), GenerateMode::kJSON);
+  AddCache(kNumberCacheKey, builder_.GetRuleId(kBasicNumber), GenerateMode::kJSON);
+  AddCache(kBooleanCacheKey, builder_.GetRuleId(kBasicBoolean), GenerateMode::kJSON);
+  AddCache(kNullCacheKey, builder_.GetRuleId(kBasicNull), GenerateMode::kJSON);
+  AddCache(kArrayCacheKey, builder_.GetRuleId(kBasicArray), GenerateMode::kJSON);
+  AddCache(kObjectCacheKey, builder_.GetRuleId(kBasicObject), GenerateMode::kJSON);
+}
+
+int32_t DeepSeekXMLToolCallingConverter::FormatProperty(
+    const std::string& key,
+    const SchemaSpecPtr& value_spec,
+    const std::string& rule_name,
+    int64_t idx
+) {
+  if (nested_object_level_ > 1) {
+    return JSONSchemaConverter::FormatProperty(key, value_spec, rule_name, idx);
+  }
+
+  static constexpr const char* kRuleSuffixes[] = {
+      "_string_prop_",
+      "_json_prop_",
+  };
+
+  std::vector<int32_t> elements;
+  for (auto mode : {GenerateMode::kString, GenerateMode::kJSON}) {
+    int32_t value_rule_id = CreateRuleConstrained(
+        value_spec, rule_name + kRuleSuffixes[static_cast<int>(mode)] + std::to_string(idx), mode
+    );
+    if (value_rule_id == kInvalidRuleId) {
+      continue;
+    }
+
+    std::vector<int32_t> prop_elements = {
+        ByteString(xml_wrapper_.key_wrapper_prefix + key + kKeySuffixes[static_cast<int>(mode)])
+    };
+    if (mode == GenerateMode::kJSON) {
+      prop_elements.push_back(WhitespaceExpression());
+    }
+    prop_elements.push_back(RuleRef(value_rule_id));
+    if (mode == GenerateMode::kJSON) {
+      prop_elements.push_back(WhitespaceExpression());
+    }
+    prop_elements.push_back(ByteString(xml_wrapper_.parameter_suffix));
+    elements.push_back(Sequence(prop_elements));
+  }
+
+  XGRAMMAR_ICHECK(!elements.empty());
+  return Choice(elements);
+}
+
+int32_t DeepSeekXMLToolCallingConverter::FormatOtherProperty(
+    int32_t key_pattern_expr,
+    const SchemaSpecPtr& value_spec,
+    const std::string& rule_name,
+    const std::string& rule_name_suffix
+) {
+  if (nested_object_level_ > 1) {
+    return JSONSchemaConverter::FormatOtherProperty(
+        key_pattern_expr, value_spec, rule_name, rule_name_suffix
+    );
+  }
+
+  static constexpr const char* kRuleSuffixes[] = {
+      "_string_",
+      "_json_",
+  };
+
+  std::vector<int32_t> elements;
+  for (auto mode : {GenerateMode::kString, GenerateMode::kJSON}) {
+    int32_t value_rule_id = CreateRuleConstrained(
+        value_spec, rule_name + kRuleSuffixes[static_cast<int>(mode)] + rule_name_suffix, mode
+    );
+    if (value_rule_id == kInvalidRuleId) {
+      continue;
+    }
+
+    std::vector<int32_t> prop_elements = {
+        ByteString(xml_wrapper_.key_wrapper_prefix),
+        key_pattern_expr,
+        ByteString(kKeySuffixes[static_cast<int>(mode)])
+    };
+    if (mode == GenerateMode::kJSON) {
+      prop_elements.push_back(WhitespaceExpression());
+    }
+    prop_elements.push_back(RuleRef(value_rule_id));
+    if (mode == GenerateMode::kJSON) {
+      prop_elements.push_back(WhitespaceExpression());
+    }
+    prop_elements.push_back(ByteString(xml_wrapper_.parameter_suffix));
+    elements.push_back(Sequence(prop_elements));
+  }
+
+  XGRAMMAR_ICHECK(!elements.empty());
+  return Choice(elements);
+}
+
+int32_t DeepSeekXMLToolCallingConverter::CreateRuleConstrained(
+    const SchemaSpecPtr& spec, const std::string& rule_name_hint, GenerateMode mode
+) {
+  auto cached = GetCache(spec->cache_key, mode);
+  if (cached.has_value()) {
+    return cached.value();
+  }
+  std::string rule_name = builder_.GetNewRuleName(rule_name_hint);
+  builder_.ReserveRuleName(rule_name);
+  int32_t body_expr = GenerateFromSpecConstrained(spec, rule_name, mode);
+  if (body_expr == kInvalidExprId) {
+    return kInvalidRuleId;
+  }
+  return builder_.AddRule(rule_name, body_expr);
+}
+
+int32_t DeepSeekXMLToolCallingConverter::GenerateFromSpecConstrained(
+    const SchemaSpecPtr& spec, const std::string& rule_name_hint, GenerateMode mode
+) {
+  return std::visit(
+      [this, &rule_name_hint, mode](const auto& s) -> int32_t {
+        using T = std::decay_t<decltype(s)>;
+        if constexpr (std::is_same_v<T, IntegerSpec>) {
+          return mode == GenerateMode::kJSON ? GenerateInteger(s, rule_name_hint) : kInvalidExprId;
+        } else if constexpr (std::is_same_v<T, NumberSpec>) {
+          return mode == GenerateMode::kJSON ? GenerateNumber(s, rule_name_hint) : kInvalidExprId;
+        } else if constexpr (std::is_same_v<T, StringSpec>) {
+          return mode == GenerateMode::kString ? GenerateString(s, rule_name_hint) : kInvalidExprId;
+        } else if constexpr (std::is_same_v<T, BooleanSpec>) {
+          return mode == GenerateMode::kJSON ? GenerateBoolean(s, rule_name_hint) : kInvalidExprId;
+        } else if constexpr (std::is_same_v<T, NullSpec>) {
+          return mode == GenerateMode::kJSON ? GenerateNull(s, rule_name_hint) : kInvalidExprId;
+        } else if constexpr (std::is_same_v<T, ArraySpec>) {
+          return mode == GenerateMode::kJSON ? GenerateArray(s, rule_name_hint) : kInvalidExprId;
+        } else if constexpr (std::is_same_v<T, ObjectSpec>) {
+          return mode == GenerateMode::kJSON ? GenerateObject(s, rule_name_hint) : kInvalidExprId;
+        } else if constexpr (std::is_same_v<T, AnySpec>) {
+          return GenerateAnyConstrained(s, rule_name_hint, mode);
+        } else if constexpr (std::is_same_v<T, ConstSpec>) {
+          return GenerateConstConstrained(s, rule_name_hint, mode);
+        } else if constexpr (std::is_same_v<T, EnumSpec>) {
+          return GenerateEnumConstrained(s, rule_name_hint, mode);
+        } else if constexpr (std::is_same_v<T, RefSpec>) {
+          return GenerateRefConstrained(s, rule_name_hint, mode);
+        } else if constexpr (std::is_same_v<T, AnyOfSpec>) {
+          return GenerateAnyOfConstrained(s, rule_name_hint, mode);
+        } else if constexpr (std::is_same_v<T, OneOfSpec>) {
+          return GenerateOneOfConstrained(s, rule_name_hint, mode);
+        } else if constexpr (std::is_same_v<T, AllOfSpec>) {
+          return GenerateAllOfConstrained(s, rule_name_hint, mode);
+        } else if constexpr (std::is_same_v<T, TypeArraySpec>) {
+          return GenerateTypeArrayConstrained(s, rule_name_hint, mode);
+        } else {
+          XGRAMMAR_LOG(FATAL) << "Unknown spec type";
+        }
+      },
+      spec->spec
+  );
+}
+
+int32_t DeepSeekXMLToolCallingConverter::GenerateAnyConstrained(
+    const AnySpec& spec, const std::string& rule_name, GenerateMode mode
+) {
+  switch (mode) {
+    case GenerateMode::kString:
+      return RuleRef(kXMLString);
+    case GenerateMode::kJSON:
+      return Choice(
+          {RuleRef(kBasicNumber),
+           RuleRef(kBasicBoolean),
+           RuleRef(kBasicNull),
+           RuleRef(kBasicArray),
+           RuleRef(kBasicObject)}
+      );
+  }
+  XGRAMMAR_ICHECK(false) << "Invalid GenerateMode";
+}
+
+int32_t DeepSeekXMLToolCallingConverter::GenerateConstConstrained(
+    const ConstSpec& spec, const std::string& rule_name, GenerateMode mode
+) {
+  picojson::value value;
+  std::string error = picojson::parse(value, spec.json_value);
+  if (error.empty() && value.is<std::string>()) {
+    return mode == GenerateMode::kString ? ByteString(value.get<std::string>()) : kInvalidExprId;
+  }
+  return mode == GenerateMode::kJSON ? ByteString(spec.json_value) : kInvalidExprId;
+}
+
+int32_t DeepSeekXMLToolCallingConverter::GenerateEnumConstrained(
+    const EnumSpec& spec, const std::string& rule_name, GenerateMode mode
+) {
+  XGRAMMAR_DCHECK(!spec.json_values.empty())
+      << "GenerateEnum called with empty enum spec for rule: " << rule_name;
+  std::vector<int32_t> values;
+  values.reserve(spec.json_values.size());
+  for (const auto& json_value : spec.json_values) {
+    picojson::value value;
+    std::string error = picojson::parse(value, json_value);
+    if (error.empty() && value.is<std::string>()) {
+      if (mode == GenerateMode::kString) {
+        values.push_back(ByteString(value.get<std::string>()));
+      }
+    } else {
+      if (mode == GenerateMode::kJSON) {
+        values.push_back(ByteString(json_value));
+      }
+    }
+  }
+  return values.empty() ? kInvalidExprId : Choice(values);
+}
+
+int32_t DeepSeekXMLToolCallingConverter::GenerateRefConstrained(
+    const RefSpec& spec, const std::string& rule_name, GenerateMode mode
+) {
+  // First check if we have a direct URI mapping.
+  std::pair uri_cache_key{spec.uri, mode};
+  if (uri_to_constrained_rule_name_.count(uri_cache_key)) {
+    int32_t rule_id = builder_.GetRuleId(uri_to_constrained_rule_name_[uri_cache_key]);
+    // kInvalidRuleId is possible only in case of self-loop (which is invalid JSON schema), other
+    // cycles would not get here and will be handled by JSONSchemaConverter::GenerateRef.
+    return rule_id == kInvalidRuleId ? kInvalidExprId : RuleRef(rule_id);
+  }
+
+  std::string rule_name_hint = GetRuleNameHintFromURI(spec.uri);
+  std::string allocated_rule_name = builder_.GetNewRuleName(rule_name_hint);
+  builder_.ReserveRuleName(allocated_rule_name);
+  uri_to_constrained_rule_name_[uri_cache_key] = allocated_rule_name;
+
+  SchemaSpecPtr resolved = ResolveRefSchema(spec, allocated_rule_name);
+  int32_t body_expr = GenerateFromSpecConstrained(resolved, allocated_rule_name, mode);
+  if (body_expr == kInvalidExprId) {
+    return kInvalidExprId;
+  }
+  int32_t allocated_rule_id = builder_.AddRule(allocated_rule_name, body_expr);
+  if (!resolved->cache_key.empty()) {
+    AddCache(resolved->cache_key, allocated_rule_id, mode);
+  }
+  return RuleRef(allocated_rule_id);
+}
+
+int32_t DeepSeekXMLToolCallingConverter::GenerateAnyOfConstrained(
+    const AnyOfSpec& spec, const std::string& rule_name, GenerateMode mode
+) {
+  std::vector<int32_t> choices;
+  for (size_t index = 0; index < spec.options.size(); ++index) {
+    int32_t rule_id = CreateRuleConstrained(
+        spec.options[index], rule_name + "_case_" + std::to_string(index), mode
+    );
+    if (rule_id != kInvalidRuleId) {
+      choices.push_back(RuleRef(rule_id));
+    }
+  }
+  return choices.empty() ? kInvalidExprId : Choice(choices);
+}
+
+int32_t DeepSeekXMLToolCallingConverter::GenerateOneOfConstrained(
+    const OneOfSpec& spec, const std::string& rule_name, GenerateMode mode
+) {
+  std::vector<int32_t> choices;
+  for (size_t index = 0; index < spec.options.size(); ++index) {
+    int32_t rule_id = CreateRuleConstrained(
+        spec.options[index], rule_name + "_case_" + std::to_string(index), mode
+    );
+    if (rule_id != kInvalidRuleId) {
+      choices.push_back(RuleRef(rule_id));
+    }
+  }
+  return choices.empty() ? kInvalidExprId : Choice(choices);
+}
+
+int32_t DeepSeekXMLToolCallingConverter::GenerateAllOfConstrained(
+    const AllOfSpec& spec, const std::string& rule_name, GenerateMode mode
+) {
+  if (spec.schemas.size() == 1) {
+    return GenerateFromSpecConstrained(spec.schemas[0], rule_name + "_case_0", mode);
+  }
+  XGRAMMAR_LOG(WARNING) << "Support for allOf with multiple options is still ongoing";
+  return GenerateFromSpecConstrained(SchemaSpec::Make(AnySpec{}, "", "any"), rule_name, mode);
+}
+
+int32_t DeepSeekXMLToolCallingConverter::GenerateTypeArrayConstrained(
+    const TypeArraySpec& spec, const std::string& rule_name, GenerateMode mode
+) {
+  std::vector<int32_t> choices;
+  for (size_t index = 0; index < spec.type_schemas.size(); ++index) {
+    int32_t rule_id = CreateRuleConstrained(
+        spec.type_schemas[index], rule_name + "_type_" + std::to_string(index), mode
+    );
+    if (rule_id != kInvalidRuleId) {
+      choices.push_back(RuleRef(rule_id));
+    }
+  }
+  return choices.empty() ? kInvalidExprId : Choice(choices);
+}
+
+void DeepSeekXMLToolCallingConverter::AddCache(
+    const std::string& key, int32_t rule_id, GenerateMode mode
+) {
+  if (key.empty()) {
+    return;
+  }
+  constrained_rule_cache_manager_.AddCache(key, mode == GenerateMode::kString, rule_id);
+}
+
+std::optional<int32_t> DeepSeekXMLToolCallingConverter::GetCache(
+    const std::string& key, GenerateMode mode
+) const {
+  if (key.empty()) {
+    return std::nullopt;
+  }
+  return constrained_rule_cache_manager_.GetCache(key, mode == GenerateMode::kString);
 }
 
 CohereXMLToolCallingConverter::CohereXMLToolCallingConverter(
@@ -834,14 +1193,17 @@ int32_t CohereXMLToolCallingConverter::FormatOtherProperty(
     const SchemaSpecPtr& schema
 ) {
   SchemaSpecPtr value_schema = schema;
-  if (!value_schema && !additional_property_stack_.empty()) {
+  bool is_original_any = value_schema && std::holds_alternative<AnySpec>(value_schema->spec);
+  if ((!value_schema || is_original_any) && !additional_property_stack_.empty()) {
+    is_original_any = false;
     value_schema = additional_property_stack_.back();
   }
-  if (!value_schema && InCohereValueContext()) {
+  if ((!value_schema || is_original_any) && InCohereValueContext()) {
+    is_original_any = false;
     value_schema = SchemaSpec::Make(AnySpec{}, "", "any");
     value_rule_id = CreateRule(value_schema, rule_name + "_" + rule_name_suffix + "_cohere_any");
   }
-  if (value_schema) {
+  if (value_schema && !is_original_any) {
     return FormatCohereParam(std::nullopt, key_pattern_expr, value_schema, value_rule_id);
   }
   return XMLToolCallingConverter::FormatOtherProperty(

--- a/cpp/json_schema_converter_ext.h
+++ b/cpp/json_schema_converter_ext.h
@@ -42,6 +42,9 @@ class XMLToolCallingConverter : public JSONSchemaConverter {
   Grammar Convert(const SchemaSpecPtr& spec);
 
  protected:
+  using JSONSchemaConverter::FormatOtherProperty;
+  using JSONSchemaConverter::FormatProperty;
+
   // Override methods for XML format
   int32_t GenerateString(const StringSpec& spec, const std::string& rule_name) override;
   int32_t GenerateObject(
@@ -78,6 +81,8 @@ class XMLToolCallingConverter : public JSONSchemaConverter {
   std::string NextSeparator(bool is_end = false) override;
 
   void AddBasicRules() override;
+  void AddBasicRules(const std::vector<std::string>& additional_rule_names);
+  virtual void AddXMLBasicRulesLevel1();
 
   void AddCache(const std::string& key, int32_t rule_id) override;
   std::optional<int32_t> GetCache(const std::string& key) const override;
@@ -127,6 +132,92 @@ class XMLToolCallingConverter : public JSONSchemaConverter {
   const XMLWrapper xml_wrapper_;
 };
 
+/*! \brief Converter for DeepSeek XML Tool Calling format. */
+class DeepSeekXMLToolCallingConverter : public XMLToolCallingConverter {
+ public:
+  DeepSeekXMLToolCallingConverter(
+      std::optional<int> indent,
+      std::optional<std::pair<std::string, std::string>> separators,
+      bool any_whitespace,
+      std::optional<int> max_whitespace_cnt,
+      RefResolver ref_resolver = nullptr,
+      bool any_order = false
+  );
+
+ protected:
+  using XMLToolCallingConverter::AddCache;
+  using XMLToolCallingConverter::FormatOtherProperty;
+  using XMLToolCallingConverter::FormatProperty;
+  using XMLToolCallingConverter::GetCache;
+
+  void AddBasicRules() override;
+  void AddXMLBasicRulesLevel1() override;
+
+  int32_t FormatProperty(
+      const std::string& key,
+      const SchemaSpecPtr& value_spec,
+      const std::string& rule_name,
+      int64_t idx
+  ) override;
+  int32_t FormatOtherProperty(
+      int32_t key_pattern_expr,
+      const SchemaSpecPtr& value_spec,
+      const std::string& rule_name,
+      const std::string& rule_name_suffix
+  ) override;
+
+ private:
+  enum class GenerateMode {
+    kString,
+    kJSON,
+  };
+
+  static const std::string kXMLAnyJSON;
+  static constexpr const char* kKeySuffixes[] = {
+      "\" string=\"true\">",
+      "\" string=\"false\">",
+  };
+
+  int32_t CreateRuleConstrained(
+      const SchemaSpecPtr& spec, const std::string& rule_name_hint, GenerateMode mode
+  );
+  int32_t GenerateFromSpecConstrained(
+      const SchemaSpecPtr& spec, const std::string& rule_name_hint, GenerateMode mode
+  );
+
+  int32_t GenerateAnyConstrained(
+      const AnySpec& spec, const std::string& rule_name, GenerateMode mode
+  );
+  int32_t GenerateConstConstrained(
+      const ConstSpec& spec, const std::string& rule_name, GenerateMode mode
+  );
+  int32_t GenerateEnumConstrained(
+      const EnumSpec& spec, const std::string& rule_name, GenerateMode mode
+  );
+  int32_t GenerateRefConstrained(
+      const RefSpec& spec, const std::string& rule_name, GenerateMode mode
+  );
+  int32_t GenerateAnyOfConstrained(
+      const AnyOfSpec& spec, const std::string& rule_name, GenerateMode mode
+  );
+  int32_t GenerateOneOfConstrained(
+      const OneOfSpec& spec, const std::string& rule_name, GenerateMode mode
+  );
+  int32_t GenerateAllOfConstrained(
+      const AllOfSpec& spec, const std::string& rule_name, GenerateMode mode
+  );
+  int32_t GenerateTypeArrayConstrained(
+      const TypeArraySpec& spec, const std::string& rule_name, GenerateMode mode
+  );
+
+  void AddCache(const std::string& key, int32_t rule_id, GenerateMode mode);
+  std::optional<int32_t> GetCache(const std::string& key, GenerateMode mode) const;
+
+  GenerateCacheManager constrained_rule_cache_manager_;
+  std::unordered_map<std::pair<std::string, GenerateMode>, std::string>
+      uri_to_constrained_rule_name_;
+};
+
 /*!
  * \brief Converter for Cohere XML Tool Calling format.
  *
@@ -146,6 +237,9 @@ class CohereXMLToolCallingConverter : public XMLToolCallingConverter {
   );
 
  protected:
+  using XMLToolCallingConverter::FormatOtherProperty;
+  using XMLToolCallingConverter::FormatProperty;
+
   int32_t GenerateString(const StringSpec& spec, const std::string& rule_name) override;
   int32_t GenerateObject(
       const ObjectSpec& spec, const std::string& rule_name, bool dummy_need_braces = false

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -48,7 +48,7 @@ def _check_minimax_grammar(schema: dict, expected_grammar: str, instance: str, a
 
 def _check_deepseek_grammar(schema: dict, expected_grammar: str, instance: str, accepted: bool):
     ebnf_grammar = _json_schema_to_ebnf(schema, json_format="deepseek_xml")
-    check_grammar_with_expected_grammar(ebnf_grammar, expected_grammar)
+    assert ebnf_grammar == expected_grammar, f"Expected:\n{expected_grammar}\nGot:\n{ebnf_grammar}"
     check_grammar_with_instance(ebnf_grammar, instance, accepted)
 
 
@@ -894,11 +894,11 @@ deepseek_test_string_schema_input_str_accepted = (
     ),
     (
         '<｜DSML｜parameter name="name" string="true">Bob</｜DSML｜parameter>\t\n<｜DSML｜parameter name="age" string="true">\t100\n</｜DSML｜parameter>',
-        True,
+        False,
     ),
     (
         '<｜DSML｜parameter name="name" string="false">Bob</｜DSML｜parameter><｜DSML｜parameter name="age" string="true">100</｜DSML｜parameter>',
-        True,
+        False,
     ),
     (
         """<｜DSML｜parameter name="name" string="true"><!DOCTYPE html>
@@ -926,23 +926,37 @@ deepseek_test_string_schema_input_str_accepted = (
 
 @pytest.mark.parametrize("input_str, accepted", deepseek_test_string_schema_input_str_accepted)
 def test_deepseek_string_schema(input_str: str, accepted: bool):
-    expected_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
-basic_string_sub ::= ("\"" | [^\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub) (= [ \n\r\t]* [,}\]:])
-basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
-basic_integer ::= ("0" | "-"? [1-9] [0-9]*)
-basic_number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
-basic_string ::= ["] basic_string_sub
-basic_boolean ::= "true" | "false"
-basic_null ::= "null"
-basic_array ::= (("[" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_any)* [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
-basic_object ::= ("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any)* [ \n\r\t]* "}") | "{" [ \n\r\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
-xml_any ::= xml_string | basic_array | basic_object
-xml_object ::= ( [ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>" ([ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>")* [ \n\r\t]*) | [ \n\r\t]*
-xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
-root_prop_1 ::= ("0" | "-"? [1-9] [0-9]*)
-root_part_0 ::= [ \n\r\t]* "<｜DSML｜parameter name=\"age\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_1 [ \n\r\t]* "</｜DSML｜parameter>" ""
-root ::=  [ \n\r\t]* (("<｜DSML｜parameter name=\"name\" string=\"" ("true" | "false") "\">" xml_string "</｜DSML｜parameter>" root_part_0)) [ \n\r\t]*
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"name\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>" root_part_0 [ \n\r\t]*))
+root_part_0 ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"age\" string=\"false\">" [ \n\r\t]* basic_integer [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
 """
     schema = {
         "type": "object",
@@ -967,22 +981,38 @@ def test_deepseek_pattern_empty_leading_alternative(input_str: str, accepted: bo
     # Regression: a pattern whose first alternative is empty ("^$|...") used to emit a bare
     # leading '|' (root_prop_0 ::= | ...) and crash the grammar parser on the deepseek_xml path.
     # It must now be emitted as root_prop_0 ::= "" | ...
-    expected_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
-basic_string_sub ::= ("\"" | [^\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub) (= [ \n\r\t]* [,}\]:])
-basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
-basic_integer ::= ("0" | "-"? [1-9] [0-9]*)
-basic_number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
-basic_string ::= ["] basic_string_sub
-basic_boolean ::= "true" | "false"
-basic_null ::= "null"
-basic_array ::= (("[" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_any)* [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
-basic_object ::= ("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any)* [ \n\r\t]* "}") | "{" [ \n\r\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
-xml_any ::= xml_string | basic_array | basic_object
-xml_object ::= ( [ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>" ([ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>")* [ \n\r\t]*) | [ \n\r\t]*
-xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
-root_prop_0 ::= "" | "h" "t" "t" "p" "s" ":" "/" "/" "x" "." "c" "o" "m" "/"
-root ::=  [ \n\r\t]* (("<｜DSML｜parameter name=\"url\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_0 [ \n\r\t]* "</｜DSML｜parameter>" "")) [ \n\r\t]*
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"url\" string=\"true\">" root_string_prop_0 "</\uff5cDSML\uff5cparameter>" [ \n\r\t]*))
+root_1 ::= ("" | ("h" "t" "t" "p" "s" ":" "/" "/" "x" "." "c" "o" "m" "/"))
+root_string_prop_0 ::= ((root_1))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
 """
     schema = {
         "type": "object",
@@ -1014,25 +1044,42 @@ deepseek_test_additional_properties_schema_input_str_accepted = (
     "input_str, accepted", deepseek_test_additional_properties_schema_input_str_accepted
 )
 def test_deepseek_additional_properties_schema(input_str: str, accepted: bool):
-    expected_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
-basic_string_sub ::= ("\"" | [^\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub) (= [ \n\r\t]* [,}\]:])
-basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
-basic_integer ::= ("0" | "-"? [1-9] [0-9]*)
-basic_number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
-basic_string ::= ["] basic_string_sub
-basic_boolean ::= "true" | "false"
-basic_null ::= "null"
-basic_array ::= (("[" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_any)* [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
-basic_object ::= ("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any)* [ \n\r\t]* "}") | "{" [ \n\r\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
-xml_any ::= xml_string | basic_array | basic_object
-xml_object ::= ( [ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>" ([ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>")* [ \n\r\t]*) | [ \n\r\t]*
-xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
-root_prop_1 ::= ("0" | "-"? [1-9] [0-9]*)
-root_addl ::= xml_string | basic_array | basic_object
-root_part_1 ::= ([ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_addl [ \n\r\t]* "</｜DSML｜parameter>")*
-root_part_0 ::= [ \n\r\t]* "<｜DSML｜parameter name=\"age\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_1 [ \n\r\t]* "</｜DSML｜parameter>" root_part_1
-root ::=  [ \n\r\t]* (("<｜DSML｜parameter name=\"name\" string=\"" ("true" | "false") "\">" xml_string "</｜DSML｜parameter>" root_part_0)) [ \n\r\t]*
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"name\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>" root_part_0 [ \n\r\t]*))
+root_string_addl ::= ((xml_string))
+root_json_addl ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+root_additional_properties ::= (([ \n\r\t]* root_additional_properties_1))
+root_part_1 ::= ((root_additional_properties{0, -1}))
+root_part_0 ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"age\" string=\"false\">" [ \n\r\t]* basic_integer [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" root_part_1))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+root_additional_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" root_string_addl "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* root_json_addl [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
 """
     schema = {
         "type": "object",
@@ -1062,25 +1109,44 @@ deepseek_test_not_required_properties_schema_input_str_accepted = (
     "input_str, accepted", deepseek_test_not_required_properties_schema_input_str_accepted
 )
 def test_deepseek_not_required_properties_schema(input_str: str, accepted: bool):
-    expected_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
-basic_string_sub ::= ("\"" | [^\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub) (= [ \n\r\t]* [,}\]:])
-basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
-basic_integer ::= ("0" | "-"? [1-9] [0-9]*)
-basic_number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
-basic_string ::= ["] basic_string_sub
-basic_boolean ::= "true" | "false"
-basic_null ::= "null"
-basic_array ::= (("[" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_any)* [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
-basic_object ::= ("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any)* [ \n\r\t]* "}") | "{" [ \n\r\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
-xml_any ::= xml_string | basic_array | basic_object
-xml_object ::= ( [ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>" ([ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>")* [ \n\r\t]*) | [ \n\r\t]*
-xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
-root_prop_1 ::= ("0" | "-"? [1-9] [0-9]*)
-root_addl ::= xml_string | basic_array | basic_object
-root_part_1 ::= ([ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_addl [ \n\r\t]* "</｜DSML｜parameter>")*
-root_part_0 ::= root_part_1 | [ \n\r\t]* "<｜DSML｜parameter name=\"age\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_1 [ \n\r\t]* "</｜DSML｜parameter>" root_part_1
-root ::= ( [ \n\r\t]* (("<｜DSML｜parameter name=\"name\" string=\"" ("true" | "false") "\">" xml_string "</｜DSML｜parameter>" root_part_0) | ("<｜DSML｜parameter name=\"age\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_1 [ \n\r\t]* "</｜DSML｜parameter>" root_part_1) | "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_addl [ \n\r\t]* "</｜DSML｜parameter>" root_part_1) [ \n\r\t]*) | [ \n\r\t]*
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* root_2 [ \n\r\t]*) | ([ \n\r\t]*))
+root_string_addl ::= ((xml_string))
+root_json_addl ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+root_additional_properties ::= (([ \n\r\t]* root_additional_properties_1))
+root_part_1 ::= ((root_additional_properties{0, -1}))
+root_part_0 ::= ((root_part_1) | ([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"age\" string=\"false\">" [ \n\r\t]* basic_integer [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" root_part_1))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+root_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" root_string_addl "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* root_json_addl [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+root_2 ::= (("<\uff5cDSML\uff5cparameter name=\"name\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>" root_part_0) | ("<\uff5cDSML\uff5cparameter name=\"age\" string=\"false\">" [ \n\r\t]* basic_integer [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" root_part_1) | (root_1 root_part_1))
+root_additional_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" root_string_addl "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* root_json_addl [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
 """
     schema = {
         "type": "object",
@@ -1103,6 +1169,10 @@ deepseek_test_part_required_properties_schema_input_str_accepted = (
     ),
     (
         '<｜DSML｜parameter name="name" string="false">Bob</｜DSML｜parameter><｜DSML｜parameter name="anything" string="true">It\'s a string.</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="name" string="true">Bob</｜DSML｜parameter><｜DSML｜parameter name="anything" string="true">It\'s a string.</｜DSML｜parameter>',
         True,
     ),
     ('<｜DSML｜parameter name="anything" string="true">It\'s a string.</｜DSML｜parameter>', False),
@@ -1113,25 +1183,42 @@ deepseek_test_part_required_properties_schema_input_str_accepted = (
     "input_str, accepted", deepseek_test_part_required_properties_schema_input_str_accepted
 )
 def test_deepseek_part_required_properties_schema(input_str: str, accepted: bool):
-    expected_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
-basic_string_sub ::= ("\"" | [^\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub) (= [ \n\r\t]* [,}\]:])
-basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
-basic_integer ::= ("0" | "-"? [1-9] [0-9]*)
-basic_number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
-basic_string ::= ["] basic_string_sub
-basic_boolean ::= "true" | "false"
-basic_null ::= "null"
-basic_array ::= (("[" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_any)* [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
-basic_object ::= ("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any)* [ \n\r\t]* "}") | "{" [ \n\r\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
-xml_any ::= xml_string | basic_array | basic_object
-xml_object ::= ( [ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>" ([ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>")* [ \n\r\t]*) | [ \n\r\t]*
-xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
-root_prop_1 ::= ("0" | "-"? [1-9] [0-9]*)
-root_addl ::= xml_string | basic_array | basic_object
-root_part_1 ::= ([ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_addl [ \n\r\t]* "</｜DSML｜parameter>")*
-root_part_0 ::= root_part_1 | [ \n\r\t]* "<｜DSML｜parameter name=\"age\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_1 [ \n\r\t]* "</｜DSML｜parameter>" root_part_1
-root ::=  [ \n\r\t]* (("<｜DSML｜parameter name=\"name\" string=\"" ("true" | "false") "\">" xml_string "</｜DSML｜parameter>" root_part_0)) [ \n\r\t]*
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"name\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>" root_part_0 [ \n\r\t]*))
+root_string_addl ::= ((xml_string))
+root_json_addl ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+root_additional_properties ::= (([ \n\r\t]* root_additional_properties_1))
+root_part_1 ::= ((root_additional_properties{0, -1}))
+root_part_0 ::= ((root_part_1) | ([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"age\" string=\"false\">" [ \n\r\t]* basic_integer [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" root_part_1))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+root_additional_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" root_string_addl "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* root_json_addl [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
 """
     schema = {
         "type": "object",
@@ -1145,6 +1232,10 @@ root ::=  [ \n\r\t]* (("<｜DSML｜parameter name=\"name\" string=\"" ("true" | 
 deepseek_test_inner_object_schema_input_str_accepted = (
     (
         '<｜DSML｜parameter name="address" string="true">{"street": "Main St", "city": "New York"}</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="address" string="false">{"street": "Main St", "city": "New York"}</｜DSML｜parameter>',
         True,
     ),
     (
@@ -1169,6 +1260,10 @@ deepseek_test_inner_object_schema_input_str_accepted = (
     ),
     (
         '<｜DSML｜parameter name="address" string="true">{"street": "Main St", "city": "New York", "additional_property": "value"}</｜DSML｜parameter><｜DSML｜parameter name="additional_property" string="true">value</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="address" string="false">{"street": "Main St", "city": "New York", "additional_property": "value"}</｜DSML｜parameter><｜DSML｜parameter name="additional_property" string="true">value</｜DSML｜parameter>',
         True,
     ),
     (
@@ -1182,28 +1277,58 @@ deepseek_test_inner_object_schema_input_str_accepted = (
     "input_str, accepted", deepseek_test_inner_object_schema_input_str_accepted
 )
 def test_deepseek_inner_object_schema(input_str: str, accepted: bool):
-    expected_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
-basic_string_sub ::= ("\"" | [^\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub) (= [ \n\r\t]* [,}\]:])
-basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
-basic_integer ::= ("0" | "-"? [1-9] [0-9]*)
-basic_number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
-basic_string ::= ["] basic_string_sub
-basic_boolean ::= "true" | "false"
-basic_null ::= "null"
-basic_array ::= (("[" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_any)* [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
-basic_object ::= ("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any)* [ \n\r\t]* "}") | "{" [ \n\r\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
-xml_any ::= xml_string | basic_array | basic_object
-xml_object ::= ( [ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>" ([ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>")* [ \n\r\t]*) | [ \n\r\t]*
-xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
-root_prop_0_addl ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
-root_prop_0_addl_key ::= ["] (("\"" | [^cs\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub | "c" ("\"" | [^i\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub | "i" ("\"" | [^t\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub | "t" ("\"" | [^y\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub | "y" ([^\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub)))) | "s" ("\"" | [^t\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub | "t" ("\"" | [^r\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub | "r" ("\"" | [^e\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub | "e" ("\"" | [^e\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub | "e" ("\"" | [^t\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub | "t" ([^\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub)))))))) (= [ \n\r\t]* [,}\]:])
-root_prop_0_part_1 ::= ([ \n\r\t]* "," [ \n\r\t]* root_prop_0_addl_key [ \n\r\t]* ":" [ \n\r\t]* root_prop_0_addl)*
-root_prop_0_part_0 ::= [ \n\r\t]* "," [ \n\r\t]* "\"city\"" [ \n\r\t]* ":" [ \n\r\t]* basic_string root_prop_0_part_1
-root_prop_0 ::= "{" [ \n\r\t]* (("\"street\"" [ \n\r\t]* ":" [ \n\r\t]* basic_string root_prop_0_part_0)) [ \n\r\t]* "}"
-root_addl ::= xml_string | basic_array | basic_object
-root_part_0 ::= ([ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_addl [ \n\r\t]* "</｜DSML｜parameter>")*
-root ::=  [ \n\r\t]* (("<｜DSML｜parameter name=\"address\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_0 [ \n\r\t]* "</｜DSML｜parameter>" root_part_0)) [ \n\r\t]*
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"address\" string=\"false\">" [ \n\r\t]* root_json_prop_0 [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" root_part_0 [ \n\r\t]*))
+root_json_prop_0_addl_key ::= (("\"" root_json_prop_0_addl_key_11)) (=([ \n\r\t]* [,}\]:]))
+root_json_prop_0_addl ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+root_json_prop_0_additional_properties ::= (([ \n\r\t]* "," [ \n\r\t]* root_json_prop_0_addl_key [ \n\r\t]* ":" [ \n\r\t]* root_json_prop_0_addl))
+root_json_prop_0_part_1 ::= ((root_json_prop_0_additional_properties{0, -1}))
+root_json_prop_0_part_0 ::= (([ \n\r\t]* "," [ \n\r\t]* "\"city\"" [ \n\r\t]* ":" [ \n\r\t]* basic_string root_json_prop_0_part_1))
+root_json_prop_0 ::= (("{" [ \n\r\t]* "\"street\"" [ \n\r\t]* ":" [ \n\r\t]* basic_string root_json_prop_0_part_0 [ \n\r\t]* "}"))
+root_string_addl ::= ((xml_string))
+root_json_addl ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+root_additional_properties ::= (([ \n\r\t]* root_additional_properties_1))
+root_part_0 ::= ((root_additional_properties{0, -1}))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+root_json_prop_0_addl_key_1 ::= (([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub))
+root_json_prop_0_addl_key_2 ::= (("\"") | ([^\0-\x1f\"\\\r\ny] basic_string_sub) | ("\\" basic_escape basic_string_sub) | ("y" root_json_prop_0_addl_key_1))
+root_json_prop_0_addl_key_3 ::= (("\"") | ([^\0-\x1f\"\\\r\nt] basic_string_sub) | ("\\" basic_escape basic_string_sub) | ("t" root_json_prop_0_addl_key_2))
+root_json_prop_0_addl_key_4 ::= (("\"") | ([^\0-\x1f\"\\\r\ni] basic_string_sub) | ("\\" basic_escape basic_string_sub) | ("i" root_json_prop_0_addl_key_3))
+root_json_prop_0_addl_key_5 ::= (([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub))
+root_json_prop_0_addl_key_6 ::= (("\"") | ([^\0-\x1f\"\\\r\nt] basic_string_sub) | ("\\" basic_escape basic_string_sub) | ("t" root_json_prop_0_addl_key_5))
+root_json_prop_0_addl_key_7 ::= (("\"") | ([^\0-\x1f\"\\\r\ne] basic_string_sub) | ("\\" basic_escape basic_string_sub) | ("e" root_json_prop_0_addl_key_6))
+root_json_prop_0_addl_key_8 ::= (("\"") | ([^\0-\x1f\"\\\r\ne] basic_string_sub) | ("\\" basic_escape basic_string_sub) | ("e" root_json_prop_0_addl_key_7))
+root_json_prop_0_addl_key_9 ::= (("\"") | ([^\0-\x1f\"\\\r\nr] basic_string_sub) | ("\\" basic_escape basic_string_sub) | ("r" root_json_prop_0_addl_key_8))
+root_json_prop_0_addl_key_10 ::= (("\"") | ([^\0-\x1f\"\\\r\nt] basic_string_sub) | ("\\" basic_escape basic_string_sub) | ("t" root_json_prop_0_addl_key_9))
+root_json_prop_0_addl_key_11 ::= (("\"") | ([^\0-\x1f\"\\\r\ncs] basic_string_sub) | ("\\" basic_escape basic_string_sub) | ("c" root_json_prop_0_addl_key_4) | ("s" root_json_prop_0_addl_key_10))
+root_additional_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" root_string_addl "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* root_json_addl [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
 """
     schema = {
         "type": "object",
@@ -1229,6 +1354,10 @@ deepseek_test_numbers_schema_input_str_accepted = (
     ),
     (
         '<｜DSML｜parameter name="name" string="true">Bob</｜DSML｜parameter><｜DSML｜parameter name="ID" string="false">123456</｜DSML｜parameter><｜DSML｜parameter name="is_student" string="true">true</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="name" string="true">Bob</｜DSML｜parameter><｜DSML｜parameter name="ID" string="false">123456</｜DSML｜parameter><｜DSML｜parameter name="is_student" string="false">true</｜DSML｜parameter>',
         True,
     ),
     (
@@ -1240,30 +1369,43 @@ deepseek_test_numbers_schema_input_str_accepted = (
 
 @pytest.mark.parametrize("input_str, accepted", deepseek_test_numbers_schema_input_str_accepted)
 def test_deepseek_numbers_schema(input_str: str, accepted: bool):
-    expected_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
-basic_string_sub ::= ("\"" | [^\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub) (= [ \n\r\t]* [,}\]:])
-basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
-basic_integer ::= ("0" | "-"? [1-9] [0-9]*)
-basic_number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
-basic_string ::= ["] basic_string_sub
-basic_boolean ::= "true" | "false"
-basic_null ::= "null"
-basic_array ::= (("[" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_any)* [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
-basic_object ::= ("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any)* [ \n\r\t]* "}") | "{" [ \n\r\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
-xml_any ::= xml_string | basic_array | basic_object
-xml_object ::= ( [ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>" ([ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>")* [ \n\r\t]*) | [ \n\r\t]*
-xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
-root_prop_1 ::= ("0" | "-"? [1-9] [0-9]*)
-root_prop_2 ::= ("0" | "-"? [1-9] [0-9]*)
-root_prop_3 ::= "true" | "false"
-root_part_2_1 ::= [ \n\r\t]* "<｜DSML｜parameter name=\"is_student\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_3 [ \n\r\t]* "</｜DSML｜parameter>" ""
-root_part_2_2 ::= "" | [ \n\r\t]* "<｜DSML｜parameter name=\"is_student\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_3 [ \n\r\t]* "</｜DSML｜parameter>" ""
-root_part_2_3 ::= ""
-root_part_1_1 ::= root_part_2_1 | [ \n\r\t]* "<｜DSML｜parameter name=\"ID\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_2 [ \n\r\t]* "</｜DSML｜parameter>" root_part_2_2
-root_part_1_2 ::= root_part_2_2 | [ \n\r\t]* "<｜DSML｜parameter name=\"ID\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_2 [ \n\r\t]* "</｜DSML｜parameter>" root_part_2_3
-root_part_0_1 ::= root_part_1_1 | [ \n\r\t]* "<｜DSML｜parameter name=\"age\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_1 [ \n\r\t]* "</｜DSML｜parameter>" root_part_1_2
-root ::=  [ \n\r\t]* (("<｜DSML｜parameter name=\"name\" string=\"" ("true" | "false") "\">" xml_string "</｜DSML｜parameter>" root_part_0_1) | ("<｜DSML｜parameter name=\"age\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_1 [ \n\r\t]* "</｜DSML｜parameter>" root_part_1_1) | ("<｜DSML｜parameter name=\"ID\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_2 [ \n\r\t]* "</｜DSML｜parameter>" root_part_2_1)) [ \n\r\t]*
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* root_1 [ \n\r\t]*))
+root_part_2_1 ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"is_student\" string=\"false\">" [ \n\r\t]* basic_boolean [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+root_part_2_2 ::= ("" | ([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"is_student\" string=\"false\">" [ \n\r\t]* basic_boolean [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+root_part_2_3 ::= ("")
+root_part_1_1 ::= ((root_part_2_1) | ([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"ID\" string=\"false\">" [ \n\r\t]* basic_integer [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" root_part_2_2))
+root_part_1_2 ::= ((root_part_2_2) | ([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"ID\" string=\"false\">" [ \n\r\t]* basic_integer [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" root_part_2_3))
+root_part_0_1 ::= ((root_part_1_1) | ([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"age\" string=\"false\">" [ \n\r\t]* basic_integer [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" root_part_1_2))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+root_1 ::= (("<\uff5cDSML\uff5cparameter name=\"name\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>" root_part_0_1) | ("<\uff5cDSML\uff5cparameter name=\"age\" string=\"false\">" [ \n\r\t]* basic_integer [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" root_part_1_1) | ("<\uff5cDSML\uff5cparameter name=\"ID\" string=\"false\">" [ \n\r\t]* basic_integer [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" root_part_2_1))
 """
     schema = {
         "type": "object",
@@ -1298,28 +1440,623 @@ deepseek_reject_wrong_parameter_format_input_str_accepted = (
 )
 def test_deepseek_reject_wrong_parameter_format(input_str: str, accepted: bool):
     """DeepSeek grammar must accept <｜DSML｜parameter name=\"key\" string=\"true|false\">, reject Qwen and Minimax formats."""
-    expected_grammar = r"""basic_escape ::= ["\\/bfnrt] | "u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]
-basic_string_sub ::= ("\"" | [^\0-\x1f\"\\\r\n] basic_string_sub | "\\" basic_escape basic_string_sub) (= [ \n\r\t]* [,}\]:])
-basic_any ::= basic_number | basic_string | basic_boolean | basic_null | basic_array | basic_object
-basic_integer ::= ("0" | "-"? [1-9] [0-9]*)
-basic_number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [+-]? [0-9]+)?
-basic_string ::= ["] basic_string_sub
-basic_boolean ::= "true" | "false"
-basic_null ::= "null"
-basic_array ::= (("[" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_any)* [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
-basic_object ::= ("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any ([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any)* [ \n\r\t]* "}") | "{" [ \n\r\t]* "}"
-xml_string ::= TagDispatch(loop_after_dispatch=false,excludes=("</｜DSML｜parameter>"))
-xml_any ::= xml_string | basic_array | basic_object
-xml_object ::= ( [ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>" ([ \n\r\t]* "<｜DSML｜parameter name=\"" xml_variable_name "\" string=\"" ("true" | "false") "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</｜DSML｜parameter>")* [ \n\r\t]*) | [ \n\r\t]*
-xml_variable_name ::= [a-zA-Z_][a-zA-Z0-9_]*
-root_prop_1 ::= ("0" | "-"? [1-9] [0-9]*)
-root_part_0 ::= [ \n\r\t]* "<｜DSML｜parameter name=\"age\" string=\"" ("true" | "false") "\">" [ \n\r\t]* root_prop_1 [ \n\r\t]* "</｜DSML｜parameter>" ""
-root ::=  [ \n\r\t]* (("<｜DSML｜parameter name=\"name\" string=\"" ("true" | "false") "\">" xml_string "</｜DSML｜parameter>" root_part_0)) [ \n\r\t]*
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"name\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>" root_part_0 [ \n\r\t]*))
+root_part_0 ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"age\" string=\"false\">" [ \n\r\t]* basic_integer [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
 """
     schema = {
         "type": "object",
         "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
         "required": ["name", "age"],
+    }
+    _check_deepseek_grammar(schema, expected_grammar, input_str, accepted)
+
+
+deepseek_mixed_string_nonstring_input_str_accepted = (
+    ('<｜DSML｜parameter name="field" string="true">hello</｜DSML｜parameter>', True),
+    ('<｜DSML｜parameter name="field" string="false">hello</｜DSML｜parameter>', False),
+    ('<｜DSML｜parameter name="field" string="false">"hello"</｜DSML｜parameter>', False),
+    ('<｜DSML｜parameter name="field" string="false">1234</｜DSML｜parameter>', True),
+    ('<｜DSML｜parameter name="field" string="false">"1234"</｜DSML｜parameter>', False),
+    ('<｜DSML｜parameter name="field" string="false">[]</｜DSML｜parameter>', True),
+    ('<｜DSML｜parameter name="field" string="false">["hello"]</｜DSML｜parameter>', True),
+    ('<｜DSML｜parameter name="field" string="false">["1234"]</｜DSML｜parameter>', True),
+    ('<｜DSML｜parameter name="field" string="false">[hello]</｜DSML｜parameter>', False),
+    ('<｜DSML｜parameter name="field" string="false">[1234]</｜DSML｜parameter>', False),
+    ('<｜DSML｜parameter name="field" string="true">quotes"newlines\n</｜DSML｜parameter>', True),
+    ('<｜DSML｜parameter name="field" string="false">quotes"newlines\n</｜DSML｜parameter>', False),
+    (
+        '<｜DSML｜parameter name="field" string="false">"quotes\\"newlines\\n"</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="field" string="false">["quotes\\"newlines\\n"]</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="field" string="false">["quotes"newlines\\n"]</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="field" string="false">["quotes\\"newlines\n"]</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="field" string="false">["quotes"newlines\n"]</｜DSML｜parameter>',
+        False,
+    ),
+)
+
+
+@pytest.mark.parametrize("input_str, accepted", deepseek_mixed_string_nonstring_input_str_accepted)
+def test_deepseek_mixed_string_nonstring(input_str: str, accepted: bool):
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* root_1 [ \n\r\t]*))
+root_string_prop_0 ::= ((xml_string))
+root_json_prop_0_case_2_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string))
+root_json_prop_0_case_2 ::= (("[" [ \n\r\t]* basic_string root_json_prop_0_case_2_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+root_json_prop_0 ::= ((basic_integer) | (root_json_prop_0_case_2))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+root_1 ::= (("<\uff5cDSML\uff5cparameter name=\"field\" string=\"true\">" root_string_prop_0 "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"field\" string=\"false\">" [ \n\r\t]* root_json_prop_0 [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+"""
+    schema = {
+        "type": "object",
+        "properties": {
+            "field": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "integer"},
+                    {"type": "array", "items": {"type": "string"}},
+                ]
+            }
+        },
+        "required": ["field"],
+    }
+    _check_deepseek_grammar(schema, expected_grammar, input_str, accepted)
+
+
+deepseek_mixed_enum_input_str_accepted = (
+    ('<｜DSML｜parameter name="field" string="true">hello</｜DSML｜parameter>', True),
+    ('<｜DSML｜parameter name="field" string="true">"hello"</｜DSML｜parameter>', False),
+    ('<｜DSML｜parameter name="field" string="false">hello</｜DSML｜parameter>', False),
+    ('<｜DSML｜parameter name="field" string="false">"hello"</｜DSML｜parameter>', False),
+    ('<｜DSML｜parameter name="field" string="false">1234</｜DSML｜parameter>', True),
+    ('<｜DSML｜parameter name="field" string="true">1234</｜DSML｜parameter>', False),
+    ('<｜DSML｜parameter name="field" string="true">5678</｜DSML｜parameter>', True),
+    ('<｜DSML｜parameter name="field" string="false">5678</｜DSML｜parameter>', False),
+    ('<｜DSML｜parameter name="field" string="true">quotes"newlines\n</｜DSML｜parameter>', True),
+    (
+        '<｜DSML｜parameter name="field" string="true">quotes\\"newlines\\n</｜DSML｜parameter>',
+        False,
+    ),
+    ('<｜DSML｜parameter name="field" string="false">quotes"newlines\n</｜DSML｜parameter>', False),
+    (
+        '<｜DSML｜parameter name="field" string="false">"quotes\\"newlines\\n"</｜DSML｜parameter>',
+        False,
+    ),
+    ('<｜DSML｜parameter name="field" string="false">\tnull\n</｜DSML｜parameter>', True),
+    ('<｜DSML｜parameter name="field" string="true">null</｜DSML｜parameter>', False),
+    ('<｜DSML｜parameter name="field" string="false">["hello"]</｜DSML｜parameter>', True),
+    ('<｜DSML｜parameter name="field" string="true">["hello"]</｜DSML｜parameter>', False),
+    (
+        '<｜DSML｜parameter name="field" string="false">["quotes\\"newlines\\n"]</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="field" string="false">["quotes"newlines\\n"]</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="field" string="false">["quotes\\"newlines\n"]</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="field" string="false">["quotes"newlines\n"]</｜DSML｜parameter>',
+        False,
+    ),
+)
+
+
+@pytest.mark.parametrize("input_str, accepted", deepseek_mixed_enum_input_str_accepted)
+def test_deepseek_mixed_enum(input_str: str, accepted: bool):
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* root_1 [ \n\r\t]*))
+root_string_prop_0 ::= (("hello") | ("5678") | ("quotes\"newlines\n"))
+root_json_prop_0 ::= (("1234") | ("null") | ("[\"hello\"]") | ("[\"quotes\\\"newlines\\n\"]"))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+root_1 ::= (("<\uff5cDSML\uff5cparameter name=\"field\" string=\"true\">" root_string_prop_0 "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"field\" string=\"false\">" [ \n\r\t]* root_json_prop_0 [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+"""
+    schema = {
+        "type": "object",
+        "properties": {
+            "field": {
+                "enum": [
+                    "hello",
+                    1234,
+                    "5678",
+                    'quotes"newlines\n',
+                    None,
+                    ["hello"],
+                    ['quotes"newlines\n'],
+                ]
+            }
+        },
+        "required": ["field"],
+    }
+    _check_deepseek_grammar(schema, expected_grammar, input_str, accepted)
+
+
+deepseek_ref_string_input_str_accepted = [
+    (
+        '<｜DSML｜parameter name="string1" string="true">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="string2" string="true">world</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="string1" string="true">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="string2" string="true">world</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="string1" string="true">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="string2" string="true">5678</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="string1" string="true">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="string2" string="true">5678</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="string1" string="true">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="string2" string="false">world</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="string1" string="true">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="string2" string="false">"world"</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="string1" string="true">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="string2" string="false">5678</｜DSML｜parameter>',
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize("input_str, accepted", deepseek_ref_string_input_str_accepted)
+def test_deepseek_ref_string(input_str: str, accepted: bool):
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"string1\" string=\"true\">" root_string_prop_0 "</\uff5cDSML\uff5cparameter>" root_part_0 [ \n\r\t]*))
+defs_String ::= ((xml_string))
+root_string_prop_0 ::= ((defs_String))
+root_string_prop_1 ::= ((defs_String))
+root_part_0 ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"string2\" string=\"true\">" root_string_prop_1 "</\uff5cDSML\uff5cparameter>"))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+"""
+    schema = {
+        "type": "object",
+        "properties": {
+            "string1": {"$ref": "#/$defs/String"},
+            "string2": {"$ref": "#/$defs/String"},
+        },
+        "required": ["string1", "string2"],
+        "$defs": {"String": {"type": "string"}},
+    }
+    _check_deepseek_grammar(schema, expected_grammar, input_str, accepted)
+
+
+deepseek_ref_integer_input_str_accepted = [
+    (
+        '<｜DSML｜parameter name="integer1" string="false">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="integer2" string="false">5678</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="integer1" string="true">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="integer2" string="false">5678</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="integer1" string="false">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="integer2" string="true">5678</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="integer1" string="true">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="integer2" string="true">5678</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="integer1" string="false">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="integer2" string="false">world</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="integer1" string="false">"hello"</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="integer2" string="false">"world"</｜DSML｜parameter>',
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize("input_str, accepted", deepseek_ref_integer_input_str_accepted)
+def test_deepseek_ref_integer(input_str: str, accepted: bool):
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"integer1\" string=\"false\">" [ \n\r\t]* root_json_prop_0 [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" root_part_0 [ \n\r\t]*))
+defs_Integer_1 ::= (("0") | (defs_Integer_1_1 [1-9] [0-9]*))
+root_json_prop_0 ::= ((defs_Integer_1))
+root_json_prop_1 ::= ((defs_Integer_1))
+root_part_0 ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"integer2\" string=\"false\">" [ \n\r\t]* root_json_prop_1 [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+defs_Integer_1_1 ::= ("" | ("-"))
+"""
+    schema = {
+        "type": "object",
+        "properties": {
+            "integer1": {"$ref": "#/$defs/Integer"},
+            "integer2": {"$ref": "#/$defs/Integer"},
+        },
+        "required": ["integer1", "integer2"],
+        "$defs": {"Integer": {"type": "integer"}},
+    }
+    _check_deepseek_grammar(schema, expected_grammar, input_str, accepted)
+
+
+deepseek_ref_mixed_input_str_accepted = [
+    (
+        '<｜DSML｜parameter name="mixed1" string="true">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="true">world</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="true">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="false">world</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="true">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="false">"world"</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="false">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="false">world</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="false">"hello"</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="false">"world"</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="true">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="true">5678</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="false">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="false">5678</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="true">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="false">5678</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="false">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="true">5678</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="true">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="true">world</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="true">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="true">5678</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="true">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="false">5678</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="true">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="false">[]</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="false">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="false">[]</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="false">[]</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="true">world</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="mixed1" string="false">[]</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="mixed2" string="false">5678</｜DSML｜parameter>',
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize("input_str, accepted", deepseek_ref_mixed_input_str_accepted)
+def test_deepseek_ref_mixed(input_str: str, accepted: bool):
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* root_1 root_part_0 [ \n\r\t]*))
+defs_Mixed ::= ((xml_string))
+root_string_prop_0 ::= ((defs_Mixed))
+defs_Mixed_1 ::= ((basic_integer))
+root_json_prop_0 ::= ((defs_Mixed_1))
+root_string_prop_1 ::= ((defs_Mixed))
+root_json_prop_1 ::= ((defs_Mixed_1))
+root_part_0 ::= (([ \n\r\t]* root_part_0_1))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+root_1 ::= (("<\uff5cDSML\uff5cparameter name=\"mixed1\" string=\"true\">" root_string_prop_0 "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"mixed1\" string=\"false\">" [ \n\r\t]* root_json_prop_0 [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+root_part_0_1 ::= (("<\uff5cDSML\uff5cparameter name=\"mixed2\" string=\"true\">" root_string_prop_1 "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"mixed2\" string=\"false\">" [ \n\r\t]* root_json_prop_1 [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+"""
+    schema = {
+        "type": "object",
+        "properties": {"mixed1": {"$ref": "#/$defs/Mixed"}, "mixed2": {"$ref": "#/$defs/Mixed"}},
+        "required": ["mixed1", "mixed2"],
+        "$defs": {"Mixed": {"type": ["string", "integer"]}},
+    }
+    _check_deepseek_grammar(schema, expected_grammar, input_str, accepted)
+
+
+deepseek_ref_recursive_input_str_accepted = [
+    (
+        '<｜DSML｜parameter name="array1" string="false">null</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="array2" string="false">[]</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="array1" string="false">[[[[[]]]], [[], [null]]]</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="array2" string="false">[null, [[null, [[]], [null]]]]</｜DSML｜parameter>',
+        True,
+    ),
+    (
+        '<｜DSML｜parameter name="array1" string="false">1234</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="array2" string="false">5678</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="array1" string="false">"hello"</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="array2" string="false">"world"</｜DSML｜parameter>',
+        False,
+    ),
+    (
+        '<｜DSML｜parameter name="array1" string="true">hello</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="array2" string="true">world</｜DSML｜parameter>',
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize("input_str, accepted", deepseek_ref_recursive_input_str_accepted)
+def test_deepseek_ref_recursive(input_str: str, accepted: bool):
+    expected_grammar = r"""basic_escape ::= (([\"\\/bfnrt]) | ("u" [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9] [A-Fa-f0-9]))
+basic_string_sub ::= (("\"") | ([^\0-\x1f\"\\\r\n] basic_string_sub) | ("\\" basic_escape basic_string_sub)) (=([ \n\r\t]* [,}\]:]))
+basic_any ::= ((basic_number) | (basic_string) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+basic_integer ::= (("0") | (basic_integer_1 [1-9] [0-9]*))
+basic_number ::= ((basic_number_1 basic_number_2 basic_number_3 basic_number_5))
+basic_string ::= (("\"" basic_string_sub))
+basic_boolean ::= (("true") | ("false"))
+basic_null ::= (("null"))
+basic_array ::= (("[" [ \n\r\t]* basic_any basic_array_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+basic_object ::= (("{" [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any basic_object_properties{0, -1} [ \n\r\t]* "}") | ("{" [ \n\r\t]* "}"))
+xml_string ::= TagDispatch(
+  loop_after_dispatch=false,
+  excludes=("</\uff5cDSML\uff5cparameter>")
+)
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
+basic_number_digits ::= (([0-9]))
+basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
+basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"array1\" string=\"false\">" [ \n\r\t]* root_json_prop_0 [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" root_part_0 [ \n\r\t]*))
+defs_Array_1_case_1_additional ::= ((defs_Array_2))
+defs_Array_2 ::= ((basic_null) | (defs_Array_2_case_1))
+defs_Array_2_case_1 ::= (("[" [ \n\r\t]* defs_Array_2_case_1_additional defs_Array_2_case_1_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+defs_Array_2_case_1_additional ::= ((defs_Array_2))
+defs_Array_2_case_1_items ::= (([ \n\r\t]* "," [ \n\r\t]* defs_Array_2_case_1_additional))
+defs_Array_1_case_1_items ::= (([ \n\r\t]* "," [ \n\r\t]* defs_Array_1_case_1_additional))
+defs_Array_1_case_1 ::= (("[" [ \n\r\t]* defs_Array_1_case_1_additional defs_Array_1_case_1_items{0, -1} [ \n\r\t]* "]") | ("[" [ \n\r\t]* "]"))
+defs_Array_1 ::= ((basic_null) | (defs_Array_1_case_1))
+root_json_prop_0 ::= ((defs_Array_1))
+root_json_prop_1 ::= ((defs_Array_1))
+root_part_0 ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"array2\" string=\"false\">" [ \n\r\t]* root_json_prop_1 [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+basic_integer_1 ::= ("" | ("-"))
+basic_number_1 ::= ("" | ("-"))
+basic_number_2 ::= (("0") | ([1-9] [0-9]*))
+basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
+basic_number_4 ::= ("" | ([+\-]))
+basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+"""
+    schema = {
+        "type": "object",
+        "properties": {"array1": {"$ref": "#/$defs/Array"}, "array2": {"$ref": "#/$defs/Array"}},
+        "required": ["array1", "array2"],
+        "$defs": {
+            "Array": {
+                "anyOf": [{"type": "null"}, {"type": "array", "items": {"$ref": "#/$defs/Array"}}]
+            }
+        },
     }
     _check_deepseek_grammar(schema, expected_grammar, input_str, accepted)
 

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -350,11 +350,11 @@ deepseek_xml_instance_is_accepted = [
     ),
     (
         '<｜DSML｜parameter name="name" string="true">Bob</｜DSML｜parameter>\t\n<｜DSML｜parameter name="age" string="true">\t100\n</｜DSML｜parameter>',
-        True,
+        False,
     ),
     (
         '<｜DSML｜parameter name="name" string="false">Bob</｜DSML｜parameter><｜DSML｜parameter name="age" string="true">100</｜DSML｜parameter>',
-        True,
+        False,
     ),
     (
         """<｜DSML｜parameter name="name" string="true"><!DOCTYPE html>
@@ -389,27 +389,23 @@ xml_string ::= TagDispatch(
   loop_after_dispatch=false,
   excludes=("</\uff5cDSML\uff5cparameter>")
 )
-xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1 "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_any_json ::= ((basic_number) | (basic_boolean) | (basic_null) | (basic_array) | (basic_object))
+xml_object ::= (([ \n\r\t]* xml_object_1 xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
 xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
 basic_number_digits ::= (([0-9]))
 basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
 basic_object_properties ::= (([ \n\r\t]* "," [ \n\r\t]* basic_string [ \n\r\t]* ":" [ \n\r\t]* basic_any))
-xml_object_properties ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_properties_1 "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
-root_0 ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"name" "\" string=\"" root_1 "\">" xml_string "</\uff5cDSML\uff5cparameter>" root_part_0 [ \n\r\t]*))
-root_prop_1 ::= (("0") | (root_prop_1_1 [1-9] [0-9]*))
-root_part_0 ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"age" "\" string=\"" root_part_0_1 "\">" [ \n\r\t]* root_prop_1 [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties ::= (([ \n\r\t]* xml_object_properties_1))
+root_0 ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"name\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>" root_part_0 [ \n\r\t]*))
+root_part_0 ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"age\" string=\"false\">" [ \n\r\t]* basic_integer [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
 basic_integer_1 ::= ("" | ("-"))
 basic_number_1 ::= ("" | ("-"))
 basic_number_2 ::= (("0") | ([1-9] [0-9]*))
 basic_number_3 ::= ("" | ("." basic_number_digits{1, -1}))
 basic_number_4 ::= ("" | ([+\-]))
 basic_number_5 ::= ("" | ([eE] basic_number_4 basic_number_digits{1, -1}))
-xml_object_1 ::= (("true") | ("false"))
-xml_object_properties_1 ::= (("true") | ("false"))
-root_1 ::= (("true") | ("false"))
-root_prop_1_1 ::= ("" | ("-"))
-root_part_0_1 ::= (("true") | ("false"))
+xml_object_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
+xml_object_properties_1 ::= (("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"true\">" xml_string "</\uff5cDSML\uff5cparameter>") | ("<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"false\">" [ \n\r\t]* xml_any_json [ \n\r\t]* "</\uff5cDSML\uff5cparameter>"))
 root ::= ((root_0))
 """,
     )


### PR DESCRIPTION
# Summary

DSML uses `string="true"` for top-level string parameters (interpreted as plain string) and `string="false"` for everything else (interpreted as JSON). Currently XGrammar does not check `string` attribute and allows both `true`/`false` for any value, which allows invalid constructs such as:
```
<｜DSML｜parameter name="name" string="false">Bob</｜DSML｜parameter>
```

# Fix

Generate two branches for top-level parameters of DeepSeek XML format: for strings and for everything else.

# Tests

Added new tests for DeepSeek XML format in `test_function_calling_converter.py`.
All Python and C++ tests passed.