### PR TITLE
docs: document the dynamic compilation option

### DIFF
--- a/docs/start/workflow_of_xgrammar.md
+++ b/docs/start/workflow_of_xgrammar.md
@@ -122,6 +122,35 @@ compiled_grammar2 = grammar_compiler.compile_grammar(grammar)
 grammar_compiler.clear_cache()
 ```
 
+### Dynamic Compilation
+
+By default, grammar compilation precomputes the adaptive token mask cache for the whole grammar.
+For large grammars, such as a JSON schema describing many tools, this precomputation dominates the
+compilation time. Set `enable_dynamic_compilation` to `True` to defer it: token masks are
+generated the first time they are needed during decoding, then stored in the
+[`xgr.CompiledGrammar`](xgrammar.CompiledGrammar) object and reused by all later steps and
+requests.
+
+```python
+grammar_compiler = xgr.GrammarCompiler(tokenizer_info, enable_dynamic_compilation=True)
+compiled_grammar = grammar_compiler.compile_json_schema(json_schema_string)
+```
+
+Dynamic compilation produces exactly the same token masks as the default mode. It reduces the
+compilation time and the initial memory usage of the compiled grammar, in exchange for extra
+mask-generation work in the first decoding steps that reach each grammar position. It is
+suitable for workloads with many distinct or rarely reused grammars, such as agentic
+applications that construct grammars on the fly. Generating masks dynamically from multiple
+threads is safe.
+
+Two behaviors to note:
+
+- Serializing a compiled grammar with
+  [`serialize_json`](xgrammar.CompiledGrammar.serialize_json) first materializes all remaining
+  token masks, so the serialized result is equivalent to that of the default mode.
+- With dynamic compilation enabled, the compilation cache only works without a memory limit.
+  If `cache_limit_bytes` is set to a value other than `-1`, the cache is disabled.
+
 ## Compiled Grammar
 
 A [`xgr.CompiledGrammar`](xgrammar.CompiledGrammar) object is associated with an [`xgr.Grammar`](xgrammar.Grammar) object and an [`xgr.TokenizerInfo`](xgrammar.TokenizerInfo) object. It contains the compiled grammar and the token mask cache. Use these methods to access the grammar and tokenizer info:

--- a/docs/using_xgrammar/engine_integration.md
+++ b/docs/using_xgrammar/engine_integration.md
@@ -29,7 +29,10 @@ Compiling a complex grammar can take non-negligible time, so it should not block
 main loop. Compile the grammar asynchronously when the request arrives, so that compilation
 overlaps with the prefill phase of the request, as shown in the figure in the next section. See
 [Multi-threaded Compilation](../start/workflow_of_xgrammar.md#multi-threaded-compilation) for
-the asynchronous compilation API.
+the asynchronous compilation API. For large grammars, constructing the compiler with
+`enable_dynamic_compilation=True` further reduces the compilation latency by generating token
+masks on first use during decoding instead of at compile time; see
+[Dynamic Compilation](../start/workflow_of_xgrammar.md#dynamic-compilation).
 
 ## Integrating into the Engine Step
 

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -130,7 +130,11 @@ class GrammarCompiler(XGRObject):
             Note that the actual memory usage may slightly exceed this value.
 
         enable_dynamic_compilation : bool, default: False
-            Whether to generate token masks when they are first needed.
+            Whether to generate token masks when they are first needed during decoding,
+            instead of precomputing them at compile time. This reduces the compilation time
+            and the initial memory usage of the compiled grammar, while producing the same
+            masks. When enabled, the compilation cache only works with an unlimited
+            cache_limit_bytes.
         """
         if not isinstance(tokenizer_info, TokenizerInfo):
             raise ValueError(


### PR DESCRIPTION
## Summary

The v0.2.6 preview introduces dynamic compilation (`enable_dynamic_compilation` on `xgr.GrammarCompiler`), but it was the only new user-facing feature in this release with no narrative documentation. This PR documents it:

- Add a **Dynamic Compilation** section to *Workflow of XGrammar* (under Grammar Compiler), covering what the option does, when to use it, mask equivalence with the default mode, thread safety, mask materialization on `serialize_json`, and the interaction with `cache_limit_bytes`.
- Add a pointer to it from the compilation-latency paragraph in *Integration with LLM Engine*.
- Expand the one-line `enable_dynamic_compilation` parameter docstring in `GrammarCompiler.__init__` so the generated API reference explains the trade-off.

Other new features in the v0.2.5..v0.2.6rc1 range (Lark/EBNF rule options, temperature APIs, `validate_tokens`, substring regexes, llguidance compatibility, etc.) were checked and are already documented.

## Test plan

- [x] `sphinx-build -b html` succeeds with no new warnings
- [x] The new `#dynamic-compilation` anchor and the cross-page link resolve in the built HTML