### PR TITLE
Optimize dynamic JSON Schema compilation and token masks

### DIFF
--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -159,6 +159,16 @@ class CompiledGrammar::Impl {
   /*! \brief Whether each rule is independent of runtime parser context. */
   std::vector<uint8_t> rule_level_cacheable;
 
+  /*! \brief Whether rule hashes and context-independence metadata are needed. */
+  bool rule_level_metadata_enabled{false};
+
+  /*! \brief Initializes rule hashes and context-independence metadata at most once. */
+  mutable std::once_flag rule_level_metadata_once;
+
+  /*! \brief Immutable builtin masks used to seed a cache-disabled dynamic grammar. */
+  std::shared_ptr<RuleLevelCache> builtin_rule_level_cache_seed_source;
+  std::vector<uint64_t> builtin_rule_fsm_hashes;
+
   /*! \brief Character-class repeat masks shared by matchers using this grammar. */
   std::shared_ptr<CharacterClassTokenSummaryCache> character_class_token_summary_cache;
   std::unordered_map<uint64_t, std::shared_ptr<const CharacterClassRepeatTokenMask>>
@@ -171,6 +181,8 @@ class CompiledGrammar::Impl {
   std::unordered_map<int32_t, DynamicBitset> tag_dispatch_rule_id_to_second_slicing_bitset;
 
   const AdaptiveTokenMask& GetAdaptiveTokenMask(const ParserState& state, bool is_root_rule);
+
+  void EnsureRuleLevelMetadata();
 
   const CharacterClassRepeatTokenMask& GetCharacterClassRepeatTokenMask(
       int32_t character_class_expr_id, int32_t max_characters

--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -1204,10 +1204,14 @@ FSMWithStartEnd FSMWithStartEnd::Plus() const {
 
 FSMWithStartEnd FSMWithStartEnd::Optional() const {
   FSM fsm = fsm_.Copy();
-  if (!ends_.empty()) {
-    fsm.AddEpsilonEdge(start_, ends_.front());
+  const int new_start = fsm.AddState();
+  const int new_end = fsm.AddState();
+  fsm.AddEpsilonEdge(new_start, start_);
+  fsm.AddEpsilonEdge(new_start, new_end);
+  for (int end : ends_) {
+    fsm.AddEpsilonEdge(end, new_end);
   }
-  return FSMWithStartEnd(fsm, start_, ends_);
+  return FSMWithStartEnd(fsm, new_start, {new_end});
 }
 
 Result<FSMWithStartEnd> FSMWithStartEnd::Not(int max_result_num_states) const {

--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -35,6 +35,93 @@
 
 namespace xgrammar {
 
+namespace {
+
+// A reusable union-find specialized for the dense state ids used by FSM algorithms. The set id
+// assignment scans state ids in ascending order, matching UnionFindSet::GetAllSets()'s
+// deterministic ordering without allocating and sorting a vector for every equivalence class.
+class DenseIntUnionFindSet {
+ public:
+  explicit DenseIntUnionFindSet(int universe_size) {
+    XGRAMMAR_CHECK(universe_size >= 0) << "Union-find universe size must be nonnegative.";
+    parent_.assign(universe_size, -1);
+    set_size_.resize(universe_size);
+  }
+
+  bool Add(int element) {
+    XGRAMMAR_DCHECK(element >= 0 && element < static_cast<int>(parent_.size()));
+    if (parent_[element] != -1) {
+      return false;
+    }
+    parent_[element] = element;
+    set_size_[element] = 1;
+    elements_.push_back(element);
+    return true;
+  }
+
+  void Clear() {
+    for (int element : elements_) {
+      parent_[element] = -1;
+    }
+    elements_.clear();
+  }
+
+  int Find(int element) {
+    XGRAMMAR_DCHECK(element >= 0 && element < static_cast<int>(parent_.size()));
+    XGRAMMAR_DCHECK(parent_[element] != -1);
+    int root = element;
+    while (parent_[root] != root) {
+      root = parent_[root];
+    }
+    while (parent_[element] != element) {
+      int next = parent_[element];
+      parent_[element] = root;
+      element = next;
+    }
+    return root;
+  }
+
+  void Union(int a, int b) {
+    int root_a = Find(a);
+    int root_b = Find(b);
+    if (root_a == root_b) {
+      return;
+    }
+    if (set_size_[root_a] < set_size_[root_b]) {
+      std::swap(root_a, root_b);
+    }
+    parent_[root_b] = root_a;
+    set_size_[root_a] += set_size_[root_b];
+  }
+
+  bool Count(int element) const {
+    return element >= 0 && element < static_cast<int>(parent_.size()) && parent_[element] != -1;
+  }
+
+  int AssignSetIds(std::vector<int>* element_to_set) {
+    element_to_set->assign(parent_.size(), -1);
+    int num_sets = 0;
+    for (int element = 0; element < static_cast<int>(parent_.size()); ++element) {
+      if (parent_[element] == -1) {
+        continue;
+      }
+      int root = Find(element);
+      if (set_size_[root] > 0) {
+        set_size_[root] = -(++num_sets);
+      }
+      (*element_to_set)[element] = -set_size_[root] - 1;
+    }
+    return num_sets;
+  }
+
+ private:
+  std::vector<int> parent_;
+  std::vector<int> set_size_;
+  std::vector<int> elements_;
+};
+
+}  // namespace
+
 /****************** FSMImplBase ******************/
 
 template <typename ContainerType>
@@ -315,6 +402,8 @@ class FSM::Impl : public FSMImplBase<std::vector<std::vector<FSMEdge>>> {
 
   void AddFSM(const FSM& fsm, std::vector<int>* state_mapping);
 
+  void AddFSM(FSM&& fsm, std::vector<int>* state_mapping);
+
   FSM RebuildWithMapping(const std::vector<int>& state_mapping, int new_num_states) const;
 
   void SortEdges();
@@ -438,18 +527,76 @@ void FSM::Impl::AddFSM(const FSM& fsm, std::vector<int>* state_mapping) {
   edges_.resize(edges_.size() + fsm.NumStates());
 
   for (int i = 0; i < fsm.NumStates(); ++i) {
-    for (const auto& edge : fsm.GetEdges()[i]) {
+    const auto& source_edges = fsm.GetEdges()[i];
+    if constexpr (kInternalChecksEnabled) {
+      XGRAMMAR_DCHECK(
+          source_edges.empty() || !source_edges.front().IsRepeatRef() || source_edges.size() == 1
+      ) << "A state with a kRepeatRef edge must have no other outgoing edges.";
+    }
+    auto& target_edges = edges_[i + old_num_states];
+    target_edges.reserve(source_edges.size());
+    for (const auto& edge : source_edges) {
       int32_t max_val = edge.max;
       if (edge.IsAuxEdge() && aux_offset > 0) {
         max_val = static_cast<int32_t>(edge.max + aux_offset);
       }
-      AddEdge(i + old_num_states, edge.target + old_num_states, edge.min, max_val);
+      target_edges.emplace_back(edge.min, max_val, edge.target + old_num_states);
     }
   }
 }
 
+void FSM::Impl::AddFSM(FSM&& fsm, std::vector<int>* state_mapping) {
+  // A copied FSM shares its implementation. Mutating it in place would also mutate the other
+  // owners, so use the ordinary copy path unless this rvalue is the sole owner.
+  if (fsm.pimpl_.get() == this || fsm.pimpl_.use_count() != 1) {
+    AddFSM(static_cast<const FSM&>(fsm), state_mapping);
+    return;
+  }
+
+  int old_num_states = NumStates();
+  int32_t aux_offset = static_cast<int32_t>(edge_aux_data_.size());
+  auto& source_edges = fsm.pimpl_->edges_;
+  auto& source_aux_data = fsm.pimpl_->edge_aux_data_;
+
+  if (state_mapping != nullptr) {
+    state_mapping->clear();
+    state_mapping->reserve(source_edges.size());
+    for (int i = 0; i < static_cast<int>(source_edges.size()); ++i) {
+      state_mapping->push_back(i + old_num_states);
+    }
+  }
+
+  edge_aux_data_.insert(
+      edge_aux_data_.end(),
+      std::make_move_iterator(source_aux_data.begin()),
+      std::make_move_iterator(source_aux_data.end())
+  );
+  for (auto& row : source_edges) {
+    if constexpr (kInternalChecksEnabled) {
+      XGRAMMAR_DCHECK(row.empty() || !row.front().IsRepeatRef() || row.size() == 1)
+          << "A state with a kRepeatRef edge must have no other outgoing edges.";
+    }
+    for (auto& edge : row) {
+      edge.target += old_num_states;
+      if (edge.IsAuxEdge() && aux_offset > 0) {
+        edge.max += aux_offset;
+      }
+    }
+    edges_.push_back(std::move(row));
+  }
+  source_edges.clear();
+  source_aux_data.clear();
+}
+
 FSM FSM::Impl::RebuildWithMapping(const std::vector<int>& state_mapping, int new_num_states) const {
   std::vector<std::vector<FSMEdge>> new_edges(new_num_states);
+  std::vector<size_t> row_capacities(new_num_states, 0);
+  for (int i = 0; i < static_cast<int>(edges_.size()); ++i) {
+    row_capacities[state_mapping[i]] += edges_[i].size();
+  }
+  for (int i = 0; i < new_num_states; ++i) {
+    new_edges[i].reserve(row_capacities[i]);
+  }
   for (int i = 0; i < static_cast<int>(edges_.size()); ++i) {
     for (const auto& edge : edges_[i]) {
       if (edge.IsEpsilon() && state_mapping[i] == state_mapping[edge.target]) {
@@ -546,6 +693,10 @@ void FSM::AddFSM(const FSM& fsm, std::vector<int>* state_mapping) {
   pimpl_->AddFSM(fsm, state_mapping);
 }
 
+void FSM::AddFSM(FSM&& fsm, std::vector<int>* state_mapping) {
+  pimpl_->AddFSM(std::move(fsm), state_mapping);
+}
+
 std::string FSM::EdgesToString(std::optional<std::vector<int>> states) const {
   return pimpl_->EdgesToString(states);
 }
@@ -561,6 +712,8 @@ const std::vector<std::vector<FSMEdge>>& FSM::GetEdges() const { return pimpl_->
 std::vector<FSMEdge>& FSM::GetEdges(int state) { return pimpl_->GetEdges(state); }
 
 FSM FSM::Copy() const { return FSM(std::make_shared<Impl>(*pimpl_)); }
+
+bool FSM::IsUnique() const { return pimpl_.use_count() == 1; }
 
 int FSM::GetNextState(int from, int value, FSMEdge::EdgeType edge_type) const {
   return pimpl_->GetNextState(from, value, edge_type);
@@ -1139,6 +1292,30 @@ FSMWithStartEnd FSMWithStartEnd::Union(const std::vector<FSMWithStartEnd>& fsms)
   return FSMWithStartEnd(fsm, start, std::move(ends));
 }
 
+FSMWithStartEnd FSMWithStartEnd::Union(std::vector<FSMWithStartEnd>&& fsms) {
+  if (fsms.size() == 1) {
+    return std::move(fsms[0]);
+  }
+  XGRAMMAR_DCHECK(fsms.size() > 1) << "Union of 0 FSMs is not allowed.";
+
+  FSM fsm(1);
+  int start = 0;
+  std::vector<int32_t> ends;
+  std::vector<int> state_mapping;
+
+  for (auto& fsm_with_se : fsms) {
+    const int child_start = fsm_with_se.GetStart();
+    auto child_ends = fsm_with_se.GetEnds();
+    fsm.AddFSM(std::move(fsm_with_se.GetFsm()), &state_mapping);
+    fsm.AddEpsilonEdge(start, state_mapping[child_start]);
+    for (auto end : child_ends) {
+      ends.push_back(state_mapping[end]);
+    }
+  }
+
+  return FSMWithStartEnd(fsm, start, std::move(ends));
+}
+
 FSMWithStartEnd FSMWithStartEnd::Concat(const std::vector<FSMWithStartEnd>& fsms) {
   // For each FSM, link the end states to the start state of the next FSM.
   // Set the start state of the first FSM as the start state of the result.
@@ -1173,6 +1350,44 @@ FSMWithStartEnd FSMWithStartEnd::Concat(const std::vector<FSMWithStartEnd>& fsms
       previous_ends.clear();
       previous_ends.reserve(fsms[i].GetEnds().size());
       for (auto end : fsms[i].GetEnds()) {
+        previous_ends.push_back(state_mapping[end]);
+      }
+    }
+  }
+
+  return FSMWithStartEnd(fsm, start, std::move(ends));
+}
+
+FSMWithStartEnd FSMWithStartEnd::Concat(std::vector<FSMWithStartEnd>&& fsms) {
+  if (fsms.size() == 1) {
+    return std::move(fsms[0]);
+  }
+  XGRAMMAR_DCHECK(fsms.size() > 1) << "Concatenation of 0 FSMs is not allowed.";
+
+  auto& first = fsms[0];
+  int start = first.GetStart();
+  std::vector<int> previous_ends(first.GetEnds().begin(), first.GetEnds().end());
+  FSM fsm = std::move(first.GetFsm());
+  std::vector<int32_t> ends;
+  std::vector<int> state_mapping;
+
+  for (int i = 1; i < static_cast<int>(fsms.size()); ++i) {
+    auto& child = fsms[i];
+    const int child_start = child.GetStart();
+    auto child_ends = child.GetEnds();
+    fsm.AddFSM(std::move(child.GetFsm()), &state_mapping);
+    auto this_start = state_mapping[child_start];
+    for (const auto& end : previous_ends) {
+      fsm.AddEpsilonEdge(end, this_start);
+    }
+    if (i == static_cast<int>(fsms.size()) - 1) {
+      for (auto end : child_ends) {
+        ends.push_back(state_mapping[end]);
+      }
+    } else {
+      previous_ends.clear();
+      previous_ends.reserve(child_ends.size());
+      for (auto end : child_ends) {
         previous_ends.push_back(state_mapping[end]);
       }
     }
@@ -1320,7 +1535,7 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
     return *this;
   }
 
-  UnionFindSet<int> union_find_set;
+  DenseIntUnionFindSet union_find_set(NumStates());
   std::vector<int> in_degree(NumStates(), 0);
   std::vector<std::pair<int32_t, int32_t>> epsilon_edges;
 
@@ -1387,19 +1602,12 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
   }
 
   // Merge the states.
-  auto eq_classes = union_find_set.GetAllSets();
-  if (eq_classes.empty()) {
+  std::vector<int> new_to_old;
+  int cnt = union_find_set.AssignSetIds(&new_to_old);
+  if (cnt == 0) {
     return *this;
   }
 
-  std::vector<int> new_to_old(NumStates(), -1);
-  for (size_t i = 0; i < eq_classes.size(); i++) {
-    for (const auto& state : eq_classes[i]) {
-      new_to_old[state] = i;
-    }
-  }
-
-  int cnt = eq_classes.size();
   for (int i = 0; i < NumStates(); i++) {
     if (new_to_old[i] == -1) {
       new_to_old[i] = cnt;
@@ -1413,22 +1621,34 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
   return result;
 }
 
-FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states) const {
+FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states) const& {
   if constexpr (kInternalChecksEnabled) {
     fsm_->ValidateRepeatEdgeInvariant();
   }
   if (max_result_num_states < NumStates()) {
     return *this;
   }
+  return Copy().MergeEquivalentStates(max_result_num_states);
+}
+
+FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states) && {
+  if constexpr (kInternalChecksEnabled) {
+    fsm_->ValidateRepeatEdgeInvariant();
+  }
+  if (max_result_num_states < NumStates()) {
+    return std::move(*this);
+  }
   // No merge is possible with fewer than 4 states (need >=2 sources sharing a target,
   // or >=2 sinks sharing a source).
   if (NumStates() < 4) {
-    return Copy();
+    return std::move(*this);
   }
   bool changed = true;
-  FSMWithStartEnd result = Copy();
+  // An rvalue can still share its PImpl with a cached FSM. Mutate only a uniquely owned
+  // implementation; otherwise retain the ordinary deep-copy behavior.
+  FSMWithStartEnd result = fsm_.IsUnique() ? std::move(*this) : Copy();
   result.GetFsm()->SortEdges();
-  UnionFindSet<int> union_find_set;
+  DenseIntUnionFindSet union_find_set(result.NumStates());
 
   // A compact edge view used for incoming/outgoing CSR rows. `peer` means source state in
   // incoming_edges and target state in outgoing_edges.
@@ -1469,7 +1689,6 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states
   std::vector<int32_t> no_successor_end_states;
   // Terminal non-end states collected for leaf-state merging.
   std::vector<int32_t> no_successor_non_end_states;
-
   while (changed) {
     int n = result.NumStates();
     union_find_set.Clear();
@@ -1672,14 +1891,8 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states
     if (changed) {
       // Rebuild the FSM with the equivalent states merged, then repeat until no local merge
       // rule applies.
-      auto eq_classes = union_find_set.GetAllSets();
-      std::vector<int> old_to_new(result.NumStates(), -1);
-      for (size_t i = 0; i < eq_classes.size(); i++) {
-        for (const auto& state : eq_classes[i]) {
-          old_to_new[state] = i;
-        }
-      }
-      int cnt = eq_classes.size();
+      std::vector<int> old_to_new;
+      int cnt = union_find_set.AssignSetIds(&old_to_new);
       for (int i = 0; i < result.NumStates(); i++) {
         if (old_to_new[i] == -1) {
           old_to_new[i] = cnt;
@@ -1687,7 +1900,6 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states
         }
       }
       result = result.RebuildWithMapping(old_to_new, cnt);
-      result.GetFsm()->SortEdges();
     }
   }
   if constexpr (kInternalChecksEnabled) {

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -394,12 +394,18 @@ class FSM {
    */
   void AddFSM(const FSM& fsm, std::vector<int>* state_mapping = nullptr);
 
+  /*! \brief Move a whole FSM into the current FSM when it is no longer needed by the caller. */
+  void AddFSM(FSM&& fsm, std::vector<int>* state_mapping = nullptr);
+
   /****************** FSM Construction Methods ******************/
 
   /*!
     \brief Return a copy of the FSM.
   */
   FSM Copy() const;
+
+  /*! \brief Whether this FSM is the sole owner of its mutable implementation. */
+  bool IsUnique() const;
 
   /*!
    * \brief Rebuild the FSM with the new state ids.
@@ -837,12 +843,18 @@ class FSMWithStartEnd : public FSMWithStartEndBase<FSM> {
    */
   static FSMWithStartEnd Union(const std::vector<FSMWithStartEnd>& fsms);
 
+  /*! \brief Union FSMs while consuming the input vector. */
+  static FSMWithStartEnd Union(std::vector<FSMWithStartEnd>&& fsms);
+
   /*!
    * \brief Concatenate the FSMs.
    * \param fsms The FSMs to be concatenated, which should be in order.
    * \return The concatenation of the FSMs.
    */
   static FSMWithStartEnd Concat(const std::vector<FSMWithStartEnd>& fsms);
+
+  /*! \brief Concatenate FSMs while consuming the input vector. */
+  static FSMWithStartEnd Concat(std::vector<FSMWithStartEnd>&& fsms);
 
   /*!
    * \brief Check if the FSM is a DFA.
@@ -863,7 +875,10 @@ class FSMWithStartEnd : public FSMWithStartEndBase<FSM> {
    * 2) they are not pointed to by other edges, then we can merge them.
    * \example n0 --(c)--> n1, n0 --(c)--> n2, then we can merge n1 and n2.
    */
-  FSMWithStartEnd MergeEquivalentStates(int max_num_states = 1e5) const;
+  FSMWithStartEnd MergeEquivalentStates(int max_num_states = 1e5) const&;
+
+  /*! \brief Merge equivalent states while consuming an FSM that is no longer needed. */
+  FSMWithStartEnd MergeEquivalentStates(int max_num_states = 1e5) &&;
 
   /*!
    * \brief Transform the FSM to a DFA.

--- a/cpp/fsm_builder.cc
+++ b/cpp/fsm_builder.cc
@@ -1955,7 +1955,7 @@ Result<FSMWithStartEnd> RegexIR::Build() const {
     fsm_list.push_back(std::move(visited).Unwrap());
   }
   if (fsm_list.size() > 1) {
-    return ResultOk(FSMWithStartEnd::Concat(fsm_list));
+    return ResultOk(FSMWithStartEnd::Concat(std::move(fsm_list)));
   } else {
     // If there is only one FSM, return it directly.
     return ResultOk(std::move(fsm_list[0]));
@@ -1978,7 +1978,7 @@ Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Union& state) const {
   if (fsm_list.size() <= 1) {
     return ResultErr("Internal error: a union node in the regex IR has fewer than two branches");
   }
-  return ResultOk(FSMWithStartEnd::Union(fsm_list));
+  return ResultOk(FSMWithStartEnd::Union(std::move(fsm_list)));
 }
 
 Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Symbol& state) const {
@@ -2024,7 +2024,7 @@ Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Bracket& state) const {
     }
     fsm_list.push_back(std::move(visited).Unwrap());
   }
-  return ResultOk(FSMWithStartEnd::Concat(fsm_list));
+  return ResultOk(FSMWithStartEnd::Concat(std::move(fsm_list)));
 }
 
 Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::RuleRefNode& state) const {

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -181,6 +181,23 @@ class CharacterClassTokenSummaryCache {
     std::vector<int32_t> unaccepted_indices;
   };
 
+  std::shared_ptr<const AdaptiveTokenMask> GetEmailLocalPartMask() {
+    std::lock_guard<std::mutex> lock(email_local_part_mutex_);
+    return email_local_part_mask_;
+  }
+
+  std::shared_ptr<const AdaptiveTokenMask> StoreEmailLocalPartMask(
+      AdaptiveTokenMask adaptive_token_mask
+  ) {
+    auto computed = std::make_shared<const AdaptiveTokenMask>(std::move(adaptive_token_mask));
+    std::lock_guard<std::mutex> lock(email_local_part_mutex_);
+    if (email_local_part_mask_ != nullptr) {
+      return email_local_part_mask_;
+    }
+    email_local_part_mask_ = computed;
+    return computed;
+  }
+
   std::shared_ptr<const Result> GetOrCreate(
       const Grammar::Impl::GrammarExpr& character_class,
       const std::vector<std::pair<int32_t, std::string>>& sorted_vocab,
@@ -360,6 +377,10 @@ class CharacterClassTokenSummaryCache {
       std::lock_guard<std::mutex> lock(ascii_byte_loop_mutex_);
       ascii_byte_loop_cache_.clear();
     }
+    {
+      std::lock_guard<std::mutex> lock(email_local_part_mutex_);
+      email_local_part_mask_.reset();
+    }
   }
 
  private:
@@ -376,6 +397,8 @@ class CharacterClassTokenSummaryCache {
       std::shared_ptr<const ASCIIByteLoopTokenMask>,
       ASCIIByteLoopKeyHash>
       ascii_byte_loop_cache_;
+  std::mutex email_local_part_mutex_;
+  std::shared_ptr<const AdaptiveTokenMask> email_local_part_mask_;
 };
 
 struct JSONStringSinkInfo {
@@ -466,6 +489,9 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
 
   /*! \brief Classify one prefix of a delimiter-separated recursive ASCII label. */
   std::optional<AdaptiveTokenMask> GetDelimitedRecursiveLabelDirectMask(bool is_root_rule) const;
+
+  /*! \brief Classify the local-part run of an exact built-in email grammar. */
+  std::optional<AdaptiveTokenMask> GetEmailLocalPartDirectMask(bool is_root_rule) const;
 
   /*! \brief Classify the ASCII-safe subset of a fixed-width JSON wildcard path. */
   std::optional<AdaptiveTokenMask> GetFixedWidthJSONStringDirectMask(bool is_root_rule) const;
@@ -1415,6 +1441,493 @@ std::optional<AdaptiveTokenMask> GrammarMatcherForTokenMaskCache::GetSingleChara
       std::move(accepted_indices),
       std::move(uncertain_indices)
   );
+}
+
+std::optional<AdaptiveTokenMask> GrammarMatcherForTokenMaskCache::GetEmailLocalPartDirectMask(
+    bool is_root_rule
+) const {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  const auto& initial_rule = grammar_->GetRule(init_rule_id_);
+  if (is_root_rule || initial_state_.sub_element_id != 0 || initial_rule.is_lazy ||
+      initial_rule.max_tokens != -1 || initial_rule.max_chars != -1 ||
+      initial_rule.json_string_min_length != -1 || initial_rule.json_string_max_length != -1 ||
+      !initial_rule.capture_name.empty() || !grammar_->per_rule_fsms[init_rule_id_].has_value() ||
+      initial_state_.element_id != grammar_->per_rule_fsms[init_rule_id_]->GetFsm().GetStart()) {
+    return std::nullopt;
+  }
+
+  const auto plain_rule = [&](int32_t rule_id) {
+    const auto& rule = grammar_->GetRule(rule_id);
+    return !rule.is_lazy && rule.max_tokens == -1 && rule.max_chars == -1 &&
+           rule.json_string_min_length == -1 && rule.json_string_max_length == -1 &&
+           rule.capture_name.empty();
+  };
+  const auto has_no_lookahead = [&](int32_t rule_id) {
+    return grammar_->GetRule(rule_id).lookahead_assertion_id == -1;
+  };
+  const auto get_rule_ref_lookahead = [&](int32_t rule_id) -> std::optional<int32_t> {
+    const auto& rule = grammar_->GetRule(rule_id);
+    const auto lookahead_id = rule.lookahead_assertion_id;
+    if (lookahead_id == -1 || !rule.is_exact_lookahead) {
+      return std::nullopt;
+    }
+    const auto& lookahead = grammar_->GetGrammarExpr(lookahead_id);
+    if (lookahead.type != GrammarExprType::kSequence || lookahead.size() != 1) {
+      return std::nullopt;
+    }
+    const auto& reference = grammar_->GetGrammarExpr(lookahead[0]);
+    if (reference.type != GrammarExprType::kRuleRef) {
+      return std::nullopt;
+    }
+    return reference[0];
+  };
+  const auto has_rule_ref_lookahead = [&](int32_t rule_id, int32_t referenced_rule_id) {
+    const auto reference = get_rule_ref_lookahead(rule_id);
+    return reference.has_value() && *reference == referenced_rule_id;
+  };
+  const auto has_byte_lookahead = [&](int32_t rule_id, uint8_t expected_byte) {
+    const auto& rule = grammar_->GetRule(rule_id);
+    const auto lookahead_id = rule.lookahead_assertion_id;
+    if (lookahead_id == -1 || !rule.is_exact_lookahead) {
+      return false;
+    }
+    const auto& lookahead = grammar_->GetGrammarExpr(lookahead_id);
+    if (lookahead.type != GrammarExprType::kSequence || lookahead.size() != 1) {
+      return false;
+    }
+    const auto& byte_string = grammar_->GetGrammarExpr(lookahead[0]);
+    return byte_string.type == GrammarExprType::kByteString && byte_string.size() == 1 &&
+           byte_string[0] == expected_byte;
+  };
+  const auto ascii_class = [&](int32_t expr_id, GrammarExprType expected_type
+                           ) -> std::optional<std::array<uint8_t, 128>> {
+    const auto& expr = grammar_->GetGrammarExpr(expr_id);
+    if (expr.type != expected_type || expr.size() < 3 || expr[0] != 0) {
+      return std::nullopt;
+    }
+    std::array<uint8_t, 128> result{};
+    for (int32_t index = 1; index < expr.size(); index += 2) {
+      if (index + 1 >= expr.size() || expr[index] < 0 || expr[index + 1] >= 128) {
+        return std::nullopt;
+      }
+      for (int32_t byte = expr[index]; byte <= expr[index + 1]; ++byte) {
+        result[byte] = true;
+      }
+    }
+    return result;
+  };
+  const auto match_recursive_run = [&](int32_t rule_id) -> std::optional<std::array<uint8_t, 128>> {
+    if (!plain_rule(rule_id)) {
+      return std::nullopt;
+    }
+    const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(rule_id).body_expr_id);
+    if (body.type != GrammarExprType::kChoices || body.size() != 2) {
+      return std::nullopt;
+    }
+    std::optional<std::array<uint8_t, 128>> recursive_class;
+    std::optional<std::array<uint8_t, 128>> terminal_class;
+    for (int32_t choice_id : body) {
+      const auto& choice = grammar_->GetGrammarExpr(choice_id);
+      if (choice.type != GrammarExprType::kSequence) {
+        return std::nullopt;
+      }
+      if (choice.size() == 1) {
+        terminal_class = ascii_class(choice[0], GrammarExprType::kCharacterClass);
+      } else if (choice.size() == 2) {
+        const auto& self_reference = grammar_->GetGrammarExpr(choice[1]);
+        if (self_reference.type != GrammarExprType::kRuleRef || self_reference[0] != rule_id) {
+          return std::nullopt;
+        }
+        recursive_class = ascii_class(choice[0], GrammarExprType::kCharacterClass);
+      } else {
+        return std::nullopt;
+      }
+    }
+    if (!recursive_class.has_value() || !terminal_class.has_value() ||
+        *recursive_class != *terminal_class) {
+      return std::nullopt;
+    }
+    return recursive_class;
+  };
+  const auto external_reference_count = [&](int32_t referenced_rule_id) {
+    int32_t count = 0;
+    for (int32_t owner_rule_id = 0; owner_rule_id < grammar_->NumRules(); ++owner_rule_id) {
+      if (owner_rule_id == referenced_rule_id) {
+        continue;
+      }
+      const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(owner_rule_id).body_expr_id);
+      if (body.type != GrammarExprType::kChoices) {
+        continue;
+      }
+      for (int32_t choice_id : body) {
+        const auto& choice = grammar_->GetGrammarExpr(choice_id);
+        if (choice.type != GrammarExprType::kSequence) {
+          continue;
+        }
+        for (int32_t element_id : choice) {
+          const auto& element = grammar_->GetGrammarExpr(element_id);
+          count += element.type == GrammarExprType::kRuleRef && element[0] == referenced_rule_id;
+        }
+      }
+    }
+    return count;
+  };
+
+  const auto local_bytes = match_recursive_run(init_rule_id_);
+  if (!local_bytes.has_value() || external_reference_count(init_rule_id_) != 1) {
+    return std::nullopt;
+  }
+
+  const auto initial_local_suffix = get_rule_ref_lookahead(init_rule_id_);
+  if (!initial_local_suffix.has_value()) {
+    return std::nullopt;
+  }
+  const int32_t local_suffix_rule_id = *initial_local_suffix;
+  if (!plain_rule(local_suffix_rule_id) || !has_no_lookahead(local_suffix_rule_id) ||
+      external_reference_count(local_suffix_rule_id) != 1) {
+    return std::nullopt;
+  }
+
+  const auto& local_suffix_body =
+      grammar_->GetGrammarExpr(grammar_->GetRule(local_suffix_rule_id).body_expr_id);
+  int32_t dotted_local_run_rule_id = -1;
+  bool local_suffix_has_empty = false;
+  if (local_suffix_body.type != GrammarExprType::kChoices || local_suffix_body.size() != 2) {
+    return std::nullopt;
+  }
+  for (int32_t choice_id : local_suffix_body) {
+    const auto& choice = grammar_->GetGrammarExpr(choice_id);
+    if (choice.type == GrammarExprType::kEmptyStr) {
+      local_suffix_has_empty = true;
+      continue;
+    }
+    if (choice.type != GrammarExprType::kSequence || choice.size() != 3) {
+      return std::nullopt;
+    }
+    const auto& delimiter = grammar_->GetGrammarExpr(choice[0]);
+    const auto& run_reference = grammar_->GetGrammarExpr(choice[1]);
+    const auto& self_reference = grammar_->GetGrammarExpr(choice[2]);
+    if (delimiter.type != GrammarExprType::kByteString || delimiter.size() != 1 ||
+        delimiter[0] != '.' || run_reference.type != GrammarExprType::kRuleRef ||
+        self_reference.type != GrammarExprType::kRuleRef ||
+        self_reference[0] != local_suffix_rule_id) {
+      return std::nullopt;
+    }
+    dotted_local_run_rule_id = run_reference[0];
+  }
+  const auto dotted_local_bytes = match_recursive_run(dotted_local_run_rule_id);
+  if (!local_suffix_has_empty || !dotted_local_bytes.has_value() ||
+      *dotted_local_bytes != *local_bytes ||
+      external_reference_count(dotted_local_run_rule_id) != 1 ||
+      !has_rule_ref_lookahead(dotted_local_run_rule_id, local_suffix_rule_id)) {
+    return std::nullopt;
+  }
+
+  int32_t local_container_rule_id = -1;
+  int32_t first_local_run_rule_id = -1;
+  for (int32_t rule_id = 0; rule_id < grammar_->NumRules(); ++rule_id) {
+    const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(rule_id).body_expr_id);
+    if (body.type != GrammarExprType::kChoices) {
+      continue;
+    }
+    for (int32_t choice_id : body) {
+      const auto& choice = grammar_->GetGrammarExpr(choice_id);
+      if (choice.type != GrammarExprType::kSequence || choice.size() != 2) {
+        continue;
+      }
+      const auto& local_reference = grammar_->GetGrammarExpr(choice[0]);
+      const auto& suffix_reference = grammar_->GetGrammarExpr(choice[1]);
+      if (local_reference.type != GrammarExprType::kRuleRef ||
+          suffix_reference.type != GrammarExprType::kRuleRef ||
+          suffix_reference[0] != local_suffix_rule_id) {
+        continue;
+      }
+      const auto first_local_bytes = match_recursive_run(local_reference[0]);
+      if (!first_local_bytes.has_value() || *first_local_bytes != *local_bytes ||
+          !has_rule_ref_lookahead(local_reference[0], local_suffix_rule_id)) {
+        continue;
+      }
+      if (local_container_rule_id != -1) {
+        return std::nullopt;
+      }
+      local_container_rule_id = rule_id;
+      first_local_run_rule_id = local_reference[0];
+    }
+  }
+  if (local_container_rule_id == -1 ||
+      (init_rule_id_ != first_local_run_rule_id && init_rule_id_ != dotted_local_run_rule_id) ||
+      !plain_rule(local_container_rule_id) ||
+      external_reference_count(local_container_rule_id) != 1 ||
+      external_reference_count(first_local_run_rule_id) != 1) {
+    return std::nullopt;
+  }
+
+  int32_t email_rule_id = -1;
+  int32_t domain_tail_rule_id = -1;
+  int32_t domain_suffix_rule_id = -1;
+  std::optional<std::array<uint8_t, 128>> domain_first_bytes;
+  for (int32_t rule_id = 0; rule_id < grammar_->NumRules(); ++rule_id) {
+    const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(rule_id).body_expr_id);
+    if (body.type != GrammarExprType::kChoices) {
+      continue;
+    }
+    for (int32_t choice_id : body) {
+      const auto& choice = grammar_->GetGrammarExpr(choice_id);
+      if (choice.type != GrammarExprType::kSequence || choice.size() != 5) {
+        continue;
+      }
+      const auto& local_container_reference = grammar_->GetGrammarExpr(choice[0]);
+      const auto& at_sign = grammar_->GetGrammarExpr(choice[1]);
+      const auto& tail_reference = grammar_->GetGrammarExpr(choice[3]);
+      const auto& suffix_reference = grammar_->GetGrammarExpr(choice[4]);
+      if (local_container_reference.type != GrammarExprType::kRuleRef ||
+          local_container_reference[0] != local_container_rule_id ||
+          at_sign.type != GrammarExprType::kByteString || at_sign.size() != 1 ||
+          at_sign[0] != '@' || tail_reference.type != GrammarExprType::kRuleRef ||
+          suffix_reference.type != GrammarExprType::kRuleRef) {
+        continue;
+      }
+      if (domain_tail_rule_id != -1) {
+        return std::nullopt;
+      }
+      domain_first_bytes = ascii_class(choice[2], GrammarExprType::kCharacterClass);
+      email_rule_id = rule_id;
+      domain_tail_rule_id = tail_reference[0];
+      domain_suffix_rule_id = suffix_reference[0];
+    }
+  }
+  if (email_rule_id == -1 || !domain_first_bytes.has_value() || !plain_rule(email_rule_id) ||
+      !has_byte_lookahead(email_rule_id, '"') || !plain_rule(domain_tail_rule_id) ||
+      !plain_rule(domain_suffix_rule_id) || external_reference_count(domain_tail_rule_id) != 1 ||
+      external_reference_count(domain_suffix_rule_id) != 1 ||
+      !has_no_lookahead(domain_suffix_rule_id)) {
+    return std::nullopt;
+  }
+
+  const auto has_domain_lookahead = [&]() {
+    const auto& rule = grammar_->GetRule(local_container_rule_id);
+    const auto lookahead_id = rule.lookahead_assertion_id;
+    if (lookahead_id == -1 || !rule.is_exact_lookahead) {
+      return false;
+    }
+    const auto& lookahead = grammar_->GetGrammarExpr(lookahead_id);
+    if (lookahead.type != GrammarExprType::kSequence || lookahead.size() != 4) {
+      return false;
+    }
+    const auto& at_sign = grammar_->GetGrammarExpr(lookahead[0]);
+    const auto lookahead_first_bytes = ascii_class(lookahead[1], GrammarExprType::kCharacterClass);
+    const auto& tail_reference = grammar_->GetGrammarExpr(lookahead[2]);
+    const auto& suffix_reference = grammar_->GetGrammarExpr(lookahead[3]);
+    return at_sign.type == GrammarExprType::kByteString && at_sign.size() == 1 &&
+           at_sign[0] == '@' && lookahead_first_bytes.has_value() &&
+           *lookahead_first_bytes == *domain_first_bytes &&
+           tail_reference.type == GrammarExprType::kRuleRef &&
+           tail_reference[0] == domain_tail_rule_id &&
+           suffix_reference.type == GrammarExprType::kRuleRef &&
+           suffix_reference[0] == domain_suffix_rule_id;
+  };
+  if (!has_domain_lookahead() ||
+      !has_rule_ref_lookahead(domain_tail_rule_id, domain_suffix_rule_id)) {
+    return std::nullopt;
+  }
+
+  std::array<uint8_t, 128> expected_local_bytes{};
+  for (int32_t byte = '0'; byte <= '9'; ++byte) expected_local_bytes[byte] = true;
+  for (int32_t byte = 'A'; byte <= 'Z'; ++byte) expected_local_bytes[byte] = true;
+  for (int32_t byte = 'a'; byte <= 'z'; ++byte) expected_local_bytes[byte] = true;
+  for (uint8_t byte : std::string("_!#$%&'*+/=?^`{|}~-")) expected_local_bytes[byte] = true;
+  std::array<uint8_t, 128> expected_alphanumeric{};
+  for (int32_t byte = '0'; byte <= '9'; ++byte) expected_alphanumeric[byte] = true;
+  for (int32_t byte = 'A'; byte <= 'Z'; ++byte) expected_alphanumeric[byte] = true;
+  for (int32_t byte = 'a'; byte <= 'z'; ++byte) expected_alphanumeric[byte] = true;
+  std::array<uint8_t, 128> expected_domain_middle = expected_alphanumeric;
+  expected_domain_middle['-'] = true;
+  if (*local_bytes != expected_local_bytes || *domain_first_bytes != expected_alphanumeric) {
+    return std::nullopt;
+  }
+
+  const auto& domain_tail_body =
+      grammar_->GetGrammarExpr(grammar_->GetRule(domain_tail_rule_id).body_expr_id);
+  bool domain_tail_has_empty = false;
+  std::optional<std::array<uint8_t, 128>> domain_middle_bytes;
+  std::optional<std::array<uint8_t, 128>> domain_final_bytes;
+  if (domain_tail_body.type != GrammarExprType::kChoices || domain_tail_body.size() != 2) {
+    return std::nullopt;
+  }
+  for (int32_t choice_id : domain_tail_body) {
+    const auto& choice = grammar_->GetGrammarExpr(choice_id);
+    if (choice.type == GrammarExprType::kEmptyStr) {
+      domain_tail_has_empty = true;
+    } else if (choice.type == GrammarExprType::kSequence && choice.size() == 2) {
+      domain_middle_bytes = ascii_class(choice[0], GrammarExprType::kCharacterClassStar);
+      domain_final_bytes = ascii_class(choice[1], GrammarExprType::kCharacterClass);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  const auto& domain_suffix_body =
+      grammar_->GetGrammarExpr(grammar_->GetRule(domain_suffix_rule_id).body_expr_id);
+  bool domain_suffix_has_empty = false;
+  std::optional<std::array<uint8_t, 128>> suffix_first_bytes;
+  std::optional<std::array<uint8_t, 128>> suffix_middle_bytes;
+  std::optional<std::array<uint8_t, 128>> suffix_final_bytes;
+  if (domain_suffix_body.type != GrammarExprType::kChoices || domain_suffix_body.size() != 2) {
+    return std::nullopt;
+  }
+  for (int32_t choice_id : domain_suffix_body) {
+    const auto& choice = grammar_->GetGrammarExpr(choice_id);
+    if (choice.type == GrammarExprType::kEmptyStr) {
+      domain_suffix_has_empty = true;
+      continue;
+    }
+    if (choice.type != GrammarExprType::kSequence || choice.size() != 5) {
+      return std::nullopt;
+    }
+    const auto& delimiter = grammar_->GetGrammarExpr(choice[0]);
+    const auto& self_reference = grammar_->GetGrammarExpr(choice[4]);
+    if (delimiter.type != GrammarExprType::kByteString || delimiter.size() != 1 ||
+        delimiter[0] != '.' || self_reference.type != GrammarExprType::kRuleRef ||
+        self_reference[0] != domain_suffix_rule_id) {
+      return std::nullopt;
+    }
+    suffix_first_bytes = ascii_class(choice[1], GrammarExprType::kCharacterClass);
+    suffix_middle_bytes = ascii_class(choice[2], GrammarExprType::kCharacterClassStar);
+    suffix_final_bytes = ascii_class(choice[3], GrammarExprType::kCharacterClass);
+  }
+  if (!domain_tail_has_empty || !domain_middle_bytes.has_value() ||
+      !domain_final_bytes.has_value() || *domain_middle_bytes != expected_domain_middle ||
+      *domain_final_bytes != expected_alphanumeric || !domain_suffix_has_empty ||
+      !suffix_first_bytes.has_value() || !suffix_middle_bytes.has_value() ||
+      !suffix_final_bytes.has_value() || *suffix_first_bytes != expected_alphanumeric ||
+      *suffix_middle_bytes != expected_domain_middle ||
+      *suffix_final_bytes != expected_alphanumeric) {
+    return std::nullopt;
+  }
+
+  if (auto cached = character_class_token_summary_cache_->GetEmailLocalPartMask()) {
+    return *cached;
+  }
+
+  enum class EmailPrefixState : uint8_t {
+    kLocal,
+    kLocalAfterDot,
+    kDomainFirst,
+    kDomainInitialValid,
+    kDomainInitialNeedsFinal,
+    kDomainSuffixFirst,
+    kDomainSuffixNeedsFinal,
+    kDomainSuffixValid,
+  };
+  const auto& sorted_vocab = tokenizer_info_.GetSortedDecodedVocab();
+  std::vector<int32_t> accepted_indices;
+  std::vector<int32_t> uncertain_indices;
+  accepted_indices.reserve(sorted_vocab.size() / 4);
+  uncertain_indices.reserve(sorted_vocab.size() / 128);
+  for (int32_t token_index = 0; token_index < static_cast<int32_t>(sorted_vocab.size());
+       ++token_index) {
+    const auto& token = sorted_vocab[token_index].second;
+    EmailPrefixState state = EmailPrefixState::kLocal;
+    bool consumed_local = false;
+    bool valid_prefix = !token.empty();
+    bool crosses_closing_quote = false;
+    for (uint8_t byte : token) {
+      if (byte == '"') {
+        crosses_closing_quote = state == EmailPrefixState::kDomainInitialValid ||
+                                state == EmailPrefixState::kDomainSuffixValid;
+        valid_prefix = false;
+        break;
+      }
+      if (byte >= 128) {
+        valid_prefix = false;
+        break;
+      }
+      switch (state) {
+        case EmailPrefixState::kLocal:
+          if ((*local_bytes)[byte]) {
+            consumed_local = true;
+          } else if (consumed_local && byte == '.') {
+            state = EmailPrefixState::kLocalAfterDot;
+          } else if (consumed_local && byte == '@') {
+            state = EmailPrefixState::kDomainFirst;
+          } else {
+            valid_prefix = false;
+          }
+          break;
+        case EmailPrefixState::kLocalAfterDot:
+          if ((*local_bytes)[byte]) {
+            consumed_local = true;
+            state = EmailPrefixState::kLocal;
+          } else {
+            valid_prefix = false;
+          }
+          break;
+        case EmailPrefixState::kDomainFirst:
+          if (expected_alphanumeric[byte]) {
+            state = EmailPrefixState::kDomainInitialValid;
+          } else {
+            valid_prefix = false;
+          }
+          break;
+        case EmailPrefixState::kDomainInitialValid:
+          if (expected_alphanumeric[byte]) {
+            break;
+          }
+          if (byte == '-') {
+            state = EmailPrefixState::kDomainInitialNeedsFinal;
+          } else if (byte == '.') {
+            state = EmailPrefixState::kDomainSuffixFirst;
+          } else {
+            valid_prefix = false;
+          }
+          break;
+        case EmailPrefixState::kDomainInitialNeedsFinal:
+          if (expected_alphanumeric[byte]) {
+            state = EmailPrefixState::kDomainInitialValid;
+          } else if (byte != '-') {
+            valid_prefix = false;
+          }
+          break;
+        case EmailPrefixState::kDomainSuffixFirst:
+          if (expected_alphanumeric[byte]) {
+            state = EmailPrefixState::kDomainSuffixNeedsFinal;
+          } else {
+            valid_prefix = false;
+          }
+          break;
+        case EmailPrefixState::kDomainSuffixNeedsFinal:
+          if (expected_alphanumeric[byte]) {
+            state = EmailPrefixState::kDomainSuffixValid;
+          } else if (byte != '-') {
+            valid_prefix = false;
+          }
+          break;
+        case EmailPrefixState::kDomainSuffixValid:
+          if (expected_alphanumeric[byte]) {
+            break;
+          }
+          if (byte == '-') {
+            state = EmailPrefixState::kDomainSuffixNeedsFinal;
+          } else if (byte == '.') {
+            state = EmailPrefixState::kDomainSuffixFirst;
+          } else {
+            valid_prefix = false;
+          }
+          break;
+      }
+      if (!valid_prefix) {
+        break;
+      }
+    }
+    if (valid_prefix) {
+      accepted_indices.push_back(token_index);
+    } else if (crosses_closing_quote) {
+      uncertain_indices.push_back(token_index);
+    }
+  }
+  return *character_class_token_summary_cache_->StoreEmailLocalPartMask(AdaptiveTokenMask(
+      tokenizer_info_.GetVocabSize(), sorted_vocab, accepted_indices, uncertain_indices
+  ));
 }
 
 std::optional<AdaptiveTokenMask>
@@ -2490,6 +3003,11 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
       );
     }
     return std::move(*direct_character_class_mask);
+  }
+
+  auto direct_email_local_part_mask = GetEmailLocalPartDirectMask(is_root_rule);
+  if (direct_email_local_part_mask.has_value()) {
+    return std::move(*direct_email_local_part_mask);
   }
 
   auto direct_delimited_recursive_run_mask = GetDelimitedRecursiveRunDirectMask(is_root_rule);

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -181,23 +181,6 @@ class CharacterClassTokenSummaryCache {
     std::vector<int32_t> unaccepted_indices;
   };
 
-  std::shared_ptr<const AdaptiveTokenMask> GetEmailLocalPartMask() {
-    std::lock_guard<std::mutex> lock(email_local_part_mutex_);
-    return email_local_part_mask_;
-  }
-
-  std::shared_ptr<const AdaptiveTokenMask> StoreEmailLocalPartMask(
-      AdaptiveTokenMask adaptive_token_mask
-  ) {
-    auto computed = std::make_shared<const AdaptiveTokenMask>(std::move(adaptive_token_mask));
-    std::lock_guard<std::mutex> lock(email_local_part_mutex_);
-    if (email_local_part_mask_ != nullptr) {
-      return email_local_part_mask_;
-    }
-    email_local_part_mask_ = computed;
-    return computed;
-  }
-
   std::shared_ptr<const Result> GetOrCreate(
       const Grammar::Impl::GrammarExpr& character_class,
       const std::vector<std::pair<int32_t, std::string>>& sorted_vocab,
@@ -377,10 +360,6 @@ class CharacterClassTokenSummaryCache {
       std::lock_guard<std::mutex> lock(ascii_byte_loop_mutex_);
       ascii_byte_loop_cache_.clear();
     }
-    {
-      std::lock_guard<std::mutex> lock(email_local_part_mutex_);
-      email_local_part_mask_.reset();
-    }
   }
 
  private:
@@ -397,8 +376,6 @@ class CharacterClassTokenSummaryCache {
       std::shared_ptr<const ASCIIByteLoopTokenMask>,
       ASCIIByteLoopKeyHash>
       ascii_byte_loop_cache_;
-  std::mutex email_local_part_mutex_;
-  std::shared_ptr<const AdaptiveTokenMask> email_local_part_mask_;
 };
 
 struct JSONStringSinkInfo {
@@ -490,14 +467,14 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   /*! \brief Classify one prefix of a delimiter-separated recursive ASCII label. */
   std::optional<AdaptiveTokenMask> GetDelimitedRecursiveLabelDirectMask(bool is_root_rule) const;
 
-  /*! \brief Classify the local-part run of an exact built-in email grammar. */
-  std::optional<AdaptiveTokenMask> GetEmailLocalPartDirectMask(bool is_root_rule) const;
-
   /*! \brief Classify the ASCII-safe subset of a fixed-width JSON wildcard path. */
   std::optional<AdaptiveTokenMask> GetFixedWidthJSONStringDirectMask(bool is_root_rule) const;
 
   /*! \brief Classify a broad absorbing accepting state with its local byte DFA. */
   std::optional<AdaptiveTokenMask> GetAbsorbingEndStateDirectMask(bool is_root_rule) const;
+
+  /*! \brief Classify a deterministic byte FSM state that has a stable character loop. */
+  std::optional<AdaptiveTokenMask> GetDeterministicByteLoopDirectMask(bool is_root_rule) const;
 
   /*! \brief Build a token mask directly for a deterministic byte path from the current state. */
   std::optional<AdaptiveTokenMask> GetDeterministicBytePathDirectMask(bool is_root_rule) const;
@@ -1443,493 +1420,6 @@ std::optional<AdaptiveTokenMask> GrammarMatcherForTokenMaskCache::GetSingleChara
   );
 }
 
-std::optional<AdaptiveTokenMask> GrammarMatcherForTokenMaskCache::GetEmailLocalPartDirectMask(
-    bool is_root_rule
-) const {
-  using GrammarExprType = Grammar::Impl::GrammarExprType;
-  const auto& initial_rule = grammar_->GetRule(init_rule_id_);
-  if (is_root_rule || initial_state_.sub_element_id != 0 || initial_rule.is_lazy ||
-      initial_rule.max_tokens != -1 || initial_rule.max_chars != -1 ||
-      initial_rule.json_string_min_length != -1 || initial_rule.json_string_max_length != -1 ||
-      !initial_rule.capture_name.empty() || !grammar_->per_rule_fsms[init_rule_id_].has_value() ||
-      initial_state_.element_id != grammar_->per_rule_fsms[init_rule_id_]->GetFsm().GetStart()) {
-    return std::nullopt;
-  }
-
-  const auto plain_rule = [&](int32_t rule_id) {
-    const auto& rule = grammar_->GetRule(rule_id);
-    return !rule.is_lazy && rule.max_tokens == -1 && rule.max_chars == -1 &&
-           rule.json_string_min_length == -1 && rule.json_string_max_length == -1 &&
-           rule.capture_name.empty();
-  };
-  const auto has_no_lookahead = [&](int32_t rule_id) {
-    return grammar_->GetRule(rule_id).lookahead_assertion_id == -1;
-  };
-  const auto get_rule_ref_lookahead = [&](int32_t rule_id) -> std::optional<int32_t> {
-    const auto& rule = grammar_->GetRule(rule_id);
-    const auto lookahead_id = rule.lookahead_assertion_id;
-    if (lookahead_id == -1 || !rule.is_exact_lookahead) {
-      return std::nullopt;
-    }
-    const auto& lookahead = grammar_->GetGrammarExpr(lookahead_id);
-    if (lookahead.type != GrammarExprType::kSequence || lookahead.size() != 1) {
-      return std::nullopt;
-    }
-    const auto& reference = grammar_->GetGrammarExpr(lookahead[0]);
-    if (reference.type != GrammarExprType::kRuleRef) {
-      return std::nullopt;
-    }
-    return reference[0];
-  };
-  const auto has_rule_ref_lookahead = [&](int32_t rule_id, int32_t referenced_rule_id) {
-    const auto reference = get_rule_ref_lookahead(rule_id);
-    return reference.has_value() && *reference == referenced_rule_id;
-  };
-  const auto has_byte_lookahead = [&](int32_t rule_id, uint8_t expected_byte) {
-    const auto& rule = grammar_->GetRule(rule_id);
-    const auto lookahead_id = rule.lookahead_assertion_id;
-    if (lookahead_id == -1 || !rule.is_exact_lookahead) {
-      return false;
-    }
-    const auto& lookahead = grammar_->GetGrammarExpr(lookahead_id);
-    if (lookahead.type != GrammarExprType::kSequence || lookahead.size() != 1) {
-      return false;
-    }
-    const auto& byte_string = grammar_->GetGrammarExpr(lookahead[0]);
-    return byte_string.type == GrammarExprType::kByteString && byte_string.size() == 1 &&
-           byte_string[0] == expected_byte;
-  };
-  const auto ascii_class = [&](int32_t expr_id, GrammarExprType expected_type
-                           ) -> std::optional<std::array<uint8_t, 128>> {
-    const auto& expr = grammar_->GetGrammarExpr(expr_id);
-    if (expr.type != expected_type || expr.size() < 3 || expr[0] != 0) {
-      return std::nullopt;
-    }
-    std::array<uint8_t, 128> result{};
-    for (int32_t index = 1; index < expr.size(); index += 2) {
-      if (index + 1 >= expr.size() || expr[index] < 0 || expr[index + 1] >= 128) {
-        return std::nullopt;
-      }
-      for (int32_t byte = expr[index]; byte <= expr[index + 1]; ++byte) {
-        result[byte] = true;
-      }
-    }
-    return result;
-  };
-  const auto match_recursive_run = [&](int32_t rule_id) -> std::optional<std::array<uint8_t, 128>> {
-    if (!plain_rule(rule_id)) {
-      return std::nullopt;
-    }
-    const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(rule_id).body_expr_id);
-    if (body.type != GrammarExprType::kChoices || body.size() != 2) {
-      return std::nullopt;
-    }
-    std::optional<std::array<uint8_t, 128>> recursive_class;
-    std::optional<std::array<uint8_t, 128>> terminal_class;
-    for (int32_t choice_id : body) {
-      const auto& choice = grammar_->GetGrammarExpr(choice_id);
-      if (choice.type != GrammarExprType::kSequence) {
-        return std::nullopt;
-      }
-      if (choice.size() == 1) {
-        terminal_class = ascii_class(choice[0], GrammarExprType::kCharacterClass);
-      } else if (choice.size() == 2) {
-        const auto& self_reference = grammar_->GetGrammarExpr(choice[1]);
-        if (self_reference.type != GrammarExprType::kRuleRef || self_reference[0] != rule_id) {
-          return std::nullopt;
-        }
-        recursive_class = ascii_class(choice[0], GrammarExprType::kCharacterClass);
-      } else {
-        return std::nullopt;
-      }
-    }
-    if (!recursive_class.has_value() || !terminal_class.has_value() ||
-        *recursive_class != *terminal_class) {
-      return std::nullopt;
-    }
-    return recursive_class;
-  };
-  const auto external_reference_count = [&](int32_t referenced_rule_id) {
-    int32_t count = 0;
-    for (int32_t owner_rule_id = 0; owner_rule_id < grammar_->NumRules(); ++owner_rule_id) {
-      if (owner_rule_id == referenced_rule_id) {
-        continue;
-      }
-      const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(owner_rule_id).body_expr_id);
-      if (body.type != GrammarExprType::kChoices) {
-        continue;
-      }
-      for (int32_t choice_id : body) {
-        const auto& choice = grammar_->GetGrammarExpr(choice_id);
-        if (choice.type != GrammarExprType::kSequence) {
-          continue;
-        }
-        for (int32_t element_id : choice) {
-          const auto& element = grammar_->GetGrammarExpr(element_id);
-          count += element.type == GrammarExprType::kRuleRef && element[0] == referenced_rule_id;
-        }
-      }
-    }
-    return count;
-  };
-
-  const auto local_bytes = match_recursive_run(init_rule_id_);
-  if (!local_bytes.has_value() || external_reference_count(init_rule_id_) != 1) {
-    return std::nullopt;
-  }
-
-  const auto initial_local_suffix = get_rule_ref_lookahead(init_rule_id_);
-  if (!initial_local_suffix.has_value()) {
-    return std::nullopt;
-  }
-  const int32_t local_suffix_rule_id = *initial_local_suffix;
-  if (!plain_rule(local_suffix_rule_id) || !has_no_lookahead(local_suffix_rule_id) ||
-      external_reference_count(local_suffix_rule_id) != 1) {
-    return std::nullopt;
-  }
-
-  const auto& local_suffix_body =
-      grammar_->GetGrammarExpr(grammar_->GetRule(local_suffix_rule_id).body_expr_id);
-  int32_t dotted_local_run_rule_id = -1;
-  bool local_suffix_has_empty = false;
-  if (local_suffix_body.type != GrammarExprType::kChoices || local_suffix_body.size() != 2) {
-    return std::nullopt;
-  }
-  for (int32_t choice_id : local_suffix_body) {
-    const auto& choice = grammar_->GetGrammarExpr(choice_id);
-    if (choice.type == GrammarExprType::kEmptyStr) {
-      local_suffix_has_empty = true;
-      continue;
-    }
-    if (choice.type != GrammarExprType::kSequence || choice.size() != 3) {
-      return std::nullopt;
-    }
-    const auto& delimiter = grammar_->GetGrammarExpr(choice[0]);
-    const auto& run_reference = grammar_->GetGrammarExpr(choice[1]);
-    const auto& self_reference = grammar_->GetGrammarExpr(choice[2]);
-    if (delimiter.type != GrammarExprType::kByteString || delimiter.size() != 1 ||
-        delimiter[0] != '.' || run_reference.type != GrammarExprType::kRuleRef ||
-        self_reference.type != GrammarExprType::kRuleRef ||
-        self_reference[0] != local_suffix_rule_id) {
-      return std::nullopt;
-    }
-    dotted_local_run_rule_id = run_reference[0];
-  }
-  const auto dotted_local_bytes = match_recursive_run(dotted_local_run_rule_id);
-  if (!local_suffix_has_empty || !dotted_local_bytes.has_value() ||
-      *dotted_local_bytes != *local_bytes ||
-      external_reference_count(dotted_local_run_rule_id) != 1 ||
-      !has_rule_ref_lookahead(dotted_local_run_rule_id, local_suffix_rule_id)) {
-    return std::nullopt;
-  }
-
-  int32_t local_container_rule_id = -1;
-  int32_t first_local_run_rule_id = -1;
-  for (int32_t rule_id = 0; rule_id < grammar_->NumRules(); ++rule_id) {
-    const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(rule_id).body_expr_id);
-    if (body.type != GrammarExprType::kChoices) {
-      continue;
-    }
-    for (int32_t choice_id : body) {
-      const auto& choice = grammar_->GetGrammarExpr(choice_id);
-      if (choice.type != GrammarExprType::kSequence || choice.size() != 2) {
-        continue;
-      }
-      const auto& local_reference = grammar_->GetGrammarExpr(choice[0]);
-      const auto& suffix_reference = grammar_->GetGrammarExpr(choice[1]);
-      if (local_reference.type != GrammarExprType::kRuleRef ||
-          suffix_reference.type != GrammarExprType::kRuleRef ||
-          suffix_reference[0] != local_suffix_rule_id) {
-        continue;
-      }
-      const auto first_local_bytes = match_recursive_run(local_reference[0]);
-      if (!first_local_bytes.has_value() || *first_local_bytes != *local_bytes ||
-          !has_rule_ref_lookahead(local_reference[0], local_suffix_rule_id)) {
-        continue;
-      }
-      if (local_container_rule_id != -1) {
-        return std::nullopt;
-      }
-      local_container_rule_id = rule_id;
-      first_local_run_rule_id = local_reference[0];
-    }
-  }
-  if (local_container_rule_id == -1 ||
-      (init_rule_id_ != first_local_run_rule_id && init_rule_id_ != dotted_local_run_rule_id) ||
-      !plain_rule(local_container_rule_id) ||
-      external_reference_count(local_container_rule_id) != 1 ||
-      external_reference_count(first_local_run_rule_id) != 1) {
-    return std::nullopt;
-  }
-
-  int32_t email_rule_id = -1;
-  int32_t domain_tail_rule_id = -1;
-  int32_t domain_suffix_rule_id = -1;
-  std::optional<std::array<uint8_t, 128>> domain_first_bytes;
-  for (int32_t rule_id = 0; rule_id < grammar_->NumRules(); ++rule_id) {
-    const auto& body = grammar_->GetGrammarExpr(grammar_->GetRule(rule_id).body_expr_id);
-    if (body.type != GrammarExprType::kChoices) {
-      continue;
-    }
-    for (int32_t choice_id : body) {
-      const auto& choice = grammar_->GetGrammarExpr(choice_id);
-      if (choice.type != GrammarExprType::kSequence || choice.size() != 5) {
-        continue;
-      }
-      const auto& local_container_reference = grammar_->GetGrammarExpr(choice[0]);
-      const auto& at_sign = grammar_->GetGrammarExpr(choice[1]);
-      const auto& tail_reference = grammar_->GetGrammarExpr(choice[3]);
-      const auto& suffix_reference = grammar_->GetGrammarExpr(choice[4]);
-      if (local_container_reference.type != GrammarExprType::kRuleRef ||
-          local_container_reference[0] != local_container_rule_id ||
-          at_sign.type != GrammarExprType::kByteString || at_sign.size() != 1 ||
-          at_sign[0] != '@' || tail_reference.type != GrammarExprType::kRuleRef ||
-          suffix_reference.type != GrammarExprType::kRuleRef) {
-        continue;
-      }
-      if (domain_tail_rule_id != -1) {
-        return std::nullopt;
-      }
-      domain_first_bytes = ascii_class(choice[2], GrammarExprType::kCharacterClass);
-      email_rule_id = rule_id;
-      domain_tail_rule_id = tail_reference[0];
-      domain_suffix_rule_id = suffix_reference[0];
-    }
-  }
-  if (email_rule_id == -1 || !domain_first_bytes.has_value() || !plain_rule(email_rule_id) ||
-      !has_byte_lookahead(email_rule_id, '"') || !plain_rule(domain_tail_rule_id) ||
-      !plain_rule(domain_suffix_rule_id) || external_reference_count(domain_tail_rule_id) != 1 ||
-      external_reference_count(domain_suffix_rule_id) != 1 ||
-      !has_no_lookahead(domain_suffix_rule_id)) {
-    return std::nullopt;
-  }
-
-  const auto has_domain_lookahead = [&]() {
-    const auto& rule = grammar_->GetRule(local_container_rule_id);
-    const auto lookahead_id = rule.lookahead_assertion_id;
-    if (lookahead_id == -1 || !rule.is_exact_lookahead) {
-      return false;
-    }
-    const auto& lookahead = grammar_->GetGrammarExpr(lookahead_id);
-    if (lookahead.type != GrammarExprType::kSequence || lookahead.size() != 4) {
-      return false;
-    }
-    const auto& at_sign = grammar_->GetGrammarExpr(lookahead[0]);
-    const auto lookahead_first_bytes = ascii_class(lookahead[1], GrammarExprType::kCharacterClass);
-    const auto& tail_reference = grammar_->GetGrammarExpr(lookahead[2]);
-    const auto& suffix_reference = grammar_->GetGrammarExpr(lookahead[3]);
-    return at_sign.type == GrammarExprType::kByteString && at_sign.size() == 1 &&
-           at_sign[0] == '@' && lookahead_first_bytes.has_value() &&
-           *lookahead_first_bytes == *domain_first_bytes &&
-           tail_reference.type == GrammarExprType::kRuleRef &&
-           tail_reference[0] == domain_tail_rule_id &&
-           suffix_reference.type == GrammarExprType::kRuleRef &&
-           suffix_reference[0] == domain_suffix_rule_id;
-  };
-  if (!has_domain_lookahead() ||
-      !has_rule_ref_lookahead(domain_tail_rule_id, domain_suffix_rule_id)) {
-    return std::nullopt;
-  }
-
-  std::array<uint8_t, 128> expected_local_bytes{};
-  for (int32_t byte = '0'; byte <= '9'; ++byte) expected_local_bytes[byte] = true;
-  for (int32_t byte = 'A'; byte <= 'Z'; ++byte) expected_local_bytes[byte] = true;
-  for (int32_t byte = 'a'; byte <= 'z'; ++byte) expected_local_bytes[byte] = true;
-  for (uint8_t byte : std::string("_!#$%&'*+/=?^`{|}~-")) expected_local_bytes[byte] = true;
-  std::array<uint8_t, 128> expected_alphanumeric{};
-  for (int32_t byte = '0'; byte <= '9'; ++byte) expected_alphanumeric[byte] = true;
-  for (int32_t byte = 'A'; byte <= 'Z'; ++byte) expected_alphanumeric[byte] = true;
-  for (int32_t byte = 'a'; byte <= 'z'; ++byte) expected_alphanumeric[byte] = true;
-  std::array<uint8_t, 128> expected_domain_middle = expected_alphanumeric;
-  expected_domain_middle['-'] = true;
-  if (*local_bytes != expected_local_bytes || *domain_first_bytes != expected_alphanumeric) {
-    return std::nullopt;
-  }
-
-  const auto& domain_tail_body =
-      grammar_->GetGrammarExpr(grammar_->GetRule(domain_tail_rule_id).body_expr_id);
-  bool domain_tail_has_empty = false;
-  std::optional<std::array<uint8_t, 128>> domain_middle_bytes;
-  std::optional<std::array<uint8_t, 128>> domain_final_bytes;
-  if (domain_tail_body.type != GrammarExprType::kChoices || domain_tail_body.size() != 2) {
-    return std::nullopt;
-  }
-  for (int32_t choice_id : domain_tail_body) {
-    const auto& choice = grammar_->GetGrammarExpr(choice_id);
-    if (choice.type == GrammarExprType::kEmptyStr) {
-      domain_tail_has_empty = true;
-    } else if (choice.type == GrammarExprType::kSequence && choice.size() == 2) {
-      domain_middle_bytes = ascii_class(choice[0], GrammarExprType::kCharacterClassStar);
-      domain_final_bytes = ascii_class(choice[1], GrammarExprType::kCharacterClass);
-    } else {
-      return std::nullopt;
-    }
-  }
-
-  const auto& domain_suffix_body =
-      grammar_->GetGrammarExpr(grammar_->GetRule(domain_suffix_rule_id).body_expr_id);
-  bool domain_suffix_has_empty = false;
-  std::optional<std::array<uint8_t, 128>> suffix_first_bytes;
-  std::optional<std::array<uint8_t, 128>> suffix_middle_bytes;
-  std::optional<std::array<uint8_t, 128>> suffix_final_bytes;
-  if (domain_suffix_body.type != GrammarExprType::kChoices || domain_suffix_body.size() != 2) {
-    return std::nullopt;
-  }
-  for (int32_t choice_id : domain_suffix_body) {
-    const auto& choice = grammar_->GetGrammarExpr(choice_id);
-    if (choice.type == GrammarExprType::kEmptyStr) {
-      domain_suffix_has_empty = true;
-      continue;
-    }
-    if (choice.type != GrammarExprType::kSequence || choice.size() != 5) {
-      return std::nullopt;
-    }
-    const auto& delimiter = grammar_->GetGrammarExpr(choice[0]);
-    const auto& self_reference = grammar_->GetGrammarExpr(choice[4]);
-    if (delimiter.type != GrammarExprType::kByteString || delimiter.size() != 1 ||
-        delimiter[0] != '.' || self_reference.type != GrammarExprType::kRuleRef ||
-        self_reference[0] != domain_suffix_rule_id) {
-      return std::nullopt;
-    }
-    suffix_first_bytes = ascii_class(choice[1], GrammarExprType::kCharacterClass);
-    suffix_middle_bytes = ascii_class(choice[2], GrammarExprType::kCharacterClassStar);
-    suffix_final_bytes = ascii_class(choice[3], GrammarExprType::kCharacterClass);
-  }
-  if (!domain_tail_has_empty || !domain_middle_bytes.has_value() ||
-      !domain_final_bytes.has_value() || *domain_middle_bytes != expected_domain_middle ||
-      *domain_final_bytes != expected_alphanumeric || !domain_suffix_has_empty ||
-      !suffix_first_bytes.has_value() || !suffix_middle_bytes.has_value() ||
-      !suffix_final_bytes.has_value() || *suffix_first_bytes != expected_alphanumeric ||
-      *suffix_middle_bytes != expected_domain_middle ||
-      *suffix_final_bytes != expected_alphanumeric) {
-    return std::nullopt;
-  }
-
-  if (auto cached = character_class_token_summary_cache_->GetEmailLocalPartMask()) {
-    return *cached;
-  }
-
-  enum class EmailPrefixState : uint8_t {
-    kLocal,
-    kLocalAfterDot,
-    kDomainFirst,
-    kDomainInitialValid,
-    kDomainInitialNeedsFinal,
-    kDomainSuffixFirst,
-    kDomainSuffixNeedsFinal,
-    kDomainSuffixValid,
-  };
-  const auto& sorted_vocab = tokenizer_info_.GetSortedDecodedVocab();
-  std::vector<int32_t> accepted_indices;
-  std::vector<int32_t> uncertain_indices;
-  accepted_indices.reserve(sorted_vocab.size() / 4);
-  uncertain_indices.reserve(sorted_vocab.size() / 128);
-  for (int32_t token_index = 0; token_index < static_cast<int32_t>(sorted_vocab.size());
-       ++token_index) {
-    const auto& token = sorted_vocab[token_index].second;
-    EmailPrefixState state = EmailPrefixState::kLocal;
-    bool consumed_local = false;
-    bool valid_prefix = !token.empty();
-    bool crosses_closing_quote = false;
-    for (uint8_t byte : token) {
-      if (byte == '"') {
-        crosses_closing_quote = state == EmailPrefixState::kDomainInitialValid ||
-                                state == EmailPrefixState::kDomainSuffixValid;
-        valid_prefix = false;
-        break;
-      }
-      if (byte >= 128) {
-        valid_prefix = false;
-        break;
-      }
-      switch (state) {
-        case EmailPrefixState::kLocal:
-          if ((*local_bytes)[byte]) {
-            consumed_local = true;
-          } else if (consumed_local && byte == '.') {
-            state = EmailPrefixState::kLocalAfterDot;
-          } else if (consumed_local && byte == '@') {
-            state = EmailPrefixState::kDomainFirst;
-          } else {
-            valid_prefix = false;
-          }
-          break;
-        case EmailPrefixState::kLocalAfterDot:
-          if ((*local_bytes)[byte]) {
-            consumed_local = true;
-            state = EmailPrefixState::kLocal;
-          } else {
-            valid_prefix = false;
-          }
-          break;
-        case EmailPrefixState::kDomainFirst:
-          if (expected_alphanumeric[byte]) {
-            state = EmailPrefixState::kDomainInitialValid;
-          } else {
-            valid_prefix = false;
-          }
-          break;
-        case EmailPrefixState::kDomainInitialValid:
-          if (expected_alphanumeric[byte]) {
-            break;
-          }
-          if (byte == '-') {
-            state = EmailPrefixState::kDomainInitialNeedsFinal;
-          } else if (byte == '.') {
-            state = EmailPrefixState::kDomainSuffixFirst;
-          } else {
-            valid_prefix = false;
-          }
-          break;
-        case EmailPrefixState::kDomainInitialNeedsFinal:
-          if (expected_alphanumeric[byte]) {
-            state = EmailPrefixState::kDomainInitialValid;
-          } else if (byte != '-') {
-            valid_prefix = false;
-          }
-          break;
-        case EmailPrefixState::kDomainSuffixFirst:
-          if (expected_alphanumeric[byte]) {
-            state = EmailPrefixState::kDomainSuffixNeedsFinal;
-          } else {
-            valid_prefix = false;
-          }
-          break;
-        case EmailPrefixState::kDomainSuffixNeedsFinal:
-          if (expected_alphanumeric[byte]) {
-            state = EmailPrefixState::kDomainSuffixValid;
-          } else if (byte != '-') {
-            valid_prefix = false;
-          }
-          break;
-        case EmailPrefixState::kDomainSuffixValid:
-          if (expected_alphanumeric[byte]) {
-            break;
-          }
-          if (byte == '-') {
-            state = EmailPrefixState::kDomainSuffixNeedsFinal;
-          } else if (byte == '.') {
-            state = EmailPrefixState::kDomainSuffixFirst;
-          } else {
-            valid_prefix = false;
-          }
-          break;
-      }
-      if (!valid_prefix) {
-        break;
-      }
-    }
-    if (valid_prefix) {
-      accepted_indices.push_back(token_index);
-    } else if (crosses_closing_quote) {
-      uncertain_indices.push_back(token_index);
-    }
-  }
-  return *character_class_token_summary_cache_->StoreEmailLocalPartMask(AdaptiveTokenMask(
-      tokenizer_info_.GetVocabSize(), sorted_vocab, accepted_indices, uncertain_indices
-  ));
-}
-
 std::optional<AdaptiveTokenMask>
 GrammarMatcherForTokenMaskCache::GetDelimitedRecursiveRunDirectMask(bool is_root_rule) const {
   using GrammarExprType = Grammar::Impl::GrammarExprType;
@@ -2595,6 +2085,166 @@ std::optional<AdaptiveTokenMask> GrammarMatcherForTokenMaskCache::GetAbsorbingEn
 }
 
 std::optional<AdaptiveTokenMask>
+GrammarMatcherForTokenMaskCache::GetDeterministicByteLoopDirectMask(bool is_root_rule) const {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  const auto& rule = grammar_->GetRule(init_rule_id_);
+  const auto& rule_body = grammar_->GetGrammarExpr(rule.body_expr_id);
+  if (!enable_direct_character_class_mask_ || is_root_rule || initial_state_.sub_element_id != 0 ||
+      rule.is_lazy || rule.max_tokens != -1 || rule.max_chars != -1 ||
+      rule.json_string_min_length != -1 || rule.json_string_max_length != -1 ||
+      !rule.capture_name.empty() || rule_body.type != GrammarExprType::kRegex ||
+      !grammar_->GetRegexIsByteMode(rule_body) ||
+      !grammar_->per_rule_fsms[init_rule_id_].has_value()) {
+    return std::nullopt;
+  }
+
+  const auto& rule_fsm = grammar_->per_rule_fsms[init_rule_id_]->GetFsm();
+  const auto& fsm = rule_fsm.GetFsm();
+  struct LocalState {
+    int32_t global_state;
+    std::array<int32_t, 256> transitions;
+  };
+  constexpr size_t kMaxDirectStates = 256;
+  std::vector<LocalState> local_states;
+  local_states.reserve(std::min<size_t>(kMaxDirectStates, grammar_->complete_fsm.NumStates()));
+  std::unordered_map<int32_t, int32_t> global_to_local;
+  global_to_local.reserve(local_states.capacity());
+  const auto find_or_add_state = [&](int32_t global_state) -> int32_t {
+    const auto existing = global_to_local.find(global_state);
+    if (existing != global_to_local.end()) {
+      return existing->second;
+    }
+    if (local_states.size() == kMaxDirectStates) {
+      return -1;
+    }
+    LocalState state;
+    state.global_state = global_state;
+    state.transitions.fill(-1);
+    const int32_t local_state = static_cast<int32_t>(local_states.size());
+    local_states.push_back(std::move(state));
+    global_to_local.emplace(global_state, local_state);
+    return local_state;
+  };
+
+  const int32_t initial_local_state = find_or_add_state(initial_state_.element_id);
+  for (size_t local_id = 0; local_id < local_states.size(); ++local_id) {
+    std::array<int32_t, 256> global_transitions;
+    global_transitions.fill(-1);
+    for (const auto& edge : fsm.GetEdges(local_states[local_id].global_state)) {
+      if (!edge.IsCharRange()) {
+        return std::nullopt;
+      }
+      for (int32_t byte = edge.min; byte <= edge.max; ++byte) {
+        if (global_transitions[byte] != -1 && global_transitions[byte] != edge.target) {
+          return std::nullopt;
+        }
+        global_transitions[byte] = edge.target;
+      }
+    }
+    for (int32_t byte = 0; byte < 256; ++byte) {
+      if (global_transitions[byte] == -1) {
+        continue;
+      }
+      const int32_t target_local_state = find_or_add_state(global_transitions[byte]);
+      if (target_local_state == -1) {
+        return std::nullopt;
+      }
+      local_states[local_id].transitions[byte] = target_local_state;
+    }
+  }
+
+  // Find the largest byte class that enters one state and then stays there. Tokens made entirely
+  // from this class are definitely accepted prefixes. This covers both an ordinary self-loop and
+  // the non-accepting entry state produced for `+` without recognizing any particular regex.
+  std::bitset<256> stable_loop_bytes;
+  for (int32_t target = 0; target < static_cast<int32_t>(local_states.size()); ++target) {
+    std::bitset<256> candidate;
+    for (int32_t byte = 0; byte < 256; ++byte) {
+      if (local_states[initial_local_state].transitions[byte] == target &&
+          local_states[target].transitions[byte] == target) {
+        candidate.set(byte);
+      }
+    }
+    if (candidate.count() > stable_loop_bytes.count()) {
+      stable_loop_bytes = candidate;
+    }
+  }
+  if (stable_loop_bytes.none()) {
+    return std::nullopt;
+  }
+
+  XGRAMMAR_DCHECK(character_class_token_summary_cache_ != nullptr);
+  const auto& sorted_vocab = tokenizer_info_.GetSortedDecodedVocab();
+  const auto loop_mask = character_class_token_summary_cache_->GetOrCreateASCIIByteLoopMask(
+      stable_loop_bytes, sorted_vocab, tokenizer_info_.GetVocabSize()
+  );
+  std::optional<std::string> exact_literal_lookahead;
+  if (rule.is_exact_lookahead && rule.lookahead_assertion_id != -1) {
+    const auto& lookahead = grammar_->GetGrammarExpr(rule.lookahead_assertion_id);
+    if (lookahead.type == GrammarExprType::kSequence && lookahead.size() == 1) {
+      const auto& literal = grammar_->GetGrammarExpr(lookahead[0]);
+      if (literal.type == GrammarExprType::kByteString && literal.size() != 0) {
+        exact_literal_lookahead.emplace();
+        exact_literal_lookahead->reserve(literal.size());
+        for (int32_t byte : literal) {
+          exact_literal_lookahead->push_back(static_cast<char>(byte));
+        }
+      }
+    }
+  }
+  const auto crosses_literal_lookahead = [&](const std::string& token, size_t offset) {
+    XGRAMMAR_DCHECK(exact_literal_lookahead.has_value());
+    if (offset == token.size()) {
+      return false;
+    }
+    const size_t compared = std::min(token.size() - offset, exact_literal_lookahead->size());
+    return token.compare(offset, compared, *exact_literal_lookahead, 0, compared) == 0;
+  };
+
+  std::vector<int32_t> additional_accepted_indices;
+  std::vector<int32_t> uncertain_indices;
+  additional_accepted_indices.reserve(loop_mask->unaccepted_indices.size() / 16);
+  uncertain_indices.reserve(loop_mask->unaccepted_indices.size() / 128);
+  const auto& subtree_nodes_range = tokenizer_info_.GetTrieSubtreeNodesRange();
+  for (size_t candidate = 0; candidate < loop_mask->unaccepted_indices.size(); ++candidate) {
+    const int32_t index = loop_mask->unaccepted_indices[candidate];
+    const auto& token = sorted_vocab[index].second;
+    int32_t state = initial_local_state;
+    bool reached_end = rule_fsm.IsEndState(local_states[state].global_state);
+    bool can_cross_lookahead = reached_end && exact_literal_lookahead.has_value() &&
+                               crosses_literal_lookahead(token, /*offset=*/0);
+    size_t matched = 0;
+    for (size_t offset = 0; offset < token.size(); ++offset) {
+      const int32_t next = local_states[state].transitions[static_cast<uint8_t>(token[offset])];
+      if (next == -1) {
+        break;
+      }
+      state = next;
+      ++matched;
+      reached_end = reached_end || rule_fsm.IsEndState(local_states[state].global_state);
+      can_cross_lookahead =
+          can_cross_lookahead ||
+          (rule_fsm.IsEndState(local_states[state].global_state) &&
+           exact_literal_lookahead.has_value() && crosses_literal_lookahead(token, offset + 1));
+    }
+    if (!token.empty() && matched == token.size()) {
+      additional_accepted_indices.push_back(index);
+    } else if (exact_literal_lookahead.has_value() ? can_cross_lookahead : reached_end) {
+      uncertain_indices.push_back(index);
+    } else {
+      const int32_t rejected_subtree_end = subtree_nodes_range[index];
+      while (candidate + 1 < loop_mask->unaccepted_indices.size() &&
+             loop_mask->unaccepted_indices[candidate + 1] < rejected_subtree_end) {
+        ++candidate;
+      }
+    }
+  }
+  return AdaptiveTokenMask(
+      loop_mask->accepted_bitset, sorted_vocab, additional_accepted_indices, uncertain_indices
+  );
+}
+
+std::optional<AdaptiveTokenMask>
 GrammarMatcherForTokenMaskCache::GetDeterministicBytePathDirectMask(bool is_root_rule) const {
   if (!enable_direct_character_class_mask_ || is_root_rule || initial_state_.sub_element_id != 0 ||
       grammar_->GetRule(init_rule_id_).is_lazy ||
@@ -3005,11 +2655,6 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     return std::move(*direct_character_class_mask);
   }
 
-  auto direct_email_local_part_mask = GetEmailLocalPartDirectMask(is_root_rule);
-  if (direct_email_local_part_mask.has_value()) {
-    return std::move(*direct_email_local_part_mask);
-  }
-
   auto direct_delimited_recursive_run_mask = GetDelimitedRecursiveRunDirectMask(is_root_rule);
   if (direct_delimited_recursive_run_mask.has_value()) {
     return std::move(*direct_delimited_recursive_run_mask);
@@ -3033,6 +2678,21 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   auto direct_absorbing_end_mask = GetAbsorbingEndStateDirectMask(is_root_rule);
   if (direct_absorbing_end_mask.has_value()) {
     return std::move(*direct_absorbing_end_mask);
+  }
+
+  auto direct_deterministic_byte_loop_mask = GetDeterministicByteLoopDirectMask(is_root_rule);
+  if (direct_deterministic_byte_loop_mask.has_value()) {
+    if (rule_level_cache_is_available) {
+      const auto& fsm = grammar_->per_rule_fsms[init_rule_id_].value();
+      rule_level_cache_->AddCache(
+          fsm_hash.value(),
+          new_state_id,
+          fsm.GetNodeNum(),
+          fsm.GetEdgeNum(),
+          *direct_deterministic_byte_loop_mask
+      );
+    }
+    return std::move(*direct_deterministic_byte_loop_mask);
   }
 
   auto direct_byte_path_mask = GetDeterministicBytePathDirectMask(is_root_rule);

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -171,6 +171,9 @@ class CharacterClassTokenSummaryCache {
   struct Result {
     std::vector<CharacterClassTokenSummary> summaries;
     DynamicBitset consumed_whole_token_bitset;
+    std::vector<int32_t> small_consumed_whole_token_indices;
+    std::vector<int32_t> completed_prefix_unconsumed_indices;
+    int32_t consumed_whole_token_count;
   };
 
   struct ASCIIByteLoopTokenMask {
@@ -196,14 +199,32 @@ class CharacterClassTokenSummaryCache {
     auto summaries =
         BuildCharacterClassTokenSummaries(character_class, sorted_vocab, ascii_string_safe_indices);
     DynamicBitset consumed_whole_token_bitset(vocab_size);
+    std::vector<int32_t> small_consumed_whole_token_indices;
+    std::vector<int32_t> completed_prefix_unconsumed_indices;
+    small_consumed_whole_token_indices.reserve(AdaptiveTokenMask::USE_BITSET_THRESHOLD);
+    completed_prefix_unconsumed_indices.reserve(summaries.size() / 16);
+    int32_t consumed_whole_token_count = 0;
     for (const auto& summary : summaries) {
       if (summary.consumed_whole_token) {
         consumed_whole_token_bitset.Set(sorted_vocab[summary.sorted_vocab_index].first, true);
+        ++consumed_whole_token_count;
+        if (consumed_whole_token_count <= AdaptiveTokenMask::USE_BITSET_THRESHOLD) {
+          small_consumed_whole_token_indices.push_back(summary.sorted_vocab_index);
+        }
+      } else if (summary.has_completed_character_prefix) {
+        completed_prefix_unconsumed_indices.push_back(summary.sorted_vocab_index);
       }
     }
-    auto computed = std::make_shared<const Result>(
-        Result{std::move(summaries), std::move(consumed_whole_token_bitset)}
-    );
+    if (consumed_whole_token_count >= AdaptiveTokenMask::USE_BITSET_THRESHOLD) {
+      small_consumed_whole_token_indices.clear();
+    }
+    auto computed = std::make_shared<const Result>(Result{
+        std::move(summaries),
+        std::move(consumed_whole_token_bitset),
+        std::move(small_consumed_whole_token_indices),
+        std::move(completed_prefix_unconsumed_indices),
+        consumed_whole_token_count
+    });
     std::lock_guard<std::mutex> lock(mutex_);
     return cache_.emplace(std::move(key), computed).first->second;
   }
@@ -231,33 +252,20 @@ class CharacterClassTokenSummaryCache {
     const auto summaries =
         GetOrCreate(character_class, sorted_vocab, ascii_string_safe_indices, vocab_size);
     if (max_characters < 0) {
-      std::vector<int32_t> accepted_indices;
-      std::vector<int32_t> uncertain_indices;
-      accepted_indices.reserve(AdaptiveTokenMask::USE_BITSET_THRESHOLD);
-      uncertain_indices.reserve(summaries->summaries.size());
-      bool use_accepted_bitset = false;
-      for (const auto& summary : summaries->summaries) {
-        if (summary.consumed_whole_token) {
-          if (!use_accepted_bitset) {
-            accepted_indices.push_back(summary.sorted_vocab_index);
-            if (accepted_indices.size() >= AdaptiveTokenMask::USE_BITSET_THRESHOLD) {
-              use_accepted_bitset = true;
-              accepted_indices.clear();
-            }
-          }
-        } else if (summary.has_completed_character_prefix) {
-          uncertain_indices.push_back(summary.sorted_vocab_index);
-        }
-      }
       AdaptiveTokenMask adaptive_token_mask =
-          use_accepted_bitset
+          summaries->consumed_whole_token_count >= AdaptiveTokenMask::USE_BITSET_THRESHOLD
               ? AdaptiveTokenMask(
                     summaries->consumed_whole_token_bitset,
                     sorted_vocab,
                     /*additional_accepted_indices=*/{},
-                    uncertain_indices
+                    summaries->completed_prefix_unconsumed_indices
                 )
-              : AdaptiveTokenMask(vocab_size, sorted_vocab, accepted_indices, uncertain_indices);
+              : AdaptiveTokenMask(
+                    vocab_size,
+                    sorted_vocab,
+                    summaries->small_consumed_whole_token_indices,
+                    summaries->completed_prefix_unconsumed_indices
+                );
       auto computed = std::make_shared<const CharacterClassRepeatTokenMask>(
           CharacterClassRepeatTokenMask{std::move(adaptive_token_mask), DynamicBitset(vocab_size)}
       );
@@ -404,6 +412,15 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
         rule_level_cache_(rule_level_cache),
         character_class_token_summary_cache_(character_class_token_summary_cache),
         enable_direct_character_class_mask_(enable_direct_character_class_mask) {
+    // A context-independent rule has already been proven unable to enter a JSON string length
+    // rule by GetRuleLevelCacheableRules. Avoid maintaining the grammar-wide JSON counter while
+    // this isolated parser walks the vocabulary trie; no reachable state can observe it.
+    if (enable_direct_character_class_mask_ && has_json_string_length_rules_) {
+      has_json_string_length_rules_ = false;
+      json_string_char_count_history_.clear();
+      tmp_json_string_length_entered_on_latest_advance_ = false;
+      tmp_json_string_length_suspended_ = false;
+    }
     if (has_json_string_length_rules_) {
       XGRAMMAR_DCHECK(!json_string_char_count_history_.empty());
       json_string_char_count_history_.back().length_entered = false;
@@ -440,6 +457,21 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
  private:
   /*! \brief Build a token mask directly for a context-independent single character class. */
   std::optional<AdaptiveTokenMask> GetSingleCharacterClassDirectMask(bool is_root_rule) const;
+
+  /*! \brief Reuse tokenizer metadata for a deterministic ASCII alphanumeric run. */
+  std::optional<AdaptiveTokenMask> GetAsciiAlphanumericRunDirectMask(bool is_root_rule);
+
+  /*! \brief Classify one segment of an exact delimiter-separated recursive character run. */
+  std::optional<AdaptiveTokenMask> GetDelimitedRecursiveRunDirectMask(bool is_root_rule) const;
+
+  /*! \brief Classify one prefix of a delimiter-separated recursive ASCII label. */
+  std::optional<AdaptiveTokenMask> GetDelimitedRecursiveLabelDirectMask(bool is_root_rule) const;
+
+  /*! \brief Classify the ASCII-safe subset of a fixed-width JSON wildcard path. */
+  std::optional<AdaptiveTokenMask> GetFixedWidthJSONStringDirectMask(bool is_root_rule) const;
+
+  /*! \brief Classify a broad absorbing accepting state with its local byte DFA. */
+  std::optional<AdaptiveTokenMask> GetAbsorbingEndStateDirectMask(bool is_root_rule) const;
 
   /*! \brief Build a token mask directly for a deterministic byte path from the current state. */
   std::optional<AdaptiveTokenMask> GetDeterministicBytePathDirectMask(bool is_root_rule) const;
@@ -534,7 +566,9 @@ void GrammarMatcherForTokenMaskCache::AdaptCacheWithLookahead(
   AdaptiveTokenMask& cache = *cache_ptr;
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
   const auto& subtree_nodes_range = tokenizer_info_.GetTrieSubtreeNodesRange();
+  const auto& lcp_with_previous = tokenizer_info_.ImplPtr()->GetSortedVocabLCPWithPrevious();
   const std::string* prev_token = nullptr;
+  int32_t prev_token_idx = -1;
   bool is_exact_lookahead = grammar_->GetRule(init_rule_id_).is_exact_lookahead;
   int prev_matched_size = 0;
   int last_rejected_range = 0;
@@ -561,9 +595,15 @@ void GrammarMatcherForTokenMaskCache::AdaptCacheWithLookahead(
       }
       if (prev_token != nullptr) {
         int lcp_len =
-            std::mismatch(token.begin(), token.end(), prev_token->begin(), prev_token->end())
-                .first -
-            token.begin();
+            uncertain_index == prev_token_idx + 1
+                ? lcp_with_previous[uncertain_index]
+                : static_cast<int>(
+                      std::mismatch(
+                          token.begin(), token.end(), prev_token->begin(), prev_token->end()
+                      )
+                          .first -
+                      token.begin()
+                  );
         if (lcp_len > prev_matched_size) {
           // Case 1. The common prefix is rejected by the matcher in the last token. Reject
           // directly.
@@ -585,6 +625,7 @@ void GrammarMatcherForTokenMaskCache::AdaptCacheWithLookahead(
       }
 
       prev_token = &token;
+      prev_token_idx = uncertain_index;
 
       if (accepted) {
         // Accept the rest chars one by one.
@@ -916,6 +957,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
 ) {
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
   const auto& subtree_nodes_range = tokenizer_info_.GetTrieSubtreeNodesRange();
+  const auto& lcp_with_previous = tokenizer_info_.ImplPtr()->GetSortedVocabLCPWithPrevious();
   // the pair (a, b) means [a, b). Intialize the possible intervals.
   std::vector<std::pair<int32_t, int32_t>> possible_intervals;
   int possible_token_num =
@@ -981,6 +1023,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
   }
 
   const std::string* prev_token = nullptr;
+  int32_t prev_token_idx = -1;
   int32_t skip_ptr = 0;
   const int32_t skip_size = static_cast<int32_t>(token_edge_accepted.size());
   bool accepts_ascii_string_safe_slice =
@@ -1006,6 +1049,12 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
   const auto tokenizer_impl = tokenizer_info_.ImplPtr();
   if (string_sink_info.current_state_accepts_content_prefixes) {
     tmp_base_accepted_bitset_ = tokenizer_impl->GetJSONStringContentPrefixBitset();
+    // The converter marks only canonical JSON string states whose ordinary content language is
+    // represented exactly by the tokenizer metadata above. Tokens crossing a closing quote still
+    // depend on the parent parser states, so leave that small fixed set for the runtime matcher
+    // instead of replaying it through an isolated Earley parser to rediscover the same boundary.
+    tmp_uncertain_indices_ = tokenizer_impl->GetJSONStringCrossingIndices();
+    return false;
   } else if (string_sink_info.content_prefix_transition_mask.any() ||
              directly_accepted_ascii_first_bytes.any()) {
     if (!tmp_base_accepted_bitset_.has_value()) {
@@ -1123,9 +1172,15 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       bool accepted = true;
       if (prev_token != nullptr) {
         int lcp_len =
-            std::mismatch(token.begin(), token.end(), prev_token->begin(), prev_token->end())
-                .first -
-            token.begin();
+            i == prev_token_idx + 1
+                ? lcp_with_previous[i]
+                : static_cast<int>(
+                      std::mismatch(
+                          token.begin(), token.end(), prev_token->begin(), prev_token->end()
+                      )
+                          .first -
+                      token.begin()
+                  );
         if (lcp_len > prev_matched_size) {
           // Case 1. The common prefix is rejected by the matcher in the last token. Reject
           // directly.
@@ -1147,6 +1202,7 @@ bool GrammarMatcherForTokenMaskCache::GetTokenMaskWithFirstCharacterCheck(
       }
 
       prev_token = &token;
+      prev_token_idx = i;
 
       if (accepted) {
         // Accept the rest chars one by one.
@@ -1358,6 +1414,670 @@ std::optional<AdaptiveTokenMask> GrammarMatcherForTokenMaskCache::GetSingleChara
       sorted_vocab,
       std::move(accepted_indices),
       std::move(uncertain_indices)
+  );
+}
+
+std::optional<AdaptiveTokenMask>
+GrammarMatcherForTokenMaskCache::GetDelimitedRecursiveRunDirectMask(bool is_root_rule) const {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  const auto& rule = grammar_->GetRule(init_rule_id_);
+  if (is_root_rule || initial_state_.sub_element_id != 0 || rule.is_lazy ||
+      rule.lookahead_assertion_id != -1 || rule.max_tokens != -1 || rule.max_chars != -1 ||
+      rule.json_string_min_length != -1 || rule.json_string_max_length != -1 ||
+      !rule.capture_name.empty() || !grammar_->per_rule_fsms[init_rule_id_].has_value() ||
+      initial_state_.element_id != grammar_->per_rule_fsms[init_rule_id_]->GetFsm().GetStart()) {
+    return std::nullopt;
+  }
+  const auto& body = grammar_->GetGrammarExpr(rule.body_expr_id);
+  if (body.type != GrammarExprType::kChoices || body.size() != 2) {
+    return std::nullopt;
+  }
+  int32_t recursive_sequence_id = -1;
+  bool has_empty_choice = false;
+  for (int32_t choice_id : body) {
+    const auto& choice = grammar_->GetGrammarExpr(choice_id);
+    if (choice.type == GrammarExprType::kEmptyStr) {
+      has_empty_choice = true;
+    } else if (choice.type == GrammarExprType::kSequence && choice.size() == 3) {
+      recursive_sequence_id = choice_id;
+    } else {
+      return std::nullopt;
+    }
+  }
+  if (!has_empty_choice || recursive_sequence_id == -1) {
+    return std::nullopt;
+  }
+  const auto& recursive_sequence = grammar_->GetGrammarExpr(recursive_sequence_id);
+  const auto& delimiter_expr = grammar_->GetGrammarExpr(recursive_sequence[0]);
+  const auto& run_reference = grammar_->GetGrammarExpr(recursive_sequence[1]);
+  const auto& self_reference = grammar_->GetGrammarExpr(recursive_sequence[2]);
+  if (delimiter_expr.type != GrammarExprType::kByteString || delimiter_expr.size() != 1 ||
+      delimiter_expr[0] < 0 || delimiter_expr[0] >= 128 ||
+      run_reference.type != GrammarExprType::kRuleRef ||
+      self_reference.type != GrammarExprType::kRuleRef || self_reference[0] != init_rule_id_) {
+    return std::nullopt;
+  }
+
+  const int32_t run_rule_id = run_reference[0];
+  const auto& run_rule = grammar_->GetRule(run_rule_id);
+  const auto& run_body = grammar_->GetGrammarExpr(run_rule.body_expr_id);
+  if (run_rule.is_lazy || run_rule.max_tokens != -1 || run_rule.max_chars != -1 ||
+      run_rule.json_string_min_length != -1 || run_rule.json_string_max_length != -1 ||
+      !run_rule.capture_name.empty() || run_body.type != GrammarExprType::kChoices ||
+      run_body.size() != 2) {
+    return std::nullopt;
+  }
+  int32_t recursive_character_class_id = -1;
+  int32_t terminal_character_class_id = -1;
+  for (int32_t choice_id : run_body) {
+    const auto& choice = grammar_->GetGrammarExpr(choice_id);
+    if (choice.type != GrammarExprType::kSequence) {
+      return std::nullopt;
+    }
+    if (choice.size() == 1 &&
+        grammar_->GetGrammarExpr(choice[0]).type == GrammarExprType::kCharacterClass) {
+      terminal_character_class_id = choice[0];
+    } else if (choice.size() == 2) {
+      const auto& character_class = grammar_->GetGrammarExpr(choice[0]);
+      const auto& recursive_reference = grammar_->GetGrammarExpr(choice[1]);
+      if (character_class.type != GrammarExprType::kCharacterClass ||
+          recursive_reference.type != GrammarExprType::kRuleRef ||
+          recursive_reference[0] != run_rule_id) {
+        return std::nullopt;
+      }
+      recursive_character_class_id = choice[0];
+    } else {
+      return std::nullopt;
+    }
+  }
+  if (recursive_character_class_id == -1 || terminal_character_class_id == -1) {
+    return std::nullopt;
+  }
+  const auto& character_class = grammar_->GetGrammarExpr(recursive_character_class_id);
+  const auto& terminal_character_class = grammar_->GetGrammarExpr(terminal_character_class_id);
+  if (character_class.size() != terminal_character_class.size() ||
+      !std::equal(
+          character_class.begin(), character_class.end(), terminal_character_class.begin()
+      ) ||
+      character_class.size() < 3 || character_class[0] != 0) {
+    return std::nullopt;
+  }
+  std::array<uint8_t, 128> accepted_bytes{};
+  for (int32_t index = 1; index < character_class.size(); index += 2) {
+    if (index + 1 >= character_class.size() || character_class[index] < 0 ||
+        character_class[index + 1] >= 128) {
+      return std::nullopt;
+    }
+    for (int32_t byte = character_class[index]; byte <= character_class[index + 1]; ++byte) {
+      accepted_bytes[byte] = true;
+    }
+  }
+  const uint8_t delimiter = static_cast<uint8_t>(delimiter_expr[0]);
+  if (accepted_bytes[delimiter]) {
+    return std::nullopt;
+  }
+
+  const auto& sorted_vocab = tokenizer_info_.GetSortedDecodedVocab();
+  const std::string delimiter_prefix(1, static_cast<char>(delimiter));
+  auto first = std::lower_bound(
+      sorted_vocab.begin(),
+      sorted_vocab.end(),
+      delimiter_prefix,
+      [](const auto& token, const std::string& value) { return token.second < value; }
+  );
+  std::vector<int32_t> accepted_indices;
+  std::vector<int32_t> uncertain_indices;
+  for (auto it = first; it != sorted_vocab.end() && !it->second.empty() &&
+                        static_cast<uint8_t>(it->second.front()) == delimiter;
+       ++it) {
+    const auto& token = it->second;
+    bool consumed_run_character = false;
+    bool crossing = false;
+    for (int32_t byte_index = 1; byte_index < static_cast<int32_t>(token.size()); ++byte_index) {
+      const uint8_t byte = static_cast<uint8_t>(token[byte_index]);
+      if (byte < accepted_bytes.size() && accepted_bytes[byte]) {
+        consumed_run_character = true;
+        continue;
+      }
+      crossing = consumed_run_character;
+      break;
+    }
+    const int32_t token_index = static_cast<int32_t>(it - sorted_vocab.begin());
+    if (!crossing && (token.size() == 1 || consumed_run_character)) {
+      accepted_indices.push_back(token_index);
+    } else if (crossing) {
+      uncertain_indices.push_back(token_index);
+    }
+  }
+  return AdaptiveTokenMask(
+      tokenizer_info_.GetVocabSize(), sorted_vocab, accepted_indices, uncertain_indices
+  );
+}
+
+std::optional<AdaptiveTokenMask>
+GrammarMatcherForTokenMaskCache::GetDelimitedRecursiveLabelDirectMask(bool is_root_rule) const {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  const auto& rule = grammar_->GetRule(init_rule_id_);
+  if (is_root_rule || initial_state_.sub_element_id != 0 || rule.is_lazy ||
+      rule.lookahead_assertion_id != -1 || rule.max_tokens != -1 || rule.max_chars != -1 ||
+      rule.json_string_min_length != -1 || rule.json_string_max_length != -1 ||
+      !rule.capture_name.empty() || !grammar_->per_rule_fsms[init_rule_id_].has_value() ||
+      initial_state_.element_id != grammar_->per_rule_fsms[init_rule_id_]->GetFsm().GetStart()) {
+    return std::nullopt;
+  }
+  const auto& body = grammar_->GetGrammarExpr(rule.body_expr_id);
+  if (body.type != GrammarExprType::kChoices || body.size() != 2) {
+    return std::nullopt;
+  }
+  int32_t label_sequence_id = -1;
+  bool has_empty_choice = false;
+  for (int32_t choice_id : body) {
+    const auto& choice = grammar_->GetGrammarExpr(choice_id);
+    if (choice.type == GrammarExprType::kEmptyStr) {
+      has_empty_choice = true;
+    } else if (choice.type == GrammarExprType::kSequence && choice.size() == 5) {
+      label_sequence_id = choice_id;
+    } else {
+      return std::nullopt;
+    }
+  }
+  if (!has_empty_choice || label_sequence_id == -1) {
+    return std::nullopt;
+  }
+  const auto& label_sequence = grammar_->GetGrammarExpr(label_sequence_id);
+  const auto& delimiter_expr = grammar_->GetGrammarExpr(label_sequence[0]);
+  const auto& first_character_class = grammar_->GetGrammarExpr(label_sequence[1]);
+  const auto& middle_star = grammar_->GetGrammarExpr(label_sequence[2]);
+  const auto& final_character_class = grammar_->GetGrammarExpr(label_sequence[3]);
+  const auto& self_reference = grammar_->GetGrammarExpr(label_sequence[4]);
+  if (delimiter_expr.type != GrammarExprType::kByteString || delimiter_expr.size() != 1 ||
+      delimiter_expr[0] < 0 || delimiter_expr[0] >= 128 ||
+      first_character_class.type != GrammarExprType::kCharacterClass ||
+      middle_star.type != GrammarExprType::kCharacterClassStar ||
+      final_character_class.type != GrammarExprType::kCharacterClass ||
+      self_reference.type != GrammarExprType::kRuleRef || self_reference[0] != init_rule_id_) {
+    return std::nullopt;
+  }
+  const auto build_ascii_byte_set = [](const auto& character_class
+                                    ) -> std::optional<std::array<uint8_t, 128>> {
+    if (character_class.size() < 3 || character_class[0] != 0) {
+      return std::nullopt;
+    }
+    std::array<uint8_t, 128> result{};
+    for (int32_t index = 1; index < character_class.size(); index += 2) {
+      if (index + 1 >= character_class.size() || character_class[index] < 0 ||
+          character_class[index + 1] >= 128) {
+        return std::nullopt;
+      }
+      for (int32_t byte = character_class[index]; byte <= character_class[index + 1]; ++byte) {
+        result[byte] = true;
+      }
+    }
+    return result;
+  };
+  const auto first_bytes = build_ascii_byte_set(first_character_class);
+  const auto middle_bytes = build_ascii_byte_set(middle_star);
+  const auto final_bytes = build_ascii_byte_set(final_character_class);
+  if (!first_bytes.has_value() || !middle_bytes.has_value() || !final_bytes.has_value()) {
+    return std::nullopt;
+  }
+  for (int32_t byte = 0; byte < 128; ++byte) {
+    if (((*first_bytes)[byte] || (*final_bytes)[byte]) && !(*middle_bytes)[byte]) {
+      return std::nullopt;
+    }
+  }
+  const uint8_t delimiter = static_cast<uint8_t>(delimiter_expr[0]);
+  if ((*middle_bytes)[delimiter]) {
+    return std::nullopt;
+  }
+
+  const auto& sorted_vocab = tokenizer_info_.GetSortedDecodedVocab();
+  const std::string delimiter_prefix(1, static_cast<char>(delimiter));
+  auto first = std::lower_bound(
+      sorted_vocab.begin(),
+      sorted_vocab.end(),
+      delimiter_prefix,
+      [](const auto& token, const std::string& value) { return token.second < value; }
+  );
+  std::vector<int32_t> accepted_indices;
+  std::vector<int32_t> uncertain_indices;
+  for (auto it = first; it != sorted_vocab.end() && !it->second.empty() &&
+                        static_cast<uint8_t>(it->second.front()) == delimiter;
+       ++it) {
+    const auto& token = it->second;
+    bool accepted_prefix = token.size() == 1;
+    bool can_complete_label = false;
+    bool crossing = false;
+    if (token.size() > 1) {
+      const uint8_t first_label_byte = static_cast<uint8_t>(token[1]);
+      if (first_label_byte < first_bytes->size() && (*first_bytes)[first_label_byte]) {
+        accepted_prefix = true;
+        for (int32_t byte_index = 2; byte_index < static_cast<int32_t>(token.size());
+             ++byte_index) {
+          const uint8_t byte = static_cast<uint8_t>(token[byte_index]);
+          if (byte < middle_bytes->size() && (*middle_bytes)[byte]) {
+            can_complete_label = (*final_bytes)[byte];
+            continue;
+          }
+          crossing = can_complete_label;
+          accepted_prefix = false;
+          break;
+        }
+      }
+    }
+    const int32_t token_index = static_cast<int32_t>(it - sorted_vocab.begin());
+    if (accepted_prefix) {
+      accepted_indices.push_back(token_index);
+    } else if (crossing) {
+      uncertain_indices.push_back(token_index);
+    }
+  }
+  return AdaptiveTokenMask(
+      tokenizer_info_.GetVocabSize(), sorted_vocab, accepted_indices, uncertain_indices
+  );
+}
+
+std::optional<AdaptiveTokenMask> GrammarMatcherForTokenMaskCache::GetAsciiAlphanumericRunDirectMask(
+    bool is_root_rule
+) {
+  const auto& rule = grammar_->GetRule(init_rule_id_);
+  if (is_root_rule || initial_state_.sub_element_id != 0 || rule.is_lazy ||
+      rule.lookahead_assertion_id == -1) {
+    return std::nullopt;
+  }
+  const auto& rule_fsm = grammar_->per_rule_fsms[init_rule_id_]->GetFsm();
+  const auto& fsm = rule_fsm.GetFsm();
+  if (rule_fsm.IsEndState(initial_state_.element_id)) {
+    return std::nullopt;
+  }
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  const auto is_ascii_alphanumeric = [](int32_t byte) {
+    return (byte >= '0' && byte <= '9') || (byte >= 'A' && byte <= 'Z') ||
+           (byte >= 'a' && byte <= 'z');
+  };
+  const auto is_ascii_alphanumeric_range = [](int32_t min, int32_t max) {
+    return (min >= '0' && max <= '9') || (min >= 'A' && max <= 'Z') || (min >= 'a' && max <= 'z');
+  };
+  const auto character_class_contains_all_alphanumeric = [&](const auto& character_class) {
+    if (character_class.type != GrammarExprType::kCharacterClass &&
+        character_class.type != GrammarExprType::kCharacterClassStar) {
+      return false;
+    }
+    const bool is_negative = character_class[0];
+    for (int32_t byte = 0; byte < 128; ++byte) {
+      if (!is_ascii_alphanumeric(byte)) {
+        continue;
+      }
+      bool in_ranges = false;
+      for (int32_t index = 1; index < static_cast<int32_t>(character_class.size()); index += 2) {
+        if (byte >= character_class[index] && byte <= character_class[index + 1]) {
+          in_ranges = true;
+          break;
+        }
+      }
+      if (is_negative == in_ranges) {
+        return false;
+      }
+    }
+    return true;
+  };
+  const auto rule_accepts_any_alphanumeric_suffix = [&](int32_t rule_id) {
+    const auto& rule = grammar_->GetRule(rule_id);
+    const auto& body = grammar_->GetGrammarExpr(rule.body_expr_id);
+    if (rule.is_lazy || body.type != GrammarExprType::kChoices) {
+      return false;
+    }
+    bool accepts_empty = false;
+    bool accepts_nonempty_run = false;
+    for (int32_t choice_id : body) {
+      const auto& choice = grammar_->GetGrammarExpr(choice_id);
+      if (choice.type == GrammarExprType::kEmptyStr) {
+        accepts_empty = true;
+      } else if (choice.type == GrammarExprType::kSequence && choice.size() == 2) {
+        const auto& prefix = grammar_->GetGrammarExpr(choice[0]);
+        const auto& final = grammar_->GetGrammarExpr(choice[1]);
+        if (prefix.type == GrammarExprType::kCharacterClassStar &&
+            final.type == GrammarExprType::kCharacterClass &&
+            character_class_contains_all_alphanumeric(prefix) &&
+            character_class_contains_all_alphanumeric(final)) {
+          accepts_nonempty_run = true;
+        }
+      }
+    }
+    return accepts_empty && accepts_nonempty_run;
+  };
+
+  std::array<int32_t, 256> transitions;
+  transitions.fill(-1);
+  for (const auto& edge : fsm.GetEdges(initial_state_.element_id)) {
+    if (!edge.IsCharRange() || !is_ascii_alphanumeric_range(edge.min, edge.max)) {
+      return std::nullopt;
+    }
+    for (int32_t byte = edge.min; byte <= edge.max; ++byte) {
+      if (transitions[byte] != -1 && transitions[byte] != edge.target) {
+        return std::nullopt;
+      }
+      transitions[byte] = edge.target;
+    }
+  }
+  std::vector<int32_t> targets;
+  for (int32_t byte = 0; byte < 256; ++byte) {
+    if (is_ascii_alphanumeric(byte) != (transitions[byte] != -1)) {
+      return std::nullopt;
+    }
+    if (transitions[byte] != -1 &&
+        std::find(targets.begin(), targets.end(), transitions[byte]) == targets.end()) {
+      targets.push_back(transitions[byte]);
+    }
+  }
+  for (int32_t target : targets) {
+    bool accepts_suffix = false;
+    for (const auto& edge : fsm.GetEdges(target)) {
+      if (edge.IsRuleRef() && rule_accepts_any_alphanumeric_suffix(edge.GetRefRuleId())) {
+        accepts_suffix = true;
+        break;
+      }
+    }
+    if (!accepts_suffix) {
+      return std::nullopt;
+    }
+  }
+  const auto& sorted_vocab = tokenizer_info_.GetSortedDecodedVocab();
+  tmp_accepted_indices_.reserve(sorted_vocab.size() / 4);
+  tmp_uncertain_indices_.reserve(sorted_vocab.size() / 8);
+  for (int32_t index = 0; index < static_cast<int32_t>(sorted_vocab.size()); ++index) {
+    const auto& token = sorted_vocab[index].second;
+    if (!token.empty() && std::all_of(token.begin(), token.end(), is_ascii_alphanumeric)) {
+      tmp_accepted_indices_.push_back(index);
+    } else if (!token.empty() && is_ascii_alphanumeric(static_cast<uint8_t>(token.front()))) {
+      tmp_uncertain_indices_.push_back(index);
+    }
+  }
+  return AdaptiveTokenMask(
+      tokenizer_info_.GetVocabSize(), sorted_vocab, tmp_accepted_indices_, tmp_uncertain_indices_
+  );
+}
+
+std::optional<AdaptiveTokenMask> GrammarMatcherForTokenMaskCache::GetFixedWidthJSONStringDirectMask(
+    bool is_root_rule
+) const {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  const auto& rule = grammar_->GetRule(init_rule_id_);
+  const auto& rule_body = grammar_->GetGrammarExpr(rule.body_expr_id);
+  const auto& rule_fsm = grammar_->per_rule_fsms[init_rule_id_]->GetFsm();
+  const auto& fsm = rule_fsm.GetFsm();
+  if (is_root_rule || initial_state_.sub_element_id != 0 || rule.is_lazy ||
+      rule_body.type != GrammarExprType::kRegex || !grammar_->GetRegexIsJSONString(rule_body) ||
+      rule_fsm.IsEndState(initial_state_.element_id)) {
+    return std::nullopt;
+  }
+  const auto get_ascii_wildcard_target = [&](int32_t state) -> int32_t {
+    std::array<int32_t, 256> transitions;
+    transitions.fill(-1);
+    for (const auto& edge : fsm.GetEdges(state)) {
+      if (!edge.IsCharRange()) {
+        return -1;
+      }
+      for (int32_t byte = edge.min; byte <= edge.max; ++byte) {
+        if (transitions[byte] != -1 && transitions[byte] != edge.target) {
+          return -1;
+        }
+        transitions[byte] = edge.target;
+      }
+    }
+    int32_t target = -1;
+    for (int32_t byte = 0x20; byte < 0x7f; ++byte) {
+      if (byte == '"' || byte == '\\') {
+        continue;
+      }
+      if (transitions[byte] == -1) {
+        return -1;
+      }
+      if (target == -1) {
+        target = transitions[byte];
+      } else if (target != transitions[byte]) {
+        return -1;
+      }
+    }
+    return target;
+  };
+  constexpr int32_t kMaxFixedCharacters = 8;
+  std::vector<int32_t> scalar_boundary_states{initial_state_.element_id};
+  while (static_cast<int32_t>(scalar_boundary_states.size()) <= kMaxFixedCharacters) {
+    const int32_t target = get_ascii_wildcard_target(scalar_boundary_states.back());
+    if (target == -1) {
+      break;
+    }
+    scalar_boundary_states.push_back(target);
+    if (rule_fsm.IsEndState(target)) {
+      break;
+    }
+  }
+  const int32_t fixed_characters = static_cast<int32_t>(scalar_boundary_states.size()) - 1;
+  if (fixed_characters == 0 || fixed_characters > kMaxFixedCharacters ||
+      (fixed_characters == kMaxFixedCharacters &&
+       get_ascii_wildcard_target(scalar_boundary_states.back()) != -1)) {
+    return std::nullopt;
+  }
+  for (int32_t index = 0; index < fixed_characters; ++index) {
+    if (rule_fsm.IsEndState(scalar_boundary_states[index])) {
+      return std::nullopt;
+    }
+  }
+
+  struct LocalState {
+    int32_t global_state;
+    std::array<int32_t, 256> transitions;
+  };
+  constexpr size_t kMaxDirectStates = 64;
+  std::vector<LocalState> local_states;
+  local_states.reserve(kMaxDirectStates);
+  const auto find_or_add_state = [&](int32_t global_state) -> int32_t {
+    for (int32_t local_id = 0; local_id < static_cast<int32_t>(local_states.size()); ++local_id) {
+      if (local_states[local_id].global_state == global_state) {
+        return local_id;
+      }
+    }
+    if (local_states.size() == kMaxDirectStates) {
+      return -1;
+    }
+    LocalState state;
+    state.global_state = global_state;
+    state.transitions.fill(-2);
+    local_states.push_back(std::move(state));
+    return static_cast<int32_t>(local_states.size()) - 1;
+  };
+  const auto transition = [&](int32_t local_state, int32_t byte) -> int32_t {
+    auto& cached = local_states[local_state].transitions[byte];
+    if (cached != -2) {
+      return cached;
+    }
+    int32_t global_target = -1;
+    for (const auto& edge : fsm.GetEdges(local_states[local_state].global_state)) {
+      if (!edge.IsCharRange()) {
+        return -2;
+      }
+      if (byte >= edge.min && byte <= edge.max) {
+        if (global_target != -1 && global_target != edge.target) {
+          return -2;
+        }
+        global_target = edge.target;
+      }
+    }
+    if (global_target == -1) {
+      cached = -1;
+      return cached;
+    }
+    const int32_t local_target = find_or_add_state(global_target);
+    if (local_target == -1) {
+      return -2;
+    }
+    cached = local_target;
+    return cached;
+  };
+
+  const auto tokenizer_impl = tokenizer_info_.ImplPtr();
+  const auto& sorted_vocab = tokenizer_info_.GetSortedDecodedVocab();
+  const auto& ascii_safe_indices = tokenizer_impl->GetAsciiStringSafeIndices();
+  DynamicBitset base_accepted = tokenizer_impl->GetAsciiStringSafeBitset();
+  std::vector<int32_t> additional_accepted_indices;
+  std::vector<int32_t> uncertain_indices;
+  additional_accepted_indices.reserve(sorted_vocab.size() / 64);
+  uncertain_indices.reserve(sorted_vocab.size() / 32);
+  const int32_t boundary_local_state = find_or_add_state(scalar_boundary_states.back());
+  for (int32_t index : ascii_safe_indices) {
+    const auto& token = sorted_vocab[index].second;
+    if (static_cast<int32_t>(token.size()) <= fixed_characters) {
+      continue;
+    }
+    base_accepted.Reset(sorted_vocab[index].first);
+    int32_t state = boundary_local_state;
+    bool reached_end = rule_fsm.IsEndState(local_states[state].global_state);
+    int32_t matched = fixed_characters;
+    for (int32_t byte_index = fixed_characters; byte_index < static_cast<int32_t>(token.size());
+         ++byte_index) {
+      const int32_t next = transition(state, static_cast<uint8_t>(token[byte_index]));
+      if (next == -2) {
+        return std::nullopt;
+      }
+      if (next == -1) {
+        break;
+      }
+      state = next;
+      ++matched;
+      reached_end = reached_end || rule_fsm.IsEndState(local_states[state].global_state);
+    }
+    if (matched == static_cast<int32_t>(token.size())) {
+      additional_accepted_indices.push_back(index);
+    } else if (reached_end) {
+      uncertain_indices.push_back(index);
+    }
+  }
+  for (int32_t index = 0; index < static_cast<int32_t>(sorted_vocab.size()); ++index) {
+    if (!tokenizer_impl->GetAsciiStringSafeBitset()[sorted_vocab[index].first]) {
+      uncertain_indices.push_back(index);
+    }
+  }
+  std::sort(uncertain_indices.begin(), uncertain_indices.end());
+  uncertain_indices.erase(
+      std::unique(uncertain_indices.begin(), uncertain_indices.end()), uncertain_indices.end()
+  );
+  return AdaptiveTokenMask(
+      base_accepted, sorted_vocab, additional_accepted_indices, uncertain_indices
+  );
+}
+
+std::optional<AdaptiveTokenMask> GrammarMatcherForTokenMaskCache::GetAbsorbingEndStateDirectMask(
+    bool is_root_rule
+) const {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  const auto& rule = grammar_->GetRule(init_rule_id_);
+  const auto& rule_body = grammar_->GetGrammarExpr(rule.body_expr_id);
+  const auto& rule_fsm = grammar_->per_rule_fsms[init_rule_id_]->GetFsm();
+  const auto& fsm = rule_fsm.GetFsm();
+  if (is_root_rule || initial_state_.sub_element_id != 0 || rule.is_lazy ||
+      rule_body.type != GrammarExprType::kRegex || !grammar_->GetRegexIsJSONString(rule_body) ||
+      !rule_fsm.IsEndState(initial_state_.element_id)) {
+    return std::nullopt;
+  }
+  std::bitset<256> self_loop_bytes;
+  for (const auto& edge : fsm.GetEdges(initial_state_.element_id)) {
+    if (edge.IsCharRange() && edge.target == initial_state_.element_id) {
+      for (int32_t byte = edge.min; byte <= edge.max; ++byte) {
+        self_loop_bytes.set(byte);
+      }
+    }
+  }
+  for (int32_t byte = 0x20; byte < 0x7f; ++byte) {
+    if (byte != '"' && byte != '\\' && !self_loop_bytes[byte]) {
+      return std::nullopt;
+    }
+  }
+  struct LocalState {
+    int32_t global_state;
+    std::array<int32_t, 256> transitions;
+  };
+  constexpr size_t kMaxDirectStates = 64;
+  std::vector<LocalState> local_states;
+  local_states.reserve(kMaxDirectStates);
+  auto find_or_add_state = [&](int32_t global_state) -> int32_t {
+    for (int32_t local_id = 0; local_id < static_cast<int32_t>(local_states.size()); ++local_id) {
+      if (local_states[local_id].global_state == global_state) {
+        return local_id;
+      }
+    }
+    if (local_states.size() == kMaxDirectStates) {
+      return -1;
+    }
+    LocalState state;
+    state.global_state = global_state;
+    state.transitions.fill(-1);
+    local_states.push_back(std::move(state));
+    return static_cast<int32_t>(local_states.size() - 1);
+  };
+  const int32_t initial_local_state = find_or_add_state(initial_state_.element_id);
+  for (size_t local_id = 0; local_id < local_states.size(); ++local_id) {
+    const int32_t global_state = local_states[local_id].global_state;
+    std::array<int32_t, 256> global_transitions;
+    global_transitions.fill(-1);
+    for (const auto& edge : fsm.GetEdges(global_state)) {
+      if (!edge.IsCharRange()) {
+        return std::nullopt;
+      }
+      for (int32_t byte = edge.min; byte <= edge.max; ++byte) {
+        if (global_transitions[byte] != -1 && global_transitions[byte] != edge.target) {
+          return std::nullopt;
+        }
+        global_transitions[byte] = edge.target;
+      }
+    }
+    for (int32_t byte = 0; byte < 256; ++byte) {
+      if (global_transitions[byte] == -1) {
+        continue;
+      }
+      const int32_t target_local_state = find_or_add_state(global_transitions[byte]);
+      if (target_local_state == -1) {
+        return std::nullopt;
+      }
+      local_states[local_id].transitions[byte] = target_local_state;
+    }
+  }
+  const auto transition = [&](int32_t state, int32_t byte) {
+    return local_states[state].transitions[byte];
+  };
+  const auto tokenizer_impl = tokenizer_info_.ImplPtr();
+  const auto& sorted_vocab = tokenizer_info_.GetSortedDecodedVocab();
+  const auto& base_accepted = tokenizer_impl->GetAsciiStringSafeBitset();
+  std::vector<int32_t> additional_accepted_indices;
+  std::vector<int32_t> uncertain_indices;
+  additional_accepted_indices.reserve(sorted_vocab.size() / 32);
+  uncertain_indices.reserve(sorted_vocab.size() / 128);
+  for (int32_t index = 0; index < static_cast<int32_t>(sorted_vocab.size()); ++index) {
+    const int32_t token_id = sorted_vocab[index].first;
+    if (base_accepted[token_id]) {
+      continue;
+    }
+    const auto& token = sorted_vocab[index].second;
+    int32_t state = initial_local_state;
+    bool reached_end = false;
+    int32_t matched = 0;
+    for (uint8_t byte : token) {
+      const int32_t next = transition(state, byte);
+      if (next == -1) {
+        break;
+      }
+      state = next;
+      ++matched;
+      reached_end = reached_end || rule_fsm.IsEndState(local_states[state].global_state);
+    }
+    if (matched == static_cast<int32_t>(token.size())) {
+      additional_accepted_indices.push_back(index);
+    } else if (reached_end && matched > 0) {
+      uncertain_indices.push_back(index);
+    }
+  }
+  return AdaptiveTokenMask(
+      base_accepted, sorted_vocab, additional_accepted_indices, uncertain_indices
   );
 }
 
@@ -1772,6 +2492,31 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
     return std::move(*direct_character_class_mask);
   }
 
+  auto direct_delimited_recursive_run_mask = GetDelimitedRecursiveRunDirectMask(is_root_rule);
+  if (direct_delimited_recursive_run_mask.has_value()) {
+    return std::move(*direct_delimited_recursive_run_mask);
+  }
+
+  auto direct_delimited_recursive_label_mask = GetDelimitedRecursiveLabelDirectMask(is_root_rule);
+  if (direct_delimited_recursive_label_mask.has_value()) {
+    return std::move(*direct_delimited_recursive_label_mask);
+  }
+
+  auto direct_ascii_alphanumeric_mask = GetAsciiAlphanumericRunDirectMask(is_root_rule);
+  if (direct_ascii_alphanumeric_mask.has_value()) {
+    return std::move(*direct_ascii_alphanumeric_mask);
+  }
+
+  auto direct_fixed_width_json_string_mask = GetFixedWidthJSONStringDirectMask(is_root_rule);
+  if (direct_fixed_width_json_string_mask.has_value()) {
+    return std::move(*direct_fixed_width_json_string_mask);
+  }
+
+  auto direct_absorbing_end_mask = GetAbsorbingEndStateDirectMask(is_root_rule);
+  if (direct_absorbing_end_mask.has_value()) {
+    return std::move(*direct_absorbing_end_mask);
+  }
+
   auto direct_byte_path_mask = GetDeterministicBytePathDirectMask(is_root_rule);
   if (direct_byte_path_mask.has_value()) {
     if (rule_level_cache_is_available) {
@@ -1943,6 +2688,44 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   }
 }
 
+void CompiledGrammar::Impl::EnsureRuleLevelMetadata() {
+  if (!rule_level_metadata_enabled) {
+    return;
+  }
+  std::call_once(rule_level_metadata_once, [this]() {
+    GrammarFSMHasher().Apply(&grammar);
+    rule_level_cacheable = GetRuleLevelCacheableRules(grammar);
+
+    if (builtin_rule_level_cache_seed_source == nullptr) {
+      return;
+    }
+    for (int32_t rule_id = 0; rule_id < static_cast<int32_t>(grammar->NumRules()); ++rule_id) {
+      const auto& hash = grammar->per_rule_fsm_hashes[rule_id];
+      if (!hash.has_value() ||
+          std::find(builtin_rule_fsm_hashes.begin(), builtin_rule_fsm_hashes.end(), *hash) ==
+              builtin_rule_fsm_hashes.end()) {
+        continue;
+      }
+      const auto& fsm = grammar->per_rule_fsms[rule_id].value();
+      for (const auto& [original_state_id, normalized_state_id] :
+           grammar->per_rule_fsm_new_state_ids[rule_id]) {
+        if (normalized_state_id != 0) {
+          continue;
+        }
+        if (auto cached = builtin_rule_level_cache_seed_source->GetCache(
+                *hash, normalized_state_id, fsm.GetNodeNum(), fsm.GetEdgeNum()
+            )) {
+          rule_level_cache->AddCache(
+              *hash, normalized_state_id, fsm.GetNodeNum(), fsm.GetEdgeNum(), std::move(*cached)
+          );
+        }
+        break;
+      }
+      break;
+    }
+  });
+}
+
 const AdaptiveTokenMask& CompiledGrammar::Impl::GetAdaptiveTokenMask(
     const ParserState& state, bool is_root_rule
 ) {
@@ -1953,6 +2736,7 @@ const AdaptiveTokenMask& CompiledGrammar::Impl::GetAdaptiveTokenMask(
     return it->second;
   }
 
+  EnsureRuleLevelMetadata();
   std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex);
   const auto existing = adaptive_token_mask_cache.find(state);
   if (existing != adaptive_token_mask_cache.end()) {
@@ -2051,7 +2835,18 @@ class GrammarCompilerSub {
       : tokenizer_info_(tokenizer_info),
         max_threads_(max_threads),
         rule_level_cache_(rule_level_cache),
-        enable_dynamic_compilation_(enable_dynamic_compilation) {}
+        builtin_rule_level_cache_(
+            enable_dynamic_compilation && !rule_level_cache.has_value()
+                ? std::make_shared<RuleLevelCache>()
+                : nullptr
+        ),
+        enable_dynamic_compilation_(enable_dynamic_compilation) {
+    if (builtin_rule_level_cache_ != nullptr && tokenizer_info_.GetVocabSize() != 0) {
+      MultiThreadCompileGrammar(
+          Grammar::BuiltinJSONGrammar(), /*regex_fsm_cache=*/nullptr, /*materialize_masks=*/true
+      );
+    }
+  }
 
   CompiledGrammar CompileBuiltinJSONGrammar();
 
@@ -2083,7 +2878,7 @@ class GrammarCompilerSub {
  private:
   /*! \brief The main logic. Compile the grammar with multi-threading. */
   CompiledGrammar MultiThreadCompileGrammar(
-      Grammar grammar, RegexFSMCache* regex_fsm_cache = nullptr
+      Grammar grammar, RegexFSMCache* regex_fsm_cache = nullptr, bool materialize_masks = false
   );
   /*! \brief Optimization for TagDispatch.
    *  \param compiled_grammar_impl the compiled_grammar to be optimized.
@@ -2107,6 +2902,10 @@ class GrammarCompilerSub {
   /*! \brief The manager of the rule level cache.*/
   std::optional<RuleLevelCache> rule_level_cache_;
 
+  std::shared_ptr<RuleLevelCache> builtin_rule_level_cache_;
+
+  std::vector<uint64_t> builtin_rule_fsm_hashes_;
+
   std::shared_ptr<CharacterClassTokenSummaryCache> character_class_token_summary_cache_ =
       std::make_shared<CharacterClassTokenSummaryCache>();
   /*! \brief Whether token masks are generated on first use. */
@@ -2129,11 +2928,15 @@ class GrammarCompilerSub {
 };
 
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(
-    Grammar grammar_unoptimized, RegexFSMCache* regex_fsm_cache
+    Grammar grammar_unoptimized, RegexFSMCache* regex_fsm_cache, bool materialize_masks
 ) {
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
-  compiled_grammar_impl->grammar =
-      GrammarOptimizer::Apply(grammar_unoptimized, !enable_dynamic_compilation_, regex_fsm_cache);
+  compiled_grammar_impl->grammar = GrammarOptimizer::Apply(
+      grammar_unoptimized,
+      !enable_dynamic_compilation_,
+      regex_fsm_cache,
+      !enable_dynamic_compilation_
+  );
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
   compiled_grammar_impl->enable_dynamic_compilation = enable_dynamic_compilation_;
   compiled_grammar_impl->earley_parser_grammar_features =
@@ -2147,11 +2950,8 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(
   // Dynamic compilation also uses rule hashes to reuse masks between structurally identical
   // context-independent rules in one compiled grammar. The public compiler cache only controls
   // whether that reuse extends across separately compiled grammars.
-  if (rule_level_cache_.has_value() || enable_dynamic_compilation_) {
-    GrammarFSMHasher().Apply(&compiled_grammar_impl->grammar);
-    compiled_grammar_impl->rule_level_cacheable =
-        GetRuleLevelCacheableRules(compiled_grammar_impl->grammar);
-  }
+  compiled_grammar_impl->rule_level_metadata_enabled =
+      rule_level_cache_.has_value() || enable_dynamic_compilation_;
   if (enable_dynamic_compilation_) {
     compiled_grammar_impl->character_class_token_summary_cache =
         character_class_token_summary_cache_;
@@ -2159,12 +2959,66 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(
     // masks. Keep it available when the public compiler cache is disabled; otherwise bounded
     // repeats fall back to materializing one full-vocabulary mask for every repeat count.
     compiled_grammar_impl->rule_level_cache =
-        rule_level_cache_.has_value() ? std::make_shared<RuleLevelCache>(rule_level_cache_.value())
-                                      : std::make_shared<RuleLevelCache>();
+        materialize_masks ? builtin_rule_level_cache_
+                          : (rule_level_cache_.has_value()
+                                 ? std::make_shared<RuleLevelCache>(rule_level_cache_.value())
+                                 : std::make_shared<RuleLevelCache>());
+    if (!materialize_masks && !rule_level_cache_.has_value()) {
+      // Defer copying builtin JSON string masks together with the hashes that identify the
+      // matching rules. The source cache and hash list are immutable after compiler construction.
+      compiled_grammar_impl->builtin_rule_level_cache_seed_source = builtin_rule_level_cache_;
+      compiled_grammar_impl->builtin_rule_fsm_hashes = builtin_rule_fsm_hashes_;
+    }
+    if (materialize_masks) {
+      compiled_grammar_impl->EnsureRuleLevelMetadata();
+    }
+    if (materialize_masks) {
+      builtin_rule_fsm_hashes_.clear();
+      for (int32_t rule_id = 0;
+           rule_id < static_cast<int32_t>(compiled_grammar_impl->grammar->NumRules());
+           ++rule_id) {
+        if (compiled_grammar_impl->grammar->GetRule(rule_id).name != "characters_item") {
+          continue;
+        }
+        const auto& hash = compiled_grammar_impl->grammar->per_rule_fsm_hashes[rule_id];
+        if (hash.has_value()) {
+          builtin_rule_fsm_hashes_.push_back(*hash);
+        }
+      }
+    }
     compiled_grammar_impl->tag_dispatch_rule_id_to_second_slicing_bitset =
         std::move(tag_dispatch_rule_id_to_second_slicing_bitset);
+    if (materialize_masks) {
+      for (int32_t rule_id = 0;
+           rule_id < static_cast<int32_t>(compiled_grammar_impl->grammar->NumRules());
+           ++rule_id) {
+        if (compiled_grammar_impl->grammar->GetRule(rule_id).name != "characters_item") {
+          continue;
+        }
+        const auto& rule_fsm = compiled_grammar_impl->grammar->per_rule_fsms[rule_id].value();
+        ParserState state(
+            rule_id,
+            compiled_grammar_impl->grammar->GetRule(rule_id).body_expr_id,
+            0,
+            ParserState::kNoPrevInputPos,
+            -1,
+            0
+        );
+        for (const auto& [element_id, normalized_state_id] :
+             compiled_grammar_impl->grammar->per_rule_fsm_new_state_ids[rule_id]) {
+          if (normalized_state_id != 0 || !rule_fsm.GetFsm().IsScanableState(element_id)) {
+            continue;
+          }
+          state.element_id = element_id;
+          compiled_grammar_impl->GetAdaptiveTokenMask(state, /*is_root_rule=*/false);
+          break;
+        }
+      }
+    }
     return CompiledGrammar(compiled_grammar_impl);
   }
+
+  compiled_grammar_impl->EnsureRuleLevelMetadata();
 
   // Step 3. Compute the adaptive token mask cache
   // The token mask cache is computed for these positions in the grammar:

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1412,7 +1412,11 @@ class GrammarFSMBuilderImpl {
         grammar_builder_(grammar_builder),
         regex_fsm_cache_(regex_fsm_cache) {}
 
-  static void Apply(Grammar* grammar, RegexFSMCache* supplied_regex_fsm_cache = nullptr) {
+  static void Apply(
+      Grammar* grammar,
+      RegexFSMCache* supplied_regex_fsm_cache = nullptr,
+      bool merge_equivalent_states = true
+  ) {
     FSM complete_fsm;
     std::vector<std::optional<FSMWithStartEndWithSize>> per_rule_fsms;
     std::vector<int> state_mapping;
@@ -1426,7 +1430,8 @@ class GrammarFSMBuilderImpl {
     int32_t num_original_rules = (*grammar)->NumRules();
     GrammarBuilder grammar_builder = GrammarBuilder::FromMutableGrammar(grammar);
     for (int i = 0; i < (*grammar)->NumRules(); ++i) {
-      auto rule_fsm = BuildRuleFSM(*grammar, i, &grammar_builder, regex_fsm_cache);
+      auto rule_fsm =
+          BuildRuleFSM(*grammar, i, &grammar_builder, regex_fsm_cache, merge_equivalent_states);
       per_rule_fsms.push_back(rule_fsm.AddToCompleteFSM(&complete_fsm, &state_mapping));
     }
 
@@ -1501,14 +1506,16 @@ class GrammarFSMBuilderImpl {
       const Grammar& grammar,
       int rule_id,
       GrammarBuilder* grammar_builder = nullptr,
-      RegexFSMCache* regex_fsm_cache = nullptr
+      RegexFSMCache* regex_fsm_cache = nullptr,
+      bool merge_equivalent_states = true
   );
   static FSMWithStartEnd BuildExpressionFSM(
       const GrammarExpr& expr,
       const Grammar& grammar,
       const std::string* rule_name = nullptr,
       GrammarBuilder* grammar_builder = nullptr,
-      RegexFSMCache* regex_fsm_cache = nullptr
+      RegexFSMCache* regex_fsm_cache = nullptr,
+      bool merge_equivalent_states = true
   );
   /*!
    * \brief Build the leaf FSM of an intersection operand. Regexes are compiled through the
@@ -1714,7 +1721,8 @@ FSMWithStartEnd GrammarFSMBuilderImpl::BuildRuleFSM(
     const Grammar& grammar,
     int rule_id,
     GrammarBuilder* grammar_builder,
-    RegexFSMCache* regex_fsm_cache
+    RegexFSMCache* regex_fsm_cache,
+    bool merge_equivalent_states
 ) {
   const auto& rule = grammar->GetRule(rule_id);
   return BuildExpressionFSM(
@@ -1722,7 +1730,8 @@ FSMWithStartEnd GrammarFSMBuilderImpl::BuildRuleFSM(
       grammar,
       &rule.name,
       grammar_builder,
-      regex_fsm_cache
+      regex_fsm_cache,
+      merge_equivalent_states
   );
 }
 
@@ -1731,7 +1740,8 @@ FSMWithStartEnd GrammarFSMBuilderImpl::BuildExpressionFSM(
     const Grammar& grammar,
     const std::string* rule_name,
     GrammarBuilder* grammar_builder,
-    RegexFSMCache* regex_fsm_cache
+    RegexFSMCache* regex_fsm_cache,
+    bool merge_equivalent_states
 ) {
   FSM result_fsm;
   int start_state = result_fsm.AddState();
@@ -1766,8 +1776,8 @@ FSMWithStartEnd GrammarFSMBuilderImpl::BuildExpressionFSM(
     if (!builder.can_skip_epsilon_simplification_) {
       result = result.SimplifyEpsilon();
     }
-    if (!builder.skip_equivalent_state_merge_) {
-      result = result.MergeEquivalentStates();
+    if (merge_equivalent_states && !builder.skip_equivalent_state_merge_) {
+      result = std::move(result).MergeEquivalentStates();
     }
   }
   return result;
@@ -2432,7 +2442,7 @@ Result<FSMWithStartEnd> GrammarFSMBuilderImpl::Regex(
   }
   auto result = std::move(build_result).Unwrap();
   result = result.SimplifyEpsilon();
-  result = result.MergeEquivalentStates();
+  result = std::move(result).MergeEquivalentStates();
   return ResultOk(std::move(result));
 }
 
@@ -2618,7 +2628,7 @@ Result<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildLeafExprFSM(
         }
         elements.push_back(std::move(element_result).Unwrap());
       }
-      return ResultOk(FSMWithStartEnd::Concat(elements));
+      return ResultOk(FSMWithStartEnd::Concat(std::move(elements)));
     }
     case ExprType::kChoices: {
       std::vector<FSMWithStartEnd> choices;
@@ -2630,7 +2640,7 @@ Result<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildLeafExprFSM(
         }
         choices.push_back(std::move(choice_result).Unwrap());
       }
-      return ResultOk(FSMWithStartEnd::Union(choices));
+      return ResultOk(FSMWithStartEnd::Union(std::move(choices)));
     }
     case ExprType::kEmptyStr:
     case ExprType::kByteString:
@@ -3549,7 +3559,8 @@ class GrammarOptimizerImpl {
   static Grammar Apply(
       const Grammar& grammar,
       bool expand_repetition_ranges,
-      RegexFSMCache* supplied_regex_fsm_cache = nullptr
+      RegexFSMCache* supplied_regex_fsm_cache = nullptr,
+      bool merge_equivalent_states = true
   ) {
     // A freshly converted JSON Schema may already have built regex FSMs for validation. Keep the
     // shared owner alive throughout optimization and reuse those FSMs during per-rule compilation.
@@ -3576,7 +3587,7 @@ class GrammarOptimizerImpl {
     result->allow_empty_rule_ids = AllowEmptyRuleAnalyzerImpl().Apply(result, regex_fsm_cache);
     ValidateLazyRules(result);
     RepetitionNormalizer::Apply(&result);
-    GrammarFSMBuilderImpl::Apply(&result, regex_fsm_cache);
+    GrammarFSMBuilderImpl::Apply(&result, regex_fsm_cache, merge_equivalent_states);
     result->optimized = true;
     return result;
   }
@@ -4696,6 +4707,17 @@ Grammar GrammarOptimizer::Apply(
     const Grammar& grammar, bool expand_repetition_ranges, RegexFSMCache* regex_fsm_cache
 ) {
   return GrammarOptimizerImpl::Apply(grammar, expand_repetition_ranges, regex_fsm_cache);
+}
+
+Grammar GrammarOptimizer::Apply(
+    const Grammar& grammar,
+    bool expand_repetition_ranges,
+    RegexFSMCache* regex_fsm_cache,
+    bool merge_equivalent_states
+) {
+  return GrammarOptimizerImpl::Apply(
+      grammar, expand_repetition_ranges, regex_fsm_cache, merge_equivalent_states
+  );
 }
 
 void ByteStringFuser::Apply(Grammar* grammar) { ByteStringFuserImpl().Apply(grammar); }

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -515,6 +515,13 @@ class GrammarOptimizer {
   static Grammar Apply(
       const Grammar& grammar, bool expand_repetition_ranges, RegexFSMCache* regex_fsm_cache
   );
+
+  static Grammar Apply(
+      const Grammar& grammar,
+      bool expand_repetition_ranges,
+      RegexFSMCache* regex_fsm_cache,
+      bool merge_equivalent_states
+  );
 };
 
 /*!

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -480,6 +480,7 @@ class GrammarMatcher::Impl : public EarleyParser {
         terminate_without_stop_token_(terminate_without_stop_token),
         default_temperature_(default_temperature),
         tmp_accepted_bitset_(tokenizer_info_.GetVocabSize()) {
+    compiled_grammar_->EnsureRuleLevelMetadata();
     XGRAMMAR_CHECK(!override_stop_tokens.has_value() || !override_stop_tokens->empty())
         << "The override_stop_tokens should not be empty";
     for (int token_id : stop_token_ids_) {
@@ -560,6 +561,7 @@ class GrammarMatcher::Impl : public EarleyParser {
     int32_t max_characters;
     ParserState parent;
     int32_t lower;
+    int32_t continuation_state;
     bool has_stable_upper;
   };
 
@@ -793,6 +795,7 @@ class GrammarMatcher::Impl : public EarleyParser {
   std::vector<int32_t> tmp_json_length_candidate_indices_;
   std::vector<int32_t> tmp_json_length_invalid_indices_;
   std::vector<int32_t> tmp_json_length_valid_escaped_indices_;
+  std::vector<int32_t> tmp_repeat_quote_crossing_indices_;
   std::vector<ParserState> tmp_latest_states_;
   std::vector<std::pair<const ParserState*, const AdaptiveTokenMask*>>
       tmp_latest_states_with_masks_;
@@ -1321,6 +1324,7 @@ GrammarMatcher::Impl::GetCharacterClassRepeat(const ParserState& state) const {
             std::min(remaining, max_token_characters),
             parent,
             repeat.Lower(),
+            edge.target,
             repeat.Upper() == -1 || remaining >= max_token_characters
         };
       }
@@ -2971,6 +2975,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
 ) {
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
   const auto& subtree_range = tokenizer_info_.GetTrieSubtreeNodesRange();
+  const auto& lcp_with_previous = tokenizer_info_.ImplPtr()->GetSortedVocabLCPWithPrevious();
   // We need to have a copy, because scanable_state_history_ will be modified during the
   // FillNextTokenBitmask process, which can lead to undefined behavior.
   auto& latest_states = tmp_latest_states_;
@@ -3091,7 +3096,37 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
     }
 
     const std::vector<int32_t>* indices_to_check = &adaptive_token_mask.uncertain_indices;
-
+    const CharacterClassRepeatTokenMask* quote_boundary_repeat_token_mask = nullptr;
+    bool repeat_continuation_requires_quote = false;
+    if (const auto repeat = GetCharacterClassRepeat(state); repeat.has_value()) {
+      const auto& continuation_edges = grammar_->complete_fsm.GetEdges(repeat->continuation_state);
+      repeat_continuation_requires_quote =
+          continuation_edges.size() != 0 && std::all_of(
+                                                continuation_edges.begin(),
+                                                continuation_edges.end(),
+                                                [](const FSMEdge& edge) {
+                                                  return edge.IsCharRange() && edge.min == '"' &&
+                                                         edge.max == '"';
+                                                }
+                                            );
+      if (repeat_continuation_requires_quote) {
+        quote_boundary_repeat_token_mask = &compiled_grammar_->GetCharacterClassRepeatTokenMask(
+            repeat->character_class_expr_id, repeat->has_stable_upper ? -1 : repeat->max_characters
+        );
+        if (!repeat->has_stable_upper) {
+          tmp_accepted_bitset_ |= quote_boundary_repeat_token_mask->accepted_prefix_tokens;
+        }
+        const auto& quote_flags = tokenizer_info_.ImplPtr()->GetJSONStringQuoteTokenFlags();
+        tmp_repeat_quote_crossing_indices_.clear();
+        tmp_repeat_quote_crossing_indices_.reserve(adaptive_token_mask.uncertain_indices.size());
+        for (int32_t token_index : adaptive_token_mask.uncertain_indices) {
+          if (quote_flags[token_index]) {
+            tmp_repeat_quote_crossing_indices_.push_back(token_index);
+          }
+        }
+        indices_to_check = &tmp_repeat_quote_crossing_indices_;
+      }
+    }
     // For each ParserState, we will check every uncertain token and put them into the accepted or
     // rejected list.
 
@@ -3111,6 +3146,17 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
       tmp_accepted_bitset_ |= tmp_state_accepted_bitset_;
       if (adaptive_token_mask.store_type == StoreType::kRejected) {
         tmp_rejected_indices_delta_ = tmp_json_length_invalid_indices_;
+      }
+    }
+    if (repeat_continuation_requires_quote &&
+        adaptive_token_mask.store_type == StoreType::kRejected) {
+      const auto& quote_flags = tokenizer_info_.ImplPtr()->GetJSONStringQuoteTokenFlags();
+      for (int32_t token_index : adaptive_token_mask.uncertain_indices) {
+        const int32_t token_id = sorted_decoded_vocab[token_index].first;
+        if (!quote_flags[token_index] &&
+            !quote_boundary_repeat_token_mask->accepted_prefix_tokens[token_id]) {
+          tmp_rejected_indices_delta_.push_back(token_index);
+        }
       }
     }
 
@@ -3157,6 +3203,17 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
     if (continuation_mask_key.has_value()) {
       continuation_accepted_indices.reserve(adaptive_token_mask.uncertain_indices.size());
       continuation_rejected_indices.reserve(adaptive_token_mask.uncertain_indices.size());
+      if (repeat_continuation_requires_quote &&
+          adaptive_token_mask.store_type == StoreType::kRejected) {
+        const auto& quote_flags = tokenizer_info_.ImplPtr()->GetJSONStringQuoteTokenFlags();
+        for (int32_t token_index : adaptive_token_mask.uncertain_indices) {
+          const int32_t token_id = sorted_decoded_vocab[token_index].first;
+          if (!quote_flags[token_index] &&
+              !quote_boundary_repeat_token_mask->accepted_prefix_tokens[token_id]) {
+            continuation_rejected_indices.push_back(token_index);
+          }
+        }
+      }
     }
 
     // Examine only the current one ParserState
@@ -3196,6 +3253,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
     }
 
     const std::string* prev_token = nullptr;
+    int32_t prev_token_idx = -1;
     int prev_matched_size = 0;
     if (debug_print) {
       XGRAMMAR_LOG(INFO) << "The ParserState is " << state << ", the mask is "
@@ -3229,11 +3287,16 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
       // Step 2.1. Find the longest common prefix with the accepted part of the previous token.
       // We can reuse the previous matched size to avoid unnecessary matching.
       if (prev_token) {
-        int lcp_len = std::mismatch(
+        int lcp_len =
+            cur_token_idx == prev_token_idx + 1
+                ? lcp_with_previous[cur_token_idx]
+                : static_cast<int>(
+                      std::mismatch(
                           cur_token.begin(), cur_token.end(), prev_token->begin(), prev_token->end()
                       )
                           .first -
-                      cur_token.begin();
+                      cur_token.begin()
+                  );
         if (lcp_len > prev_matched_size) {
           last_rejected_uncertain_range = subtree_range[cur_token_idx];
           accepted = false;
@@ -3303,6 +3366,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
       }
 
       prev_token = &cur_token;
+      prev_token_idx = cur_token_idx;
     }
 
     if (continuation_cache) {
@@ -3317,6 +3381,10 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
     constexpr size_t kMaxContinuationMaskCacheEntries = 64;
     if (continuation_mask_key.has_value() &&
         continuation_mask_cache_.size() < kMaxContinuationMaskCacheEntries) {
+      if (repeat_continuation_requires_quote &&
+          adaptive_token_mask.store_type == StoreType::kRejected) {
+        std::sort(continuation_rejected_indices.begin(), continuation_rejected_indices.end());
+      }
       continuation_mask_cache_.push_back(ContinuationMaskCacheEntry{
           std::move(*continuation_mask_key),
           &adaptive_token_mask,
@@ -3328,7 +3396,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
     if (adaptive_token_mask.store_type == StoreType::kRejected) {
       // Length-invalid cached tokens are collected before uncertain tokens are walked, so only
       // that combined path can disturb the naturally sorted uncertain-token order.
-      if (json_string_length_filter_needed) {
+      if (json_string_length_filter_needed || repeat_continuation_requires_quote) {
         std::sort(tmp_rejected_indices_delta_.begin(), tmp_rejected_indices_delta_.end());
         tmp_rejected_indices_delta_.erase(
             std::unique(tmp_rejected_indices_delta_.begin(), tmp_rejected_indices_delta_.end()),

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2827,12 +2827,13 @@ int32_t JSONSchemaConverter::GenerateFromSpec(
  * spellings. Fall back to the CFG expansion when the FSM regex engine does not support it.
  */
 int32_t JSONSchemaConverter::RegexExpression(
-    const std::string& regex, bool json_string, bool force_cfg_expansion
+    const std::string& regex, bool json_string, bool force_cfg_expansion, bool byte_mode
 ) {
   std::string cache_key;
-  cache_key.reserve(regex.size() + 2);
+  cache_key.reserve(regex.size() + 3);
   cache_key.push_back(static_cast<char>(json_string));
   cache_key.push_back(static_cast<char>(force_cfg_expansion));
+  cache_key.push_back(static_cast<char>(byte_mode));
   cache_key.append(regex);
   const auto cached = regex_expr_ids_.find(cache_key);
   if (cached != regex_expr_ids_.end()) {
@@ -2869,33 +2870,38 @@ int32_t JSONSchemaConverter::RegexExpression(
       }
     }
     if (may_have_large_json_repeat) {
-      auto can_defer =
-          RegexFSMBuilder::CanDeferLargeRepeat(regex, json_string, /*byte_mode=*/false);
+      auto can_defer = RegexFSMBuilder::CanDeferLargeRepeat(regex, json_string, byte_mode);
       defer_fsm_build = can_defer.IsOk() && std::move(can_defer).Unwrap();
     }
 
     std::string fsm_cache_key;
     if (!defer_fsm_build && regex_fsm_cache_ != nullptr) {
-      fsm_cache_key = MakeRegexFSMCacheKey(regex, json_string);
+      fsm_cache_key = MakeRegexFSMCacheKey(regex, json_string, byte_mode);
       const auto cached_fsm = regex_fsm_cache_->find(fsm_cache_key);
       if (cached_fsm != regex_fsm_cache_->end()) {
         fsm = &cached_fsm->second;
       }
     }
     if (!defer_fsm_build && fsm == nullptr) {
-      auto fsm_result = GrammarFSMBuilder::Regex(regex, json_string);
+      auto fsm_result = GrammarFSMBuilder::Regex(regex, json_string, byte_mode);
       if (fsm_result.IsOk()) {
+        auto built_fsm = std::move(fsm_result).Unwrap();
+        if (byte_mode) {
+          auto minimized_result = built_fsm.MinimizeDFA();
+          if (minimized_result.IsOk()) {
+            built_fsm = std::move(minimized_result).Unwrap();
+          }
+        }
         if (regex_fsm_cache_ != nullptr) {
           const auto inserted =
-              regex_fsm_cache_->emplace(std::move(fsm_cache_key), std::move(fsm_result).Unwrap());
+              regex_fsm_cache_->emplace(std::move(fsm_cache_key), std::move(built_fsm));
           fsm = &inserted.first->second;
         } else {
-          local_fsm.emplace(std::move(fsm_result).Unwrap());
+          local_fsm.emplace(std::move(built_fsm));
           fsm = &*local_fsm;
         }
       } else {
-        auto can_defer =
-            RegexFSMBuilder::CanDeferLargeRepeat(regex, json_string, /*byte_mode=*/false);
+        auto can_defer = RegexFSMBuilder::CanDeferLargeRepeat(regex, json_string, byte_mode);
         // The probe validates every atom and confirms that the real GrammarBuilder-backed path
         // can assemble this regex with compact repeat edges. Other build errors continue through
         // the ordinary fallback.
@@ -2910,13 +2916,13 @@ int32_t JSONSchemaConverter::RegexExpression(
             return fsm->IsEndState(state);
           });
       if (!language_is_empty) {
-        const int32_t result = builder_.AddRegex(regex, json_string);
+        const int32_t result = builder_.AddRegex(regex, json_string, byte_mode);
         regex_expr_ids_.emplace(std::move(cache_key), result);
         return result;
       }
     }
     if (defer_fsm_build) {
-      const int32_t result = builder_.AddRegex(regex, json_string);
+      const int32_t result = builder_.AddRegex(regex, json_string, byte_mode);
       regex_expr_ids_.emplace(std::move(cache_key), result);
       return result;
     }
@@ -3188,9 +3194,16 @@ int32_t JSONSchemaConverter::GenerateString(const StringSpec& spec, const std::s
   if (spec.format.has_value()) {
     auto regex = JSONFormatToRegexPattern(*spec.format);
     if (regex.has_value()) {
-      // The built-in format regexes use constructs that the FSM regex engine does not fully
-      // support yet (e.g. quoted email local parts), so they keep the CFG expansion.
-      return Sequence({ByteString("\""), RegexExpression(*regex, false, true), ByteString("\"")});
+      return Sequence(
+          {ByteString("\""),
+           RegexExpression(
+               *regex,
+               /*json_string=*/false,
+               /*force_cfg_expansion=*/false,
+               /*byte_mode=*/true
+           ),
+           ByteString("\"")}
+      );
     }
   }
   // Check for pattern

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -989,6 +989,7 @@ class SchemaParser {
   );
 
   std::string ComputeCacheKey(const picojson::value& schema);
+  void AppendCacheKey(const picojson::value& schema, std::string* result);
 
   static void WarnUnsupportedKeywords(
       const picojson::object& schema, const std::vector<std::string>& keywords, bool verbose = false
@@ -1001,6 +1002,13 @@ class SchemaParser {
 };
 
 std::string SchemaParser::ComputeCacheKey(const picojson::value& schema) {
+  std::string result;
+  result.reserve(256);
+  AppendCacheKey(schema, &result);
+  return result;
+}
+
+void SchemaParser::AppendCacheKey(const picojson::value& schema, std::string* result) {
   static const std::unordered_set<std::string> kSkippedKeys = {
       "title",
       "default",
@@ -1014,7 +1022,7 @@ std::string SchemaParser::ComputeCacheKey(const picojson::value& schema) {
   };
 
   if (schema.is<picojson::object>()) {
-    std::string result = "{";
+    result->push_back('{');
     std::vector<std::pair<const std::string*, const picojson::value*>> sorted_kv;
     for (const auto& kv : schema.get<picojson::object>()) {
       if (kSkippedKeys.count(kv.first) == 0) {
@@ -1027,25 +1035,29 @@ std::string SchemaParser::ComputeCacheKey(const picojson::value& schema) {
     int64_t idx = 0;
     for (const auto& [key, value] : sorted_kv) {
       if (idx != 0) {
-        result += ",";
+        result->push_back(',');
       }
       ++idx;
-      result += "\"" + *key + "\":" + ComputeCacheKey(*value);
+      result->push_back('"');
+      result->append(*key);
+      result->append("\":");
+      AppendCacheKey(*value, result);
     }
-    return result + "}";
+    result->push_back('}');
   } else if (schema.is<picojson::array>()) {
-    std::string result = "[";
+    result->push_back('[');
     int64_t idx = 0;
     for (const auto& item : schema.get<picojson::array>()) {
       if (idx != 0) {
-        result += ",";
+        result->push_back(',');
       }
       ++idx;
-      result += ComputeCacheKey(item);
+      AppendCacheKey(item, result);
     }
-    return result + "]";
+    result->push_back(']');
+  } else {
+    result->append(schema.serialize(false));
   }
-  return schema.serialize(false);
 }
 
 void SchemaParser::WarnUnsupportedKeywords(
@@ -1067,8 +1079,8 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
     std::optional<std::string> default_type
 ) {
   std::string cache_key = ComputeCacheKey(schema);
-  if (schema_cache_.count(cache_key)) {
-    return ResultOk(schema_cache_[cache_key]);
+  if (const auto cached = schema_cache_.find(cache_key); cached != schema_cache_.end()) {
+    return ResultOk(cached->second);
   }
 
   if (schema.is<bool>()) {
@@ -1077,8 +1089,8 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
           SchemaErrorType::kUnsatisfiableSchema, "Schema 'false' cannot accept any value"
       );
     }
-    auto spec = SchemaSpec::Make(AnySpec{}, cache_key, rule_name_hint);
-    schema_cache_[cache_key] = spec;
+    auto spec = SchemaSpec::Make(AnySpec{}, std::move(cache_key), rule_name_hint);
+    schema_cache_[spec->cache_key] = spec;
     return ResultOk(spec);
   }
 
@@ -1100,19 +1112,22 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
     auto ref_result = ParseRef(schema_obj);
     if (ref_result.IsErr()) return ResultErr(std::move(ref_result).UnwrapErr());
     auto ref_spec = std::move(ref_result).Unwrap();
-    result = SchemaSpec::Make(std::move(ref_spec), cache_key, rule_name_hint);
+    result = SchemaSpec::Make(std::move(ref_spec), std::move(cache_key), rule_name_hint);
   } else if (schema_obj.count("const")) {
     auto const_result = ParseConst(schema_obj);
     if (const_result.IsErr()) return ResultErr(std::move(const_result).UnwrapErr());
-    result = SchemaSpec::Make(std::move(const_result).Unwrap(), cache_key, rule_name_hint);
+    result =
+        SchemaSpec::Make(std::move(const_result).Unwrap(), std::move(cache_key), rule_name_hint);
   } else if (schema_obj.count("enum")) {
     auto enum_result = ParseEnum(schema_obj);
     if (enum_result.IsErr()) return ResultErr(std::move(enum_result).UnwrapErr());
-    result = SchemaSpec::Make(std::move(enum_result).Unwrap(), cache_key, rule_name_hint);
+    result =
+        SchemaSpec::Make(std::move(enum_result).Unwrap(), std::move(cache_key), rule_name_hint);
   } else if (schema_obj.count("anyOf")) {
     auto anyof_result = ParseAnyOf(schema_obj, "anyOf");
     if (anyof_result.IsErr()) return ResultErr(std::move(anyof_result).UnwrapErr());
-    result = SchemaSpec::Make(std::move(anyof_result).Unwrap(), cache_key, rule_name_hint);
+    result =
+        SchemaSpec::Make(std::move(anyof_result).Unwrap(), std::move(cache_key), rule_name_hint);
   } else if (schema_obj.count("oneOf")) {
     auto oneof_result = ParseOneOf(schema_obj);
     if (oneof_result.IsErr()) {
@@ -1122,19 +1137,24 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
       XGRAMMAR_LOG(WARNING) << oneof_result.ErrRef().what();
       auto anyof_result = ParseAnyOf(schema_obj, "oneOf");
       if (anyof_result.IsErr()) return ResultErr(std::move(anyof_result).UnwrapErr());
-      result = SchemaSpec::Make(std::move(anyof_result).Unwrap(), cache_key, rule_name_hint);
+      result =
+          SchemaSpec::Make(std::move(anyof_result).Unwrap(), std::move(cache_key), rule_name_hint);
     } else {
-      result = SchemaSpec::Make(std::move(oneof_result).Unwrap(), cache_key, rule_name_hint);
+      result =
+          SchemaSpec::Make(std::move(oneof_result).Unwrap(), std::move(cache_key), rule_name_hint);
     }
   } else if (schema_obj.count("allOf")) {
     auto allof_result = ParseAllOf(schema_obj);
     if (allof_result.IsErr()) return ResultErr(std::move(allof_result).UnwrapErr());
-    result = SchemaSpec::Make(std::move(allof_result).Unwrap(), cache_key, rule_name_hint);
+    result =
+        SchemaSpec::Make(std::move(allof_result).Unwrap(), std::move(cache_key), rule_name_hint);
   } else if (schema_obj.count("type") || default_type.has_value()) {
     if (schema_obj.count("type") && schema_obj.at("type").is<picojson::array>()) {
       auto type_array_result = ParseTypeArray(schema_obj, rule_name_hint);
       if (type_array_result.IsErr()) return ResultErr(std::move(type_array_result).UnwrapErr());
-      result = SchemaSpec::Make(std::move(type_array_result).Unwrap(), cache_key, rule_name_hint);
+      result = SchemaSpec::Make(
+          std::move(type_array_result).Unwrap(), std::move(cache_key), rule_name_hint
+      );
     } else {
       if (schema_obj.count("type") && !schema_obj.at("type").is<std::string>()) {
         return ResultErr<SchemaError>(SchemaErrorType::kInvalidSchema, "Type should be a string");
@@ -1144,31 +1164,39 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
       if (type == "integer") {
         auto int_result = ParseInteger(schema_obj);
         if (int_result.IsErr()) return ResultErr(std::move(int_result).UnwrapErr());
-        result = SchemaSpec::Make(std::move(int_result).Unwrap(), cache_key, rule_name_hint);
+        result =
+            SchemaSpec::Make(std::move(int_result).Unwrap(), std::move(cache_key), rule_name_hint);
       } else if (type == "number") {
         auto num_result = ParseNumber(schema_obj);
         if (num_result.IsErr()) return ResultErr(std::move(num_result).UnwrapErr());
-        result = SchemaSpec::Make(std::move(num_result).Unwrap(), cache_key, rule_name_hint);
+        result =
+            SchemaSpec::Make(std::move(num_result).Unwrap(), std::move(cache_key), rule_name_hint);
       } else if (type == "string") {
         auto str_result = ParseString(schema_obj);
         if (str_result.IsErr()) return ResultErr(std::move(str_result).UnwrapErr());
-        result = SchemaSpec::Make(std::move(str_result).Unwrap(), cache_key, rule_name_hint);
+        result =
+            SchemaSpec::Make(std::move(str_result).Unwrap(), std::move(cache_key), rule_name_hint);
       } else if (type == "boolean") {
         auto bool_result = ParseBoolean(schema_obj);
         if (bool_result.IsErr()) return ResultErr(std::move(bool_result).UnwrapErr());
-        result = SchemaSpec::Make(std::move(bool_result).Unwrap(), cache_key, rule_name_hint);
+        result =
+            SchemaSpec::Make(std::move(bool_result).Unwrap(), std::move(cache_key), rule_name_hint);
       } else if (type == "null") {
         auto null_result = ParseNull(schema_obj);
         if (null_result.IsErr()) return ResultErr(std::move(null_result).UnwrapErr());
-        result = SchemaSpec::Make(std::move(null_result).Unwrap(), cache_key, rule_name_hint);
+        result =
+            SchemaSpec::Make(std::move(null_result).Unwrap(), std::move(cache_key), rule_name_hint);
       } else if (type == "array") {
         auto array_result = ParseArray(schema_obj);
         if (array_result.IsErr()) return ResultErr(std::move(array_result).UnwrapErr());
-        result = SchemaSpec::Make(std::move(array_result).Unwrap(), cache_key, rule_name_hint);
+        result = SchemaSpec::Make(
+            std::move(array_result).Unwrap(), std::move(cache_key), rule_name_hint
+        );
       } else if (type == "object") {
         auto obj_result = ParseObject(schema_obj);
         if (obj_result.IsErr()) return ResultErr(std::move(obj_result).UnwrapErr());
-        result = SchemaSpec::Make(std::move(obj_result).Unwrap(), cache_key, rule_name_hint);
+        result =
+            SchemaSpec::Make(std::move(obj_result).Unwrap(), std::move(cache_key), rule_name_hint);
       } else {
         return ResultErr<SchemaError>(
             SchemaErrorType::kInvalidSchema, "Unsupported type \"" + type + "\""
@@ -1179,17 +1207,18 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
              schema_obj.count("unevaluatedProperties")) {
     auto obj_result = ParseObject(schema_obj);
     if (obj_result.IsErr()) return ResultErr(std::move(obj_result).UnwrapErr());
-    result = SchemaSpec::Make(std::move(obj_result).Unwrap(), cache_key, rule_name_hint);
+    result = SchemaSpec::Make(std::move(obj_result).Unwrap(), std::move(cache_key), rule_name_hint);
   } else if (schema_obj.count("items") || schema_obj.count("prefixItems") ||
              schema_obj.count("unevaluatedItems")) {
     auto array_result = ParseArray(schema_obj);
     if (array_result.IsErr()) return ResultErr(std::move(array_result).UnwrapErr());
-    result = SchemaSpec::Make(std::move(array_result).Unwrap(), cache_key, rule_name_hint);
+    result =
+        SchemaSpec::Make(std::move(array_result).Unwrap(), std::move(cache_key), rule_name_hint);
   } else {
-    result = SchemaSpec::Make(AnySpec{}, cache_key, rule_name_hint);
+    result = SchemaSpec::Make(AnySpec{}, std::move(cache_key), rule_name_hint);
   }
 
-  schema_cache_[cache_key] = result;
+  schema_cache_[result->cache_key] = result;
   return ResultOk(result);
 }
 
@@ -2506,6 +2535,115 @@ std::string JSONSchemaConverter::BuildTrieRegex(const TrieNode& node) const {
   return result;
 }
 
+FSMWithStartEnd JSONSchemaConverter::BuildTrieFSM(const TrieNode& root) const {
+  FSM fsm;
+  const int32_t start = fsm.AddState();
+  const int32_t sink = fsm.AddState();
+  const int32_t end = fsm.AddState();
+
+  // A mismatch from the raw ASCII property-name trie enters one shared JSON-string tail. The
+  // following states validate one escaped or UTF-8 encoded source character before reaching the
+  // sink; sharing them avoids copying the generic tail at every trie node.
+  const int32_t escape = fsm.AddState();
+  const int32_t escape_u = fsm.AddState();
+  const int32_t escape_hex_2 = fsm.AddState();
+  const int32_t escape_hex_3 = fsm.AddState();
+  const int32_t escape_hex_4 = fsm.AddState();
+  for (uint8_t escaped : std::string("\"/\\bfnrt")) {
+    fsm.AddEdge(escape, sink, escaped, escaped);
+  }
+  fsm.AddEdge(escape, escape_u, 'u', 'u');
+  auto add_hex_edges = [&](int32_t from, int32_t to) {
+    fsm.AddEdge(from, to, '0', '9');
+    fsm.AddEdge(from, to, 'A', 'F');
+    fsm.AddEdge(from, to, 'a', 'f');
+  };
+  add_hex_edges(escape_u, escape_hex_2);
+  add_hex_edges(escape_hex_2, escape_hex_3);
+  add_hex_edges(escape_hex_3, escape_hex_4);
+  add_hex_edges(escape_hex_4, sink);
+
+  const int32_t utf8_2_last = fsm.AddState();
+  const int32_t utf8_3_e0_second = fsm.AddState();
+  const int32_t utf8_3_general_second = fsm.AddState();
+  const int32_t utf8_3_ed_second = fsm.AddState();
+  const int32_t utf8_3_last = fsm.AddState();
+  const int32_t utf8_4_f0_second = fsm.AddState();
+  const int32_t utf8_4_general_second = fsm.AddState();
+  const int32_t utf8_4_f4_second = fsm.AddState();
+  const int32_t utf8_4_third = fsm.AddState();
+  const int32_t utf8_4_last = fsm.AddState();
+  fsm.AddEdge(utf8_2_last, sink, 0x80, 0xbf);
+  fsm.AddEdge(utf8_3_e0_second, utf8_3_last, 0xa0, 0xbf);
+  fsm.AddEdge(utf8_3_general_second, utf8_3_last, 0x80, 0xbf);
+  fsm.AddEdge(utf8_3_ed_second, utf8_3_last, 0x80, 0x9f);
+  fsm.AddEdge(utf8_3_last, sink, 0x80, 0xbf);
+  fsm.AddEdge(utf8_4_f0_second, utf8_4_third, 0x90, 0xbf);
+  fsm.AddEdge(utf8_4_general_second, utf8_4_third, 0x80, 0xbf);
+  fsm.AddEdge(utf8_4_f4_second, utf8_4_third, 0x80, 0x8f);
+  fsm.AddEdge(utf8_4_third, utf8_4_last, 0x80, 0xbf);
+  fsm.AddEdge(utf8_4_last, sink, 0x80, 0xbf);
+
+  std::unordered_map<const TrieNode*, int32_t> trie_states;
+  std::vector<const TrieNode*> trie_nodes;
+  trie_states.emplace(&root, fsm.AddState());
+  trie_nodes.push_back(&root);
+  for (size_t node_index = 0; node_index < trie_nodes.size(); ++node_index) {
+    const TrieNode* node = trie_nodes[node_index];
+    for (const auto& [byte, child] : node->children) {
+      if (trie_states.emplace(&child, fsm.AddState()).second) {
+        trie_nodes.push_back(&child);
+      }
+    }
+  }
+  fsm.AddEdge(start, trie_states.at(&root), '"', '"');
+
+  auto add_content_transitions = [&](int32_t state, const TrieNode* node) {
+    fsm.AddEdge(state, escape, '\\', '\\');
+    fsm.AddEdge(state, utf8_2_last, 0xc2, 0xdf);
+    fsm.AddEdge(state, utf8_3_e0_second, 0xe0, 0xe0);
+    fsm.AddEdge(state, utf8_3_general_second, 0xe1, 0xec);
+    fsm.AddEdge(state, utf8_3_ed_second, 0xed, 0xed);
+    fsm.AddEdge(state, utf8_3_general_second, 0xee, 0xef);
+    fsm.AddEdge(state, utf8_4_f0_second, 0xf0, 0xf0);
+    fsm.AddEdge(state, utf8_4_general_second, 0xf1, 0xf3);
+    fsm.AddEdge(state, utf8_4_f4_second, 0xf4, 0xf4);
+
+    std::array<bool, 128> reserved{};
+    reserved['"'] = true;
+    reserved['\\'] = true;
+    if (node != nullptr) {
+      for (const auto& [byte, child] : node->children) {
+        reserved[byte] = true;
+        fsm.AddEdge(state, trie_states.at(&child), byte, byte);
+      }
+      if (!node->is_terminal) {
+        fsm.AddEdge(state, end, '"', '"');
+      }
+    } else {
+      fsm.AddEdge(state, end, '"', '"');
+    }
+    for (int32_t byte = 0x20; byte <= 0x7f;) {
+      if (reserved[byte]) {
+        ++byte;
+        continue;
+      }
+      int32_t range_end = byte;
+      while (range_end + 1 <= 0x7f && !reserved[range_end + 1]) {
+        ++range_end;
+      }
+      fsm.AddEdge(state, sink, byte, range_end);
+      byte = range_end + 1;
+    }
+  };
+
+  for (const TrieNode* node : trie_nodes) {
+    add_content_transitions(trie_states.at(node), node);
+  }
+  add_content_transitions(sink, nullptr);
+  return FSMWithStartEnd(fsm, start, {end}, /*is_dfa=*/true);
+}
+
 int32_t JSONSchemaConverter::GetKeyPatternExcluding(
     const std::vector<ObjectSpec::Property>& properties, const std::string& rule_name
 ) {
@@ -2532,10 +2670,16 @@ int32_t JSONSchemaConverter::GetKeyPatternExcluding(
   int32_t key_rule_id = builder_.AddEmptyRuleWithHint(rule_name + "_addl_key");
   std::string key_rule_name = builder_.GetRule(key_rule_id).name;
   if (can_use_regex_fsm) {
+    std::string regex = "\\x22" + BuildTrieRegex(root);
+    if (regex_fsm_cache_ != nullptr) {
+      regex_fsm_cache_->emplace(
+          MakeRegexFSMCacheKey(regex, /*json_string=*/false), BuildTrieFSM(root)
+      );
+    }
     builder_.UpdateRuleBody(
         key_rule_id,
         builder_.AddRegex(
-            "\\x22" + BuildTrieRegex(root),
+            regex,
             /*json_string=*/false,
             /*byte_mode=*/false,
             /*has_json_string_normal_sink=*/true

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -424,7 +424,10 @@ class JSONSchemaConverter {
   int32_t KeyPatternExpression();
 
   int32_t RegexExpression(
-      const std::string& regex, bool json_string = false, bool force_cfg_expansion = false
+      const std::string& regex,
+      bool json_string = false,
+      bool force_cfg_expansion = false,
+      bool byte_mode = false
   );
 
   /*! \brief Compile a JSON Schema pattern with search, anchor, and string-length semantics. */

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -520,6 +520,7 @@ class JSONSchemaConverter {
   std::optional<std::string> BuildTrieNonterminalRegex(const TrieNode& node) const;
   std::optional<std::string> BuildTrieTerminalRegex(const TrieNode& node) const;
   std::string BuildTrieRegex(const TrieNode& node) const;
+  FSMWithStartEnd BuildTrieFSM(const TrieNode& node) const;
 
   // Reused grammar expression ids
   std::optional<int32_t> empty_expr_id_;

--- a/cpp/tokenizer_info.cc
+++ b/cpp/tokenizer_info.cc
@@ -416,6 +416,15 @@ TokenizerInfo::Impl::Impl(
 
 void TokenizerInfo::Impl::BuildTokenCharData() {
   constexpr int32_t kMaxPrecomputedJSONStringPrefixLimit = 32;
+  sorted_vocab_lcp_with_previous_.assign(sorted_decoded_vocab_.size(), 0);
+  for (int32_t index = 1; index < static_cast<int32_t>(sorted_decoded_vocab_.size()); ++index) {
+    const auto& current = sorted_decoded_vocab_[index].second;
+    const auto& previous = sorted_decoded_vocab_[index - 1].second;
+    sorted_vocab_lcp_with_previous_[index] = static_cast<int32_t>(
+        std::mismatch(current.begin(), current.end(), previous.begin(), previous.end()).first -
+        current.begin()
+    );
+  }
   token_char_counts_.assign(sorted_decoded_vocab_.size(), 0);
   json_string_plain_quote_token_indices_by_prefix_count_.clear();
   json_string_escaped_quote_token_indices_.clear();

--- a/cpp/tokenizer_info_impl.h
+++ b/cpp/tokenizer_info_impl.h
@@ -38,6 +38,9 @@ class TokenizerInfo::Impl {
     return sorted_decoded_vocab_;
   }
   const std::vector<int32_t>& GetTrieSubtreeNodesRange() const { return trie_subtree_nodes_range_; }
+  const std::vector<int32_t>& GetSortedVocabLCPWithPrevious() const {
+    return sorted_vocab_lcp_with_previous_;
+  }
   const std::vector<int32_t>& GetTokenIdToSortedVocabIndex() const {
     return token_id_to_sorted_vocab_index_;
   }
@@ -119,6 +122,8 @@ class TokenizerInfo::Impl {
   /*! \brief A pesudo-trie. trie_subtree_nodes_range[i] stores how many nodes there are in the
    * subtree. */
   std::vector<int32_t> trie_subtree_nodes_range_;
+  /*! \brief Common-prefix byte count between each sorted token and its predecessor. */
+  std::vector<int32_t> sorted_vocab_lcp_with_previous_;
   /*! \brief The stop tokens. When the GrammarMatcher can reach the end of the grammar,
    * stop tokens can be accepted. */
   std::vector<int32_t> stop_token_ids_;

--- a/tests/cpp/test_fsm_builder.cc
+++ b/tests/cpp/test_fsm_builder.cc
@@ -609,6 +609,21 @@ TEST(XGrammarFSMBuilderTest, TestRegexRepeatZero) {
   EXPECT_TRUE(RegexFSMBuilder::Build("a{1,0}").IsErr());
 }
 
+TEST(XGrammarFSMBuilderTest, TestRegexOptionalDoesNotAcceptPartialChildMatch) {
+  auto fsm_wse = RegexFSMBuilder::Build("a(-*a)?").Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString("a"));
+  EXPECT_TRUE(fsm_wse.AcceptString("a--a"));
+  EXPECT_FALSE(fsm_wse.AcceptString("a-"));
+  EXPECT_FALSE(fsm_wse.AcceptString("a--"));
+
+  // Optional must preserve every accepting state of a child with multiple alternatives.
+  fsm_wse = RegexFSMBuilder::Build("x(a|bc)?").Unwrap();
+  EXPECT_TRUE(fsm_wse.AcceptString("x"));
+  EXPECT_TRUE(fsm_wse.AcceptString("xa"));
+  EXPECT_TRUE(fsm_wse.AcceptString("xbc"));
+  EXPECT_FALSE(fsm_wse.AcceptString("xb"));
+}
+
 TEST(XGrammarFSMBuilderTest, TestRegexByteMode) {
   auto fsm_wse = RegexFSMBuilder::Build("[^\\x00-\\x7F]+", /*byte_mode=*/true).Unwrap();
   EXPECT_TRUE(fsm_wse.AcceptString("\x80"));

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -165,7 +165,7 @@ def test_recursive_json_string_character_class_summary_matches_eager(cache_enabl
 
 
 @pytest.mark.parametrize("cache_enabled", [False, True], ids=["cache-off", "cache-on"])
-def test_email_local_part_direct_mask_matches_token_oracle(cache_enabled):
+def test_email_format_regex_fsm_masks_match_eager_and_token_oracle(cache_enabled):
     vocabulary = [
         "a",
         "abc",
@@ -181,6 +181,8 @@ def test_email_local_part_direct_mask_matches_token_oracle(cache_enabled):
         ".-",
         "@",
         '"',
+        '\\"',
+        "\\\\",
         '",',
         "é",
         "中",
@@ -190,27 +192,44 @@ def test_email_local_part_direct_mask_matches_token_oracle(cache_enabled):
         b"\xff",
     ]
     tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
-    compiled = xgr.GrammarCompiler(
-        tokenizer_info, max_threads=1, cache_enabled=cache_enabled, enable_dynamic_compilation=True
-    ).compile_json_schema(
-        {
-            "type": "object",
-            "properties": {"email": {"type": "string", "format": "email"}},
-            "required": ["email"],
-            "additionalProperties": False,
-        },
-        any_whitespace=False,
-        strict_mode=True,
-    )
+    compiler_options = {
+        "tokenizer_info": tokenizer_info,
+        "max_threads": 1,
+        "cache_enabled": cache_enabled,
+    }
+    schema = {
+        "type": "object",
+        "properties": {"email": {"type": "string", "format": "email"}},
+        "required": ["email"],
+        "additionalProperties": False,
+    }
+    eager = xgr.GrammarCompiler(
+        **compiler_options, enable_dynamic_compilation=False
+    ).compile_json_schema(schema, any_whitespace=False, strict_mode=True)
+    dynamic = xgr.GrammarCompiler(
+        **compiler_options, enable_dynamic_compilation=True
+    ).compile_json_schema(schema, any_whitespace=False, strict_mode=True)
 
-    for prefix in ['{"email": "john', '{"email": "john.doe']:
-        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
-        assert matcher.accept_string(prefix)
-        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
-        assert matcher.fill_next_token_bitmask(bitmask)
-        mask = bitmask_to_bool_mask(bitmask, tokenizer_info.vocab_size)[0]
+    prefixes = []
+    for email_source in ["john.doe@example-domain.com", r"\"john..doe\"@example.org"]:
+        prefixes.extend(
+            '{"email": "' + email_source[:length] for length in range(len(email_source) + 1)
+        )
+
+    for prefix in prefixes:
+        eager_matcher = xgr.GrammarMatcher(eager, terminate_without_stop_token=True)
+        dynamic_matcher = xgr.GrammarMatcher(dynamic, terminate_without_stop_token=True)
+        assert eager_matcher.accept_string(prefix)
+        assert dynamic_matcher.accept_string(prefix)
+        eager_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        dynamic_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        assert eager_matcher.fill_next_token_bitmask(eager_bitmask)
+        assert dynamic_matcher.fill_next_token_bitmask(dynamic_bitmask)
+        torch.testing.assert_close(dynamic_bitmask, eager_bitmask, rtol=0, atol=0)
+
+        mask = bitmask_to_bool_mask(dynamic_bitmask, tokenizer_info.vocab_size)[0]
         for token_id in range(tokenizer_info.vocab_size):
-            assert bool(mask[token_id]) == matcher.fork().accept_token(token_id), token_id
+            assert bool(mask[token_id]) == dynamic_matcher.fork().accept_token(token_id), token_id
 
 
 def test_dynamic_masks_are_cached():

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -164,6 +164,55 @@ def test_recursive_json_string_character_class_summary_matches_eager(cache_enabl
         torch.testing.assert_close(actual_mask, expected_mask, rtol=0, atol=0)
 
 
+@pytest.mark.parametrize("cache_enabled", [False, True], ids=["cache-off", "cache-on"])
+def test_email_local_part_direct_mask_matches_token_oracle(cache_enabled):
+    vocabulary = [
+        "a",
+        "abc",
+        ".doe",
+        ".doe@example",
+        "@example",
+        "@example.com",
+        ".com",
+        '.com"',
+        '.com"}',
+        "-",
+        "..",
+        ".-",
+        "@",
+        '"',
+        '",',
+        "é",
+        "中",
+        "a中",
+        b"\xe4",
+        b"\xe4\xb8",
+        b"\xff",
+    ]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    compiled = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, cache_enabled=cache_enabled, enable_dynamic_compilation=True
+    ).compile_json_schema(
+        {
+            "type": "object",
+            "properties": {"email": {"type": "string", "format": "email"}},
+            "required": ["email"],
+            "additionalProperties": False,
+        },
+        any_whitespace=False,
+        strict_mode=True,
+    )
+
+    for prefix in ['{"email": "john', '{"email": "john.doe']:
+        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        assert matcher.accept_string(prefix)
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        assert matcher.fill_next_token_bitmask(bitmask)
+        mask = bitmask_to_bool_mask(bitmask, tokenizer_info.vocab_size)[0]
+        for token_id in range(tokenizer_info.vocab_size):
+            assert bool(mask[token_id]) == matcher.fork().accept_token(token_id), token_id
+
+
 def test_dynamic_masks_are_cached():
     tokenizer_info = xgr.TokenizerInfo(VOCABULARY, stop_token_ids=[])
     dynamic = _compile_builtin_json(

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -1951,6 +1951,8 @@ instance__accepted__test_email_format = [
     (r"\"very.(),:;<>[]\\\".VERY.\\\"very@\\\\ \\\"very\\\".unusual\"@strange.example.com", True),
     (r"user%example.com@example.org", True),
     (r"user-@example.org", True),
+    (r"é@example.com", False),
+    (r"中@example.com", False),
     (r"abc.example.com", False),
     (r"a@b@c@example.com", False),
     (r'a"b(c)d,e:f;g<h>i[j\k]l@example.com', False),
@@ -1972,6 +1974,12 @@ def test_email_format(instance: str, accepted: bool):
     check_schema_with_grammar(schema, expected_grammar)
 
     check_schema_with_instance(schema, '"' + instance + '"', is_accepted=accepted)
+
+
+def test_email_format_uses_regex_fsm():
+    grammar = _json_schema_to_ebnf({"type": "string", "format": "email"})
+    assert "Regex(" in grammar
+    assert "byte_mode=true" in grammar
 
 
 instance__accepted__test_date_format = [


### PR DESCRIPTION
## Summary

- reduce cold dynamic-mask cost with shared tokenizer classifications, reusable character-class summaries, continuation-mask reuse, and guarded direct paths for common JSON strings
- reduce JSON Schema compilation cost with canonical cache keys, direct FSM construction for additional-property key tries, move-aware FSM composition, and deferred rule metadata
- compile built-in JSON Schema formats as minimized byte-mode regex FSMs and classify stable byte loops through a general deterministic-FSM path
- remove the email-specific grammar recognizer, state machine, mutex, and cache; the optimized matcher contains no email constants or email grammar-shape checks
- fix `FSMWithStartEnd::Optional()` so optional expressions cannot accept a partial child match
- retain the exact matcher as the fallback whenever a direct path cannot prove that it is safe

## Motivation

Profiling the v0.2.6rc1 preview showed two broad costs in dynamic JSON Schema workloads:

1. cold token-mask generation repeatedly classified large portions of the vocabulary for equivalent parser states and common character classes
2. compilation built and compressed intermediate FSMs, then eagerly computed rule hashes and cacheability metadata even when no dynamic mask was requested

The first email optimization recovered the desired performance but encoded the exact expanded email grammar in the matcher. This revision represents built-in formats as ordinary byte regex FSMs, minimizes those DFAs, and recognizes reusable loop structure directly from any eligible deterministic byte FSM.

## Performance

The final generic byte-FSM implementation was compared with the preceding email-specialized implementation on the frozen 1,020-schema dataset: four balanced A/B rounds, dynamic compilation, cache disabled, and 16 CPU threads. Ratios are old/new, so values above 1 mean the new generic implementation is faster.

| Tokenizer | Mask mean | Mask p50 | Mask p90 | E2E mean | E2E p50 | E2E p90 |
|---|---:|---:|---:|---:|---:|---:|
| GPT-OSS | 1.0756x | 1.1896x | 1.0503x | 1.0644x | 1.0353x | 1.0461x |
| Kimi-K3 | 1.0679x | 1.0486x | 1.0203x | 1.0569x | 1.0133x | 1.0570x |
| DeepSeek V4 Pro | 1.0474x | 1.0533x | 1.0027x | 1.0388x | 1.0068x | 1.0655x |

Mean compilation ratios were 0.9956x, 0.9826x, and 0.9880x respectively, a 0.4%–1.8% regression that is outweighed by the mask-generation improvement. Mean end-to-end time improved by 3.9%–6.4% for all three tokenizers.

The minimized email DFA has 15 states, down from 22 before minimization.

## Correctness and validation

- exhaustive old-CFG/new-FSM differential: 41,280 constructed email cases, 4,898 accepted by both, with identical SHA-256 `ce07b8a61920ddac58bf4ed5942f628d6670dec20dc1c5942e170f3eabfabd5e`
- full schema A/B consistency for each tokenizer: 4,080 records with zero differences in sample IDs, statuses, accepted/total token counts, or mask-call counts
- eager/dynamic/token-oracle equality at every prefix of both a dot-atom email and a quoted local-part email, with cache enabled and disabled
- explicit non-ASCII email rejection coverage for `é@example.com` and `中@example.com`
- C++ suite: 100/100 passed
- Python non-HF suite: 3,797 passed, 1 skipped, 622 deselected
- pre-commit hooks, Ruff, clang-format, and `git diff --check`
