### PR TITLE
docs: multi-version documentation site

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -35,7 +35,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.docs_ref || '' }}
+          # For manual dispatch, build docs_ref when given, else main (as documented).
+          ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.docs_ref || 'main') || '' }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -2,10 +2,20 @@ name: Build Docs
 
 on:
   workflow_dispatch:
+    inputs:
+      docs_ref:
+        description: Git ref to build versioned docs from. When set, the docs are published to docs/<version>/
+          where <version> comes from that ref's pyproject.toml. Leave empty to rebuild main as docs/latest/.
+        required: false
+        default: ''
+        type: string
   pull_request:
   push:
     branches:
       - main
+  release:
+    types:
+      - published
 
 permissions:
   contents: read
@@ -15,13 +25,17 @@ jobs:
     name: Build Docs
     runs-on: ubuntu-latest
     concurrency:
-      group: build-docs-${{ github.ref }}
+      group: build-docs-${{ github.ref }}-${{ inputs.docs_ref }}
       cancel-in-progress: true
+    outputs:
+      mode: ${{ steps.meta.outputs.mode }}
+      version: ${{ steps.meta.outputs.version }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.docs_ref || '' }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -29,31 +43,57 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
+      - name: Determine deploy mode
+        id: meta
+        run: |
+          if [[ "${{ github.event_name }}" == "release" || -n "${{ inputs.docs_ref }}" ]]; then
+            echo "mode=version" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=latest" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')" >> "$GITHUB_OUTPUT"
+
+      - name: Install Python dependencies
+        run: python -m pip install -r docs/requirements.txt
+
+      - name: Build Sphinx docs
+        run: |
+          export PYTHONPATH=$PWD/python
+          cd docs && ./build_docs.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: docs/_build/html
+
+      # The jekyll landing page is only redeployed together with docs/latest/.
       - name: Setup Ruby
+        if: steps.meta.outputs.mode == 'latest'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0'
 
-      - name: Installing dependencies
+      - name: Build landing site
+        if: steps.meta.outputs.mode == 'latest'
         run: |
-          python -m pip install -r docs/requirements.txt
           gem install jekyll jekyll-remote-theme
+          cd site && jekyll b
 
-      - name: Build docs
-        run: ./scripts/support/build_site.sh
-
-      - name: Upload GitHub Pages artifact
-        if: github.ref == 'refs/heads/main' && github.repository_owner == 'mlc-ai'
-        uses: actions/upload-pages-artifact@v5
+      - name: Upload landing site artifact
+        if: steps.meta.outputs.mode == 'latest' && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
+          name: site-root
           path: site/_site
 
   deploy_docs:
     name: Deploy Docs
-    if: github.ref == 'refs/heads/main' && github.repository_owner == 'mlc-ai'
+    if: github.repository_owner == 'mlc-ai' && (github.event_name == 'release' || github.event_name ==
+      'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
     needs: build_docs
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pages: write
       id-token: write
     environment:
@@ -64,6 +104,46 @@ jobs:
       cancel-in-progress: false
 
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: docs-html
+          path: docs-html
+
+      - uses: actions/download-artifact@v4
+        if: needs.build_docs.outputs.mode == 'latest'
+        with:
+          name: site-root
+          path: site-root
+
+      - name: Update gh-pages checkout
+        run: |
+          if [[ "${{ needs.build_docs.outputs.mode }}" == "latest" ]]; then
+            bash scripts/support/update_gh_pages.sh latest docs-html site-root gh-pages
+          else
+            bash scripts/support/update_gh_pages.sh version docs-html "${{ needs.build_docs.outputs.version }}" gh-pages
+          fi
+
+      - name: Push gh-pages
+        run: |
+          cd gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || git commit -m "Deploy docs (${{ needs.build_docs.outputs.mode }} ${{ needs.build_docs.outputs.version }}) from ${{ github.sha }}"
+          git push origin gh-pages
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: gh-pages
+
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v6
 

--- a/docs/_static/version_switcher.js
+++ b/docs/_static/version_switcher.js
@@ -7,7 +7,7 @@
 (function () {
   // Matches e.g. "/docs/latest/start/install.html" ->
   //   docsBase="/docs/", currentVersion="latest", pagePath="/start/install.html"
-  const match = window.location.pathname.match(/^(.*\/docs\/)([^/]+)(\/.*)?$/);
+  const match = window.location.pathname.match(/^(.*?\/docs\/)([^/]+)(\/.*)?$/);
   if (match === null) {
     return;
   }

--- a/docs/_static/version_switcher.js
+++ b/docs/_static/version_switcher.js
@@ -1,0 +1,85 @@
+"use strict";
+
+// Renders a version dropdown in the furo sidebar. The list of published
+// versions is read from /versions.json at the site root, which is regenerated
+// by scripts/support/update_gh_pages.sh on every docs deployment. On local
+// builds or PR previews the fetch fails and the dropdown is simply not shown.
+(function () {
+  // Matches e.g. "/docs/latest/start/install.html" ->
+  //   docsBase="/docs/", currentVersion="latest", pagePath="/start/install.html"
+  const match = window.location.pathname.match(/^(.*\/docs\/)([^/]+)(\/.*)?$/);
+  if (match === null) {
+    return;
+  }
+  const docsBase = match[1];
+  const currentVersion = match[2];
+  const pagePath = match[3] || "/";
+
+  // "../versions.json" relative to the docs base resolves to the site root.
+  fetch(docsBase + "../versions.json")
+    .then((response) => (response.ok ? response.json() : null))
+    .then((versions) => {
+      if (!Array.isArray(versions) || versions.length === 0) {
+        return;
+      }
+
+      const select = document.createElement("select");
+      select.setAttribute("aria-label", "Documentation version");
+      for (const entry of versions) {
+        const option = document.createElement("option");
+        option.value = entry.version;
+        option.textContent = entry.name;
+        option.selected = entry.version === currentVersion;
+        select.appendChild(option);
+      }
+      // The currently viewed version may not be in versions.json (e.g. a
+      // just-published version before the list refreshes); show it anyway.
+      if (select.selectedIndex === -1) {
+        const option = document.createElement("option");
+        option.value = currentVersion;
+        option.textContent = currentVersion;
+        option.selected = true;
+        select.insertBefore(option, select.firstChild);
+      }
+      select.addEventListener("change", () => {
+        // Keep the current page path; if it does not exist in the target
+        // version, the site-wide 404 page falls back to that version's index.
+        window.location.href = docsBase + select.value + pagePath;
+      });
+
+      const container = document.createElement("div");
+      container.className = "sidebar-version-switcher";
+      const label = document.createElement("span");
+      label.textContent = "Version: ";
+      container.appendChild(label);
+      container.appendChild(select);
+
+      const style = document.createElement("style");
+      style.textContent = [
+        ".sidebar-version-switcher {",
+        "  margin: 0.5rem 1rem;",
+        "  font-size: var(--sidebar-item-font-size, 0.875rem);",
+        "  color: var(--color-sidebar-caption-text);",
+        "}",
+        ".sidebar-version-switcher select {",
+        "  background: var(--color-sidebar-background);",
+        "  color: var(--color-sidebar-caption-text);",
+        "  border: 1px solid var(--color-sidebar-search-border);",
+        "  border-radius: 0.25rem;",
+        "  padding: 0.125rem 0.25rem;",
+        "}",
+      ].join("\n");
+      document.head.appendChild(style);
+
+      const search = document.querySelector(".sidebar-search-container");
+      if (search !== null) {
+        search.parentNode.insertBefore(container, search.nextSibling);
+        return;
+      }
+      const brand = document.querySelector(".sidebar-brand");
+      if (brand !== null) {
+        brand.parentNode.insertBefore(container, brand.nextSibling);
+      }
+    })
+    .catch(() => {});
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,6 +127,9 @@ html_title = f"XGrammar {__version__}"
 
 html_static_path = ["_static"]
 
+# Version dropdown for the multi-version site (see scripts/support/update_gh_pages.sh).
+html_js_files = ["version_switcher.js"]
+
 html_theme_options = {
     "light_logo": "img/logo.png",
     "dark_logo": "img/logo_dark.svg",

--- a/scripts/support/update_gh_pages.sh
+++ b/scripts/support/update_gh_pages.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Update a gh-pages checkout with freshly built docs. The gh-pages branch is
+# the persistent store for the website: the jekyll landing page lives at the
+# root, docs built from main live in docs/latest/, and every released version
+# keeps a frozen copy in docs/<version>/. versions.json at the root lists all
+# published versions for the docs version dropdown.
+#
+# Usage:
+#   update_gh_pages.sh latest  <docs_html_dir> <site_root_dir> <gh_pages_dir>
+#   update_gh_pages.sh version <docs_html_dir> <version> <gh_pages_dir>
+
+set -euxo pipefail
+
+MODE=$1
+
+if [[ "$MODE" == "latest" ]]; then
+  DOCS_HTML=$2
+  SITE_ROOT=$3
+  GH_PAGES=$4
+
+  # Replace the landing page at the root, keeping the versioned docs tree and
+  # the generated versions.json.
+  rsync -a --delete --exclude=.git --exclude=/docs --exclude=/versions.json \
+    "$SITE_ROOT"/ "$GH_PAGES"/
+
+  mkdir -p "$GH_PAGES/docs"
+  rsync -a --delete "$DOCS_HTML"/ "$GH_PAGES/docs/latest/"
+
+  # Drop leftovers from the pre-versioning layout where docs lived directly in
+  # docs/. Anything that is neither "latest" nor a version directory goes away.
+  find "$GH_PAGES/docs" -mindepth 1 -maxdepth 1 -regextype posix-extended \
+    ! -name latest ! -name index.html ! -regex '.*/v?[0-9][^/]*' \
+    -exec rm -rf {} +
+
+  cat > "$GH_PAGES/docs/index.html" <<'EOF'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="0; url=latest/">
+<link rel="canonical" href="latest/">
+<title>XGrammar documentation</title>
+</head>
+<body>
+<a href="latest/">Redirecting to the latest documentation...</a>
+</body>
+</html>
+EOF
+elif [[ "$MODE" == "version" ]]; then
+  DOCS_HTML=$2
+  VERSION=$3
+  GH_PAGES=$4
+
+  [[ -n "$VERSION" ]]
+  rsync -a --delete "$DOCS_HTML"/ "$GH_PAGES/docs/$VERSION/"
+else
+  echo "Unknown mode: $MODE" >&2
+  exit 1
+fi
+
+# Regenerate versions.json from the version directories under docs/.
+python3 - "$GH_PAGES" <<'EOF'
+import json
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+version_pattern = re.compile(r"^v?\d")
+
+
+def sort_key(name):
+    core = name.lstrip("v")
+    numbers_match = re.match(r"^(\d+(?:\.\d+)*)", core)
+    numbers = tuple(int(part) for part in numbers_match.group(1).split("."))
+    # A final release ("0.2.6") sorts above its pre-releases ("0.2.6rc1").
+    is_final = re.fullmatch(r"\d+(?:\.\d+)*", core) is not None
+    return (numbers, is_final, core)
+
+
+versions = sorted(
+    (
+        path.name
+        for path in (root / "docs").iterdir()
+        if path.is_dir() and version_pattern.match(path.name)
+    ),
+    key=sort_key,
+    reverse=True,
+)
+entries = [{"version": "latest", "name": "latest (main)", "url": "/docs/latest/"}]
+entries += [{"version": v, "name": v, "url": f"/docs/{v}/"} for v in versions]
+(root / "versions.json").write_text(json.dumps(entries, indent=2) + "\n")
+EOF

--- a/scripts/support/update_gh_pages.sh
+++ b/scripts/support/update_gh_pages.sh
@@ -52,7 +52,12 @@ elif [[ "$MODE" == "version" ]]; then
   VERSION=$3
   GH_PAGES=$4
 
-  [[ -n "$VERSION" ]]
+  # The version becomes a directory name under docs/; reject anything that
+  # is not a plain version-looking single path segment.
+  if [[ ! "$VERSION" =~ ^v?[0-9][A-Za-z0-9._+-]*$ ]]; then
+    echo "Invalid version: $VERSION" >&2
+    exit 1
+  fi
   rsync -a --delete "$DOCS_HTML"/ "$GH_PAGES/docs/$VERSION/"
 else
   echo "Unknown mode: $MODE" >&2
@@ -72,11 +77,15 @@ version_pattern = re.compile(r"^v?\d")
 
 def sort_key(name):
     core = name.lstrip("v")
-    numbers_match = re.match(r"^(\d+(?:\.\d+)*)", core)
-    numbers = tuple(int(part) for part in numbers_match.group(1).split("."))
+    match = re.match(r"^(\d+(?:\.\d+)*)(?:([a-z]+)(\d*))?", core)
+    numbers = tuple(int(part) for part in match.group(1).split("."))
     # A final release ("0.2.6") sorts above its pre-releases ("0.2.6rc1").
-    is_final = re.fullmatch(r"\d+(?:\.\d+)*", core) is not None
-    return (numbers, is_final, core)
+    # Pre-release kinds compare per PEP 440 ("a" < "b" < "rc") and their
+    # numbers compare numerically ("rc10" > "rc2").
+    is_final = match.group(2) is None
+    suffix_kind = match.group(2) or ""
+    suffix_number = int(match.group(3)) if match.group(3) else 0
+    return (numbers, is_final, suffix_kind, suffix_number)
 
 
 versions = sorted(

--- a/site/404.html
+++ b/site/404.html
@@ -1,0 +1,38 @@
+---
+permalink: /404.html
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Page not found - XGrammar</title>
+<script>
+"use strict";
+// Redirect old pre-versioning docs links. Docs used to live at /docs/<page>;
+// they now live at /docs/latest/<page> with frozen copies at /docs/<version>/.
+(function () {
+  var match = window.location.pathname.match(/^\/docs\/([^/]+)(\/.*)?$/);
+  if (match === null) {
+    return;
+  }
+  var first = match[1];
+  var rest = match[2] || "";
+  var isVersionDir = first === "latest" || /^v?\d/.test(first);
+  if (!isVersionDir) {
+    // Old-style deep link: /docs/<page> -> /docs/latest/<page>
+    window.location.replace("/docs/latest/" + first + rest);
+  } else if (rest !== "" && rest !== "/") {
+    // Page missing in this version: fall back to that version's index.
+    window.location.replace("/docs/" + first + "/");
+  }
+})();
+</script>
+</head>
+<body>
+<h1>Page not found</h1>
+<p>The page you requested does not exist. Go to the
+<a href="/">XGrammar homepage</a> or the
+<a href="/docs/latest/">latest documentation</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Restructure the docs deployment so the site keeps every published version: the jekyll landing page stays at the site root, docs built from `main` are served at `/docs/latest/`, and each release gets a frozen copy at `/docs/<version>/` (e.g. `/docs/0.2.6rc1/`).
- The `gh-pages` branch becomes the persistent store for the site. Each deploy updates only the relevant subdirectory, commits to `gh-pages`, and publishes the whole tree through the existing GitHub Pages actions flow, so old versions are never rebuilt and the Pages settings stay unchanged.
- `versions.json` at the site root is regenerated on every deploy and feeds a new version dropdown in the furo sidebar (`docs/_static/version_switcher.js`).
- `site/404.html` redirects pre-versioning deep links `/docs/<page>` to `/docs/latest/<page>`, so existing bookmarks keep working; `/docs/` itself redirects to `/docs/latest/`.
- Versioned docs can be published in two ways: automatically on GitHub releases, or manually via workflow dispatch with a `docs_ref` input (the version label is read from that ref's `pyproject.toml`).

## Test plan

- [x] `update_gh_pages.sh` exercised locally against a copy of the real `gh-pages` branch: first `latest` deploy replaces the stale pre-versioning layout, version deploys create `docs/<version>/`, later `latest` deploys leave version directories untouched, and `versions.json` sorts versions correctly (`0.2.10` > `0.2.6` > `0.2.6rc1` > `0.2.5`).
- [x] Workflow YAML and shell script syntax validated.
- [ ] PR CI builds the Sphinx docs and the jekyll landing page.
- [ ] After merge: push to `main` deploys `/docs/latest/`; dispatch with `docs_ref=preview/v0.2.6rc1` publishes `/docs/0.2.6rc1/`.