### PR TITLE
fix(json_schema): emit nothing for empty XML tool-call objects

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -3104,7 +3104,11 @@ int32_t JSONSchemaConverter::GenerateObject(
 
   int32_t result = need_braces ? Sequence({ByteString("{"), content, ByteString("}")}) : content;
   if (could_be_empty) {
-    int32_t empty_content = any_whitespace_ ? WhitespaceExpression() : Empty();
+    // Outside braces (XML parameter zones) an empty object must emit
+    // nothing: the surrounding tag template already supplies the whitespace,
+    // and a whitespace-only alternative would be a self-loop that burns the
+    // whole generation budget on tabs (issue #802).
+    int32_t empty_content = any_whitespace_ && need_braces ? WhitespaceExpression() : Empty();
     int32_t empty_result =
         need_braces ? Sequence({ByteString("{"), empty_content, ByteString("}")}) : empty_content;
     return has_content ? Choice({result, empty_result}) : empty_result;

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3552,6 +3552,27 @@ def test_prefix_items_no_additional_items_allows_shorter():
     check_schema_with_instance(schema, '["a"]', is_accepted=True)
     check_schema_with_instance(schema, '["a", 1]', is_accepted=True)
     check_schema_with_instance(schema, '["a", 1, true]', is_accepted=False)
+def test_qwen_xml_empty_object_emits_nothing():
+    # Regression for issue #802: a qwen_xml tool-call object with no
+    # properties must emit nothing, letting the structural tag's end
+    # take over, instead of a whitespace-only self-loop that never
+    # leaves the parameter zone.
+    ebnf = _json_schema_to_ebnf(
+        {"type": "object", "properties": {}, "required": []}, json_format="qwen_xml"
+    )
+    root_lines = [line for line in ebnf.splitlines() if line.startswith("root ")]
+    assert len(root_lines) == 1
+    assert "[ \\n\\t]*" not in root_lines[0]
+
+
+def test_qwen_xml_nonempty_object_keeps_parameter_zone():
+    # Guard against over-fixing #802: a qwen_xml object with
+    # properties still emits the parameter-zone production.
+    ebnf = _json_schema_to_ebnf(
+        {"type": "object", "properties": {"a": {"type": "integer"}}, "required": []},
+        json_format="qwen_xml",
+    )
+    assert "<parameter=" in ebnf
 
 
 def test_property_names_preserves_additional_properties_value_schema():

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3552,6 +3552,8 @@ def test_prefix_items_no_additional_items_allows_shorter():
     check_schema_with_instance(schema, '["a"]', is_accepted=True)
     check_schema_with_instance(schema, '["a", 1]', is_accepted=True)
     check_schema_with_instance(schema, '["a", 1, true]', is_accepted=False)
+
+
 def test_qwen_xml_empty_object_emits_nothing():
     # Regression for issue #802: a qwen_xml tool-call object with no
     # properties must emit nothing, letting the structural tag's end

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -197,7 +197,7 @@ xml_string ::= TagDispatch(
   excludes=("</parameter>")
 )
 xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\r\t]* "<parameter=" xml_variable_name ">" [ \n\r\t]* xml_any [ \n\r\t]* "</parameter>" xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_object ::= ("" | ([ \n\r\t]* "<parameter=" xml_variable_name ">" [ \n\r\t]* xml_any [ \n\r\t]* "</parameter>" xml_object_properties{0, -1} [ \n\r\t]*))
 xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
 basic_number_digits ::= (([0-9]))
 basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
@@ -308,7 +308,7 @@ xml_string ::= TagDispatch(
   excludes=("</parameter>")
 )
 xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\r\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</parameter>" xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_object ::= ("" | ([ \n\r\t]* "<parameter name=\"" xml_variable_name "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</parameter>" xml_object_properties{0, -1} [ \n\r\t]*))
 xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
 basic_number_digits ::= (([0-9]))
 basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
@@ -390,7 +390,7 @@ xml_string ::= TagDispatch(
   excludes=("</\uff5cDSML\uff5cparameter>")
 )
 xml_any ::= ((xml_string) | (basic_array) | (basic_object))
-xml_object ::= (([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1 "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" xml_object_properties{0, -1} [ \n\r\t]*) | ([ \n\r\t]*))
+xml_object ::= ("" | ([ \n\r\t]* "<\uff5cDSML\uff5cparameter name=\"" xml_variable_name "\" string=\"" xml_object_1 "\">" [ \n\r\t]* xml_any [ \n\r\t]* "</\uff5cDSML\uff5cparameter>" xml_object_properties{0, -1} [ \n\r\t]*))
 xml_variable_name ::= (([a-zA-Z_] [a-zA-Z0-9_]*))
 basic_number_digits ::= (([0-9]))
 basic_array_items ::= (([ \n\r\t]* "," [ \n\r\t]* basic_any))
@@ -737,7 +737,10 @@ def test_json_schema_style_kimi_k3_xml_empty_object():
         "style": "kimi_k3_xml",
     }
     check_stag_with_instance(stag_format, "", True)
-    check_stag_with_instance(stag_format, "\n", True)
+    # No whitespace-only self-loop in the empty parameter zone (issue #802):
+    # the zone must emit nothing and hand control to the tag end.
+    check_stag_with_instance(stag_format, "\n", False)
+    check_stag_with_instance(stag_format, "\t", False)
 
 
 def test_json_schema_style_kimi_k3_xml_object_argument_uses_json():


### PR DESCRIPTION
## Root Cause
For brace-less objects (the XML tool-calling parameter zone) `GenerateObject` built the empty alternative as the whitespace expression `[ \n\t]*` — a self-loop with no non-whitespace continuation. A tool with `parameters = {"type": "object", "properties": {}, "required": []}` therefore left the matcher consuming whitespace forever once the model entered the zone (Qwen favors `\t` there), burning the whole generation budget — vllm-project/vllm#50989.

## Fix
Emit an empty production for the empty alternative when the object is not wrapped in braces. The surrounding tag template already supplies the whitespace, so the tag's `end` takes over immediately. JSON objects (braces) keep the whitespace variant, and the non-empty XML parameter production is unchanged.

- `{"type": "object", "properties": {}, "required": []}` with `qwen_xml` → `root ::= ("")` (was `root ::= [ \n\t]*`)

## Test
- New: `test_qwen_xml_empty_object_emits_nothing` (root rule contains no whitespace loop) and `test_qwen_xml_nonempty_object_keeps_parameter_zone` (guard against over-fixing).
- Updated `test_json_schema_style_kimi_k3_xml_empty_object`: the empty zone no longer accepts `"\n"`/`"\t"` (the zone emits nothing).
- Updated 3 recorded `xml_object` grammar strings in `test_structural_tag_converter.py` (`"" |` replaces the trailing whitespace alternative).
- Local: full `tests/python` suite 3252 passed (694 skipped HF_TOKEN-gated); ruff / black 24.1.0 / clang-format 19.1.7 clean.

## Diff scope
3 files, +35/-5 (`cpp/json_schema_converter.cc` empty-alternative selection; two python test files).

## AI Disclosure
Root cause, fix, and the recorded-grammar updates were AI-assisted; the intermediate over-broad variant was caught by the structural-tag suite and narrowed to the brace-less case, then verified against the full suite and human-reviewed.

Fixes #802