### PR TITLE
fix: don't truncate strings at embedded NUL bytes in EscapeString and ByteToLatin1

### DIFF
--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -196,36 +196,13 @@ std::string GrammarPrinter::PrintRegex(const GrammarExpr& grammar_expr) {
 }
 
 std::string GrammarPrinter::PrintSubstring(const GrammarExpr& grammar_expr) {
-  // EscapeString(std::string) stops at embedded NUL bytes, so escape codepoint by codepoint to
-  // keep NUL chunks (allowed by substring expressions) re-parseable.
-  auto escape_chunk = [](const std::string& chunk) {
-    std::string result = "\"";
-    size_t offset = 0;
-    while (offset < chunk.size()) {
-      if (chunk[offset] == '\0') {
-        result += "\\0";
-        ++offset;
-        continue;
-      }
-      auto [codepoint, length] = ParseNextUTF8(chunk.c_str() + offset);
-      if (codepoint == CharHandlingError::kInvalidUTF8) {
-        result += EscapeString(static_cast<uint8_t>(chunk[offset]));
-        ++offset;
-        continue;
-      }
-      result += EscapeString(codepoint);
-      offset += static_cast<size_t>(length);
-    }
-    return result + "\"";
-  };
-
   auto chunks = grammar_->GetSubstringChunks(grammar_expr);
   std::string result = "Substring(";
   for (size_t i = 0; i < chunks.size(); ++i) {
     if (i > 0) {
       result += ", ";
     }
-    result += escape_chunk(chunks[i]);
+    result += PrintString(chunks[i]);
   }
   return result + ")";
 }

--- a/cpp/support/encoding.h
+++ b/cpp/support/encoding.h
@@ -299,10 +299,12 @@ inline std::optional<CharHandlingError> Latin1ToBytes(
 */
 inline void ByteToLatin1(const std::string& bytes, std::string* result) {
   result->clear();
-  const char* data = bytes.c_str();
+  const size_t len = bytes.size();
 
-  for (int current_idx = 0; *(data + current_idx) != '\0'; current_idx++) {
-    const unsigned char& current_char = static_cast<unsigned char>(*(data + current_idx));
+  // Iterate by length rather than via c_str() so that embedded NUL bytes are not treated as the
+  // end of the string.
+  for (size_t i = 0; i < len; ++i) {
+    const unsigned char current_char = static_cast<unsigned char>(bytes[i]);
 
     // Ascii character, directly add to result.
     if (current_char <= 0x7F) {
@@ -379,9 +381,24 @@ inline std::string EscapeString(uint8_t raw_char) {
 
 inline std::string EscapeString(std::string raw_str) {
   std::string res;
-  auto codepoints = ParseUTF8(raw_str.c_str(), true);
-  for (auto c : codepoints) {
-    res += EscapeString(c);
+  size_t offset = 0;
+  while (offset < raw_str.size()) {
+    // Embedded NUL bytes are valid in arbitrary byte sequences (e.g. "\0" in a byte string),
+    // so handle them explicitly rather than relying on c_str()-style null-termination.
+    if (raw_str[offset] == '\0') {
+      res += "\\0";
+      ++offset;
+      continue;
+    }
+    auto [codepoint, length] = ParseNextUTF8(raw_str.c_str() + offset);
+    if (codepoint == CharHandlingError::kInvalidUTF8) {
+      // Invalid UTF-8 byte: escape the raw byte.
+      res += EscapeString(static_cast<uint8_t>(raw_str[offset]));
+      ++offset;
+      continue;
+    }
+    res += EscapeString(codepoint);
+    offset += static_cast<size_t>(length);
   }
   return res;
 }

--- a/tests/cpp/test_encoding.cc
+++ b/tests/cpp/test_encoding.cc
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+#include <xgrammar/xgrammar.h>
+
+#include <string>
+
+#include "support/encoding.h"
+
+using namespace xgrammar;
+
+TEST(XGrammarEncodingTest, EscapeStringPreservesEmbeddedNulBytes) {
+  // Embedded NUL bytes are valid in arbitrary byte sequences and must be escaped rather than
+  // treated as the end of the string.
+  EXPECT_EQ(EscapeString(std::string("a\0b", 3)), "a\\0b");
+  EXPECT_EQ(EscapeString(std::string("\0", 1)), "\\0");
+  EXPECT_EQ(EscapeString(std::string("\0\0", 2)), "\\0\\0");
+}
+
+TEST(XGrammarEncodingTest, EscapeStringPreservesInvalidAndMultibyteBytes) {
+  // Invalid UTF-8 bytes are escaped as raw bytes instead of being dropped.
+  EXPECT_EQ(EscapeString(std::string("\xFF", 1)), "\\xff");
+  EXPECT_EQ(EscapeString(std::string("\x80", 1)), "\\x80");
+  // Valid multi-byte UTF-8, an embedded NUL and a trailing invalid byte are all preserved.
+  EXPECT_EQ(EscapeString(std::string("a\x00\xFFz", 4)), "a\\0\\xffz");
+}
+
+TEST(XGrammarEncodingTest, ByteToLatin1RoundTripsArbitraryBytes) {
+  // All byte values, including NUL and non-ASCII bytes, must round-trip through the Latin-1
+  // serialization used by the JSON serializer.
+  std::string bytes;
+  for (int b = 0; b < 256; ++b) {
+    bytes.push_back(static_cast<char>(b));
+  }
+  std::string latin1;
+  ByteToLatin1(bytes, &latin1);
+  std::string back;
+  auto error = Latin1ToBytes(latin1, &back);
+  EXPECT_FALSE(error.has_value());
+  EXPECT_EQ(back, bytes);
+}
+
+TEST(XGrammarEncodingTest, GrammarToStringPreservesNulByteString) {
+  // A byte string containing a NUL byte must survive the ToString -> FromEBNF round-trip.
+  Grammar grammar = Grammar::FromEBNF("root ::= \"a\\0b\"");
+  std::string printed = grammar.ToString();
+  EXPECT_EQ(printed, "root ::= ((\"a\\0b\"))\n");
+
+  Grammar reparsed = Grammar::FromEBNF(printed);
+  EXPECT_EQ(reparsed.ToString(), printed);
+}


### PR DESCRIPTION
Fixes #866

# fix: don't truncate strings at embedded NUL bytes in EscapeString and ByteToLatin1

## Problem

`EscapeString(std::string)` and `ByteToLatin1` in `cpp/support/encoding.h` iterate over
their input by `c_str()` / null-termination, so an embedded `\0` byte is treated as the
end of the string and every byte after it is silently dropped.

### `EscapeString(std::string)` — user-visible via `Grammar::ToString()`

A grammar byte string can legally contain a NUL byte (e.g. `\0` in EBNF, `\x00` in a
regex, or a substring chunk), but `Grammar::ToString()` loses the NUL byte and everything
after it:

```cpp
Grammar::FromEBNF("root ::= \"a\\0b\"").ToString()
// before: root ::= (("a"))
// after:  root ::= (("a\0b"))
```

The codebase already knew about this — `GrammarPrinter::PrintSubstring` carried a
workaround ("EscapeString(std::string) stops at embedded NUL bytes"), and
`cpp/tvm_ffi/tvm_ffi.cc` strips `\0` from regex strings.

### `ByteToLatin1` — latent data loss in string serialization

`AutoSerializeJSONValue<std::string>` routes every `std::string` member through
`ByteToLatin1`, so any string containing a NUL byte is silently truncated before it
reaches `picojson` (which itself handles `\0` correctly via `\u0000`).

Scope note: grammar **byte strings are unaffected here** — they are stored as
`std::vector<int32_t>` and serialized as int arrays, so `Grammar::SerializeJSON()`
already round-trips them correctly. The realistic exposure is `std::string` members that
can hold arbitrary bytes, notably `TokenizerInfo`'s `decoded_vocab` for byte-level
tokenizers, plus any future string field. Fixing this is cheap correctness hardening.

## Fix

- `EscapeString(std::string)` now iterates by `raw_str.size()` using `ParseNextUTF8`,
  explicitly escaping embedded NUL bytes as `\0` and invalid UTF-8 bytes as raw `\xNN`
  bytes (mirroring the existing substring workaround).
- `ByteToLatin1` now iterates by `bytes.size()` instead of scanning a `c_str()`.
- `GrammarPrinter::PrintSubstring` now uses the fixed `EscapeString` via `PrintString`,
  removing the now-redundant manual workaround.

## Tests

Added `tests/cpp/test_encoding.cc` covering:

- `EscapeString` with embedded NUL bytes.
- `EscapeString` with invalid/multibyte UTF-8 bytes.
- `ByteToLatin1` → `Latin1ToBytes` round-trip over all 256 byte values.
- `Grammar::FromEBNF("root ::= \"a\\0b\"").ToString()` round-trip.

All four tests fail on `main` and pass with this change. Full C++ suite: 71/71.

## Notes for reviewers

- `ParseNextUTF8` is safe to call at `c_str() + offset` for any `offset < size` because
  `c_str()` is NUL-terminated and the loop stops as soon as it reaches the terminator.
- The `PrintSubstring` output is byte-identical to before (the removed lambda and the new
  `EscapeString(std::string)` produce the same escaping).
