### PR TITLE
fix: mask cache key, FSM aliasing, and lazy metadata race on the v0.2.6 preview branch

### DIFF
--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -300,7 +300,7 @@ std::optional<SerializationError> DeserializeJSONValue(
 /************** CompiledGrammar **************/
 
 std::size_t MemorySize(const CompiledGrammar::Impl& impl) {
-  std::lock_guard<std::mutex> lock(impl.adaptive_token_mask_cache_mutex);
+  std::scoped_lock lock(impl.adaptive_token_mask_cache_mutex, impl.rule_level_metadata_mutex);
   return MemorySize(impl.grammar) + MemorySize(impl.adaptive_token_mask_cache) +
          MemorySize(impl.tag_dispatch_rule_id_to_second_slicing_bitset) +
          MemorySize(impl.rule_level_cacheable) +

--- a/cpp/compiled_grammar_impl.h
+++ b/cpp/compiled_grammar_impl.h
@@ -165,6 +165,9 @@ class CompiledGrammar::Impl {
   /*! \brief Initializes rule hashes and context-independence metadata at most once. */
   mutable std::once_flag rule_level_metadata_once;
 
+  /*! \brief Protects lazy rule metadata from concurrent memory-size inspection. */
+  mutable std::mutex rule_level_metadata_mutex;
+
   /*! \brief Immutable builtin masks used to seed a cache-disabled dynamic grammar. */
   std::shared_ptr<RuleLevelCache> builtin_rule_level_cache_seed_source;
   std::vector<uint64_t> builtin_rule_fsm_hashes;

--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -548,7 +548,15 @@ void FSM::Impl::AddFSM(const FSM& fsm, std::vector<int>* state_mapping) {
 void FSM::Impl::AddFSM(FSM&& fsm, std::vector<int>* state_mapping) {
   // A copied FSM shares its implementation. Mutating it in place would also mutate the other
   // owners, so use the ordinary copy path unless this rvalue is the sole owner.
-  if (fsm.pimpl_.get() == this || fsm.pimpl_.use_count() != 1) {
+  // If the source is this FSM itself, first make an independent snapshot. The ordinary copy path
+  // cannot read from and append to the same vectors: resizing the destination would also change
+  // the source being iterated.
+  if (fsm.pimpl_.get() == this) {
+    FSM independent = fsm.Copy();
+    AddFSM(independent, state_mapping);
+    return;
+  }
+  if (fsm.pimpl_.use_count() != 1) {
     AddFSM(static_cast<const FSM&>(fsm), state_mapping);
     return;
   }
@@ -1372,6 +1380,12 @@ FSMWithStartEnd FSMWithStartEnd::Concat(std::vector<FSMWithStartEnd>&& fsms) {
   int start = first.GetStart();
   std::vector<int> previous_ends(first.GetEnds().begin(), first.GetEnds().end());
   FSM fsm = std::move(first.GetFsm());
+  // Moving the handle does not make its shared implementation unique.  If another input (or an
+  // external copy) aliases the first FSM, appending to fsm would mutate that not-yet-consumed
+  // source as well.  Detach the destination once before the concatenation loop.
+  if (!fsm.IsUnique()) {
+    fsm = fsm.Copy();
+  }
   std::vector<int32_t> ends;
   std::vector<int> state_mapping;
 

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -2871,6 +2871,7 @@ void CompiledGrammar::Impl::EnsureRuleLevelMetadata() {
     return;
   }
   std::call_once(rule_level_metadata_once, [this]() {
+    std::lock_guard<std::mutex> lock(rule_level_metadata_mutex);
     GrammarFSMHasher().Apply(&grammar);
     rule_level_cacheable = GetRuleLevelCacheableRules(grammar);
 

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -1477,6 +1477,20 @@ std::optional<std::vector<int32_t>> GrammarMatcher::Impl::GetContinuationMaskCac
       state.char_budget_deadline,
       IsCompleted()
   };
+  if (has_json_string_length_rules_) {
+    XGRAMMAR_DCHECK(!json_string_char_count_history_.empty());
+    const auto& counter = json_string_char_count_history_.back();
+    key.insert(
+        key.end(),
+        {counter.count,
+         static_cast<int32_t>(counter.unicode_value),
+         counter.unicode_digits_remaining,
+         counter.unicode_follows_high_surrogate,
+         counter.length_entered,
+         counter.length_suspended,
+         static_cast<int32_t>(counter.phase)}
+    );
+  }
   if (!canonicalize_context) {
     const auto parent_row = rule_id_to_completable_states_[state.rule_start_pos];
     if (parent_row.size() > kMaxParentStatesForContinuationMaskCache) {
@@ -3187,7 +3201,14 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
       );
       if (cached != continuation_mask_cache_.end()) {
         if (adaptive_token_mask.store_type == StoreType::kRejected) {
-          tmp_rejected_indices_delta_ = cached->rejected_indices;
+          if (json_string_length_filter_needed || repeat_continuation_requires_quote) {
+            std::sort(tmp_rejected_indices_delta_.begin(), tmp_rejected_indices_delta_.end());
+            tmp_rejected_indices_delta_.erase(
+                std::unique(tmp_rejected_indices_delta_.begin(), tmp_rejected_indices_delta_.end()),
+                tmp_rejected_indices_delta_.end()
+            );
+          }
+          IntsetUnion(&tmp_rejected_indices_delta_, cached->rejected_indices);
           IntsetUnion(&tmp_rejected_indices_delta_, adaptive_token_mask.rejected_indices);
           IntsetIntersection(&tmp_rejected_indices_, tmp_rejected_indices_delta_);
         } else {

--- a/tests/cpp/test_fsm.cc
+++ b/tests/cpp/test_fsm.cc
@@ -116,6 +116,21 @@ TEST(XGrammarFSMTest, ConnectionTest) {
   std::cout << "Connection Test Passed!" << std::endl;
 }
 
+TEST(XGrammarFSMTest, MoveConcatHandlesSharedInputFSM) {
+  FSM fsm(2);
+  fsm.AddEdge(0, 1, 'a', 'a');
+  FSMWithStartEnd shared(fsm, 0, {1});
+  std::vector<FSMWithStartEnd> inputs{shared, shared, shared};
+
+  auto concatenated = FSMWithStartEnd::Concat(std::move(inputs));
+
+  EXPECT_TRUE(concatenated.AcceptString("aaa"));
+  EXPECT_FALSE(concatenated.AcceptString("a"));
+  EXPECT_FALSE(concatenated.AcceptString("aa"));
+  EXPECT_FALSE(concatenated.AcceptString("aaaa"));
+  EXPECT_TRUE(shared.AcceptString("a"));
+}
+
 TEST(XGrammarFSMTest, SymbolTest) {
   std::cout << "--------- Symbol Test Starts! -----------" << std::endl;
   std::cout << "--------- Symbol Test1 -----------" << std::endl;

--- a/tests/cpp/test_grammar_matcher.cc
+++ b/tests/cpp/test_grammar_matcher.cc
@@ -1,10 +1,14 @@
 #include <gtest/gtest.h>
 #include <xgrammar/xgrammar.h>
 
+#include <atomic>
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <thread>
 #include <vector>
+
+#include "compiled_grammar_impl.h"
 
 namespace xgrammar {
 namespace {
@@ -83,6 +87,54 @@ TEST(GrammarMatcherTest, EOSExpressionConsumesStopTokenInsideGrammar) {
   EXPECT_FALSE(matcher.IsCompleted());
   EXPECT_FALSE(matcher.IsTerminated());
   EXPECT_TRUE(matcher.AcceptToken(2));
+}
+
+TEST(GrammarMatcherTest, MemorySizeIsSafeDuringLazyMetadataInitialization) {
+  std::string grammar = "root ::= r0\n";
+  constexpr int kRules = 512;
+  for (int i = 0; i < kRules; ++i) {
+    grammar += "r" + std::to_string(i) + " ::= [ab]";
+    if (i + 1 < kRules) {
+      grammar += " r" + std::to_string(i + 1);
+    }
+    grammar += " | \"\"\n";
+  }
+
+  TokenizerInfo tokenizer_info({"a", "b", "ab", "ba"});
+  GrammarCompiler compiler(
+      tokenizer_info,
+      /*max_threads=*/1,
+      /*cache_enabled=*/false,
+      /*max_memory_bytes=*/-1,
+      /*enable_dynamic_compilation=*/true
+  );
+  auto compiled = compiler.CompileGrammar(grammar);
+
+  std::atomic<bool> reader_ready{false};
+  std::atomic<bool> start{false};
+  std::atomic<bool> done{false};
+  std::atomic<bool> observed_zero_size{false};
+  std::thread reader([&]() {
+    reader_ready.store(true, std::memory_order_release);
+    while (!start.load(std::memory_order_acquire)) {
+    }
+    while (!done.load(std::memory_order_acquire)) {
+      if (compiled.MemorySizeBytes() == 0) {
+        observed_zero_size.store(true, std::memory_order_relaxed);
+      }
+    }
+  });
+  while (!reader_ready.load(std::memory_order_acquire)) {
+  }
+  start.store(true, std::memory_order_release);
+  compiled.ImplPtr()->EnsureRuleLevelMetadata();
+  done.store(true, std::memory_order_release);
+  reader.join();
+
+  EXPECT_FALSE(observed_zero_size.load(std::memory_order_relaxed));
+  EXPECT_EQ(
+      compiled.ImplPtr()->rule_level_cacheable.size(), compiled.ImplPtr()->grammar->NumRules()
+  );
 }
 
 }  // namespace

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -840,6 +840,42 @@ def test_continuation_transition_cache_filters_active_json_length(
             assert bool(allowed_tokens[token_id]) == oracle.accept_token(token_id), token_id
 
 
+@pytest.mark.parametrize("enable_dynamic_compilation", [False, True])
+def test_continuation_mask_cache_separates_json_string_lengths(enable_dynamic_compilation: bool):
+    pairs = [
+        chr(first) + chr(second)
+        for first in range(ord("a"), ord("n"))
+        for second in range(ord("a"), ord("n"))
+    ]
+    vocabulary = (
+        ['"', 'a"', "a", "abcd", r"\u0061", r'\u0061"', r'\u0061a"', r'\u0061aa"']
+        + pairs
+        + [pair + '"' for pair in pairs]
+    )
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    compiled = xgr.GrammarCompiler(
+        tokenizer_info,
+        max_threads=1,
+        cache_enabled=False,
+        enable_dynamic_compilation=enable_dynamic_compilation,
+    ).compile_grammar(
+        'root[json_string_min_length=2, json_string_max_length=3] ::= "\\"" body "\\""\n'
+        'body ::= [a-m] body | "\\\\u0061" body | ""'
+    )
+    matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+    bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+
+    assert matcher.accept_string('"')
+    assert matcher.fill_next_token_bitmask(bitmask)
+
+    assert matcher.accept_token(vocabulary.index("a"))
+    xgr.reset_token_bitmask(bitmask)
+    assert matcher.fill_next_token_bitmask(bitmask)
+    allowed_tokens = bitmask_to_bool_mask(bitmask, tokenizer_info.vocab_size)[0]
+    for token_id in range(tokenizer_info.vocab_size):
+        assert bool(allowed_tokens[token_id]) == matcher.fork().accept_token(token_id), token_id
+
+
 def test_continuation_mask_cache_classifies_tokens_independently_of_other_states(capfd):
     suffixes = [
         chr(first) + chr(second)


### PR DESCRIPTION
This PR fixes three correctness issues found while reviewing the dynamic compilation and token mask optimizations on this branch (#846).

## 1. FSM move-merge crashes when inputs alias each other

`FSM::AddFSM(FSM&&)` fell back to the in-place copy path when the rvalue aliased the destination, so growing the destination arrays also grew the source being iterated, which segfaults. `FSMWithStartEnd::Concat(std::move(...))` had the same problem when several inputs shared one underlying FSM (e.g. identical regex fragments served from the regex FSM cache): appending to the first input mutated the not-yet-consumed ones, duplicating content. The fix snapshots the source on self-append and detaches the destination once when it is not uniquely owned. Regression: `XGrammarFSMTest.MoveConcatHandlesSharedInputFSM`.

## 2. Continuation mask cache ignores JSON string length state

The continuation mask cache key did not include the JSON string length counter (decoded character count, pending unicode escape digits, surrogate flag, lexical phase). A matcher could reuse a mask computed at a different decoded string length and wrongly allow or reject tokens under `minLength`/`maxLength` constraints. The key now includes the full counter state, and on a cache hit the already-computed length-filtered rejections are merged with the cached rejection set instead of being overwritten. Regression: `test_continuation_mask_cache_separates_json_string_lengths`.

## 3. Data race between lazy rule metadata and memory accounting

`EnsureRuleLevelMetadata()` writes the rule-level metadata vectors under `std::call_once` on first matcher creation, while `MemorySizeBytes()` read the same vectors holding only the adaptive token mask cache mutex. ThreadSanitizer reports a data race when a thread queries memory size while another creates the first matcher. The metadata now has its own mutex taken by both sides, keeping initialization lazy. Regression: `GrammarMatcherTest.MemorySizeIsSafeDuringLazyMetadataInitialization`.

All C++ tests (102) and the dynamic compilation Python suite (68) pass. A/B benchmarks of the same tree with and without these commits (compilation, per-token mask filling with and without length constraints in both compilation modes, first-matcher creation, memory accounting) show no regression on length-unconstrained paths; length-constrained jit mask filling costs 2-4% from the finer cache key, and `memory_size_bytes` gains one mutex acquisition (~20ns per call).