### PR TITLE
[Fix] Desugar anyOf/oneOf/allOf with sibling keywords instead of silently dropping them

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -839,8 +839,22 @@ Result<picojson::object, SchemaError> MergeConjunctiveSchemaObjects(
         "present on both sides of the conjunction"
     );
   }
+  auto is_string_array = [](const picojson::value& v) {
+    if (!v.is<picojson::array>()) {
+      return false;
+    }
+    const auto& arr = v.get<picojson::array>();
+    return std::all_of(arr.begin(), arr.end(), [](const picojson::value& element) {
+      return element.is<std::string>();
+    });
+  };
   picojson::object merged = lhs;
   for (const auto& [key, value] : rhs) {
+    if (key == "required" && !is_string_array(value)) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kInvalidSchema, "required must be an array of strings"
+      );
+    }
     auto it = merged.find(key);
     if (it == merged.end()) {
       merged[key] = value;
@@ -850,7 +864,7 @@ Result<picojson::object, SchemaError> MergeConjunctiveSchemaObjects(
       continue;  // keep lhs annotation
     }
     if (key == "required") {
-      if (!it->second.is<picojson::array>() || !value.is<picojson::array>()) {
+      if (!is_string_array(it->second)) {
         return ResultErr<SchemaError>(
             SchemaErrorType::kInvalidSchema, "required must be an array of strings"
         );
@@ -949,7 +963,9 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
     if (primary == "allOf") {
       // Fold every branch and the siblings into one equivalent schema object. This also fixes
       // allOf with multiple options, which previously degraded to an unconstrained grammar.
-      bool fused_ok = !branches.empty();
+      // An empty allOf constrains nothing (vacuous truth), so with siblings present it desugars
+      // to the siblings alone; without siblings it keeps the existing dispatch path.
+      bool fused_ok = !branches.empty() || !siblings.empty();
       picojson::object fused = siblings;
       for (const auto& branch : branches) {
         if (branch.is<bool>()) {

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -767,6 +767,121 @@ void SchemaParser::WarnUnsupportedKeywords(
   }
 }
 
+/*!
+ * \brief Keywords that only annotate a schema and impose no constraint on instances.
+ */
+inline bool IsAnnotationKeyword(const std::string& key) {
+  static const std::unordered_set<std::string> kAnnotationKeywords = {
+      "$schema",
+      "$id",
+      "$comment",
+      "title",
+      "description",
+      "default",
+      "examples",
+      "deprecated",
+      "readOnly",
+      "writeOnly",
+      "$defs",
+      "definitions",
+  };
+  return kAnnotationKeywords.count(key) > 0;
+}
+
+/*!
+ * \brief Merge two conjoined schema objects into a single object with the same meaning.
+ *
+ * JSON Schema keywords at one node are conjunctive, so two schema objects that must hold
+ * simultaneously can be merged by taking the union of their keywords, as long as no keyword's
+ * meaning changes by being placed next to the other object's keywords. Returns
+ * kUnsupportedSchema when an equivalent merge cannot be constructed, so the caller can fail
+ * loudly instead of dropping constraints.
+ */
+Result<picojson::object, SchemaError> MergeConjunctiveSchemaObjects(
+    const picojson::object& lhs, const picojson::object& rhs
+) {
+  // $ref cannot be merged textually without resolving it first.
+  static const std::unordered_set<std::string> kUnmergeableKeywords = {"$ref"};
+  // Keywords whose meaning depends on sibling keywords in the same schema object (e.g.
+  // additionalProperties is scoped by the properties/patternProperties beside it). They may all
+  // come from one side only; splitting them across sides would change their meaning.
+  static const std::unordered_set<std::string> kStructuralKeywords = {
+      "properties",
+      "patternProperties",
+      "additionalProperties",
+      "unevaluatedProperties",
+      "propertyNames",
+      "items",
+      "prefixItems",
+      "unevaluatedItems",
+      "contains",
+      "minContains",
+      "maxContains",
+  };
+  auto has_any = [](const picojson::object& obj, const std::unordered_set<std::string>& keys) {
+    for (const auto& [key, value] : obj) {
+      if (keys.count(key) > 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+  if (has_any(lhs, kUnmergeableKeywords) || has_any(rhs, kUnmergeableKeywords)) {
+    return ResultErr<SchemaError>(
+        SchemaErrorType::kUnsupportedSchema,
+        "Cannot merge combinator siblings: $ref cannot be merged with other keywords"
+    );
+  }
+  if (has_any(lhs, kStructuralKeywords) && has_any(rhs, kStructuralKeywords)) {
+    return ResultErr<SchemaError>(
+        SchemaErrorType::kUnsupportedSchema,
+        "Cannot merge combinator siblings: structural keywords (properties/items/...) are "
+        "present on both sides of the conjunction"
+    );
+  }
+  picojson::object merged = lhs;
+  for (const auto& [key, value] : rhs) {
+    auto it = merged.find(key);
+    if (it == merged.end()) {
+      merged[key] = value;
+      continue;
+    }
+    if (IsAnnotationKeyword(key)) {
+      continue;  // keep lhs annotation
+    }
+    if (key == "required") {
+      if (!it->second.is<picojson::array>() || !value.is<picojson::array>()) {
+        return ResultErr<SchemaError>(
+            SchemaErrorType::kInvalidSchema, "required must be an array of strings"
+        );
+      }
+      picojson::array result = it->second.get<picojson::array>();
+      for (const auto& item : value.get<picojson::array>()) {
+        bool found = false;
+        for (const auto& existing : result) {
+          if (existing.serialize(false) == item.serialize(false)) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          result.push_back(item);
+        }
+      }
+      it->second = picojson::value(result);
+      continue;
+    }
+    if (it->second.serialize(false) == value.serialize(false)) {
+      continue;  // identical constraints collapse
+    }
+    return ResultErr<SchemaError>(
+        SchemaErrorType::kUnsupportedSchema,
+        "Cannot merge combinator siblings: conflicting values for keyword \"" + key + "\""
+    );
+  }
+  return ResultOk(std::move(merged));
+}
+
 Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
     const picojson::value& schema,
     const std::string& rule_name_hint,
@@ -799,6 +914,117 @@ Result<SchemaSpecPtr, SchemaError> SchemaParser::Parse(
   WarnUnsupportedKeywords(
       schema_obj, {"not", "if", "then", "else", "dependentRequired", "dependentSchemas"}
   );
+
+  // JSON Schema keywords are conjunctive: every keyword present at a node applies
+  // simultaneously. The dispatch chain below handles exactly one keyword group per node, so a
+  // combinator (anyOf/oneOf/allOf) would shadow its structural siblings: e.g.
+  // {"properties": ..., "additionalProperties": false, "anyOf": [...]} used to compile as if
+  // only the anyOf were present, silently producing an under-constrained grammar. Desugar such
+  // nodes before dispatching:
+  //   {K..., anyOf: [B1..Bn]}  ->  {anyOf: [merge(K,B1) .. merge(K,Bn)]}
+  //     (sound by distributivity of conjunction over disjunction; same for oneOf)
+  //   {K..., allOf: [B1..Bn]}  ->  merge(K, B1, .., Bn)
+  // and fail with kUnsupportedSchema when an equivalent merge cannot be constructed, rather
+  // than dropping constraints.
+  if (schema_obj.count("anyOf") || schema_obj.count("oneOf") || schema_obj.count("allOf")) {
+    // Non-annotation keywords beside the primary combinator (may include other combinators;
+    // those are desugared recursively).
+    const std::string primary = schema_obj.count("allOf")   ? "allOf"
+                                : schema_obj.count("anyOf") ? "anyOf"
+                                                            : "oneOf";
+    picojson::object siblings;
+    for (const auto& [key, value] : schema_obj) {
+      if (key == primary || IsAnnotationKeyword(key)) {
+        continue;
+      }
+      siblings[key] = value;
+    }
+    if (!schema_obj.at(primary).is<picojson::array>()) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kInvalidSchema, primary + " must be an array"
+      );
+    }
+    const auto& branches = schema_obj.at(primary).get<picojson::array>();
+
+    if (primary == "allOf") {
+      // Fold every branch and the siblings into one equivalent schema object. This also fixes
+      // allOf with multiple options, which previously degraded to an unconstrained grammar.
+      bool fused_ok = !branches.empty();
+      picojson::object fused = siblings;
+      for (const auto& branch : branches) {
+        if (branch.is<bool>()) {
+          if (branch.get<bool>()) {
+            continue;  // {} constrains nothing
+          }
+          return ResultErr<SchemaError>(
+              SchemaErrorType::kUnsatisfiableSchema, "allOf contains a 'false' schema"
+          );
+        }
+        if (!branch.is<picojson::object>()) {
+          fused_ok = false;
+          break;
+        }
+        auto merge_result = MergeConjunctiveSchemaObjects(fused, branch.get<picojson::object>());
+        if (merge_result.IsErr()) {
+          if (!siblings.empty()) {
+            return ResultErr(std::move(merge_result).UnwrapErr());
+          }
+          fused_ok = false;  // pure allOf: fall back to the existing ParseAllOf path
+          break;
+        }
+        fused = std::move(merge_result).Unwrap();
+      }
+      if (fused_ok) {
+        auto sub_result = Parse(picojson::value(fused), rule_name_hint, default_type);
+        if (sub_result.IsErr()) {
+          return sub_result;
+        }
+        auto spec = std::move(sub_result).Unwrap();
+        schema_cache_[cache_key] = spec;
+        return ResultOk(spec);
+      }
+    } else if (!siblings.empty()) {
+      // anyOf/oneOf with structural siblings: distribute the siblings into every branch.
+      picojson::array merged_branches;
+      bool distributed_ok = true;
+      for (const auto& branch : branches) {
+        if (branch.is<bool>()) {
+          if (branch.get<bool>()) {
+            merged_branches.push_back(picojson::value(siblings));
+          }
+          // a 'false' branch can never be satisfied and is dropped
+          continue;
+        }
+        if (!branch.is<picojson::object>()) {
+          distributed_ok = false;
+          break;
+        }
+        auto merge_result =
+            MergeConjunctiveSchemaObjects(siblings, branch.get<picojson::object>());
+        if (merge_result.IsErr()) {
+          return ResultErr(std::move(merge_result).UnwrapErr());
+        }
+        merged_branches.push_back(picojson::value(std::move(merge_result).Unwrap()));
+      }
+      if (distributed_ok) {
+        if (merged_branches.empty()) {
+          return ResultErr<SchemaError>(
+              SchemaErrorType::kUnsatisfiableSchema,
+              primary + " contains no satisfiable branch"
+          );
+        }
+        picojson::object rewritten;
+        rewritten[primary] = picojson::value(merged_branches);
+        auto sub_result = Parse(picojson::value(rewritten), rule_name_hint, default_type);
+        if (sub_result.IsErr()) {
+          return sub_result;
+        }
+        auto spec = std::move(sub_result).Unwrap();
+        schema_cache_[cache_key] = spec;
+        return ResultOk(spec);
+      }
+    }
+  }
 
   SchemaSpecPtr result;
 

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3489,6 +3489,32 @@ def test_allof_multiple_options_fused():
     check_schema_with_instance(schema, {}, is_accepted=False, any_whitespace=False)
 
 
+def test_empty_allof_with_structural_siblings():
+    # allOf: [] is vacuously true (the spec requires a non-empty array, but tolerate it):
+    # the structural siblings must still apply instead of being dropped.
+    schema = {
+        "type": "object",
+        "properties": {"modifier": {"enum": ["", "dark"]}},
+        "allOf": [],
+        "additionalProperties": False,
+    }
+    check_schema_with_instance(schema, {"modifier": "dark"}, any_whitespace=False)
+    check_schema_with_instance(schema, {"zzz": [1, 2, 3]}, is_accepted=False, any_whitespace=False)
+
+
+def test_merged_required_with_non_string_elements_raises():
+    # The conjunctive merge must validate required element types instead of failing with an
+    # opaque picojson type error downstream.
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "string"}},
+        "anyOf": [{"required": [123]}],
+        "additionalProperties": False,
+    }
+    with pytest.raises(Exception, match="required must be an array of strings"):
+        xgr.Grammar.from_json_schema(json.dumps(schema), any_whitespace=False)
+
+
 def test_combinator_sibling_merge_conflict_raises():
     """When an equivalent merge cannot be constructed, compilation must fail loudly instead of
     silently dropping constraints."""

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3410,5 +3410,108 @@ def test_compile_json_schema_any_order(cache_enabled: bool):
     assert ordered != any_order
 
 
+def test_anyof_with_structural_siblings():
+    """Regression test for https://github.com/mlc-ai/xgrammar/issues/858: a combinator used to
+    shadow its structural siblings (properties/additionalProperties/...), silently compiling to
+    an under-constrained grammar."""
+    schema = {
+        "type": "object",
+        "properties": {"modifier": {"enum": ["", "dark"]}},
+        "anyOf": [{"required": ["modifier"]}],
+        "additionalProperties": False,
+    }
+    check_schema_with_instance(schema, {"modifier": "dark"}, any_whitespace=False)
+    check_schema_with_instance(schema, {"modifier": ""}, any_whitespace=False)
+    # additionalProperties: false must survive the sibling anyOf
+    check_schema_with_instance(schema, {"zzz": [1, 2, 3]}, is_accepted=False, any_whitespace=False)
+    # the property subschema must survive as well
+    check_schema_with_instance(schema, {"modifier": 42}, is_accepted=False, any_whitespace=False)
+    # the distributed required from the anyOf branch must apply
+    check_schema_with_instance(schema, {}, is_accepted=False, any_whitespace=False)
+    # non-objects must be rejected
+    check_schema_with_instance(schema, [1, "two"], is_accepted=False, any_whitespace=False)
+    check_schema_with_instance(schema, '"just a string"', is_accepted=False, any_whitespace=False)
+
+
+def test_oneof_with_structural_siblings():
+    schema = {
+        "type": "object",
+        "properties": {"modifier": {"enum": ["", "dark"]}},
+        "oneOf": [{"required": ["modifier"]}],
+        "additionalProperties": False,
+    }
+    check_schema_with_instance(schema, {"modifier": "dark"}, any_whitespace=False)
+    check_schema_with_instance(schema, {"zzz": [1, 2, 3]}, is_accepted=False, any_whitespace=False)
+    check_schema_with_instance(schema, {}, is_accepted=False, any_whitespace=False)
+
+
+def test_anyof_siblings_distributed_over_multiple_branches():
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "string"}, "b": {"type": "integer"}},
+        "additionalProperties": False,
+        "anyOf": [{"required": ["a"]}, {"required": ["b"]}],
+    }
+    check_schema_with_instance(schema, {"a": "x"}, any_whitespace=False)
+    check_schema_with_instance(schema, {"b": 1}, any_whitespace=False)
+    check_schema_with_instance(schema, {"a": "x", "b": 1}, any_whitespace=False)
+    check_schema_with_instance(schema, {}, is_accepted=False, any_whitespace=False)
+    check_schema_with_instance(schema, {"c": 1}, is_accepted=False, any_whitespace=False)
+
+
+def test_allof_with_structural_siblings():
+    schema = {
+        "type": "object",
+        "properties": {"modifier": {"enum": ["", "dark"]}},
+        "allOf": [{"required": ["modifier"]}],
+        "additionalProperties": False,
+    }
+    check_schema_with_instance(schema, {"modifier": "dark"}, any_whitespace=False)
+    check_schema_with_instance(schema, {"zzz": [1, 2, 3]}, is_accepted=False, any_whitespace=False)
+    check_schema_with_instance(schema, {}, is_accepted=False, any_whitespace=False)
+
+
+def test_allof_multiple_options_fused():
+    """allOf with multiple mergeable options used to degrade to an unconstrained grammar
+    ("Support for allOf with multiple options is still ongoing")."""
+    schema = {
+        "allOf": [
+            {
+                "type": "object",
+                "properties": {"modifier": {"enum": ["", "dark"]}},
+                "additionalProperties": False,
+            },
+            {"required": ["modifier"]},
+        ]
+    }
+    check_schema_with_instance(schema, {"modifier": ""}, any_whitespace=False)
+    check_schema_with_instance(schema, {"zzz": [1, 2, 3]}, is_accepted=False, any_whitespace=False)
+    check_schema_with_instance(schema, {}, is_accepted=False, any_whitespace=False)
+
+
+def test_combinator_sibling_merge_conflict_raises():
+    """When an equivalent merge cannot be constructed, compilation must fail loudly instead of
+    silently dropping constraints."""
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "string"}},
+        "anyOf": [{"properties": {"a": {"type": "integer"}}}],
+    }
+    with pytest.raises(Exception):
+        xgr.Grammar.from_json_schema(json.dumps(schema))
+
+
+def test_anyof_with_annotation_siblings_unchanged():
+    # Annotation-only siblings (title/description/...) must not trigger desugaring.
+    schema = {
+        "title": "A union",
+        "description": "desc",
+        "anyOf": [{"type": "integer"}, {"type": "string"}],
+    }
+    check_schema_with_instance(schema, 1, any_whitespace=False)
+    check_schema_with_instance(schema, '"x"', any_whitespace=False)
+    check_schema_with_instance(schema, [1], is_accepted=False, any_whitespace=False)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
## Summary

Fixes #858.

`SchemaParser::Parse` dispatches on a first-match basis, so when a node contains `anyOf` / `oneOf` / `allOf`, the parser returns at the combinator branch and silently drops all sibling keywords (`properties`, `additionalProperties`, `required`, `type`, ...). Since JSON Schema keywords are conjunctive, this produced under-constrained grammars that accept invalid output — e.g. with `strict_mode=true` and `additionalProperties: false`, arbitrary keys with arbitrary values were accepted.

This PR desugars such nodes into an equivalent combinator-only schema before dispatch, instead of dropping constraints:

- **`allOf` + siblings**: fold all branches and the non-annotation siblings into a single fused schema object via a conservative conjunctive merge. This also fixes the multi-option `allOf` degradation ("Support for allOf with multiple options is still ongoing") for mergeable cases.
- **`anyOf` / `oneOf` + siblings**: distribute the siblings into each branch (conjunction distributes over disjunction: `S ∧ (B₁ ∨ B₂) ≡ (S∧B₁) ∨ (S∧B₂)`), producing a pure union that the existing `ParseAnyOf` / `ParseOneOf` paths handle. `oneOf` mutual-exclusivity handling is unchanged: the rewritten node re-enters the existing disjointness proof.
- **Annotation-only siblings** (`title`, `description`, `$defs`, `default`, ...) do not trigger desugaring, so existing pure-union schemas compile exactly as before.

### Merge rules (conservative by design)

The merge only claims equivalence when it is sound:

- `required` arrays are unioned; identical values collapse; annotations keep the outer value.
- Structural keywords (`properties`, `patternProperties`, `additionalProperties`, `unevaluatedProperties`, `propertyNames`, `items`, `prefixItems`, `unevaluatedItems`, `contains`, `minContains`, `maxContains`) are allowed from **one side only**. Merging two `properties` maps per-key, or unioning them under a changed `additionalProperties` context, is not sound in general, so we don't attempt it.
- `$ref` next to other keywords is not merged.

**Behavior change (intended):** when an equivalent merge cannot be constructed, compilation now fails with `kUnsupportedSchema` (surfaced as an exception) instead of silently generating an over-accepting grammar. Shapes with no non-annotation siblings are untouched, so this only affects schemas that were previously compiled incorrectly. If a silent fallback is preferred for any of these cases, happy to adjust.

`allOf` with multiple options that cannot be fused falls through to the existing `ParseAllOf` path, exactly as before — no regression for that tier.

## Validation

- New regression tests in `tests/python/test_json_schema_converter.py` covering: `anyOf`/`oneOf`/`allOf` with structural siblings (accept valid, reject extra keys / wrong value types / missing distributed `required` / non-objects), sibling distribution over multiple branches, multi-option `allOf` fusion, unmergeable conflict raising, and annotation-only siblings remaining unchanged.
- Full upstream suite: `tests/python/test_json_schema_converter.py` 525 passed; `test_json_schema_direct_converter.py`, `test_grammar_parser.py`, `test_grammar_matcher_json_schema.py`, `test_structural_tag_converter.py` all pass (1088 passed, 110 HF-token-gated skips).
- A 7-schema × 5-instance differential probe matrix against `jsonschema` (the shapes from #858, including controls) goes from 16 over-accepts to 0 mismatches with this patch.

Repro from #858, before → after:

```jsonc
// schema
{"type": "object",
 "properties": {"modifier": {"enum": ["", "dark"]}},
 "anyOf": [{"required": ["modifier"]}],
 "additionalProperties": false}
// instance {"zzz": [1, 2, 3]}
// before: accepted (grammar compiled to root ::= root_case_0, any JSON object)
// after:  rejected; {"modifier": "dark"} accepted; {} rejected (required distributes)
```
