### PR TITLE
[Release] Backport regex repeat fix and bump v0.2.6rc2

### DIFF
--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -100,8 +100,14 @@ void AdaptiveTokenMask::RecomputeAcceptedCount(size_t sorted_vocab_size) {
 }
 
 void AdaptiveTokenMask::RecomputeJSONStringMetadata(const TokenizerInfo& tokenizer_info) {
-  // Direct local-completion masks carry this derived metadata when they are built. Avoid walking
-  // a large crossing-token vocabulary again on the first dynamic mask fill.
+  // Direct local-completion masks carry final metadata when they are built: the crossing-token
+  // bitset comes from the summary and must be kept. Recomputing here would replace a non-JSON
+  // summary's bitset with an empty one, which the bulk-OR fast path then reads out of bounds.
+  if (local_completion_summary != nullptr) {
+    return;
+  }
+  // JSON-compatible masks already cover the full vocabulary. Avoid walking a large
+  // crossing-token vocabulary again on the first dynamic mask fill.
   if (all_uncertain_tokens_are_json_string_crossing &&
       uncertain_token_bitset.Size() == tokenizer_info.GetVocabSize()) {
     return;

--- a/cpp/fsm_builder.cc
+++ b/cpp/fsm_builder.cc
@@ -3019,6 +3019,7 @@ Result<FSMWithStartEnd> RegexFSMBuilder::BuildWithForbiddenChars(
       }
     }
   }
+  new_fsm.SetEdgeAuxData(std::vector<int32_t>(fsm.GetEdgeAuxData()));
   return ResultOk(FSMWithStartEnd(new_fsm, fsm_wse.GetStart(), fsm_wse.GetEnds()));
 }
 

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -286,10 +286,12 @@ std::vector<uint8_t> GetPureFSMSemanticsRules(const Grammar& grammar) {
       }
     }
   }
-  // A rule's own lookahead is checked when the optimized completion byte is advanced. A
-  // non-redundant lookahead in a different referenced rule would instead be skipped with the
-  // local prefix, so conservatively invalidate each of its callers. Self-recursive tail calls
-  // complete at the same boundary and do not introduce another lookahead position.
+  // Lookahead assertions are only enforced during compile-time mask adaptation, never when the
+  // online parser advances bytes. A candidate rule's own non-redundant lookahead is instead
+  // enforced by filtering the crossing tokens when its local-completion summary is built. A
+  // non-redundant lookahead in a referenced rule would still be skipped with the local prefix,
+  // so conservatively invalidate each of its callers. Self-recursive tail calls complete at the
+  // same boundary and do not introduce another lookahead position.
   for (int32_t rule_id = 0; rule_id < grammar->NumRules(); ++rule_id) {
     if (redundant_lookahead[rule_id]) {
       continue;
@@ -318,7 +320,8 @@ std::shared_ptr<const LocalCompletionTokenSummary> BuildLocalCompletionTokenSumm
     const Grammar& grammar,
     int32_t rule_id,
     const TokenizerInfo& tokenizer_info,
-    bool has_pure_fsm_semantics
+    bool has_pure_fsm_semantics,
+    bool enforce_own_lookahead
 ) {
   if (rule_id < 0 || rule_id >= grammar->NumRules() || tokenizer_info.GetVocabSize() == 0 ||
       !grammar->per_rule_fsms[rule_id].has_value()) {
@@ -502,6 +505,86 @@ std::shared_ptr<const LocalCompletionTokenSummary> BuildLocalCompletionTokenSumm
     // finite vocabulary has proven otherwise identical to JSON lexical behavior.
     summary->accepted_prefix_tokens = tokenizer_impl->GetJSONStringContentPrefixBitset();
   }
+  // A non-redundant lookahead on the candidate rule itself must keep filtering crossing tokens
+  // exactly like the fallback path's lookahead adaptation: a crossing token whose suffix cannot
+  // start the assertion is rejected. JSON-length-compatible summaries are exempt: their
+  // machine-generated closing-context lookahead matches the rule's true successors, which the
+  // per-fill suffix reparse already enforces exactly, and the quote-suffix machinery requires
+  // the full crossing set. If the assertion cannot become a byte-level DFA, skip the
+  // optimization so the fallback path enforces it.
+  if (enforce_own_lookahead && !summary->json_string_length_compatible) {
+    const int32_t lookahead_id = grammar->GetRule(rule_id).lookahead_assertion_id;
+    XGRAMMAR_DCHECK(lookahead_id != -1);
+    auto lookahead_fsm =
+        GrammarFSMBuilder::Sequence(grammar->GetGrammarExpr(lookahead_id), grammar);
+    if (!lookahead_fsm.has_value()) {
+      return nullptr;
+    }
+    const auto simplified = lookahead_fsm->SimplifyEpsilon();
+    for (int32_t state = 0; state < simplified.NumStates(); ++state) {
+      for (const auto& edge : simplified.GetFsm().GetEdges(state)) {
+        if (!edge.IsCharRange() && !edge.IsEpsilon()) {
+          return nullptr;
+        }
+      }
+    }
+    auto lookahead_dfa_result = simplified.MinimizeDFA(64);
+    if (lookahead_dfa_result.IsErr()) {
+      return nullptr;
+    }
+    const auto lookahead_dfa = std::move(lookahead_dfa_result).Unwrap();
+    std::vector<std::array<int32_t, 256>> lookahead_transitions(lookahead_dfa.NumStates());
+    for (auto& state_transitions : lookahead_transitions) {
+      state_transitions.fill(FSM::kNoNextState);
+    }
+    for (int32_t state = 0; state < lookahead_dfa.NumStates(); ++state) {
+      for (const auto& edge : lookahead_dfa.GetFsm().GetEdges(state)) {
+        if (!edge.IsCharRange() || edge.min < 0 || edge.max > 255) {
+          return nullptr;
+        }
+        for (int32_t byte = edge.min; byte <= edge.max; ++byte) {
+          lookahead_transitions[state][byte] = edge.target;
+        }
+      }
+    }
+    const auto lookahead_allows = [&](const LocalCompletionCrossingToken& crossing) {
+      const std::string& token = sorted_vocab[crossing.sorted_vocab_index].second;
+      int32_t state = lookahead_dfa.GetStart();
+      if (lookahead_dfa.IsEndState(state)) {
+        return true;
+      }
+      for (size_t offset = crossing.suffix_offset; offset < token.size(); ++offset) {
+        state = lookahead_transitions[state][static_cast<uint8_t>(token[offset])];
+        if (state == FSM::kNoNextState) {
+          return false;
+        }
+        if (lookahead_dfa.IsEndState(state)) {
+          return true;
+        }
+      }
+      return true;
+    };
+    std::vector<LocalCompletionCrossingToken> kept_crossings;
+    kept_crossings.reserve(summary->crossings_by_suffix.size());
+    for (const auto& crossing : summary->crossings_by_suffix) {
+      if (lookahead_allows(crossing)) {
+        kept_crossings.push_back(crossing);
+      } else {
+        summary->crossing_tokens.Reset(sorted_vocab[crossing.sorted_vocab_index].first);
+      }
+    }
+    if (kept_crossings.size() != summary->crossings_by_suffix.size()) {
+      summary->crossings_by_suffix = std::move(kept_crossings);
+      summary->crossing_indices.clear();
+      for (const auto& crossing : summary->crossings_by_suffix) {
+        summary->crossing_indices.push_back(crossing.sorted_vocab_index);
+      }
+      std::sort(summary->crossing_indices.begin(), summary->crossing_indices.end());
+    }
+    if (summary->crossing_indices.empty()) {
+      return nullptr;
+    }
+  }
   return summary;
 }
 
@@ -509,10 +592,11 @@ std::vector<std::shared_ptr<const LocalCompletionTokenSummary>> BuildLocalComple
     const Grammar& grammar, const TokenizerInfo& tokenizer_info
 ) {
   const auto pure_fsm_semantics = GetPureFSMSemanticsRules(grammar);
+  const auto redundant_lookahead = GetRedundantLookaheadRules(grammar);
   std::vector<std::shared_ptr<const LocalCompletionTokenSummary>> result(grammar->NumRules());
   for (int32_t rule_id = 0; rule_id < grammar->NumRules(); ++rule_id) {
     result[rule_id] = BuildLocalCompletionTokenSummary(
-        grammar, rule_id, tokenizer_info, pure_fsm_semantics[rule_id]
+        grammar, rule_id, tokenizer_info, pure_fsm_semantics[rule_id], !redundant_lookahead[rule_id]
     );
   }
   return result;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xgrammar"
-version = "0.2.6rc1"
+version = "0.2.6rc2"
 description = "Efficient, Flexible and Portable Structured Generation"
 authors = [{ name = "MLC Team" }]
 readme = "README.md"

--- a/tests/cpp/test_fsm_builder.cc
+++ b/tests/cpp/test_fsm_builder.cc
@@ -447,6 +447,34 @@ TEST(XGrammarFSMBuilderTest, TestRegexBuildWithForbiddenChars) {
   EXPECT_TRUE(fsm_wse.AcceptString("你好"));
 }
 
+TEST(XGrammarFSMBuilderTest, TestRegexBuildWithForbiddenCharsPreservesRepeatAuxData) {
+  const auto& forbidden = GrammarFSMBuilder::JSONStringForbiddenChars();
+  GrammarBuilder builder;
+
+  auto fsm_wse =
+      RegexFSMBuilder::BuildWithForbiddenChars("[^\\n\\r]{1,129}", forbidden, &builder).Unwrap();
+  const auto& fsm = fsm_wse.GetFsm();
+  const auto& aux_data = fsm.GetEdgeAuxData();
+  ASSERT_FALSE(aux_data.empty());
+
+  bool found_repeat_edge = false;
+  for (int state = 0; state < fsm.NumStates(); ++state) {
+    for (const auto& edge : fsm.GetEdges(state)) {
+      if (!edge.IsRepeatRef()) {
+        continue;
+      }
+      found_repeat_edge = true;
+      ASSERT_GE(edge.GetAuxIndex(), 0);
+      ASSERT_LT(edge.GetAuxIndex() + 2, static_cast<int32_t>(aux_data.size()));
+
+      auto repeat_info = fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
+      EXPECT_EQ(repeat_info.Lower(), 1);
+      EXPECT_EQ(repeat_info.Upper(), 129);
+    }
+  }
+  EXPECT_TRUE(found_repeat_edge);
+}
+
 TEST(XGrammarFSMBuilderTest, TestGrammarFSMBuilderRegex) {
   // The compiled regex automaton must preserve the language after simplification.
   auto fsm_wse = GrammarFSMBuilder::Regex("(ab)+").Unwrap();

--- a/tests/python/test_dynamic_compilation.py
+++ b/tests/python/test_dynamic_compilation.py
@@ -806,6 +806,75 @@ guarded ::= "x" (= "z")"""
         assert bool(allowed[token_id]) == dynamic_matcher.fork().accept_token(token_id), token_id
 
 
+def test_local_completion_all_accepted_suffixes_match_eager_and_oracle():
+    # Every crossing token's suffix is accepted here, so the dynamic fill takes the bulk-OR
+    # branch over the crossing-token bitset. The lazy path must keep the summary's bitset
+    # intact instead of clearing it during JSON metadata recomputation.
+    safe_tokens = ["q" * length for length in range(1, 40)]
+    crossing_tokens = ["a" * length + ";>" for length in range(1, 40)] + [";>", ";"]
+    vocabulary = safe_tokens + crossing_tokens + ["a", "q", ">", b"\xff"]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    grammar = xgr.Grammar.from_ebnf(
+        r"""root ::= "<" body ">"
+body ::= (";" | [a-z] body)"""
+    )
+    options = {"tokenizer_info": tokenizer_info, "max_threads": 1, "cache_enabled": False}
+    eager = xgr.GrammarCompiler(**options, enable_dynamic_compilation=False).compile_grammar(
+        grammar
+    )
+    dynamic = xgr.GrammarCompiler(**options, enable_dynamic_compilation=True).compile_grammar(
+        grammar
+    )
+
+    def fill(compiled_grammar):
+        matcher = xgr.GrammarMatcher(compiled_grammar, terminate_without_stop_token=True)
+        assert matcher.accept_string("<")
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        assert matcher.fill_next_token_bitmask(bitmask)
+        return matcher, bitmask
+
+    _, eager_bitmask = fill(eager)
+    dynamic_matcher, dynamic_bitmask = fill(dynamic)
+    torch.testing.assert_close(dynamic_bitmask, eager_bitmask, rtol=0, atol=0)
+    allowed = bitmask_to_bool_mask(dynamic_bitmask, tokenizer_info.vocab_size)[0]
+    assert allowed[vocabulary.index(";>")]
+    assert allowed[vocabulary.index("a;>")]
+    for token_id in range(tokenizer_info.vocab_size):
+        assert bool(allowed[token_id]) == dynamic_matcher.fork().accept_token(token_id), token_id
+
+
+@pytest.mark.parametrize("enable_dynamic_compilation", [False, True], ids=["eager", "dynamic"])
+def test_local_completion_respects_rule_own_lookahead(enable_dynamic_compilation):
+    # body carries its own non-redundant lookahead (= ">") while the true successor is "!".
+    # The mask must filter crossing tokens with the lookahead whether or not the rule
+    # qualifies for the local-completion optimization (unique vs. two completion bytes).
+    vocabulary = ["a;!", "aa;!", "a;>", "a", ";", "!", ">", b"\xff"]
+    tokenizer_info = xgr.TokenizerInfo(vocabulary, stop_token_ids=[])
+    optimizable = xgr.Grammar.from_ebnf(
+        r"""root ::= "<" body "!"
+body ::= (";" | [a-z] body) (= ">")"""
+    )
+    fallback = xgr.Grammar.from_ebnf(
+        r"""root ::= "<" body "!"
+body ::= (";" | ":" | [a-z] body) (= ">")"""
+    )
+    options = {"tokenizer_info": tokenizer_info, "max_threads": 1, "cache_enabled": False}
+    for grammar in (optimizable, fallback):
+        compiled = xgr.GrammarCompiler(
+            **options, enable_dynamic_compilation=enable_dynamic_compilation
+        ).compile_grammar(grammar)
+        matcher = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        assert matcher.accept_string("<")
+        bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+        assert matcher.fill_next_token_bitmask(bitmask)
+        allowed = bitmask_to_bool_mask(bitmask, tokenizer_info.vocab_size)[0]
+        assert not allowed[vocabulary.index("a;!")]
+        assert not allowed[vocabulary.index("aa;!")]
+        assert not allowed[vocabulary.index("a;>")]
+        assert allowed[vocabulary.index("a")]
+        assert allowed[vocabulary.index(";")]
+
+
 @pytest.mark.parametrize("cache_enabled", [False, True], ids=["cache-off", "cache-on"])
 def test_email_format_regex_fsm_masks_match_eager_and_token_oracle(cache_enabled):
     shared_prefix = "a" * 64


### PR DESCRIPTION
## Summary

- backport #864 to preserve repeat-edge auxiliary data when rebuilding JSON-string regex finite-state machines, fixing #863 on the `v0.2.6rc2` preview branch;
- fix two correctness issues in the generalized local-completion token masks introduced by #854 (details below);
- bump the package version from `0.2.6rc1` to `0.2.6rc2`;
- verify that the string-length fixes for #805 and #852 already included through #853, #854, and #856 remain correct and fast in the final release-candidate wheel.

## Local-completion mask fixes

- **Lazy-path crossing bitset loss (segfault).** `RecomputeJSONStringMetadata` replaced the summary-provided crossing-token bitset of a non-JSON local-completion mask with an empty bitset on the lazy compilation path. When every crossing suffix was accepted, the bulk-OR fast path read through the empty bitset's null buffer and segfaulted in release builds (or silently rejected every crossing token). Masks that carry a local-completion summary now keep their final metadata. Repro: `root ::= "<" body ">"`, `body ::= (";" | [a-z] body)` with all crossing suffixes valid — dynamic compilation crashed on the first `fill_next_token_bitmask` while eager compilation worked.
- **Own-rule lookahead bypass.** A rule's own non-redundant lookahead assertion was bypassed whenever the rule qualified for the local-completion direct mask, while the fallback path still enforced it, so the same `(= ...)` assertion filtered the mask or not depending on whether the optimization applied. The summary builder now compiles the assertion into a byte-level DFA and filters out crossing tokens whose suffix cannot start the assertion, matching the fallback semantics; if the assertion cannot become a byte-level DFA, the optimization is skipped. JSON-length-compatible summaries are exempt: their machine-generated closing-context lookahead matches the rule's true successors, which the per-fill suffix reparse already enforces exactly, and the quote-suffix machinery requires the full crossing set.

## Issue verification

- **#863:** the large bounded-repeat regression test confirms that `{1,129}` repeat-reference edges retain valid lower/upper metadata after forbidden-character filtering. The original JSON Schema compilation and matching reproduction completes without a crash.
- **#805:** on a pinned Modal CPU with the 70,257-token adversarial vocabulary, independent matcher first-fill P50 latency for `minLength=128/129/200` is `0.009429/0.009946/0.009587 ms` on the final wheel with both mask fixes included; the maximum across all 21 samples is `0.161177 ms`.
- **#852:** on the Kimi-K3 tokenizer and 273-token reproduction trace, cumulative fill time with `maxLength=100000` is `5.621020 ms`, versus `4.590498 ms` without the bound (about `1.22x`, rather than the reported `~300x`).

## Testing

- `103/103` C++ tests passed in a Release build with internal checks enabled
- `284 passed` in `test_dynamic_compilation.py`, including three new regression tests covering the bulk-OR crossing path and own-rule lookahead filtering in eager/dynamic and optimizable/fallback combinations
- `3741 passed, 1 skipped, 622 deselected` in the remaining Python suite with external-model tests excluded; the skip is MLX-only
- `pre-commit run --all-files`
- final wheel: `xgrammar-0.2.6rc2-cp312-cp312-linux_x86_64.whl`
- wheel SHA-256: `7fb22d16c689057164b3f0a53f4f17a424777370c797d7e0f9aa962b9fd1f8d0`
- Modal run: https://modal.com/apps/ubospica/main/ap-zshECll9WHUbjicNbcUKER
