### PR TITLE
fix(json_schema): treat bare 'contains' as minContains=1

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1232,6 +1232,28 @@ Result<ArraySpec, SchemaError> SchemaParser::ParseArray(const picojson::object& 
     }
     spec.min_items = std::max(spec.min_items, schema.at("minContains").get<int64_t>());
   }
+  if (schema.count("contains")) {
+    // Draft 2020-12: a bare 'contains' implies minContains = 1 (at least one
+    // element must match). Previously the keyword was ignored entirely, so a
+    // shapeless array compiled as if unconstrained and, in strict mode, as an
+    // only-empty-array grammar accepting exactly the document the schema
+    // forbids (issue #833). Model it with the same min-count approximation
+    // already used for 'minContains'; 'contains: false' (no element may match)
+    // cannot be expressed as a count and is rejected explicitly.
+    auto contains_value = schema.at("contains");
+    if (!contains_value.is<picojson::object>() && !contains_value.is<bool>()) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kInvalidSchema, "contains must be an object or a boolean"
+      );
+    }
+    if (contains_value.is<bool>() && !contains_value.get<bool>()) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kUnsatisfiableSchema,
+          "contains: false requires that no element match, which is not supported"
+      );
+    }
+    spec.min_items = std::max(spec.min_items, static_cast<int64_t>(1));
+  }
   if (schema.count("maxItems")) {
     if (!schema.at("maxItems").is<int64_t>() || schema.at("maxItems").get<int64_t>() < 0) {
       return ResultErr<SchemaError>(

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3552,6 +3552,33 @@ def test_prefix_items_no_additional_items_allows_shorter():
     check_schema_with_instance(schema, '["a"]', is_accepted=True)
     check_schema_with_instance(schema, '["a", 1]', is_accepted=True)
     check_schema_with_instance(schema, '["a", 1, true]', is_accepted=False)
+def test_contains_implies_min_one_non_strict():
+    # Regression for issue #833: a bare 'contains' implies minContains = 1 per
+    # Draft 2020-12; previously the keyword was ignored entirely and the array
+    # compiled as if unconstrained.
+    schema = {"type": "array", "contains": {"type": "integer"}}
+    check_schema_with_instance(schema, "[]", is_accepted=False, strict_mode=False)
+    check_schema_with_instance(schema, "[1]", is_accepted=True, strict_mode=False)
+    check_schema_with_instance(schema, "[1, 2]", is_accepted=True, strict_mode=False)
+
+
+def test_contains_strict_mode_raises_instead_of_only_empty():
+    # Regression for issue #833: strict mode (unevaluatedItems=false) cannot
+    # satisfy a bare 'contains' on a shapeless array; it must raise the
+    # unsatisfiable-schema error instead of compiling an only-empty grammar
+    # that accepts [] (the one document the schema forbids).
+    schema = {"type": "array", "contains": {"type": "integer"}}
+    with pytest.raises(Exception, match="minItems is greater than the number of prefixItems"):
+        _json_schema_to_ebnf(schema)
+
+
+def test_contains_false_is_rejected():
+    # Regression for issue #833: 'contains: false' (no element may match the
+    # schema) cannot be expressed as a count and must fail loudly instead of
+    # compiling a silently wrong grammar.
+    schema = {"type": "array", "contains": False}
+    with pytest.raises(Exception, match="not supported"):
+        _json_schema_to_ebnf(schema)
 
 
 def test_property_names_preserves_additional_properties_value_schema():

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3552,6 +3552,8 @@ def test_prefix_items_no_additional_items_allows_shorter():
     check_schema_with_instance(schema, '["a"]', is_accepted=True)
     check_schema_with_instance(schema, '["a", 1]', is_accepted=True)
     check_schema_with_instance(schema, '["a", 1, true]', is_accepted=False)
+
+
 def test_contains_implies_min_one_non_strict():
     # Regression for issue #833: a bare 'contains' implies minContains = 1 per
     # Draft 2020-12; previously the keyword was ignored entirely and the array


### PR DESCRIPTION
## Root Cause
`ParseArray` only honored `minContains`; a bare `contains` was ignored entirely. A shapeless array (`type: "array"` with no `items`/`prefixItems`) carrying `contains` therefore compiled as if unconstrained — and in strict mode (unevaluatedItems=false) as an only-empty-array grammar that accepts `[]`, which is exactly the document `contains` forbids (issue #833).

## Fix
Per Draft 2020-12, `contains` implies `minContains = 1`. Model it with the same min-count approximation already used for `minContains`:

- `contains: <schema>` → `min_items = max(min_items, 1)`. Non-strict mode now accepts arrays with at least one element; strict mode raises the existing unsatisfiable-schema error ("minItems is greater than the number of prefixItems...") instead of compiling a silently inverted grammar.
- `contains: false` (no element may match) cannot be expressed as a count → explicit unsatisfiable-schema error instead of silent miscompilation.
- `contains` with a non-object/non-boolean value → invalid-schema error.

## Test
3 new regression tests in `tests/python/test_json_schema_converter.py`:
- non-strict: `[]` rejected, `[1]` and `[1, 2]` accepted;
- strict: raises the unsatisfiable-schema error (previously compiled to only-`[]`);
- `contains: false` raises instead of compiling silently wrong.
Local: full `tests/python` suite 3253 passed (694 skipped HF_TOKEN-gated); ruff/black 24.1.0/clang-format 19.1.7 clean.

## Diff scope
2 files, +51/-0 (`cpp/json_schema_converter.cc` ParseArray block; `tests/python/test_json_schema_converter.py`).

## AI Disclosure
Analysis and patch were AI-assisted; the strict_mode semantics (documented as unevaluatedItems=false) and the min-count approximation for `contains` were verified against the repo docs and existing `minContains` handling before submission, and the change was human-reviewed. The general shapeless-array behavior for keywords that do not imply elements (`uniqueItems`/`maxItems`/unknown keys) is the documented strict-mode semantic and is left unchanged.

Fixes #833