### PR TITLE
[fix]: reject NUL characters in regex instead of crashing

### DIFF
--- a/cpp/regex_converter.cc
+++ b/cpp/regex_converter.cc
@@ -24,6 +24,14 @@ class RegexConverter {
  public:
   explicit RegexConverter(const std::string& regex) : regex_(regex) {
     if (!regex.empty()) {
+      // ParseUTF8 takes a C string and stops at the first NUL, so a regex
+      // containing one would either yield an empty codepoint vector (leading
+      // NUL -- an out-of-bounds read below) or be silently truncated to the
+      // prefix. A NUL is never meaningful in a regex, so reject it here.
+      if (regex.find('\0') != std::string::npos) {
+        XGRAMMAR_LOG(FATAL) << "The regex must not contain null characters.";
+        XGRAMMAR_UNREACHABLE();
+      }
       regex_codepoints_ = ParseUTF8(regex_.c_str(), false);
       if (regex_codepoints_[0] == kInvalidUTF8) {
         XGRAMMAR_LOG(FATAL) << "The regex is not a valid UTF-8 string.";

--- a/tests/python/test_regex_converter.py
+++ b/tests/python/test_regex_converter.py
@@ -509,5 +509,18 @@ def test_empty(regex: str):
     assert not _is_grammar_accept_string(grammar, "a")
 
 
+# A NUL makes the std::string non-empty while its c_str() is empty (leading NUL)
+# or truncated (later NUL). ParseUTF8 consumes the C string, so a leading NUL
+# used to yield an empty codepoint vector and an out-of-bounds read, and a later
+# one silently compiled just the prefix.
+null_regex = ["\0", "\0abc", "a\0b", "[0-9]+\0"]
+
+
+@pytest.mark.parametrize("regex", null_regex)
+def test_null_character(regex: str):
+    with pytest.raises(RuntimeError, match="The regex must not contain null characters."):
+        xgr.Grammar.from_regex(regex)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
This PR is mainly for solving the bug of a regex whose first byte is NUL segfaults `Grammar.from_regex`. A NUL in any later position silently truncates the pattern instead.

Major consumers already added their own Python-level NUL guard because this crash cannot be caught downstream previously:

- vLLM — https://github.com/vllm-project/vllm/pull/51796
- SGLang — https://github.com/sgl-project/sglang/pull/34679

Those remain useful while older xgrammar releases are pinned, but they only cover the paths each project routes through `regex`. Fixing it here removes the need for the workaround and covers every entry point — including a JSON schema's `pattern`, which reaches the same converter.

```python
python3 -c 'import xgrammar; xgrammar.Grammar.from_regex(chr(0))'   # SIGSEGV
```

Because it is a signal rather than an exception, a caller cannot catch it: in a serving stack a single request carrying such a regex takes the whole process down.

## Root cause

`RegexConverter`'s constructor guards on `std::string::empty()` but then hands `regex_.c_str()` to `ParseUTF8`, which stops at the first NUL. Those are different predicates:

```cpp
if (!regex.empty()) {                                    // std::string is non-empty
  regex_codepoints_ = ParseUTF8(regex_.c_str(), false);  // ...but c_str() is empty
  if (regex_codepoints_[0] == kInvalidUTF8) {            // empty vector -> OOB read
```

- **Leading NUL** — `c_str()` is `""`, `ParseUTF8` returns an empty vector, and `regex_codepoints_[0]` reads past the end. SIGSEGV.
- **Later NUL** — `c_str()` is truncated, so only the prefix is compiled into the grammar. No crash, no warning, wrong result.

`ParseUTF8` has no length-aware overload, so the C string is the only thing it can key on.

This is the same family as #409, which fixed the empty-regex crash by adding the `!regex.empty()` guard — that guard checks the `std::string`, not the C string.

## Fix

Reject a NUL in the constructor, before `ParseUTF8`. `XGRAMMAR_LOG(FATAL)` surfaces in Python as an ordinary `RuntimeError`, the same path an unbalanced `[` already takes, so callers can handle it. This closes the silent-truncation case too.

Considered instead: making `ParseUTF8` length-aware so a NUL becomes a literal codepoint. That is a larger change to a shared utility, and it gives NUL a meaning a regex does not need. Happy to go that way if you prefer.

## Tests

`tests/python/test_regex_converter.py::test_null_character` — four cases, two leading NUL (the crash) and two non-leading (the truncation), so the check cannot later be narrowed to `startswith()`.

Built and run on aarch64:

- 4/4 new cases pass.
- **70 existing tests in that file still pass** (12 skipped: `hf_token_required`).
- Reached through a serving stack, an unmodified SGLang goes from a dead server to a clean HTTP 400 with the fix applied to xgrammar alone.