### PR TITLE
Optimize JSON Schema string length constraints

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -3190,19 +3190,31 @@ int32_t JSONSchemaConverter::GenerateNumber(const NumberSpec& spec, const std::s
 }
 
 int32_t JSONSchemaConverter::GenerateString(const StringSpec& spec, const std::string& rule_name) {
+  auto apply_length_constraint = [&](int32_t string_expr, const char* rule_suffix) {
+    if (spec.min_length == 0 && spec.max_length == -1) {
+      return string_expr;
+    }
+    int32_t length_rule_id = builder_.AddRuleWithHint(rule_name + rule_suffix, string_expr);
+    builder_.UpdateJSONStringLength(length_rule_id, spec.min_length, spec.max_length);
+    return RuleRef(length_rule_id);
+  };
+
   // Check for format
   if (spec.format.has_value()) {
     auto regex = JSONFormatToRegexPattern(*spec.format);
     if (regex.has_value()) {
-      return Sequence(
-          {ByteString("\""),
-           RegexExpression(
-               *regex,
-               /*json_string=*/false,
-               /*force_cfg_expansion=*/false,
-               /*byte_mode=*/true
-           ),
-           ByteString("\"")}
+      return apply_length_constraint(
+          Sequence(
+              {ByteString("\""),
+               RegexExpression(
+                   *regex,
+                   /*json_string=*/false,
+                   /*force_cfg_expansion=*/false,
+                   /*byte_mode=*/true
+               ),
+               ByteString("\"")}
+          ),
+          "_length"
       );
     }
   }
@@ -3213,23 +3225,9 @@ int32_t JSONSchemaConverter::GenerateString(const StringSpec& spec, const std::s
          JSONSchemaPatternExpression(*spec.pattern, spec.min_length, spec.max_length),
          ByteString("\"")}
     );
-    if (spec.min_length == 0 && spec.max_length == -1) {
-      return pattern_string;
-    }
-    int32_t length_rule_id =
-        builder_.AddRuleWithHint(rule_name + "_pattern_length", pattern_string);
-    builder_.UpdateJSONStringLength(length_rule_id, spec.min_length, spec.max_length);
-    return RuleRef(length_rule_id);
+    return apply_length_constraint(pattern_string, "_pattern_length");
   }
-  // Check for length constraints
-  if (spec.min_length != 0 || spec.max_length != -1) {
-    int32_t character =
-        builder_.AddCharacterClass({{'"', '"'}, {'\\', '\\'}, {'\r', '\r'}, {'\n', '\n'}}, true);
-    int32_t body = Repeat(rule_name + "_characters", character, spec.min_length, spec.max_length);
-    return Sequence({ByteString("\""), body, ByteString("\"")});
-  }
-  // Default string
-  return Sequence({ByteString("\""), RuleRef(kBasicStringSub)});
+  return apply_length_constraint(Sequence({ByteString("\""), RuleRef(kBasicStringSub)}), "_length");
 }
 
 int32_t JSONSchemaConverter::GenerateBoolean(

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -165,6 +165,76 @@ def test_recursive_json_string_character_class_summary_matches_eager(cache_enabl
 
 
 @pytest.mark.parametrize("cache_enabled", [False, True], ids=["cache-off", "cache-on"])
+def test_plain_json_string_length_masks_match_eager_and_token_oracle(cache_enabled):
+    vocabulary = [
+        '"',
+        '"}',
+        "a",
+        "ab",
+        "abc",
+        "abcd",
+        'a"',
+        'ab"',
+        'abc"',
+        'abcd"',
+        "é",
+        'é"',
+        "中",
+        '中"',
+        r"\u0061",
+        r'\u0061"',
+        r"\ud83d\ude00",
+        r'\ud83d\ude00"',
+        r"\"",
+        r"\\",
+        b"\xe4",
+        b"\xe4\xb8",
+        b"\xff",
+    ]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    compiler_options = {
+        "tokenizer_info": tokenizer_info,
+        "max_threads": 1,
+        "cache_enabled": cache_enabled,
+    }
+    schema = {
+        "type": "object",
+        "properties": {"value": {"type": "string", "minLength": 2, "maxLength": 3}},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    eager = xgr.GrammarCompiler(
+        **compiler_options, enable_dynamic_compilation=False
+    ).compile_json_schema(schema, any_whitespace=False, strict_mode=True)
+    dynamic = xgr.GrammarCompiler(
+        **compiler_options, enable_dynamic_compilation=True
+    ).compile_json_schema(schema, any_whitespace=False, strict_mode=True)
+
+    prefixes = [
+        '{"value": "',
+        '{"value": "a',
+        '{"value": "ab',
+        '{"value": "abc',
+        r'{"value": "\u0061',
+        r'{"value": "\ud83d\ude00a',
+    ]
+    for prefix in prefixes:
+        eager_matcher = xgr.GrammarMatcher(eager, terminate_without_stop_token=True)
+        dynamic_matcher = xgr.GrammarMatcher(dynamic, terminate_without_stop_token=True)
+        assert eager_matcher.accept_string(prefix)
+        assert dynamic_matcher.accept_string(prefix)
+        eager_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        dynamic_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        assert eager_matcher.fill_next_token_bitmask(eager_bitmask)
+        assert dynamic_matcher.fill_next_token_bitmask(dynamic_bitmask)
+        torch.testing.assert_close(dynamic_bitmask, eager_bitmask, rtol=0, atol=0)
+
+        mask = bitmask_to_bool_mask(dynamic_bitmask, tokenizer_info.vocab_size)[0]
+        for token_id in range(tokenizer_info.vocab_size):
+            assert bool(mask[token_id]) == dynamic_matcher.fork().accept_token(token_id), token_id
+
+
+@pytest.mark.parametrize("cache_enabled", [False, True], ids=["cache-off", "cache-on"])
 def test_email_format_regex_fsm_masks_match_eager_and_token_oracle(cache_enabled):
     vocabulary = [
         "a",
@@ -573,7 +643,7 @@ def test_rule_mask_sharing_respects_json_length_entry_and_reuses_inner_rule(
     )
 
     unbounded = compiler.compile_grammar(
-        'root ::= "x" target\n' 'target ::= "\\"" body "\\""\n' "body ::= [a]*"
+        'root ::= "x" target\ntarget ::= "\\"" body "\\""\nbody ::= [a]*'
     )
     matcher = xgr.GrammarMatcher(unbounded, terminate_without_stop_token=True)
     assert matcher.accept_string('x"')

--- a/tests/python/test_grammar_matcher_json_schema.py
+++ b/tests/python/test_grammar_matcher_json_schema.py
@@ -612,8 +612,8 @@ def test_json_schema_number_without_constraint():
 @pytest.mark.hf_token_required
 def test_rule_level_cache_cross_grammar():
     """
-    This test ensures the result after applying the rule-level cache is consistent with the previous
-    version (without rule-level cache).
+    This test ensures the result after applying the rule-level cache is consistent with a
+    cache-disabled compiler.
     """
 
     # fmt: off
@@ -918,44 +918,35 @@ def test_rule_level_cache_cross_grammar():
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_fast=True, trust_remote_code=True)
     tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
     grammar_compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=True)
-    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
     compiled_grammar_a = grammar_compiler.compile_json_schema(schema_a)
     compiled_grammar_b = grammar_compiler.compile_json_schema(schema_b)
     input_bytes_a = string_a.encode("utf-8")
-    matcher_a = xgr.GrammarMatcher(compiled_grammar_a)
     input_bytes_b = string_b.encode("utf-8")
-    matcher_b = xgr.GrammarMatcher(compiled_grammar_b)
 
-    rejected_sizes = []
+    def assert_mask_traces_equal(cached_grammar, reference_grammar, input_bytes):
+        cached_matcher = xgr.GrammarMatcher(cached_grammar)
+        reference_matcher = xgr.GrammarMatcher(reference_grammar)
+        cached_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        reference_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        for c in input_bytes:
+            cached_matcher.fill_next_token_bitmask(cached_bitmask)
+            reference_matcher.fill_next_token_bitmask(reference_bitmask)
+            assert cached_bitmask.equal(reference_bitmask)
+            assert cached_matcher.accept_string(bytes([c]))
+            assert reference_matcher.accept_string(bytes([c]))
+        cached_matcher.fill_next_token_bitmask(cached_bitmask)
+        reference_matcher.fill_next_token_bitmask(reference_bitmask)
+        assert cached_bitmask.equal(reference_bitmask)
 
-    for i, c in enumerate(input_bytes_a):
-        matcher_a.fill_next_token_bitmask(token_bitmask)
-        rejected_token_ids = _get_masked_tokens_from_bitmask(
-            token_bitmask, tokenizer_info.vocab_size
-        )
-        rejected_sizes.append(len(rejected_token_ids))
-        assert rejected_sizes[-1] == rejected_a[i], (rejected_sizes[-1], rejected_a[i])
-        assert matcher_a.accept_string(bytes([c]))
-
-    matcher_a.fill_next_token_bitmask(token_bitmask)
-    rejected_token_ids = _get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size)
-    rejected_sizes.append(len(rejected_token_ids))
-    assert rejected_sizes[-1] == rejected_a[-1]
-    rejected_sizes = []
-
-    for i, c in enumerate(input_bytes_b):
-        matcher_b.fill_next_token_bitmask(token_bitmask)
-        rejected_token_ids = _get_masked_tokens_from_bitmask(
-            token_bitmask, tokenizer_info.vocab_size
-        )
-        rejected_sizes.append(len(rejected_token_ids))
-        assert rejected_sizes[-1] == rejected_b[i], (rejected_sizes[-1], rejected_b[i])
-        assert matcher_b.accept_string(bytes([c]))
-
-    matcher_b.fill_next_token_bitmask(token_bitmask)
-    rejected_token_ids = _get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size)
-    rejected_sizes.append(len(rejected_token_ids))
-    assert rejected_sizes[-1] == rejected_b[-1]
+    # Keep the historical arrays as guards that the two long test inputs did not drift. Their
+    # values predate decoded JSON string length enforcement and are no longer semantic oracles.
+    assert len(rejected_a) == len(input_bytes_a) + 1
+    assert len(rejected_b) == len(input_bytes_b) + 1
+    reference_compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=False)
+    reference_a = reference_compiler.compile_json_schema(schema_a)
+    reference_b = reference_compiler.compile_json_schema(schema_b)
+    assert_mask_traces_equal(compiled_grammar_a, reference_a, input_bytes_a)
+    assert_mask_traces_equal(compiled_grammar_b, reference_b, input_bytes_b)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_grammar_parser.py
+++ b/tests/python/test_grammar_parser.py
@@ -344,13 +344,13 @@ def test_repetition_range_unbounded_roundtrip():
 
 
 def test_repetition_range_unbounded_json_schema():
-    """JSON schema minLength produces {n, -1} which round-trips through the parser."""
+    """JSON schema minLength uses runtime metadata that round-trips through the parser."""
     import json
 
     schema = json.dumps({"type": "string", "minLength": 2})
     grammar_1 = xgr.Grammar.from_json_schema(schema)
     output_1 = str(grammar_1)
-    assert "{2, -1}" in output_1
+    assert "root_length[json_string_min_length=2]" in output_1
     output_2 = str(xgr.Grammar.from_ebnf(output_1))
     assert output_1 == output_2
 

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2438,7 +2438,8 @@ def test_min_max_length():
     schema = {"type": "string", "minLength": 1, "maxLength": 10}
 
     ebnf_grammar = basic_json_rules_ebnf + (
-        r"""root ::= "\"" [^"\\\r\n]{1,10} "\""
+        r"""root ::= root_length
+root_length[json_string_min_length=1, json_string_max_length=10] ::= "\"" basic_string_sub
 """
     )
 
@@ -2449,6 +2450,33 @@ def test_min_max_length():
 
     check_schema_with_instance(schema, instance_accepted, any_whitespace=True)
     check_schema_with_instance(schema, instance_rejected, is_accepted=False, any_whitespace=True)
+
+
+@pytest.mark.parametrize(
+    "instance,accepted",
+    [
+        ('"a"', False),
+        ('"ab"', True),
+        ('"abc"', True),
+        ('"abcd"', False),
+        ('"é中"', True),
+        (r'"\u0061b"', True),
+        (r'"\ud83d\ude00a"', True),
+        (r'"\"a"', True),
+        (r'"\\a"', True),
+    ],
+)
+def test_min_max_length_counts_decoded_json_characters(instance: str, accepted: bool):
+    schema = {"type": "string", "minLength": 2, "maxLength": 3}
+    check_schema_with_instance(schema, instance, is_accepted=accepted, any_whitespace=False)
+
+
+def test_format_and_length_constraints_are_both_enforced():
+    schema = {"type": "string", "format": "email", "maxLength": 8}
+    check_schema_with_instance(schema, '"a@b.co"', any_whitespace=False)
+    check_schema_with_instance(
+        schema, '"verylong@example.com"', is_accepted=False, any_whitespace=False
+    )
 
 
 def test_type_array():
@@ -2462,7 +2490,8 @@ def test_type_array():
 
     ebnf_grammar = basic_json_rules_ebnf + (
         r"""root_type_0 ::= ( ( [1-9] | "1" "0" ) )
-root_type_1 ::= "\"" [^"\\\r\n]{1,10} "\""
+root_type_1 ::= root_type_1_length
+root_type_1_length[json_string_min_length=1, json_string_max_length=10] ::= "\"" basic_string_sub
 root ::= root_type_0 | root_type_1
 """
     )


### PR DESCRIPTION
## Motivation

Dynamic JSON Schema compilation still lowered plain `minLength` and `maxLength` constraints to counted grammar repetitions. This retained large parser-state sets for `minLength` and made bounded string states less reusable for `maxLength`. The plain-string lowering also excluded valid JSON escapes, while recognized `format` schemas returned before applying their length constraints.

## Changes

- Reuse the complete JSON string grammar for plain length-constrained strings.
- Enforce decoded character counts through the existing JSON string length rule metadata.
- Apply length metadata to recognized string formats as well as pattern strings.
- Keep unconstrained strings on their existing grammar and runtime path.
- Add eager/dynamic, cache-enabled/cache-disabled, Unicode, escape, format, serialization, and per-token mask coverage.
- Compare the cross-grammar shared-cache regression against a cache-disabled compiler with exact masks at every input position.

## Performance

The final wheel was benchmarked against `preview/v0.2.6rc1` in one Modal container pinned to one AMD EPYC 7R13 logical CPU.

| Workload | Baseline | This PR |
|---|---:|---:|
| `minLength=128` mask median | 41.641 ms | 8.066 ms |
| `minLength=129` mask median | 39.722 ms | 8.653 ms |
| `minLength=200` mask median | 40.537 ms | 8.322 ms |
| Kimi-K3 bounded 273-token mask total | 4.189 ms | 2.125 ms |
| Kimi-K3 bounded cold maximum | 3.103 ms | 0.516 ms |
| Kimi-K3 bounded/unbounded steady median | — | 5.140/5.100 µs |

The `minLength` cases improve by 4.59–5.16× and remain flat across the former threshold. The bounded and unbounded steady-state medians are equivalent; the remaining bounded cost is one small cold fill.

## Testing

- `941 passed` across the six directly affected Python test modules
- `3809 passed, 1 skipped, 622 deselected` across the repository with external-model tests deselected
- `100% tests passed, 0 tests failed out of 100` in a Release C++ build with internal checks enabled
- Repository pre-commit formatters, Ruff, and `git diff --check`

Fixes #805.
Fixes #852.
