### PR TITLE
fix(json_schema): support draft-07 positional items and additionalItems

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -1173,15 +1173,68 @@ Result<ArraySpec, SchemaError> SchemaParser::ParseArray(const picojson::object& 
     }
   }
 
+  // Draft-07 form: "items" may be an array of schemas applied positionally,
+  // equivalent to prefixItems (with additionalItems governing the elements
+  // beyond that list). Parse that positional form into prefix_items so the
+  // rest of this function treats it uniformly with prefixItems.
+  if (schema.count("items") && schema.at("items").is<picojson::array>()) {
+    for (const auto& item : schema.at("items").get<picojson::array>()) {
+      if (item.is<bool>() && !item.get<bool>()) {
+        return ResultErr<SchemaError>(
+            SchemaErrorType::kUnsatisfiableSchema, "items contains false"
+        );
+      } else if (!item.is<picojson::object>()) {
+        return ResultErr<SchemaError>(
+            SchemaErrorType::kInvalidSchema, "items array must only contain objects or booleans"
+        );
+      }
+      auto item_result = Parse(item, "item");
+      if (item_result.IsErr()) return ResultErr(std::move(item_result).UnwrapErr());
+      spec.prefix_items.push_back(std::move(item_result).Unwrap());
+    }
+  }
+
   if (schema.count("items")) {
     auto items_value = schema.at("items");
-    if (!items_value.is<bool>() && !items_value.is<picojson::object>()) {
+    if (!items_value.is<bool>() && !items_value.is<picojson::object>() &&
+        !items_value.is<picojson::array>()) {
       return ResultErr<SchemaError>(
-          SchemaErrorType::kInvalidSchema, "items must be a boolean or an object"
+          SchemaErrorType::kInvalidSchema, "items must be a boolean, an object or an array"
       );
     }
-    if (items_value.is<bool>() && !items_value.get<bool>()) {
-      spec.allow_additional_items = false;
+    if (items_value.is<picojson::array>()) {
+      // The positional items were parsed into prefix_items above. Without an
+      // explicit additionalItems we follow the strict-mode default, matching
+      // prefixItems behaviour.
+      if (schema.count("additionalItems")) {
+        auto additional_items_value = schema.at("additionalItems");
+        if (!additional_items_value.is<bool>() && !additional_items_value.is<picojson::object>()) {
+          return ResultErr<SchemaError>(
+              SchemaErrorType::kInvalidSchema, "additionalItems must be a boolean or an object"
+          );
+        }
+        if (additional_items_value.is<bool>()) {
+          spec.allow_additional_items = additional_items_value.get<bool>();
+          if (spec.allow_additional_items) {
+            spec.additional_items = SchemaSpec::Make(AnySpec{}, "", "any");
+          }
+        } else {
+          spec.allow_additional_items = true;
+          auto additional_result = Parse(additional_items_value, "additional_item");
+          if (additional_result.IsErr()) return ResultErr(std::move(additional_result).UnwrapErr());
+          spec.additional_items = std::move(additional_result).Unwrap();
+        }
+      } else if (!config_.strict_mode) {
+        spec.allow_additional_items = true;
+        spec.additional_items = SchemaSpec::Make(AnySpec{}, "", "any");
+      } else {
+        spec.allow_additional_items = false;
+      }
+    } else if (items_value.is<bool>()) {
+      spec.allow_additional_items = items_value.get<bool>();
+      if (spec.allow_additional_items) {
+        spec.additional_items = SchemaSpec::Make(AnySpec{}, "", "any");
+      }
     } else {
       spec.allow_additional_items = true;
       auto items_result = Parse(items_value, "item");
@@ -1208,6 +1261,30 @@ Result<ArraySpec, SchemaError> SchemaParser::ParseArray(const picojson::object& 
     spec.additional_items = SchemaSpec::Make(AnySpec{}, "", "any");
   } else {
     spec.allow_additional_items = false;
+  }
+
+  // Draft-07 keyword: additionalItems only has meaning when a positional item
+  // list (prefixItems or a positional "items" array) is present; it constrains
+  // the elements beyond that list. Without a positional list the draft says it
+  // is ignored, so apply it only in that case.
+  if (schema.count("additionalItems") && !spec.prefix_items.empty()) {
+    auto additional_items_value = schema.at("additionalItems");
+    if (!additional_items_value.is<bool>() && !additional_items_value.is<picojson::object>()) {
+      return ResultErr<SchemaError>(
+          SchemaErrorType::kInvalidSchema, "additionalItems must be a boolean or an object"
+      );
+    }
+    if (additional_items_value.is<bool>()) {
+      spec.allow_additional_items = additional_items_value.get<bool>();
+      if (spec.allow_additional_items) {
+        spec.additional_items = SchemaSpec::Make(AnySpec{}, "", "any");
+      }
+    } else {
+      spec.allow_additional_items = true;
+      auto additional_result = Parse(additional_items_value, "additional_item");
+      if (additional_result.IsErr()) return ResultErr(std::move(additional_result).UnwrapErr());
+      spec.additional_items = std::move(additional_result).Unwrap();
+    }
   }
 
   if (schema.count("minItems")) {

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -1069,7 +1069,18 @@ schema__err_message__test_array_schema_error_cases = [
         "prefixItems must be an array of objects or booleans",
     ),
     ({"type": "array", "prefixItems": [False]}, "prefixItems contains false"),
-    ({"type": "array", "items": "not an object"}, "items must be a boolean or an object"),
+    (
+        {"type": "array", "items": "not an object"},
+        "items must be a boolean, an object or an array",
+    ),
+    (
+        {"type": "array", "items": ["not an object"]},
+        "items array must only contain objects or booleans",
+    ),
+    (
+        {"type": "array", "prefixItems": [{"type": "integer"}], "additionalItems": "bad"},
+        "additionalItems must be a boolean or an object",
+    ),
     (
         {"type": "array", "unevaluatedItems": "not an object"},
         "unevaluatedItems must be a boolean or an object",
@@ -1346,6 +1357,72 @@ def test_array_with_only_items_keyword():
     check_schema_with_instance(schema_unevaluated_items, instance_accepted, any_whitespace=False)
     check_schema_with_instance(
         schema_unevaluated_items, instance_rejected, is_accepted=False, any_whitespace=False
+    )
+
+
+def test_draft07_positional_items_and_additional_items():
+    # draft-07: "items" may be an array of schemas applied positionally, with
+    # "additionalItems" governing the elements beyond that list.
+    schema_positional = {
+        "type": "array",
+        "items": [{"type": "integer"}, {"type": "string"}],
+        "additionalItems": False,
+    }
+    check_schema_with_instance(schema_positional, [1, "x"], any_whitespace=False)
+    check_schema_with_instance(schema_positional, [1, "x", 2], is_accepted=False, any_whitespace=False)
+    check_schema_with_instance(schema_positional, [1], is_accepted=False, any_whitespace=False)
+
+    # additionalItems: true (or absent) allows extra elements of any type.
+    schema_positional_loose = {"type": "array", "items": [{"type": "integer"}], "additionalItems": True}
+    check_schema_with_instance(schema_positional_loose, [1, "x", 2], any_whitespace=False)
+    check_schema_with_instance(schema_positional_loose, ["x"], is_accepted=False, any_whitespace=False)
+    # Without an explicit additionalItems the strict-mode default applies,
+    # matching prefixItems: extra elements are rejected in strict mode...
+    check_schema_with_instance(
+        {"type": "array", "items": [{"type": "integer"}]}, [1, 2, 3], is_accepted=False, any_whitespace=False
+    )
+    # ...and accepted in non-strict mode (draft-07 default is true).
+    check_schema_with_instance(
+        {"type": "array", "items": [{"type": "integer"}]}, [1, 2, 3], any_whitespace=False, strict_mode=False
+    )
+
+    # additionalItems as a schema constrains every element beyond the positional list.
+    schema_positional_schema = {
+        "type": "array",
+        "items": [{"type": "integer"}],
+        "additionalItems": {"type": "string"},
+    }
+    check_schema_with_instance(schema_positional_schema, [1, "a", "b"], any_whitespace=False)
+    check_schema_with_instance(schema_positional_schema, [1, 2], is_accepted=False, any_whitespace=False)
+
+    # The same keyword also applies after prefixItems (draft-07 semantics).
+    schema_prefix_additional = {
+        "type": "array",
+        "prefixItems": [{"type": "integer"}],
+        "additionalItems": True,
+    }
+    check_schema_with_instance(schema_prefix_additional, [1, 2], any_whitespace=False)
+    schema_prefix_additional_schema = {
+        "type": "array",
+        "prefixItems": [{"type": "integer"}],
+        "additionalItems": {"type": "string"},
+    }
+    check_schema_with_instance(schema_prefix_additional_schema, [1, "x"], any_whitespace=False)
+    check_schema_with_instance(schema_prefix_additional_schema, [1, 2], is_accepted=False, any_whitespace=False)
+    check_schema_with_instance(schema_prefix_additional_schema, [1], any_whitespace=False)
+
+    # draft-07: when items is a boolean/schema (not an array), additionalItems
+    # has no meaning and is ignored — items: true accepts every element.
+    check_schema_with_instance(
+        {"type": "array", "items": True, "additionalItems": False},
+        [1, "x"],
+        any_whitespace=False,
+    )
+    check_schema_with_instance(
+        {"type": "array", "items": True, "additionalItems": True}, [1, "x"], any_whitespace=False
+    )
+    check_schema_with_instance(
+        {"type": "array", "items": False, "additionalItems": False}, [], any_whitespace=False
     )
 
 

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -1069,10 +1069,7 @@ schema__err_message__test_array_schema_error_cases = [
         "prefixItems must be an array of objects or booleans",
     ),
     ({"type": "array", "prefixItems": [False]}, "prefixItems contains false"),
-    (
-        {"type": "array", "items": "not an object"},
-        "items must be a boolean, an object or an array",
-    ),
+    ({"type": "array", "items": "not an object"}, "items must be a boolean, an object or an array"),
     (
         {"type": "array", "items": ["not an object"]},
         "items array must only contain objects or booleans",
@@ -1369,21 +1366,35 @@ def test_draft07_positional_items_and_additional_items():
         "additionalItems": False,
     }
     check_schema_with_instance(schema_positional, [1, "x"], any_whitespace=False)
-    check_schema_with_instance(schema_positional, [1, "x", 2], is_accepted=False, any_whitespace=False)
+    check_schema_with_instance(
+        schema_positional, [1, "x", 2], is_accepted=False, any_whitespace=False
+    )
     check_schema_with_instance(schema_positional, [1], is_accepted=False, any_whitespace=False)
 
     # additionalItems: true (or absent) allows extra elements of any type.
-    schema_positional_loose = {"type": "array", "items": [{"type": "integer"}], "additionalItems": True}
+    schema_positional_loose = {
+        "type": "array",
+        "items": [{"type": "integer"}],
+        "additionalItems": True,
+    }
     check_schema_with_instance(schema_positional_loose, [1, "x", 2], any_whitespace=False)
-    check_schema_with_instance(schema_positional_loose, ["x"], is_accepted=False, any_whitespace=False)
+    check_schema_with_instance(
+        schema_positional_loose, ["x"], is_accepted=False, any_whitespace=False
+    )
     # Without an explicit additionalItems the strict-mode default applies,
     # matching prefixItems: extra elements are rejected in strict mode...
     check_schema_with_instance(
-        {"type": "array", "items": [{"type": "integer"}]}, [1, 2, 3], is_accepted=False, any_whitespace=False
+        {"type": "array", "items": [{"type": "integer"}]},
+        [1, 2, 3],
+        is_accepted=False,
+        any_whitespace=False,
     )
     # ...and accepted in non-strict mode (draft-07 default is true).
     check_schema_with_instance(
-        {"type": "array", "items": [{"type": "integer"}]}, [1, 2, 3], any_whitespace=False, strict_mode=False
+        {"type": "array", "items": [{"type": "integer"}]},
+        [1, 2, 3],
+        any_whitespace=False,
+        strict_mode=False,
     )
 
     # additionalItems as a schema constrains every element beyond the positional list.
@@ -1393,7 +1404,9 @@ def test_draft07_positional_items_and_additional_items():
         "additionalItems": {"type": "string"},
     }
     check_schema_with_instance(schema_positional_schema, [1, "a", "b"], any_whitespace=False)
-    check_schema_with_instance(schema_positional_schema, [1, 2], is_accepted=False, any_whitespace=False)
+    check_schema_with_instance(
+        schema_positional_schema, [1, 2], is_accepted=False, any_whitespace=False
+    )
 
     # The same keyword also applies after prefixItems (draft-07 semantics).
     schema_prefix_additional = {
@@ -1408,15 +1421,15 @@ def test_draft07_positional_items_and_additional_items():
         "additionalItems": {"type": "string"},
     }
     check_schema_with_instance(schema_prefix_additional_schema, [1, "x"], any_whitespace=False)
-    check_schema_with_instance(schema_prefix_additional_schema, [1, 2], is_accepted=False, any_whitespace=False)
+    check_schema_with_instance(
+        schema_prefix_additional_schema, [1, 2], is_accepted=False, any_whitespace=False
+    )
     check_schema_with_instance(schema_prefix_additional_schema, [1], any_whitespace=False)
 
     # draft-07: when items is a boolean/schema (not an array), additionalItems
     # has no meaning and is ignored — items: true accepts every element.
     check_schema_with_instance(
-        {"type": "array", "items": True, "additionalItems": False},
-        [1, "x"],
-        any_whitespace=False,
+        {"type": "array", "items": True, "additionalItems": False}, [1, "x"], any_whitespace=False
     )
     check_schema_with_instance(
         {"type": "array", "items": True, "additionalItems": True}, [1, "x"], any_whitespace=False


### PR DESCRIPTION
Fixes #840

## Description

Draft-07 schemas may write `items` as an **array of schemas** applied positionally (equivalent to 2020-12 `prefixItems`), with `additionalItems` constraining the elements beyond that list. XGrammar previously:

- rejected positional `items` arrays with `"items must be a boolean or an object"`, and
- silently ignored `additionalItems` entirely — so `{"prefixItems": [{"type": "integer"}], "additionalItems": true}` rejected `[1, 2]` though draft-07 calls it valid, and `additionalItems: <schema>` had no effect.

Both are fixed here:

1. `ParseArray` now parses a positional `items` array into `prefix_items`, reusing the existing prefixItems semantics and error messages.
2. `additionalItems` (boolean or schema) is applied after any positional list, matching draft-07: `false` closes the array, `true` leaves extra elements unrestricted, a schema constrains them. When `items` is a single schema/boolean (non-positional), `additionalItems` has no meaning per the draft and is left untouched.
3. Without an explicit `additionalItems`, the strict/non-strict default is preserved so positional `items` behaves exactly like `prefixItems` today.

## Tests

- Extended `schema__err_message__test_array_schema_error_cases` (positional items element type, `additionalItems` type check).
- Added `test_draft07_positional_items_and_additional_items` covering: positional items + `additionalItems` false/true/schema, `prefixItems` + `additionalItems` (the two repro cases from #840), non-strict defaults, and boolean `items`.
- `tests/python/test_json_schema_converter.py`: **521 passed**; adjacent `test_json_schema_direct_converter.py` / `test_grammar_matcher_json_schema.py`: 29 passed (110 skipped = HF-token model tests, unrelated).
- `clang-format` (v19.1.7, project pin) clean.

## Checklist

- [x] Tests added/updated and passing
- [x] Commit formatted with project clang-format config