### PR TITLE
fix: allow JSON escapes and count code points in length-bounded strings

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2368,14 +2368,46 @@ int32_t JSONSchemaConverter::GenerateString(const StringSpec& spec, const std::s
   }
   // Check for length constraints
   if (spec.min_length != 0 || spec.max_length != -1) {
-    // A length bound limits HOW MANY characters a string has, not which ones.
-    // Without the escape branch \", \\, \n and \uXXXX are unrepresentable, so a
-    // model that needs one cannot close the string and runs to the token limit.
+    // A length bound counts characters, so each repetition must be exactly one
+    // character: an unescaped code point, a short escape, a non-surrogate
+    // \uXXXX, or a surrogate PAIR -- one code point spelled as two escapes.
+    // kBasicEscape cannot be reused here: it treats every \uXXXX alike, which
+    // would make a pair cost two and admit unpaired surrogates.
     int32_t normal_character = builder_.AddCharacterClass(
         {{0, 0x1f}, {'"', '"'}, {'\\', '\\'}, {'\r', '\r'}, {'\n', '\n'}}, true
     );
-    int32_t character =
-        Choice({normal_character, Sequence({ByteString("\\"), RuleRef(kBasicEscape)})});
+    int32_t short_escape = builder_.AddCharacterClass(
+        {{'"', '"'},
+         {'\\', '\\'},
+         {'/', '/'},
+         {'b', 'b'},
+         {'f', 'f'},
+         {'n', 'n'},
+         {'r', 'r'},
+         {'t', 't'}}
+    );
+    int32_t hex = builder_.AddCharacterClass({{'0', '9'}, {'A', 'F'}, {'a', 'f'}});
+    // Surrogates are U+D800-U+DFFF, i.e. "D" followed by 8-F.
+    int32_t hex_but_d =
+        builder_.AddCharacterClass({{'0', '9'}, {'A', 'C'}, {'E', 'F'}, {'a', 'c'}, {'e', 'f'}});
+    int32_t d = builder_.AddCharacterClass({{'D', 'D'}, {'d', 'd'}});
+    int32_t below_surrogates = builder_.AddCharacterClass({{'0', '7'}});
+    int32_t high_surrogate = builder_.AddCharacterClass({{'8', '9'}, {'A', 'B'}, {'a', 'b'}});
+    int32_t low_surrogate = builder_.AddCharacterClass({{'C', 'F'}, {'c', 'f'}});
+    int32_t bmp_escape = Sequence(
+        {ByteString("u"),
+         Choice({Sequence({hex_but_d, hex, hex, hex}), Sequence({d, below_surrogates, hex, hex})})}
+    );
+    int32_t surrogate_pair_escape = Sequence(
+        {ByteString("u"), d, high_surrogate, hex, hex, ByteString("\\u"), d, low_surrogate, hex, hex
+        }
+    );
+    int32_t character = Choice(
+        {normal_character,
+         Sequence({ByteString("\\"), short_escape}),
+         Sequence({ByteString("\\"), bmp_escape}),
+         Sequence({ByteString("\\"), surrogate_pair_escape})}
+    );
     int32_t body = Repeat(rule_name + "_characters", character, spec.min_length, spec.max_length);
     return Sequence({ByteString("\""), body, ByteString("\"")});
   }

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2368,8 +2368,14 @@ int32_t JSONSchemaConverter::GenerateString(const StringSpec& spec, const std::s
   }
   // Check for length constraints
   if (spec.min_length != 0 || spec.max_length != -1) {
+    // A length bound limits HOW MANY characters a string has, not which ones.
+    // Without the escape branch \", \\, \n and \uXXXX are unrepresentable, so a
+    // model that needs one cannot close the string and runs to the token limit.
+    int32_t normal_character = builder_.AddCharacterClass(
+        {{0, 0x1f}, {'"', '"'}, {'\\', '\\'}, {'\r', '\r'}, {'\n', '\n'}}, true
+    );
     int32_t character =
-        builder_.AddCharacterClass({{'"', '"'}, {'\\', '\\'}, {'\r', '\r'}, {'\n', '\n'}}, true);
+        Choice({normal_character, Sequence({ByteString("\\"), RuleRef(kBasicEscape)})});
     int32_t body = Repeat(rule_name + "_characters", character, spec.min_length, spec.max_length);
     return Sequence({ByteString("\""), body, ByteString("\"")});
   }

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2406,7 +2406,7 @@ def test_min_max_length():
     schema = {"type": "string", "minLength": 1, "maxLength": 10}
 
     ebnf_grammar = basic_json_rules_ebnf + (
-        r"""root_characters ::= [^\0-\x1f"\\\r\n] | "\\" basic_escape
+        r"""root_characters ::= [^\0-\x1f"\\\r\n] | "\\" [\"\\/bfnrt] | "\\" "u" ([0-9A-CE-Fa-ce-f] [0-9A-Fa-f]{3} | [Dd] [0-7] [0-9A-Fa-f]{2}) | "\\" "u" [Dd] [89ABab] [0-9A-Fa-f]{2} "\\u" [Dd] [C-Fc-f] [0-9A-Fa-f]{2}
 root ::= "\"" root_characters{1,10} "\""
 """
     )
@@ -2441,6 +2441,34 @@ def test_min_max_length_allows_escapes():
     check_schema_with_instance(
         schema, r'"\n\n\n\n\n\n\n\n\n\n\n"', is_accepted=False, any_whitespace=True
     )
+
+
+def test_min_max_length_counts_surrogate_pair_as_one_character():
+    # U+1F600 is ONE code point, so it costs one repetition however it is spelled.
+    schema = {"type": "string", "maxLength": 1}
+
+    check_schema_with_instance(schema, r'"\ud83d\ude00"', any_whitespace=True)
+    check_schema_with_instance(schema, '"\U0001f600"', any_whitespace=True)
+    check_schema_with_instance(schema, r'"\uD83D\uDE00"', any_whitespace=True)
+
+    # Two of them exceed the bound.
+    check_schema_with_instance(
+        schema, r'"\ud83d\ude00\ud83d\ude00"', is_accepted=False, any_whitespace=True
+    )
+
+
+def test_min_max_length_rejects_lone_surrogate():
+    # A lone surrogate does not decode to valid UTF-8, so it is not a character
+    # the bound could count.
+    schema = {"type": "string", "maxLength": 4}
+
+    check_schema_with_instance(schema, r'"\ud800"', is_accepted=False, any_whitespace=True)
+    check_schema_with_instance(schema, r'"\udc00"', is_accepted=False, any_whitespace=True)
+    # Wrong order is not a pair either.
+    check_schema_with_instance(schema, r'"\ude00\ud83d"', is_accepted=False, any_whitespace=True)
+    # Non-surrogate \uXXXX is unaffected.
+    check_schema_with_instance(schema, r'"\ud7ff"', any_whitespace=True)
+    check_schema_with_instance(schema, r'"\ue000"', any_whitespace=True)
 
 
 def test_type_array():

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2406,7 +2406,8 @@ def test_min_max_length():
     schema = {"type": "string", "minLength": 1, "maxLength": 10}
 
     ebnf_grammar = basic_json_rules_ebnf + (
-        r"""root ::= "\"" [^"\\\r\n]{1,10} "\""
+        r"""root_characters ::= [^\0-\x1f"\\\r\n] | "\\" basic_escape
+root ::= "\"" root_characters{1,10} "\""
 """
     )
 
@@ -2417,6 +2418,29 @@ def test_min_max_length():
 
     check_schema_with_instance(schema, instance_accepted, any_whitespace=True)
     check_schema_with_instance(schema, instance_rejected, is_accepted=False, any_whitespace=True)
+
+
+def test_min_max_length_allows_escapes():
+    # A length bound must not change WHICH characters a string may contain. The
+    # length-bounded path used a class with no escape alternative, so \", \\, \n
+    # and \uXXXX were unrepresentable and a model needing one could not close the
+    # string -- it kept emitting until it hit the token limit.
+    schema = {"type": "string", "maxLength": 10}
+
+    check_schema_with_instance(schema, r'"ab\ncd"', any_whitespace=True)
+    check_schema_with_instance(schema, r'"say \"hi\""', any_whitespace=True)
+    check_schema_with_instance(schema, r'"back\\sl"', any_whitespace=True)
+    check_schema_with_instance(schema, r'"a\u0062c"', any_whitespace=True)
+    check_schema_with_instance(schema, '"a\u00e9b"', any_whitespace=True)
+
+    # An unescaped control character is still invalid JSON.
+    check_schema_with_instance(schema, '"ab\ncd"', is_accepted=False, any_whitespace=True)
+
+    # The bound still bites: one escape is one character.
+    check_schema_with_instance(schema, r'"\n\n\n\n\n\n\n\n\n\n"', any_whitespace=True)
+    check_schema_with_instance(
+        schema, r'"\n\n\n\n\n\n\n\n\n\n\n"', is_accepted=False, any_whitespace=True
+    )
 
 
 def test_type_array():


### PR DESCRIPTION
A string schema carrying `minLength` or `maxLength` takes a separate lowering from the unbounded one, and that path had two defects. Two commits, reviewable independently.

**`a87833a` -- allow JSON escapes.** The length-bounded character class had no escape alternative:

```
[^"\\\r\n]{min,max}
```

so `\"`, `\\`, `\n` and `\uXXXX` were unrepresentable inside a bounded string. Under constrained decoding a model that needs an escape finds every continuation masked, emits whatever the grammar still allows, and never closes the string -- the generation runs to the token limit. The class also gains the C0 range, which RFC 8259 forbids unescaped and this path had been admitting.

This is the same fix as #822, which is the earlier PR.

**`e14ff8d` -- count code points, not escapes.** `basic_escape` treats every `\uXXXX` alike, so a surrogate pair (one code point spelled as two escapes) cost two repetitions while the raw UTF-8 spelling cost one -- `maxLength: 1` accepted one spelling of U+1F600 and rejected the other. Unpaired `\uD800` was also legal, admitting strings with no valid UTF-8 decoding. The `\u` forms are now enumerated instead of delegating to `basic_escape`: a non-surrogate `\uXXXX` is one repetition, a high+low pair is one repetition, and a lone surrogate matches nothing.

This is the part #800's "Expected behavior" asks for and the escape fix alone does not deliver. The unbounded path is unchanged -- only the bounded path counts characters.

**Tests.** `test_min_max_length_allows_escapes` passes with either fix. The two surrogate tests fail with the escape fix alone (`assert False == True` for the pair, `assert True == False` for the lone surrogate), so they pin the second commit specifically. 547 tests pass across `test_json_schema_converter.py` and `test_json_schema_direct_converter.py`.

Fixes #800
