### PR TITLE
fix(json_schema): merge additionalProperties schema into patternProperties objects

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2966,6 +2966,24 @@ int32_t JSONSchemaConverter::GenerateObject(
                )}
           ));
         }
+        // Merge with existing additionalProperties if present. Without this,
+        // a typed additionalProperties schema was silently dropped whenever
+        // patternProperties existed but no named properties did (issue #826,
+        // patternProperties manifestation).
+        if (additional_property) {
+          int32_t value_rule_id =
+              CreateRule(additional_property, rule_name + "_" + additional_suffix);
+          property_choices.push_back(Sequence(
+              {beginning_separator,
+               FormatOtherProperty(
+                   KeyPatternExpression(),
+                   value_rule_id,
+                   rule_name,
+                   additional_suffix,
+                   /*schema=*/nullptr
+               )}
+          ));
+        }
       } else {
         int32_t key_rule_id = CreateRule(spec.property_names, rule_name + "_name");
         int32_t value_rule_id = builder_.GetRuleId(GetBasicAnyRuleName());

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3410,5 +3410,21 @@ def test_compile_json_schema_any_order(cache_enabled: bool):
     assert ordered != any_order
 
 
+def test_pattern_properties_preserves_additional_properties_value_schema():
+    # Regression for issue #826 (patternProperties manifestation): without
+    # named properties, a typed additionalProperties schema was dropped,
+    # so keys outside the patterns were rejected entirely. Keys matching
+    # a pattern keep their pattern value schema (choice semantics, the
+    # same as the named-properties case).
+    schema = {
+        "type": "object",
+        "patternProperties": {"^x[0-9]+$": {"type": "integer"}},
+        "additionalProperties": {"type": "string"},
+    }
+    check_schema_with_instance(schema, '{"x1": 1}', is_accepted=True)
+    check_schema_with_instance(schema, '{"y": "hello"}', is_accepted=True)
+    check_schema_with_instance(schema, '{"y": 1}', is_accepted=False)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
## Root Cause
In `GenerateObject` Case 1b (no named properties), the `patternProperties` branch built only the pattern choices and **ignored a typed `additionalProperties` schema entirely** — keys outside the patterns were not generatable at all, the same value-schema loss reported for `propertyNames` in #826 (fixed in #836).

## Fix
Add the additional-property alternative with its value schema, mirroring the named-properties case (Case 1a):

- `{"patternProperties": {"^x[0-9]+$": {"type": "integer"}}, "additionalProperties": {"type": "string"}}`
  - `{"x1": 1}` accepted (pattern key, pattern value schema)
  - `{"y": "hello"}` accepted (was rejected before — the additional value schema is now enforced)
  - `{"y": 1}` rejected (additional value schema is `string`)
- Keys matching a pattern keep their pattern value schema (choice semantics, identical to the named-properties case).

## Test
- New `test_pattern_properties_preserves_additional_properties_value_schema` (typed value fixture; anchored pattern so the assertion is stable under both current and Draft-unanchored regex semantics, cf. #838).
- Local: full `tests/python` suite 3251 passed (694 skipped HF_TOKEN-gated); ruff / black 24.1.0 / clang-format 19.1.7 clean.

## Diff scope
2 files, +34/-0 (`cpp/json_schema_converter.cc` Case 1b pattern branch; `tests/python/test_json_schema_converter.py`).

## AI Disclosure
Root-cause analysis and patch were AI-assisted; the choice-semantics trade-off was verified against the existing Case 1a construction and the full suite, then human-reviewed.

Fixes #826 (patternProperties manifestation).