### PR TITLE
fix(json_schema): apply propertyNames to the additional branch beside patternProperties

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2896,12 +2896,21 @@ int32_t JSONSchemaConverter::GenerateObject(
             RuleRef(key_rule_id), value_rule_id, rule_name, pattern_suffix, pattern_property.schema
         ));
       }
-      // Merge with existing additionalProperties if present
+      // Merge with existing additionalProperties if present. When
+      // propertyNames also constrains the keys, apply it to the additional
+      // branch so non-pattern keys cannot bypass the name constraint
+      // (issue #841). Pattern-matching keys keep their pattern key rule
+      // (choice semantics; a key matching both cannot be intersected by a
+      // static grammar).
       if (effective_additional) {
         int32_t value_rule_id =
             CreateRule(effective_additional, rule_name + "_" + effective_suffix);
+        int32_t additional_key_rule_id = KeyPatternExpression();
+        if (spec.property_names) {
+          additional_key_rule_id = RuleRef(CreateRule(spec.property_names, rule_name + "_name"));
+        }
         patterns.push_back(FormatOtherProperty(
-            KeyPatternExpression(),
+            additional_key_rule_id,
             value_rule_id,
             rule_name,
             effective_suffix,
@@ -2973,10 +2982,17 @@ int32_t JSONSchemaConverter::GenerateObject(
         if (additional_property) {
           int32_t value_rule_id =
               CreateRule(additional_property, rule_name + "_" + additional_suffix);
+          // When propertyNames also constrains the keys, apply it to the
+          // additional branch so non-pattern keys cannot bypass the name
+          // constraint (issue #841).
+          int32_t additional_key_rule_id = KeyPatternExpression();
+          if (spec.property_names) {
+            additional_key_rule_id = RuleRef(CreateRule(spec.property_names, rule_name + "_name"));
+          }
           property_choices.push_back(Sequence(
               {beginning_separator,
                FormatOtherProperty(
-                   KeyPatternExpression(),
+                   additional_key_rule_id,
                    value_rule_id,
                    rule_name,
                    additional_suffix,

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2966,6 +2966,24 @@ int32_t JSONSchemaConverter::GenerateObject(
                )}
           ));
         }
+        // Merge with existing additionalProperties if present. Without this,
+        // a typed additionalProperties schema was silently dropped whenever
+        // patternProperties existed but no named properties did (issue #826,
+        // patternProperties manifestation).
+        if (additional_property) {
+          int32_t value_rule_id =
+              CreateRule(additional_property, rule_name + "_" + additional_suffix);
+          property_choices.push_back(Sequence(
+              {beginning_separator,
+               FormatOtherProperty(
+                   KeyPatternExpression(),
+                   value_rule_id,
+                   rule_name,
+                   additional_suffix,
+                   /*schema=*/nullptr
+               )}
+          ));
+        }
       } else {
         int32_t key_rule_id = CreateRule(spec.property_names, rule_name + "_name");
         int32_t value_rule_id = builder_.GetRuleId(GetBasicAnyRuleName());

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3426,5 +3426,21 @@ def test_pattern_properties_preserves_additional_properties_value_schema():
     check_schema_with_instance(schema, '{"y": 1}', is_accepted=False)
 
 
+def test_property_names_constrains_additional_keys_with_pattern_properties():
+    # Regression for issue #841: when patternProperties and propertyNames
+    # coexist, propertyNames must still constrain the additional branch's
+    # keys. Pattern-matching keys keep their pattern key rule (choice
+    # semantics; a static grammar cannot intersect the two).
+    schema = {
+        "type": "object",
+        "patternProperties": {"^x[0-9]+$": {"type": "integer"}},
+        "propertyNames": {"pattern": "^[a-z0-9]+$"},
+        "additionalProperties": {"type": "string"},
+    }
+    check_schema_with_instance(schema, '{"x1": 1}', is_accepted=True)
+    check_schema_with_instance(schema, '{"y": "ok"}', is_accepted=True)
+    check_schema_with_instance(schema, '{"UPPER": "bad"}', is_accepted=False)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3410,5 +3410,21 @@ def test_compile_json_schema_any_order(cache_enabled: bool):
     assert ordered != any_order
 
 
+def test_pattern_properties_preserves_additional_properties_value_schema():
+    # Regression for issue #826 (patternProperties manifestation): without
+    # named properties, a typed additionalProperties schema was dropped,
+    # so keys outside the patterns were rejected entirely. Keys matching
+    # a pattern keep their pattern value schema (choice semantics, the
+    # same as the named-properties case).
+    schema = {
+        "type": "object",
+        "patternProperties": {"^x[0-9]+$": {"type": "integer"}},
+        "additionalProperties": {"type": "string"},
+    }
+    check_schema_with_instance(schema, '{"x1": 1}', is_accepted=True)
+    check_schema_with_instance(schema, '{"y": "hello"}', is_accepted=True)
+    check_schema_with_instance(schema, '{"y": 1}', is_accepted=False)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
> **Stacked on #839** — please review/merge that first; this branch contains its commit plus the propertyNames change.

## Root Cause
When `patternProperties` and `propertyNames` coexist, the additional-property branch used the unrestricted key pattern, so keys that violate `propertyNames` (and match no pattern) were accepted. `propertyNames` applies to **all** key names per Draft 2020-12; the converter enforced it only when `patternProperties` was absent.

## Fix
Route the additional branch through the `propertyNames` key rule when present, in both the named-properties path (Case 1a) and the pattern-only path (Case 1b):

- `{"patternProperties": {"^x[0-9]+$": {"type": "integer"}}, "propertyNames": {"pattern": "^[a-z0-9]+$"}, "additionalProperties": {"type": "string"}}`
  - `{"x1": 1}` accepted (pattern key, pattern value schema)
  - `{"y": "ok"}` accepted (name passes propertyNames, value passes additionalProperties)
  - `{"UPPER": "bad"}` **rejected** (was accepted — name violates propertyNames)
- Pattern-matching keys keep their pattern key rule (choice semantics; a static grammar cannot intersect the pattern with propertyNames).

## Test
- New `test_property_names_constrains_additional_keys_with_pattern_properties` (anchored patterns, stable under both current and Draft-unanchored regex semantics, cf. #838).
- Local: full `tests/python` suite 3252 passed (694 skipped HF_TOKEN-gated); ruff / black 24.1.0 / clang-format 19.1.7 clean.

## Diff scope
2 files, +35/-3 (`cpp/json_schema_converter.cc` Case 1a + Case 1b merge sites; `tests/python/test_json_schema_converter.py`).

## AI Disclosure
Root-cause analysis and patch were AI-assisted; the static-grammar intersection limit was verified against the existing choice-semantics construction, and the change was human-reviewed after a full-suite run.

Fixes #841 (self-reported; no pre-existing issue).