### PR TITLE
Add Windows ARM64 support to CI

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -21,6 +21,7 @@ jobs:
           - {os: ubuntu-latest, arch: x86_64, build: 'cp*-manylinux*'}
           - {os: ubuntu-24.04-arm, arch: aarch64, build: 'cp*-manylinux*'}
           - {os: windows-latest, arch: AMD64, build: 'cp*'}
+          - {os: windows-11-arm, arch: ARM64, build: 'cp*'}
           - {os: macos-14, arch: arm64, build: 'cp*'}
           - {os: macos-15-intel, arch: x86_64, build: 'cp*',}
 

--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -21,7 +21,7 @@ jobs:
           - {os: ubuntu-latest, arch: x86_64, build: 'cp*-manylinux*'}
           - {os: ubuntu-24.04-arm, arch: aarch64, build: 'cp*-manylinux*'}
           - {os: windows-latest, arch: AMD64, build: 'cp*'}
-          - {os: windows-11-arm, arch: ARM64, build: 'cp*'}
+          - {os: windows-11-vs2026-arm, arch: ARM64, build: 'cp*'}
           - {os: macos-14, arch: arm64, build: 'cp*'}
           - {os: macos-15-intel, arch: x86_64, build: 'cp*',}
 

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -38,7 +38,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-14, macos-15-intel]
         python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
         include:
-          # Exercise NVIDIA's Windows ARM64 CUDA nightlies across supported Python versions.
+          # Native Windows ARM64 PyTorch wheels are available for Python 3.11-3.13.
           - {os: windows-11-vs2026-arm, python: '3.11'}
           - {os: windows-11-vs2026-arm, python: '3.12'}
           - {os: windows-11-vs2026-arm, python: '3.13'}
@@ -81,12 +81,9 @@ jobs:
           echo "$(brew --prefix llvm@17)/bin" >> "$GITHUB_PATH"
           clang++ --version
 
-      - name: Install NVIDIA PyTorch nightly on Windows ARM64
+      - name: Install PyTorch on Windows ARM64
         if: matrix.os == 'windows-11-vs2026-arm'
-        run: >
-          python -m pip install --pre
-          --extra-index-url https://pypi.nvidia.com/nvtorch_oot_nightly
-          torch
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Build xgrammar from source
         run: |

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -38,7 +38,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-14, macos-15-intel]
         python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
         include:
-          # Native Windows ARM64 PyTorch wheels are available for Python 3.11-3.13.
+          # Exercise NVIDIA's Windows ARM64 CUDA nightlies across supported Python versions.
           - {os: windows-11-vs2026-arm, python: '3.11'}
           - {os: windows-11-vs2026-arm, python: '3.12'}
           - {os: windows-11-vs2026-arm, python: '3.13'}
@@ -81,9 +81,12 @@ jobs:
           echo "$(brew --prefix llvm@17)/bin" >> "$GITHUB_PATH"
           clang++ --version
 
-      - name: Install PyTorch on Windows ARM64
+      - name: Install NVIDIA PyTorch nightly on Windows ARM64
         if: matrix.os == 'windows-11-vs2026-arm'
-        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+        run: >
+          python -m pip install --pre
+          --extra-index-url https://pypi.nvidia.com/nvtorch_oot_nightly
+          torch
 
       - name: Build xgrammar from source
         run: |

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -37,6 +37,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-14, macos-15-intel]
         python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        include:
+          # Native Windows ARM64 PyTorch wheels are available for Python 3.11-3.13.
+          - {os: windows-11-vs2026-arm, python: '3.11'}
+          - {os: windows-11-vs2026-arm, python: '3.12'}
+          - {os: windows-11-vs2026-arm, python: '3.13'}
         exclude:
           - os: macos-14
             python: '3.14t'
@@ -75,6 +80,10 @@ jobs:
           echo "CXX=$(brew --prefix llvm@17)/bin/clang++" >> "$GITHUB_ENV"
           echo "$(brew --prefix llvm@17)/bin" >> "$GITHUB_PATH"
           clang++ --version
+
+      - name: Install PyTorch on Windows ARM64
+        if: matrix.os == 'windows-11-vs2026-arm'
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Build xgrammar from source
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "10.14" }
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v --exclude libtvm_ffi.dylib --ignore-missing-dependencies {wheel}"
 
 [tool.cibuildwheel.windows]
-archs = ["AMD64"]
+archs = ["AMD64", "ARM64"]
 before-build = "pip install delvewheel"
 # Exclude tvm_ffi.dll: provided by apache-tvm-ffi at import time (see TVM-FFI Python Packaging docs)
 repair-wheel-command = "delvewheel repair --exclude tvm_ffi.dll -w {dest_dir} {wheel}"


### PR DESCRIPTION
Hi @Ubospica , I'm from Microsoft and recently I'm working on improving Python ecosystem support for Windows on Arm.
So I updates the CI workflows to add support for Windows ARM64 build and release. Could you please help to review? Thanks.

**Platform support updates:**

* Added a new build job for Windows ARM64 (`os: windows-11-vs2026-arm`, `arch: ARM64`) in the GitHub Actions workflow file `.github/workflows/build_and_release.yaml`.
* Updated the `pyproject.toml` configuration to include `ARM64` in the list of Windows architectures for `cibuildwheel`, allowing wheels to be built for both `AMD64` and `ARM64` on Windows.