### PR TITLE
feat: support dynamic tags for MiniMax M3 XML

### DIFF
--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -23,6 +23,318 @@ using GrammarExprType = Grammar::Impl::GrammarExprType;
 
 using GrammarExpr = Grammar::Impl::GrammarExpr;
 
+const EarleyParser::UniqueKeySemanticState& EarleyParser::GetUniqueKeySemanticState(int32_t state_id
+) const {
+  static const UniqueKeySemanticState kEmptyState;
+  if (state_id == 0) {
+    return kEmptyState;
+  }
+  XGRAMMAR_DCHECK(unique_key_context_storage_ != nullptr);
+  XGRAMMAR_DCHECK(
+      state_id > 0 &&
+      state_id < static_cast<int32_t>(unique_key_context_storage_->semantic_states.size())
+  );
+  return unique_key_context_storage_->semantic_states[state_id];
+}
+
+const EarleyParser::UniqueKeyContextNode& EarleyParser::GetUniqueKeyContext(int32_t context_id
+) const {
+  static const UniqueKeyContextNode kRootContext;
+  if (context_id == 0) {
+    return kRootContext;
+  }
+  XGRAMMAR_DCHECK(unique_key_context_storage_ != nullptr);
+  XGRAMMAR_DCHECK(
+      context_id > 0 &&
+      context_id < static_cast<int32_t>(unique_key_context_storage_->contexts.size())
+  );
+  return unique_key_context_storage_->contexts[context_id];
+}
+
+void EarleyParser::EnsureUniqueKeyContextStorage() {
+  if (unique_key_context_storage_ == nullptr) {
+    unique_key_context_storage_ = std::make_shared<UniqueKeyContextStorage>();
+  } else if (unique_key_context_storage_.use_count() > 1) {
+    unique_key_context_storage_ =
+        std::make_shared<UniqueKeyContextStorage>(*unique_key_context_storage_);
+  }
+}
+
+int32_t EarleyParser::InternUniqueKeySemanticState(
+    int32_t current_context_id, int32_t entry_context_id
+) {
+  if (current_context_id == 0 && entry_context_id == 0) {
+    return 0;
+  }
+  EnsureUniqueKeyContextStorage();
+  const uint64_t key = (static_cast<uint64_t>(static_cast<uint32_t>(current_context_id)) << 32) |
+                       static_cast<uint32_t>(entry_context_id);
+  if (auto it = unique_key_context_storage_->semantic_state_ids.find(key);
+      it != unique_key_context_storage_->semantic_state_ids.end()) {
+    return it->second;
+  }
+  XGRAMMAR_CHECK(
+      unique_key_context_storage_->semantic_states.size() <
+      static_cast<size_t>(std::numeric_limits<int32_t>::max())
+  ) << "Too many branch-local DynamicTag uniqueness states";
+  const int32_t result = static_cast<int32_t>(unique_key_context_storage_->semantic_states.size());
+  unique_key_context_storage_->semantic_states.push_back({current_context_id, entry_context_id});
+  unique_key_context_storage_->semantic_state_ids.emplace(key, result);
+  return result;
+}
+
+int32_t EarleyParser::InternUniqueKeyContext(UniqueKeyContextNode node) {
+  node.signature_hash = HashCombine(
+      static_cast<uint8_t>(node.kind),
+      node.parent_id,
+      node.scope_rule_id,
+      node.scope_start_pos,
+      node.name_start_byte,
+      node.byte_length,
+      node.nearest_scope_context_id,
+      node.name_hash
+  );
+  EnsureUniqueKeyContextStorage();
+  const auto range =
+      unique_key_context_storage_->context_ids_by_hash.equal_range(node.signature_hash);
+  for (auto it = range.first; it != range.second; ++it) {
+    const auto& existing = unique_key_context_storage_->contexts[it->second];
+    if (existing.kind == node.kind && existing.parent_id == node.parent_id &&
+        existing.scope_rule_id == node.scope_rule_id &&
+        existing.scope_start_pos == node.scope_start_pos &&
+        existing.name_start_byte == node.name_start_byte &&
+        existing.byte_length == node.byte_length &&
+        existing.nearest_scope_context_id == node.nearest_scope_context_id &&
+        existing.name_hash == node.name_hash) {
+      return it->second;
+    }
+  }
+  XGRAMMAR_CHECK(
+      unique_key_context_storage_->contexts.size() <
+      static_cast<size_t>(std::numeric_limits<int32_t>::max())
+  ) << "Too many branch-local DynamicTag uniqueness contexts";
+  const int32_t result = static_cast<int32_t>(unique_key_context_storage_->contexts.size());
+  unique_key_context_storage_->contexts.push_back(std::move(node));
+  unique_key_context_storage_->context_ids_by_hash.emplace(
+      unique_key_context_storage_->contexts.back().signature_hash, result
+  );
+  if (unique_key_context_storage_->contexts.back().kind == UniqueKeyContextNode::Kind::kKey) {
+    const auto& context = unique_key_context_storage_->contexts.back();
+    unique_key_context_storage_->key_context_ids_by_scope_and_name_hash.emplace(
+        HashCombine(context.nearest_scope_context_id, context.name_hash), result
+    );
+  }
+  return result;
+}
+
+int32_t EarleyParser::MakeChildUniqueKeyState(
+    int32_t parent_state_id, int32_t child_rule_id, int32_t child_start_pos
+) {
+  if (!track_unique_key_contexts_) {
+    return parent_state_id;
+  }
+  const auto parent = GetUniqueKeySemanticState(parent_state_id);
+  int32_t child_context_id = parent.current_context_id;
+  if (IsUniqueKeyScopeRule(child_rule_id)) {
+    UniqueKeyContextNode scope;
+    scope.kind = UniqueKeyContextNode::Kind::kScope;
+    scope.parent_id = child_context_id;
+    scope.scope_rule_id = child_rule_id;
+    scope.scope_start_pos = child_start_pos;
+    child_context_id = InternUniqueKeyContext(std::move(scope));
+  } else if (parent.current_context_id == parent.entry_context_id) {
+    return parent_state_id;
+  }
+  return InternUniqueKeySemanticState(child_context_id, parent.current_context_id);
+}
+
+std::optional<int32_t> EarleyParser::CompleteUniqueKeyState(
+    int32_t parent_state_id, const ParserState& completed_state
+) {
+  if (!track_unique_key_contexts_) {
+    return parent_state_id;
+  }
+  const auto parent = GetUniqueKeySemanticState(parent_state_id);
+  const auto child = GetUniqueKeySemanticState(completed_state.unique_key_state_id);
+  if (parent.current_context_id != child.entry_context_id) {
+    return std::nullopt;
+  }
+  int32_t completed_context_id = child.current_context_id;
+  if (IsUniqueKeyScopeRule(completed_state.rule_id)) {
+    const auto& current = GetUniqueKeyContext(completed_context_id);
+    if (current.kind == UniqueKeyContextNode::Kind::kKey) {
+      completed_context_id = current.nearest_scope_context_id;
+    }
+    const auto& scope = GetUniqueKeyContext(completed_context_id);
+    if (scope.kind != UniqueKeyContextNode::Kind::kScope ||
+        scope.scope_rule_id != completed_state.rule_id ||
+        scope.scope_start_pos != completed_state.rule_start_pos) {
+      return std::nullopt;
+    }
+    completed_context_id = scope.parent_id;
+  }
+  if (completed_context_id == parent.current_context_id) {
+    return parent_state_id;
+  }
+  if (completed_context_id == child.current_context_id &&
+      parent.entry_context_id == child.entry_context_id) {
+    return completed_state.unique_key_state_id;
+  }
+  return InternUniqueKeySemanticState(completed_context_id, parent.entry_context_id);
+}
+
+int32_t EarleyParser::AppendUniqueKey(
+    int32_t state_id, int32_t name_start_byte, int32_t byte_length, uint64_t name_hash
+) {
+  XGRAMMAR_DCHECK(track_unique_key_contexts_);
+  const auto semantic_state = GetUniqueKeySemanticState(state_id);
+  const auto& previous = GetUniqueKeyContext(semantic_state.current_context_id);
+  XGRAMMAR_DCHECK(
+      previous.kind == UniqueKeyContextNode::Kind::kScope ||
+      previous.kind == UniqueKeyContextNode::Kind::kKey
+  );
+  UniqueKeyContextNode key;
+  key.kind = UniqueKeyContextNode::Kind::kKey;
+  key.parent_id = semantic_state.current_context_id;
+  key.name_start_byte = name_start_byte;
+  key.byte_length = byte_length;
+  key.nearest_scope_context_id = previous.kind == UniqueKeyContextNode::Kind::kScope
+                                     ? semantic_state.current_context_id
+                                     : previous.nearest_scope_context_id;
+  XGRAMMAR_DCHECK(key.nearest_scope_context_id > 0);
+  key.scope_key_depth =
+      previous.kind == UniqueKeyContextNode::Kind::kScope ? 1 : previous.scope_key_depth + 1;
+  key.name_hash = name_hash;
+  const uint64_t bloom_bit_1 = uint64_t{1} << (name_hash & 63);
+  const uint64_t bloom_bit_2 = uint64_t{1} << ((name_hash >> 32) & 63);
+  key.name_bloom = previous.name_bloom | bloom_bit_1 | bloom_bit_2;
+  const int32_t key_context_id = InternUniqueKeyContext(std::move(key));
+  return InternUniqueKeySemanticState(key_context_id, semantic_state.entry_context_id);
+}
+
+int32_t EarleyParser::RemapUniqueKeyStateRows(
+    int32_t state_id, int32_t from_row, int32_t to_row, UniqueKeyRowRemapCache* remap_cache
+) {
+  if (state_id == 0 || from_row == to_row) {
+    return state_id;
+  }
+  XGRAMMAR_DCHECK(remap_cache != nullptr);
+  auto& remapped_context_ids = remap_cache->context_ids;
+  auto& remapped_semantic_state_ids = remap_cache->semantic_state_ids;
+  auto& context_path = remap_cache->context_path;
+  if (auto it = remapped_semantic_state_ids.find(state_id);
+      it != remapped_semantic_state_ids.end()) {
+    return it->second;
+  }
+  if (remapped_context_ids.empty()) {
+    remapped_context_ids.emplace(0, 0);
+  }
+
+  const auto semantic_state = GetUniqueKeySemanticState(state_id);
+  auto remap_context = [&](int32_t context_id) {
+    context_path.clear();
+    auto remapped_it = remapped_context_ids.find(context_id);
+    while (remapped_it == remapped_context_ids.end()) {
+      context_path.push_back(context_id);
+      context_id = GetUniqueKeyContext(context_id).parent_id;
+      remapped_it = remapped_context_ids.find(context_id);
+    }
+
+    int32_t remapped_id = remapped_it->second;
+    while (!context_path.empty()) {
+      const int32_t original_id = context_path.back();
+      context_path.pop_back();
+      auto context = GetUniqueKeyContext(original_id);
+      auto parent_it = remapped_context_ids.find(context.parent_id);
+      XGRAMMAR_DCHECK(parent_it != remapped_context_ids.end());
+      context.parent_id = parent_it->second;
+      if (context.kind == UniqueKeyContextNode::Kind::kKey) {
+        auto scope_it = remapped_context_ids.find(context.nearest_scope_context_id);
+        XGRAMMAR_DCHECK(scope_it != remapped_context_ids.end());
+        context.nearest_scope_context_id = scope_it->second;
+      }
+      if (context.kind == UniqueKeyContextNode::Kind::kScope &&
+          context.scope_start_pos == from_row) {
+        context.scope_start_pos = to_row;
+      }
+      remapped_id = InternUniqueKeyContext(std::move(context));
+      remapped_context_ids.emplace(original_id, remapped_id);
+    }
+    return remapped_id;
+  };
+
+  const int32_t result = InternUniqueKeySemanticState(
+      remap_context(semantic_state.current_context_id),
+      remap_context(semantic_state.entry_context_id)
+  );
+  remapped_semantic_state_ids.emplace(state_id, result);
+  return result;
+}
+
+EarleyParser::UniqueKeyContextSnapshot EarleyParser::SnapshotUniqueKeyContexts() const {
+  if (unique_key_context_storage_ == nullptr) {
+    return {};
+  }
+  return {
+      unique_key_context_storage_->contexts.size(),
+      unique_key_context_storage_->semantic_states.size()
+  };
+}
+
+void EarleyParser::RestoreUniqueKeyContexts(const UniqueKeyContextSnapshot& snapshot) {
+  if (unique_key_context_storage_ == nullptr) {
+    return;
+  }
+  XGRAMMAR_DCHECK(snapshot.num_contexts >= 1 && snapshot.num_semantic_states >= 1);
+  XGRAMMAR_DCHECK(snapshot.num_contexts <= unique_key_context_storage_->contexts.size());
+  XGRAMMAR_DCHECK(
+      snapshot.num_semantic_states <= unique_key_context_storage_->semantic_states.size()
+  );
+  if (snapshot.num_contexts == unique_key_context_storage_->contexts.size() &&
+      snapshot.num_semantic_states == unique_key_context_storage_->semantic_states.size()) {
+    return;
+  }
+  EnsureUniqueKeyContextStorage();
+  for (size_t index = unique_key_context_storage_->semantic_states.size();
+       index > snapshot.num_semantic_states;
+       --index) {
+    const auto& state = unique_key_context_storage_->semantic_states[index - 1];
+    const uint64_t key =
+        (static_cast<uint64_t>(static_cast<uint32_t>(state.current_context_id)) << 32) |
+        static_cast<uint32_t>(state.entry_context_id);
+    unique_key_context_storage_->semantic_state_ids.erase(key);
+  }
+  unique_key_context_storage_->semantic_states.resize(snapshot.num_semantic_states);
+  for (size_t index = unique_key_context_storage_->contexts.size(); index > snapshot.num_contexts;
+       --index) {
+    const auto& context = unique_key_context_storage_->contexts[index - 1];
+    if (context.kind == UniqueKeyContextNode::Kind::kKey) {
+      const auto name_range =
+          unique_key_context_storage_->key_context_ids_by_scope_and_name_hash.equal_range(
+              HashCombine(context.nearest_scope_context_id, context.name_hash)
+          );
+      bool found = false;
+      for (auto it = name_range.first; it != name_range.second; ++it) {
+        if (it->second == static_cast<int32_t>(index - 1)) {
+          unique_key_context_storage_->key_context_ids_by_scope_and_name_hash.erase(it);
+          found = true;
+          break;
+        }
+      }
+      XGRAMMAR_CHECK(found) << "DynamicTag unique-key index is inconsistent";
+    }
+    const auto range =
+        unique_key_context_storage_->context_ids_by_hash.equal_range(context.signature_hash);
+    for (auto it = range.first; it != range.second; ++it) {
+      if (it->second == static_cast<int32_t>(index - 1)) {
+        unique_key_context_storage_->context_ids_by_hash.erase(it);
+        break;
+      }
+    }
+  }
+  unique_key_context_storage_->contexts.resize(snapshot.num_contexts);
+}
+
 bool EarleyParser::IsCompleted() const { return is_completed_.back(); }
 
 bool EarleyParser::CompletionConsumedMarker(const ParserState& state) const {
@@ -153,53 +465,46 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
     if (ref_id != state.rule_id) {
       continue;
     }
+    auto completed_parent = parent_state;
+    if (track_unique_key_contexts_) {
+      auto completed_unique_key_state =
+          CompleteUniqueKeyState(parent_state.unique_key_state_id, state);
+      if (!completed_unique_key_state.has_value()) {
+        continue;
+      }
+      completed_parent.unique_key_state_id = *completed_unique_key_state;
+    }
     XGRAMMAR_DCHECK(
-        parent_state.rule_id == -1 || grammar_->per_rule_fsms[parent_state.rule_id].has_value()
+        completed_parent.rule_id == -1 ||
+        grammar_->per_rule_fsms[completed_parent.rule_id].has_value()
     );
-    if (parent_state.rule_id == -1) {
-      const auto& parent_expr = grammar_->GetGrammarExpr(parent_state.sequence_id);
-      const auto& element_expr = grammar_->GetGrammarExpr(parent_expr[parent_state.element_id]);
+    if (completed_parent.rule_id == -1) {
+      const auto& parent_expr = grammar_->GetGrammarExpr(completed_parent.sequence_id);
+      const auto& element_expr = grammar_->GetGrammarExpr(parent_expr[completed_parent.element_id]);
       // The new rule is not referenced by a fsm.
       XGRAMMAR_DCHECK(
           element_expr.type == GrammarExprType::kRuleRef ||
           element_expr.type == GrammarExprType::kRepeat
       );
       if (element_expr.type == GrammarExprType::kRuleRef) {
-        Enqueue(ParserState{
-            parent_state.rule_id,
-            parent_state.sequence_id,
-            parent_state.element_id + 1,
-            parent_state.rule_start_pos,
-            parent_state.budget_deadline,
-            0,
-            0,
-            0,
-            parent_state.active_temperature_rule_id,
-            parent_state.char_budget_deadline
-        });
+        completed_parent.element_id++;
+        completed_parent.repeat_count = 0;
+        Enqueue(std::move(completed_parent));
         continue;
       }
       XGRAMMAR_DCHECK(element_expr.type == GrammarExprType::kRepeat);
       // The parent state is a repeat, we need to increase the repeat count.
-      auto new_state = parent_state;
+      auto new_state = completed_parent;
       const int32_t& min_repeat_count = element_expr[1];
       const int32_t& max_repeat_count = element_expr[2];
       new_state.repeat_count++;
       // The repeat rule can be completed, and we advance the state. Don't forget to
       // reset the repeat count.
       if (new_state.repeat_count >= min_repeat_count) {
-        Enqueue(ParserState{
-            parent_state.rule_id,
-            parent_state.sequence_id,
-            parent_state.element_id + 1,
-            parent_state.rule_start_pos,
-            parent_state.budget_deadline,
-            0,
-            0,
-            0,
-            parent_state.active_temperature_rule_id,
-            parent_state.char_budget_deadline
-        });
+        auto completed_repeat = completed_parent;
+        completed_repeat.element_id++;
+        completed_repeat.repeat_count = 0;
+        Enqueue(std::move(completed_repeat));
       }
       // If the repeat count is less than the max repeat count, we can continue to
       // visit the repeat state for another round.
@@ -209,50 +514,33 @@ void EarleyParser::Complete(const ParserState& state, bool debug_print, bool mar
       continue;
     }
     // If the rule is referenced by a fsm, we need to advance the fsm.
-    XGRAMMAR_DCHECK(grammar_->per_rule_fsms[parent_state.rule_id].has_value());
+    XGRAMMAR_DCHECK(grammar_->per_rule_fsms[completed_parent.rule_id].has_value());
 
     // Check if the parent_state sits on a kRepeatRef edge
     bool handled_as_repeat = false;
-    const auto& parent_fsm = grammar_->per_rule_fsms[parent_state.rule_id].value();
-    for (const auto& edge : parent_fsm.GetFsm().GetFsm().GetEdges(parent_state.element_id)) {
+    const auto& parent_fsm = grammar_->per_rule_fsms[completed_parent.rule_id].value();
+    for (const auto& edge : parent_fsm.GetFsm().GetFsm().GetEdges(completed_parent.element_id)) {
       // Because of invariance, a state with a kRepeatRef edge has exactly one outgoing edge.
       if (!edge.IsRepeatRef()) continue;
       auto info = grammar_->complete_fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
       if (info.RuleId() != ref_id) continue;
       handled_as_repeat = true;
-      int32_t new_count = parent_state.repeat_count + 1;
+      int32_t new_count = completed_parent.repeat_count + 1;
       if (new_count >= info.Lower()) {
-        Enqueue(ParserState{
-            parent_state.rule_id,
-            parent_state.sequence_id,
-            edge.target,
-            parent_state.rule_start_pos,
-            parent_state.budget_deadline,
-            0,
-            0,
-            0,
-            parent_state.active_temperature_rule_id,
-            parent_state.char_budget_deadline
-        });
+        auto completed_repeat = completed_parent;
+        completed_repeat.element_id = edge.target;
+        completed_repeat.repeat_count = 0;
+        Enqueue(std::move(completed_repeat));
       }
       if (new_count < info.Upper()) {
-        Enqueue(ParserState{
-            parent_state.rule_id,
-            parent_state.sequence_id,
-            parent_state.element_id,
-            parent_state.rule_start_pos,
-            parent_state.budget_deadline,
-            0,
-            new_count,
-            0,
-            parent_state.active_temperature_rule_id,
-            parent_state.char_budget_deadline
-        });
+        auto continued_repeat = completed_parent;
+        continued_repeat.repeat_count = new_count;
+        Enqueue(std::move(continued_repeat));
       }
       break;
     }
     if (!handled_as_repeat) {
-      Enqueue(parent_state);
+      Enqueue(std::move(completed_parent));
     }
   }
 }
@@ -286,18 +574,12 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
     }
     case GrammarExprType::kCharacterClassStar: {
       if (state.sub_element_id == 0) {
-        Enqueue(ParserState{
-            state.rule_id,
-            state.sequence_id,
-            state.element_id + 1,
-            state.rule_start_pos,
-            state.budget_deadline,
-            0,
-            0,
-            0,
-            state.active_temperature_rule_id,
-            state.char_budget_deadline
-        });
+        auto completed_star = state;
+        completed_star.element_id++;
+        completed_star.sub_element_id = 0;
+        completed_star.repeat_count = 0;
+        completed_star.partial_codepoint = 0;
+        Enqueue(std::move(completed_star));
       }
       return std::make_pair(true, false);
     }
@@ -309,18 +591,12 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
       XGRAMMAR_DCHECK(state.repeat_count <= max_repeat_count);
       ExpandNextRuleRefElement(state, grammar_expr, &element_expr, debug_print);
       if (state.repeat_count >= min_repeat_count) {
-        Enqueue(ParserState{
-            state.rule_id,
-            state.sequence_id,
-            state.element_id + 1,
-            state.rule_start_pos,
-            state.budget_deadline,
-            0,
-            0,
-            0,
-            state.active_temperature_rule_id,
-            state.char_budget_deadline
-        });
+        auto completed_repeat = state;
+        completed_repeat.element_id++;
+        completed_repeat.sub_element_id = 0;
+        completed_repeat.repeat_count = 0;
+        completed_repeat.partial_codepoint = 0;
+        Enqueue(std::move(completed_repeat));
       }
       return std::make_pair(false, false);
     }
@@ -431,6 +707,17 @@ bool EarleyParser::Advance(const uint8_t ch, bool debug_print) {
   if (!tmp_completed_lazy_occurrences_.empty()) {
     RemoveCommittedLazyStates();
   }
+  if (!unique_key_scope_rules_.empty() && tmp_states_to_be_added_.empty() &&
+      !tmp_accept_stop_token_) {
+    rule_id_to_completable_states_.PopBack(1);
+    if (capture_tracking_) {
+      capture_event_history_.PopBack(1);
+    }
+    if (has_char_budget_rules_) {
+      char_count_history_.pop_back();
+    }
+    return false;
+  }
   is_completed_.push_back(tmp_accept_stop_token_);
   scanable_state_history_.PushBack(tmp_states_to_be_added_);
   if (has_char_budget_rules_) {
@@ -454,23 +741,21 @@ void EarleyParser::RemoveCommittedLazyStates() {
   );
 }
 
-EarleyParser::EarleyParser(const Grammar& grammar, std::optional<ParserState> initial_state)
+EarleyParser::EarleyParser(
+    const Grammar& grammar, std::optional<ParserState> initial_state, bool track_unique_key_contexts
+)
     : grammar_(grammar),
       fsm_state_flags_cache_(grammar->NumRules()),
-      rule_is_nullable_(grammar->NumRules(), 0) {
+      rule_is_nullable_(grammar->NumRules(), 0),
+      track_unique_key_contexts_(track_unique_key_contexts) {
   if (!grammar->optimized) {
     XGRAMMAR_LOG(FATAL) << "The grammar is not optimized. Please optimize the grammar before using "
                            "the Earley parser.";
   }
   for (int32_t i = 0; i < grammar_->NumRules(); ++i) {
-    has_budget_rules_ = has_budget_rules_ || grammar_->GetRule(i).max_tokens >= 0;
-    has_char_budget_rules_ = has_char_budget_rules_ || grammar_->GetRule(i).max_chars >= 0;
-    if (has_budget_rules_ && has_char_budget_rules_) {
-      break;
-    }
-  }
-  for (int32_t i = 0; i < grammar_->NumRules(); ++i) {
     const auto& rule = grammar_->GetRule(i);
+    has_budget_rules_ = has_budget_rules_ || rule.max_tokens >= 0;
+    has_char_budget_rules_ = has_char_budget_rules_ || rule.max_chars >= 0;
     const auto* suffix_stop_info = grammar_->GetSuffixStopInfo(i);
     capture_tracking_ =
         capture_tracking_ || !rule.capture_name.empty() ||
@@ -479,10 +764,22 @@ EarleyParser::EarleyParser(const Grammar& grammar, std::optional<ParserState> in
         has_hidden_capture_rules_ ||
         (suffix_stop_info != nullptr &&
          (suffix_stop_info->hidden_suffix_bytes > 0 || suffix_stop_info->hidden_stop_bytes > 0));
-    if (capture_tracking_ && has_hidden_capture_rules_) {
-      break;
+    if (IsDynamicTagRule(i)) {
+      has_dynamic_tag_rules_ = true;
+      const auto body = grammar_->GetGrammarExpr(rule.body_expr_id);
+      int32_t scope_rule_id = grammar_->GetDynamicTagUniqueKeyScopeRuleId(body);
+      if (scope_rule_id >= 0) {
+        XGRAMMAR_DCHECK(scope_rule_id < grammar_->NumRules());
+        if (unique_key_scope_rules_.empty()) {
+          unique_key_scope_rules_.assign(grammar_->NumRules(), 0);
+          dynamic_tag_unique_key_scope_rule_ids_.assign(grammar_->NumRules(), -1);
+        }
+        unique_key_scope_rules_[scope_rule_id] = 1;
+        dynamic_tag_unique_key_scope_rule_ids_[i] = scope_rule_id;
+      }
     }
   }
+  track_unique_key_contexts_ = track_unique_key_contexts_ && !unique_key_scope_rules_.empty();
   for (int32_t rule_id : grammar_->allow_empty_rule_ids) {
     rule_is_nullable_[rule_id] = true;
   }
@@ -510,20 +807,31 @@ uint8_t EarleyParser::InitializeFsmStateFlags(int32_t rule_id, int32_t state_id)
   if (edges.size() != 0) {
     flags |= kFsmStateHasEdges;
   }
+  if (!has_dynamic_tag_rules_) {
+    for (const auto& edge : edges) {
+      if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken()) {
+        flags |= kFsmStateScanable;
+      } else if (edge.IsRuleRef() || edge.IsEpsilon() || edge.IsRepeatRef()) {
+        flags |= kFsmStateNonTerminal;
+      }
+    }
+    return flags;
+  }
   for (const auto& edge : edges) {
-    if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken()) {
+    if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken() || edge.IsBackReference()) {
       flags |= kFsmStateScanable;
-    } else if (edge.IsRuleRef() || edge.IsEpsilon() || edge.IsRepeatRef()) {
+    } else if (edge.IsRuleRef() || edge.IsCaptureStart() || edge.IsCaptureEnd() ||
+               edge.IsEpsilon() || edge.IsRepeatRef()) {
       flags |= kFsmStateNonTerminal;
     }
   }
   return flags;
 }
 
-ParserState EarleyParser::RootInitialState() const {
+ParserState EarleyParser::RootInitialState() {
   const auto root_rule_id = grammar_->GetRootRuleId();
   XGRAMMAR_DCHECK(grammar_->per_rule_fsms[root_rule_id].has_value());
-  return ParserState(
+  ParserState result(
       root_rule_id,
       grammar_->GetRule(root_rule_id).body_expr_id,
       grammar_->per_rule_fsms[root_rule_id]->GetFsm().GetStart(),
@@ -535,6 +843,12 @@ ParserState EarleyParser::RootInitialState() const {
       ResolveActiveTemperatureRule(root_rule_id, -1),
       CharDeadlineForRule(root_rule_id, -1)
   );
+  if (track_unique_key_contexts_) {
+    result.unique_key_state_id = MakeChildUniqueKeyState(
+        /*parent_state_id=*/0, root_rule_id, ParserState::kNoPrevInputPos
+    );
+  }
+  return result;
 }
 
 void EarleyParser::PushStateAndExpand(const ParserState& state) {
@@ -581,6 +895,7 @@ void EarleyParser::Reset() {
   char_budget_entry_history_.clear();
   tmp_char_budget_entered_ = false;
   capture_recording_ = false;
+  RestoreUniqueKeyContexts({});
   XGRAMMAR_DCHECK(tmp_process_state_queue_.empty());
   PushStateAndExpand(RootInitialState());
 }
@@ -609,11 +924,12 @@ void EarleyParser::ExpandNextRuleRefElement(
   bool right_recursion_to_root = false;
   // The right-recursion optimization elides the completion of the parent rule (and, in the
   // to-root case, corrupts the start position of the child rule), so it must be disabled when
-  // either rule produces capture-history events.
+  // either rule produces capture-history events or the parent closes a unique-key scope.
   if (state.element_id != grammar_expr.size() - 1 ||
       sub_grammar_expr->type == GrammarExprType::kRepeat ||
       (state.rule_start_pos == rule_id_to_completable_states_.size() - 1) ||
-      RuleNeedsCaptureEvent(state.rule_id) || RuleNeedsCaptureEvent(ref_rule_id)) {
+      RuleNeedsCaptureEvent(state.rule_id) || RuleNeedsCaptureEvent(ref_rule_id) ||
+      (!unique_key_scope_rules_.empty() && IsUniqueKeyScopeRule(state.rule_id))) {
     // It's not the right recursion, or it's the root rule.
     rule_id_to_completable_states_.PushBackInLatestRow(std::make_pair(ref_rule_id, state));
   } else {
@@ -634,9 +950,18 @@ void EarleyParser::ExpandNextRuleRefElement(
       std::vector<std::pair<int32_t, ParserState>> to_added_states;
       for (const auto& parent_state_iter : parent_states_map) {
         if (parent_state_iter.first != state.rule_id) continue;
-        const auto& parent_state = parent_state_iter.second;
+        auto parent_state = parent_state_iter.second;
+        if (track_unique_key_contexts_) {
+          // Preserve the branch-local mutations that the elided completion would have carried
+          // into this ancestor before the recursive child eventually completes it.
+          auto propagated_state = CompleteUniqueKeyState(parent_state.unique_key_state_id, state);
+          if (!propagated_state.has_value()) {
+            continue;
+          }
+          parent_state.unique_key_state_id = *propagated_state;
+        }
         if (!in_vec(parent_state)) {
-          to_added_states.push_back({ref_rule_id, parent_state});
+          to_added_states.push_back({ref_rule_id, std::move(parent_state)});
         }
       }
       for (const auto& to_add_state : to_added_states) {
@@ -647,18 +972,12 @@ void EarleyParser::ExpandNextRuleRefElement(
 
   if (IsRuleNullable(ref_rule_id)) {
     XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kSequence);
-    Enqueue(ParserState{
-        state.rule_id,
-        state.sequence_id,
-        state.element_id + 1,
-        state.rule_start_pos,
-        state.budget_deadline,
-        0,
-        0,
-        0,
-        state.active_temperature_rule_id,
-        state.char_budget_deadline
-    });
+    auto skipped_nullable = state;
+    skipped_nullable.element_id++;
+    skipped_nullable.sub_element_id = 0;
+    skipped_nullable.repeat_count = 0;
+    skipped_nullable.partial_codepoint = 0;
+    Enqueue(std::move(skipped_nullable));
   }
 
   // If the reference rule is not visited, we need to add it to the queue.
@@ -670,18 +989,23 @@ void EarleyParser::ExpandNextRuleRefElement(
 
   XGRAMMAR_DCHECK(grammar_->per_rule_fsms[ref_rule_id].has_value());
   const auto& ref_fsm = grammar_->per_rule_fsms[ref_rule_id].value();
+  const int32_t child_start_pos = right_recursion_to_root
+                                      ? ParserState::kNoPrevInputPos
+                                      : int32_t(rule_id_to_completable_states_.size() - 1);
   Enqueue(ParserState{
       ref_rule_id,
       ref_grammar_expr_id,
       ref_fsm.GetFsm().GetStart(),
-      right_recursion_to_root ? ParserState::kNoPrevInputPos
-                              : int32_t(rule_id_to_completable_states_.size() - 1),
+      child_start_pos,
       DeadlineForRule(ref_rule_id, state.budget_deadline),
       0,
       0,
       0,
       ResolveActiveTemperatureRule(ref_rule_id, state.active_temperature_rule_id),
-      CharDeadlineForRule(ref_rule_id, state.char_budget_deadline)
+      CharDeadlineForRule(ref_rule_id, state.char_budget_deadline),
+      track_unique_key_contexts_
+          ? MakeChildUniqueKeyState(state.unique_key_state_id, ref_rule_id, child_start_pos)
+          : state.unique_key_state_id
   });
 }
 
@@ -698,21 +1022,45 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
           edge.target,
           state.rule_start_pos,
           state.budget_deadline,
+          state.sub_element_id,
           0,
-          0,
-          0,
+          state.partial_codepoint,
           state.active_temperature_rule_id,
-          state.char_budget_deadline
+          state.char_budget_deadline,
+          state.unique_key_state_id
       });
       continue;
     }
+    if (edge.IsCaptureStart()) {
+      XGRAMMAR_DCHECK(IsDynamicTagRule(state.rule_id));
+      auto capture_started = state;
+      capture_started.element_id = edge.target;
+      capture_started.sub_element_id =
+          static_cast<int32_t>(rule_id_to_completable_states_.size()) - 1;
+      Enqueue(std::move(capture_started));
+      continue;
+    }
+    if (edge.IsCaptureEnd()) {
+      XGRAMMAR_DCHECK(IsDynamicTagRule(state.rule_id));
+      auto capture_ended = state;
+      capture_ended.element_id = edge.target;
+      capture_ended.partial_codepoint =
+          static_cast<int32_t>(rule_id_to_completable_states_.size()) - 1;
+      Enqueue(std::move(capture_ended));
+      continue;
+    }
 
+    ParserState transition_state = state;
     int target;
     int ref_rule_id;
     bool is_repeat = false;
     RepeatEdgeRef repeat_info{nullptr};
 
     if (edge.IsRuleRef()) {
+      if (IsUniqueKeyDynamicTagRule(state.rule_id) &&
+          !PrepareDynamicTagContent(&transition_state)) {
+        continue;
+      }
       target = edge.target;
       ref_rule_id = edge.GetRefRuleId();
     } else if (edge.IsRepeatRef()) {
@@ -721,21 +1069,13 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
       target = edge.target;
       ref_rule_id = repeat_info.RuleId();
 
-      if (state.repeat_count >= repeat_info.Lower()) {
-        Enqueue(ParserState{
-            state.rule_id,
-            state.sequence_id,
-            target,
-            state.rule_start_pos,
-            state.budget_deadline,
-            0,
-            0,
-            0,
-            state.active_temperature_rule_id,
-            state.char_budget_deadline
-        });
+      if (transition_state.repeat_count >= repeat_info.Lower()) {
+        auto completed_repeat = transition_state;
+        completed_repeat.element_id = target;
+        completed_repeat.repeat_count = 0;
+        Enqueue(std::move(completed_repeat));
       }
-      if (state.repeat_count >= repeat_info.Upper()) {
+      if (transition_state.repeat_count >= repeat_info.Upper()) {
         continue;
       }
     } else {
@@ -750,9 +1090,10 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
     const uint8_t target_flags = GetFsmStateFlags(state.rule_id, target);
     if (!is_repeat && !(target_flags & kFsmStateHasEdges) && (target_flags & kFsmStateEnd) &&
         state.rule_start_pos != static_cast<int32_t>(rule_id_to_completable_states_.size() - 1) &&
-        !RuleNeedsCaptureEvent(state.rule_id) && !RuleNeedsCaptureEvent(ref_rule_id)) {
+        !RuleNeedsCaptureEvent(state.rule_id) && !RuleNeedsCaptureEvent(ref_rule_id) &&
+        (unique_key_scope_rules_.empty() || !IsUniqueKeyScopeRule(state.rule_id))) {
       // It's a right recursion. We can optimize it. The optimization elides the completion of
-      // the parent rule, so it is disabled when either rule produces capture-history events.
+      // the parent rule, so it is disabled for capture events and unique-key scope boundaries.
       // If it's the right recursion, we need to add the ancestors of the parent state.
       if (state.rule_start_pos == ParserState::kNoPrevInputPos) {
         // In this case, we can mark the new state as the root state to speed up.
@@ -771,9 +1112,19 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
         std::vector<std::pair<int32_t, ParserState>> to_added_states;
         for (const auto& parent_state_iter : parent_states_map) {
           if (parent_state_iter.first != state.rule_id) continue;
-          const auto& parent_state = parent_state_iter.second;
+          auto parent_state = parent_state_iter.second;
+          if (track_unique_key_contexts_) {
+            // Preserve the branch-local mutations that the elided completion would have carried
+            // into this ancestor before the recursive child eventually completes it.
+            auto propagated_state =
+                CompleteUniqueKeyState(parent_state.unique_key_state_id, transition_state);
+            if (!propagated_state.has_value()) {
+              continue;
+            }
+            parent_state.unique_key_state_id = *propagated_state;
+          }
           if (!in_vec(parent_state)) {
-            to_added_states.push_back({ref_rule_id, parent_state});
+            to_added_states.push_back({ref_rule_id, std::move(parent_state)});
           }
         }
         for (const auto& to_add_state : to_added_states) {
@@ -791,11 +1142,12 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
                  state.element_id,
                  state.rule_start_pos,
                  state.budget_deadline,
-                 0,
+                 state.sub_element_id,
                  state.repeat_count,
-                 0,
+                 state.partial_codepoint,
                  state.active_temperature_rule_id,
-                 state.char_budget_deadline
+                 state.char_budget_deadline,
+                 transition_state.unique_key_state_id
              }}
         );
       } else {
@@ -808,11 +1160,12 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
                  target,
                  state.rule_start_pos,
                  state.budget_deadline,
+                 state.sub_element_id,
                  0,
-                 0,
-                 0,
+                 state.partial_codepoint,
                  state.active_temperature_rule_id,
-                 state.char_budget_deadline
+                 state.char_budget_deadline,
+                 transition_state.unique_key_state_id
              }}
         );
       }
@@ -820,18 +1173,10 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
 
     // Check if the reference rule can be empty.
     if (!is_repeat && IsRuleNullable(ref_rule_id)) {
-      Enqueue(ParserState{
-          state.rule_id,
-          state.sequence_id,
-          target,
-          state.rule_start_pos,
-          state.budget_deadline,
-          0,
-          0,
-          0,
-          state.active_temperature_rule_id,
-          state.char_budget_deadline
-      });
+      auto skipped_nullable = transition_state;
+      skipped_nullable.element_id = target;
+      skipped_nullable.repeat_count = 0;
+      Enqueue(std::move(skipped_nullable));
     }
 
     // If the reference rule is not visited, we need to add it to the queue.
@@ -843,18 +1188,25 @@ void EarleyParser::ExpandNextRuleRefElementOnFSM(const ParserState& state, bool 
 
     XGRAMMAR_DCHECK(grammar_->per_rule_fsms[ref_rule_id].has_value());
     const auto& ref_fsm = grammar_->per_rule_fsms[ref_rule_id].value();
+    const int32_t child_start_pos = right_recursion_to_root
+                                        ? ParserState::kNoPrevInputPos
+                                        : int32_t(rule_id_to_completable_states_.size() - 1);
     Enqueue(ParserState{
         ref_rule_id,
         ref_grammar_expr_id,
         ref_fsm.GetFsm().GetStart(),
-        right_recursion_to_root ? ParserState::kNoPrevInputPos
-                                : int32_t(rule_id_to_completable_states_.size() - 1),
-        DeadlineForRule(ref_rule_id, state.budget_deadline),
+        child_start_pos,
+        DeadlineForRule(ref_rule_id, transition_state.budget_deadline),
         0,
         0,
         0,
-        ResolveActiveTemperatureRule(ref_rule_id, state.active_temperature_rule_id),
-        CharDeadlineForRule(ref_rule_id, state.char_budget_deadline)
+        ResolveActiveTemperatureRule(ref_rule_id, transition_state.active_temperature_rule_id),
+        CharDeadlineForRule(ref_rule_id, transition_state.char_budget_deadline),
+        track_unique_key_contexts_
+            ? MakeChildUniqueKeyState(
+                  transition_state.unique_key_state_id, ref_rule_id, child_start_pos
+              )
+            : transition_state.unique_key_state_id
     });
   }
 }
@@ -1144,7 +1496,55 @@ void EarleyParser::AdvanceCharacterClassStar(
 void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
   XGRAMMAR_DCHECK(state.rule_id != -1 && grammar_->per_rule_fsms[state.rule_id].has_value());
   const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
-  for (const auto& edge : current_fsm.GetFsm().GetFsm().GetEdges(state.element_id)) {
+  const auto& edges = current_fsm.GetFsm().GetFsm().GetEdges(state.element_id);
+  if (!has_dynamic_tag_rules_) {
+    for (const auto& edge : edges) {
+      if ((!edge.IsCharRange()) || ch < edge.min || ch > edge.max) {
+        continue;
+      }
+      auto new_state = state;
+      new_state.element_id = edge.target;
+      const uint8_t flags = GetFsmStateFlags(state.rule_id, edge.target);
+      if (!(flags & kFsmStateNonTerminal) && !(flags & kFsmStateEnd) &&
+          (flags & kFsmStateScanable)) {
+        EnqueueWithoutProcessing(std::move(new_state));
+      } else {
+        Enqueue(std::move(new_state));
+      }
+    }
+    return;
+  }
+  for (const auto& edge : edges) {
+    if (edge.IsBackReference()) {
+      auto progress = GetBackReferenceProgress(state);
+      if (!progress.has_value()) {
+        if (AllowWildcardBackReference()) {
+          EnqueueWithoutProcessing(state);
+          auto completed = state;
+          completed.element_id = edge.target;
+          completed.sub_element_id = 0;
+          completed.repeat_count = 0;
+          completed.partial_codepoint = 0;
+          Enqueue(std::move(completed));
+        }
+        continue;
+      }
+      if (progress->next_byte != ch) {
+        continue;
+      }
+      auto new_state = state;
+      if (progress->is_last_byte) {
+        new_state.element_id = edge.target;
+        new_state.sub_element_id = 0;
+        new_state.repeat_count = 0;
+        new_state.partial_codepoint = 0;
+        Enqueue(std::move(new_state));
+      } else {
+        ++new_state.repeat_count;
+        EnqueueWithoutProcessing(std::move(new_state));
+      }
+      continue;
+    }
     if ((!edge.IsCharRange()) || ch < edge.min || ch > edge.max) {
       continue;
     }
@@ -1227,6 +1627,17 @@ bool EarleyParser::AdvanceAtomicToken(
   }
   if (!tmp_completed_lazy_occurrences_.empty()) {
     RemoveCommittedLazyStates();
+  }
+  if (!unique_key_scope_rules_.empty() && tmp_states_to_be_added_.empty() &&
+      !tmp_accept_stop_token_) {
+    rule_id_to_completable_states_.PopBack(1);
+    if (capture_tracking_) {
+      capture_event_history_.PopBack(1);
+    }
+    if (has_char_budget_rules_) {
+      char_count_history_.pop_back();
+    }
+    return false;
   }
   is_completed_.push_back(tmp_accept_stop_token_);
   scanable_state_history_.PushBack(tmp_states_to_be_added_);

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -9,9 +9,11 @@
 #include <algorithm>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <ostream>
 #include <queue>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -54,7 +56,8 @@ struct ParserState {
       const int32_t& repeat_count = 0,
       const int32_t& partial_codepoint = 0,
       const int32_t& active_temperature_rule_id = -1,
-      const int32_t& char_budget_deadline = -1
+      const int32_t& char_budget_deadline = -1,
+      const int32_t& unique_key_state_id = 0
   )
       : rule_id(rule_id),
         sequence_id(sequence_id),
@@ -65,7 +68,8 @@ struct ParserState {
         repeat_count(repeat_count),
         partial_codepoint(partial_codepoint),
         active_temperature_rule_id(active_temperature_rule_id),
-        char_budget_deadline(char_budget_deadline) {}
+        char_budget_deadline(char_budget_deadline),
+        unique_key_state_id(unique_key_state_id) {}
 
   /*!
    * \brief A rule_start_pos value of kNoPrevInputPos means this ParserState is the root of the
@@ -93,13 +97,15 @@ struct ParserState {
    * is predicted and inherited by the states inside it. */
   int32_t budget_deadline = -1;
 
-  /*! \brief The id of the sub element in the current element of the sequence. */
+  /*! \brief The id of the sub element in the current element of the sequence. In a DynamicTag
+   * FSM, this stores the parser row at the start of the captured opening name. */
   int32_t sub_element_id = 0;
 
   /*! \brief The number of times the element is repeated. It will be used in kRepeat.*/
   int32_t repeat_count = 0;
 
-  /*! \brief Partial codepoint accumulated during UTF-8 decoding for positive character classes. */
+  /*! \brief Partial codepoint accumulated during UTF-8 decoding. In a DynamicTag FSM, this
+   * stores the parser row at the end of the captured opening name; the two uses cannot overlap. */
   int32_t partial_codepoint = 0;
 
   /*! \brief The innermost active rule that specifies a sampling temperature. */
@@ -108,6 +114,10 @@ struct ParserState {
   /*! \brief The number of Unicode codepoints this derivation may consume before its active
    * character budget expires; -1 means unlimited. Stored as an absolute input position. */
   int32_t char_budget_deadline = -1;
+
+  /*! \brief Matcher-local state for branch-scoped DynamicTag key uniqueness. Zero for grammars
+   * that do not use scoped dynamic keys. */
+  int32_t unique_key_state_id = 0;
 
   /*!
    * \brief Lexicographic order over all fields. It is only used to sort the states for
@@ -127,7 +137,10 @@ struct ParserState {
     if (active_temperature_rule_id != other.active_temperature_rule_id) {
       return active_temperature_rule_id < other.active_temperature_rule_id;
     }
-    return char_budget_deadline < other.char_budget_deadline;
+    if (char_budget_deadline != other.char_budget_deadline) {
+      return char_budget_deadline < other.char_budget_deadline;
+    }
+    return unique_key_state_id < other.unique_key_state_id;
   }
 
   friend std::ostream& operator<<(std::ostream& os, const ParserState& state) {
@@ -156,6 +169,9 @@ struct ParserState {
     if (char_budget_deadline != -1) {
       result += ", char_budget_deadline=" + std::to_string(char_budget_deadline);
     }
+    if (unique_key_state_id != 0) {
+      result += ", unique_key_state_id=" + std::to_string(unique_key_state_id);
+    }
     result += ")";
     return result;
   }
@@ -172,13 +188,17 @@ XGRAMMAR_MEMBER_ARRAY(
     &ParserState::repeat_count,
     &ParserState::partial_codepoint,
     &ParserState::active_temperature_rule_id,
-    &ParserState::char_budget_deadline
+    &ParserState::char_budget_deadline,
+    &ParserState::unique_key_state_id
 );
 
 /*!
- * \brief Hash of a state used as the key of the adaptive token mask cache. The token mask of a
- * state does not depend on rule_start_pos, repeat_count or partial_codepoint, so they are
- * ignored. Pairs with StateEqualForCache.
+ * \brief Hash of a state used as the key of the adaptive token mask cache.
+ *
+ * The reusable cache is keyed only by grammar position. Runtime-dependent fields are ignored:
+ * character budgets are handled by boundary checks, and DynamicTag backreferences and scoped
+ * key uniqueness use a conservative cache plus matcher-local exact checks. Pairs with
+ * StateEqualForCache.
  */
 class StateHashForCache {
  public:
@@ -212,7 +232,8 @@ class StateEqualForParsing {
            lhs.partial_codepoint == rhs.partial_codepoint &&
            lhs.budget_deadline == rhs.budget_deadline &&
            lhs.active_temperature_rule_id == rhs.active_temperature_rule_id &&
-           lhs.char_budget_deadline == rhs.char_budget_deadline;
+           lhs.char_budget_deadline == rhs.char_budget_deadline &&
+           lhs.unique_key_state_id == rhs.unique_key_state_id;
   }
 };
 
@@ -223,7 +244,7 @@ class StateEqualForParsing {
 class StateHashForParsing {
  public:
   size_t operator()(const ParserState& state) const {
-    return HashCombine(
+    const uint64_t base_hash = HashCombine(
         state.rule_id,
         state.sequence_id,
         state.element_id,
@@ -235,6 +256,10 @@ class StateHashForParsing {
         state.active_temperature_rule_id,
         state.char_budget_deadline
     );
+    // Keep the ordinary-grammar hot path at its original hashing cost. DynamicTag uniqueness is
+    // opt-in, and zero is the only value used by grammars that do not request it.
+    return state.unique_key_state_id == 0 ? base_hash
+                                          : HashCombine(base_hash, state.unique_key_state_id);
   }
 };
 
@@ -468,6 +493,132 @@ class EarleyParser {
    */
   bool capture_recording_ = false;
 
+  /*! \brief Whether the optimized grammar contains a DynamicTag rule. */
+  bool has_dynamic_tag_rules_ = false;
+
+  /*! \brief Rules whose concrete occurrences delimit DynamicTag key-uniqueness scopes. */
+  std::vector<uint8_t> unique_key_scope_rules_;
+
+  /*! \brief Scope rule id for each scoped DynamicTag rule, or -1. Empty if none exist. */
+  std::vector<int32_t> dynamic_tag_unique_key_scope_rule_ids_;
+
+  /*! \brief Whether this parser instance performs matcher-local uniqueness tracking. The
+   * compiler's conservative parsers leave this disabled so runtime IDs never enter caches. */
+  bool track_unique_key_contexts_ = false;
+
+  struct UniqueKeyContextNode {
+    enum class Kind : uint8_t { kRoot, kScope, kKey };
+
+    Kind kind = Kind::kRoot;
+    int32_t parent_id = 0;
+    int32_t scope_rule_id = -1;
+    int32_t scope_start_pos = ParserState::kNoPrevInputPos;
+    int32_t name_start_byte = -1;
+    int32_t byte_length = 0;
+    int32_t nearest_scope_context_id = 0;
+    int32_t scope_key_depth = 0;
+    uint64_t name_hash = 0;
+    uint64_t name_bloom = 0;
+    uint64_t signature_hash = 0;
+  };
+
+  struct UniqueKeySemanticState {
+    int32_t current_context_id = 0;
+    int32_t entry_context_id = 0;
+  };
+
+  struct UniqueKeyContextStorage {
+    std::vector<UniqueKeyContextNode> contexts{UniqueKeyContextNode{}};
+    std::vector<UniqueKeySemanticState> semantic_states{UniqueKeySemanticState{}};
+    std::unordered_multimap<uint64_t, int32_t> context_ids_by_hash;
+    std::unordered_map<uint64_t, int32_t> semantic_state_ids;
+    std::unordered_multimap<uint64_t, int32_t> key_context_ids_by_scope_and_name_hash;
+  };
+
+  struct UniqueKeyContextSnapshot {
+    size_t num_contexts = 1;
+    size_t num_semantic_states = 1;
+  };
+
+  std::shared_ptr<UniqueKeyContextStorage> unique_key_context_storage_;
+
+  const UniqueKeySemanticState& GetUniqueKeySemanticState(int32_t state_id) const;
+
+  const UniqueKeyContextNode& GetUniqueKeyContext(int32_t context_id) const;
+
+  int32_t InternUniqueKeySemanticState(int32_t current_context_id, int32_t entry_context_id);
+
+  int32_t InternUniqueKeyContext(UniqueKeyContextNode node);
+
+  int32_t MakeChildUniqueKeyState(
+      int32_t parent_state_id, int32_t child_rule_id, int32_t child_start_pos
+  );
+
+  std::optional<int32_t> CompleteUniqueKeyState(
+      int32_t parent_state_id, const ParserState& completed_state
+  );
+
+  int32_t AppendUniqueKey(
+      int32_t state_id, int32_t name_start_byte, int32_t byte_length, uint64_t name_hash
+  );
+
+  struct UniqueKeyRowRemapCache {
+    std::unordered_map<int32_t, int32_t> context_ids;
+    std::unordered_map<int32_t, int32_t> semantic_state_ids;
+    std::vector<int32_t> context_path;
+  };
+
+  int32_t RemapUniqueKeyStateRows(
+      int32_t state_id, int32_t from_row, int32_t to_row, UniqueKeyRowRemapCache* remap_cache
+  );
+
+  UniqueKeyContextSnapshot SnapshotUniqueKeyContexts() const;
+
+  void RestoreUniqueKeyContexts(const UniqueKeyContextSnapshot& snapshot);
+
+  void EnsureUniqueKeyContextStorage();
+
+  bool IsDynamicTagRule(int32_t rule_id) const {
+    return rule_id >= 0 && grammar_->GetGrammarExpr(grammar_->GetRule(rule_id).body_expr_id).type ==
+                               Grammar::Impl::GrammarExprType::kDynamicTag;
+  }
+
+  bool IsUniqueKeyDynamicTagRule(int32_t rule_id) const {
+    return rule_id >= 0 &&
+           rule_id < static_cast<int32_t>(dynamic_tag_unique_key_scope_rule_ids_.size()) &&
+           dynamic_tag_unique_key_scope_rule_ids_[rule_id] >= 0;
+  }
+
+  int32_t GetDynamicTagUniqueKeyScopeRuleId(int32_t rule_id) const {
+    XGRAMMAR_DCHECK(IsUniqueKeyDynamicTagRule(rule_id));
+    return dynamic_tag_unique_key_scope_rule_ids_[rule_id];
+  }
+
+  bool IsUniqueKeyScopeRule(int32_t rule_id) const {
+    return rule_id >= 0 && rule_id < static_cast<int32_t>(unique_key_scope_rules_.size()) &&
+           unique_key_scope_rules_[rule_id] != 0;
+  }
+
+  struct BackReferenceProgress {
+    uint8_t next_byte;
+    bool is_last_byte;
+  };
+
+  /*! \brief Get the next byte required by a backreference state. GrammarMatcher overrides this
+   * using its matcher-local committed and speculative byte history. */
+  virtual std::optional<BackReferenceProgress> GetBackReferenceProgress(const ParserState& state
+  ) const {
+    return std::nullopt;
+  }
+
+  /*! \brief Whether a backreference should be over-approximated as one or more arbitrary bytes.
+   * Used only while compiling a conservative token mask; normal matching always returns false. */
+  virtual bool AllowWildcardBackReference() const { return false; }
+
+  /*! \brief Validate a scoped DynamicTag name and update this derivation's uniqueness state
+   * after its opening suffix is fully matched. */
+  virtual bool PrepareDynamicTagContent(ParserState* state) { return true; }
+
   /*!
    * \brief The history of capture events. capture_event_history_[i] stores the events recorded
    * when input position i was created. Kept aligned with scanable_state_history_ row-by-row
@@ -556,7 +707,7 @@ class EarleyParser {
   std::pair<bool, bool> Predict(const ParserState& state, bool debug_print = false);
 
   /*! \brief The initial state expanded from the root rule of the grammar. */
-  ParserState RootInitialState() const;
+  ParserState RootInitialState();
 
   /*! \brief Resolve the active temperature rule when entering a rule. */
   int32_t ResolveActiveTemperatureRule(int32_t rule_id, int32_t inherited_rule_id) const;
@@ -672,8 +823,12 @@ class EarleyParser {
    * from the root rule of the grammar.
    */
   explicit EarleyParser(
-      const Grammar& grammar, std::optional<ParserState> initial_state = std::nullopt
+      const Grammar& grammar,
+      std::optional<ParserState> initial_state = std::nullopt,
+      bool track_unique_key_contexts = false
   );
+
+  virtual ~EarleyParser() = default;
 
   /*!
    * \brief From the current states, advance to the next state.

--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -133,6 +133,12 @@ std::string FSMImplBase<ContainerType>::EdgesToString(std::optional<std::vector<
           result += std::to_string(info.TokenIds()[k]);
         }
         result += ")->" + std::to_string(edge.target);
+      } else if (edge.min == FSMEdge::EdgeType::kCaptureStart) {
+        result += "CaptureStart->" + std::to_string(edge.target);
+      } else if (edge.min == FSMEdge::EdgeType::kCaptureEnd) {
+        result += "CaptureEnd->" + std::to_string(edge.target);
+      } else if (edge.min == FSMEdge::EdgeType::kBackReference) {
+        result += "BackReference->" + std::to_string(edge.target);
       }
       if (j < static_cast<int>(edges.size()) - 1) {
         result += ", ";
@@ -248,6 +254,16 @@ class FSM::Impl : public FSMImplBase<std::vector<std::vector<FSMEdge>>> {
 
   void AddRuleEdge(int from, int to, int32_t rule_id) {
     AddEdge(from, to, FSMEdge::EdgeType::kRuleRef, rule_id);
+  }
+
+  void AddCaptureEndEdge(int from, int to) { AddEdge(from, to, FSMEdge::EdgeType::kCaptureEnd, 0); }
+
+  void AddBackReferenceEdge(int from, int to) {
+    AddEdge(from, to, FSMEdge::EdgeType::kBackReference, 0);
+  }
+
+  void AddCaptureStartEdge(int from, int to) {
+    AddEdge(from, to, FSMEdge::EdgeType::kCaptureStart, 0);
   }
 
   void AddEpsilonEdge(int from, int to) { AddEdge(from, to, FSMEdge::EdgeType::kEpsilon, 0); }
@@ -484,6 +500,12 @@ void FSM::AddEdge(int from, int to, FSMEdge::EdgeType type, int32_t value) {
 void FSM::AddEpsilonEdge(int from, int to) { pimpl_->AddEpsilonEdge(from, to); }
 
 void FSM::AddRuleEdge(int from, int to, int32_t rule_id) { pimpl_->AddRuleEdge(from, to, rule_id); }
+
+void FSM::AddCaptureEndEdge(int from, int to) { pimpl_->AddCaptureEndEdge(from, to); }
+
+void FSM::AddBackReferenceEdge(int from, int to) { pimpl_->AddBackReferenceEdge(from, to); }
+
+void FSM::AddCaptureStartEdge(int from, int to) { pimpl_->AddCaptureStartEdge(from, to); }
 
 void FSM::AddEOSEdge(int from, int to) { pimpl_->AddEOSEdge(from, to); }
 
@@ -1025,9 +1047,9 @@ FSMWithStartEnd FSMWithStartEnd::Optional() const {
 }
 
 Result<FSMWithStartEnd> FSMWithStartEnd::Not(int max_result_num_states) const {
-  // Check if the FSM contains any rule references.
+  // Stateful runtime transitions cannot be complemented as a regular language.
   if (!IsLeaf()) {
-    XGRAMMAR_LOG(FATAL) << "Not operation is not supported for FSM with rule references.";
+    XGRAMMAR_LOG(FATAL) << "Not operation is not supported for non-leaf FSMs.";
   }
   FSMWithStartEnd result;
   if (is_dfa_) {
@@ -1152,10 +1174,25 @@ Result<FSMWithStartEnd> FSMWithStartEnd::Intersect(
     const FSMWithStartEnd& lhs, const FSMWithStartEnd& rhs, int max_result_num_states
 ) {
   if (!lhs.IsLeaf() || !rhs.IsLeaf()) {
-    return ResultErr("Intersect only support leaf fsm!");
+    return ResultErr("Intersect only supports FSMs without rule references");
   }
-  auto lhs_dfa_raw = lhs.ToDFA();
-  auto rhs_dfa_raw = rhs.ToDFA();
+  auto is_byte_regular = [](const FSMWithStartEnd& fsm) {
+    std::unordered_set<int> reachable_states;
+    fsm.GetReachableStates(&reachable_states);
+    for (int state : reachable_states) {
+      for (const auto& edge : fsm.GetFsm().GetEdges(state)) {
+        if (!edge.IsCharRange() && !edge.IsEpsilon()) {
+          return false;
+        }
+      }
+    }
+    return true;
+  };
+  if (!is_byte_regular(lhs) || !is_byte_regular(rhs)) {
+    return ResultErr("Intersect only supports byte-regular FSMs");
+  }
+  auto lhs_dfa_raw = lhs.ToDFA(max_result_num_states);
+  auto rhs_dfa_raw = rhs.ToDFA(max_result_num_states);
 
   if (lhs_dfa_raw.IsErr()) {
     return lhs_dfa_raw;
@@ -1191,6 +1228,9 @@ Result<FSMWithStartEnd> FSMWithStartEnd::Intersect(
         int min_value = std::max(lhs_edge.min, rhs_edge.min);
         int max_value = std::min(lhs_edge.max, rhs_edge.max);
         if (state_map.find(std::make_pair(lhs_edge.target, rhs_edge.target)) == state_map.end()) {
+          if (result.NumStates() >= max_result_num_states) {
+            return ResultErr("The number of states exceeds the limit.");
+          }
           state_map[{lhs_edge.target, rhs_edge.target}] = result.AddState();
           queue.push({lhs_edge.target, rhs_edge.target});
         }
@@ -1231,6 +1271,10 @@ bool FSMWithStartEnd::IsDFA() {
           return false;  // Duplicate rule transition.
         }
         rule_transitions.insert(edge.GetRefRuleId());
+        continue;
+      }
+      if (edge.IsCaptureStart() || edge.IsCaptureEnd() || edge.IsBackReference()) {
+        return false;
       }
       // kRepeatRef: by invariant, a state with kRepeatRef has exactly one edge, always
       // deterministic.
@@ -1598,6 +1642,13 @@ FSMWithStartEnd FSMWithStartEnd::MergeEquivalentStates(int max_result_num_states
 }
 
 Result<FSMWithStartEnd> FSMWithStartEnd::MinimizeDFA(int max_num_states) const {
+  for (const auto& edges : fsm_->GetEdges()) {
+    if (std::any_of(edges.begin(), edges.end(), [](const FSMEdge& edge) {
+          return edge.IsCaptureStart() || edge.IsCaptureEnd() || edge.IsBackReference();
+        })) {
+      return ResultErr("Cannot minimize an FSM with runtime-dependent transitions");
+    }
+  }
   FSMWithStartEnd now_fsm(FSM(0), 0, std::vector<int32_t>(), true);
   if (NumStates() > max_num_states) {
     return ResultErr("The number of states exceeds the limit.");
@@ -1726,15 +1777,48 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
   if (NumStates() > max_num_states) {
     return ResultErr("The number of states exceeds the limit.");
   }
+  for (const auto& edges : fsm_->GetEdges()) {
+    if (std::any_of(edges.begin(), edges.end(), [](const FSMEdge& edge) {
+          return edge.IsCaptureStart() || edge.IsCaptureEnd() || edge.IsBackReference();
+        })) {
+      return ResultErr("Cannot determinize an FSM with runtime-dependent transitions");
+    }
+  }
   FSMWithStartEnd dfa(FSM(0), 0, std::vector<int32_t>(), true);
   std::vector<std::unordered_set<int>> closures;
+  const auto closure_hash = [](const std::vector<int>& key) {
+    uint64_t seed = 0;
+    for (int state : key) {
+      HashCombineBinary(seed, std::hash<int>{}(state));
+    }
+    return static_cast<size_t>(seed);
+  };
+  std::unordered_map<std::vector<int>, int32_t, decltype(closure_hash)> closure_ids(
+      0, closure_hash
+  );
+  auto find_or_add_closure = [&](std::unordered_set<int> closure) -> std::optional<int32_t> {
+    std::vector<int> key(closure.begin(), closure.end());
+    std::sort(key.begin(), key.end());
+    if (auto it = closure_ids.find(key); it != closure_ids.end()) {
+      return it->second;
+    }
+    if (closures.size() >= static_cast<size_t>(max_num_states)) {
+      return std::nullopt;
+    }
+    int32_t id = static_cast<int32_t>(closures.size());
+    closures.push_back(std::move(closure));
+    closure_ids.emplace(std::move(key), id);
+    return id;
+  };
   std::unordered_set<int> rules;
   std::unordered_set<int32_t> repeat_aux_indices;
   int now_process = 0;
   std::unordered_set<int> closure;
   closure.insert(start_);
   fsm_.GetEpsilonClosure(&closure);
-  closures.push_back(closure);
+  if (!find_or_add_closure(std::move(closure)).has_value()) {
+    return ResultErr("The number of states exceeds the limit.");
+  }
   while (now_process < static_cast<int>(closures.size())) {
     rules.clear();
     repeat_aux_indices.clear();
@@ -1808,18 +1892,11 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
           }
         }
       }
-      bool flag = false;
-      for (int j = 0; j < static_cast<int>(closures.size()); j++) {
-        if (closures[j] == next_closure) {
-          dfa.GetFsm().AddEdge(now_process, j, interval.first, interval.second);
-          flag = true;
-          break;
-        }
+      auto target = find_or_add_closure(std::move(next_closure));
+      if (!target.has_value()) {
+        return ResultErr("The number of states exceeds the limit.");
       }
-      if (!flag) {
-        dfa.GetFsm().AddEdge(now_process, closures.size(), interval.first, interval.second);
-        closures.push_back(next_closure);
-      }
+      dfa.GetFsm().AddEdge(now_process, *target, interval.first, interval.second);
     }
     for (auto rule : rules) {
       std::unordered_set<int> next_closure;
@@ -1838,18 +1915,11 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
           }
         }
       }
-      bool flag = false;
-      for (int j = 0; j < static_cast<int>(closures.size()); j++) {
-        if (closures[j] == next_closure) {
-          dfa.GetFsm().AddRuleEdge(now_process, j, rule);
-          flag = true;
-          break;
-        }
+      auto target = find_or_add_closure(std::move(next_closure));
+      if (!target.has_value()) {
+        return ResultErr("The number of states exceeds the limit.");
       }
-      if (!flag) {
-        dfa.GetFsm().AddRuleEdge(now_process, closures.size(), rule);
-        closures.push_back(next_closure);
-      }
+      dfa.GetFsm().AddRuleEdge(now_process, *target, rule);
     }
 
     for (auto aux_idx : repeat_aux_indices) {
@@ -1867,18 +1937,11 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
           }
         }
       }
-      bool flag = false;
-      for (int j = 0; j < static_cast<int>(closures.size()); j++) {
-        if (closures[j] == next_closure) {
-          dfa.GetFsm().AddEdge(now_process, j, FSMEdge::EdgeType::kRepeatRef, aux_idx);
-          flag = true;
-          break;
-        }
+      auto target = find_or_add_closure(std::move(next_closure));
+      if (!target.has_value()) {
+        return ResultErr("The number of states exceeds the limit.");
       }
-      if (!flag) {
-        dfa.GetFsm().AddEdge(now_process, closures.size(), FSMEdge::EdgeType::kRepeatRef, aux_idx);
-        closures.push_back(next_closure);
-      }
+      dfa.GetFsm().AddEdge(now_process, *target, FSMEdge::EdgeType::kRepeatRef, aux_idx);
     }
 
     for (auto aux_idx : token_aux_indices) {
@@ -1896,18 +1959,11 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
           }
         }
       }
-      bool flag = false;
-      for (int j = 0; j < static_cast<int>(closures.size()); j++) {
-        if (closures[j] == next_closure) {
-          dfa.GetFsm().AddEdge(now_process, j, FSMEdge::EdgeType::kToken, aux_idx);
-          flag = true;
-          break;
-        }
+      auto target = find_or_add_closure(std::move(next_closure));
+      if (!target.has_value()) {
+        return ResultErr("The number of states exceeds the limit.");
       }
-      if (!flag) {
-        dfa.GetFsm().AddEdge(now_process, closures.size(), FSMEdge::EdgeType::kToken, aux_idx);
-        closures.push_back(next_closure);
-      }
+      dfa.GetFsm().AddEdge(now_process, *target, FSMEdge::EdgeType::kToken, aux_idx);
     }
 
     for (auto aux_idx : exclude_token_aux_indices) {
@@ -1925,20 +1981,11 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
           }
         }
       }
-      bool flag = false;
-      for (int j = 0; j < static_cast<int>(closures.size()); j++) {
-        if (closures[j] == next_closure) {
-          dfa.GetFsm().AddEdge(now_process, j, FSMEdge::EdgeType::kExcludeToken, aux_idx);
-          flag = true;
-          break;
-        }
+      auto target = find_or_add_closure(std::move(next_closure));
+      if (!target.has_value()) {
+        return ResultErr("The number of states exceeds the limit.");
       }
-      if (!flag) {
-        dfa.GetFsm().AddEdge(
-            now_process, closures.size(), FSMEdge::EdgeType::kExcludeToken, aux_idx
-        );
-        closures.push_back(next_closure);
-      }
+      dfa.GetFsm().AddEdge(now_process, *target, FSMEdge::EdgeType::kExcludeToken, aux_idx);
     }
 
     now_process++;

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -56,6 +56,15 @@ struct FSMEdge {
     //! Accepts any token NOT in the given set. max = aux index into edge_aux_data
     //! (layout: [count, token_id_0, token_id_1, ...]).
     kExcludeToken = -6,
+    //! Zero-width marker recording the end input position of a DynamicTag opening name.
+    //! max is reserved and must be zero.
+    kCaptureEnd = -7,
+    //! Replays the bytes between the DynamicTag opening-name start and kCaptureEnd in the same
+    //! rule occurrence. max is reserved and must be zero.
+    kBackReference = -8,
+    //! Zero-width marker recording the start input position of a DynamicTag opening name.
+    //! max is reserved and must be zero.
+    kCaptureStart = -9,
   };
 
   inline static constexpr int kMaxChar = 255;
@@ -120,6 +129,12 @@ struct FSMEdge {
   bool IsToken() const { return min == EdgeType::kToken; }
 
   bool IsExcludeToken() const { return min == EdgeType::kExcludeToken; }
+
+  bool IsCaptureEnd() const { return min == EdgeType::kCaptureEnd; }
+
+  bool IsBackReference() const { return min == EdgeType::kBackReference; }
+
+  bool IsCaptureStart() const { return min == EdgeType::kCaptureStart; }
 
   /*!
    * \brief Get the rule id of the edge.
@@ -345,6 +360,15 @@ class FSM {
    * \param rule_id The rule id to reference.
    */
   void AddRuleEdge(int from, int to, int32_t rule_id);
+
+  /*! \brief Add a zero-width marker that records the end of a DynamicTag opening name. */
+  void AddCaptureEndEdge(int from, int to);
+
+  /*! \brief Add an edge that replays a name captured earlier in the same rule occurrence. */
+  void AddBackReferenceEdge(int from, int to);
+
+  /*! \brief Add a zero-width marker that records the start of a DynamicTag opening name. */
+  void AddCaptureStartEdge(int from, int to);
 
   /*!
    * \brief Add an EOS transition between two states.
@@ -631,11 +655,24 @@ class FSMWithStartEndBase {
    */
   bool IsScanableState(int state) const {
     for (const auto& edge : fsm_.GetEdges(state)) {
-      if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken()) {
+      if (edge.IsCharRange() || edge.IsToken() || edge.IsExcludeToken() || edge.IsBackReference()) {
         return true;
       }
     }
     return false;
+  }
+
+  /*! \brief Whether the state has only backreference edges and at least one exists. */
+  bool IsBackReferenceOnlyScanableState(int state) const {
+    bool has_backreference = false;
+    for (const auto& edge : fsm_.GetEdges(state)) {
+      if (edge.IsBackReference()) {
+        has_backreference = true;
+      } else {
+        return false;
+      }
+    }
+    return has_backreference;
   }
 
   /*!
@@ -645,7 +682,8 @@ class FSMWithStartEndBase {
    */
   bool IsNonTerminalState(int state) const {
     for (const auto& edge : fsm_.GetEdges(state)) {
-      if (edge.IsRuleRef() || edge.IsEpsilon() || edge.IsRepeatRef()) {
+      if (edge.IsRuleRef() || edge.IsCaptureStart() || edge.IsCaptureEnd() || edge.IsEpsilon() ||
+          edge.IsRepeatRef()) {
         return true;
       }
     }
@@ -1038,7 +1076,8 @@ inline bool FSMWithStartEndBase<FSMType>::IsLeaf() const {
   GetReachableStates(&reachable_states);
   for (const auto& state : reachable_states) {
     for (const auto& edge : fsm_.GetEdges(state)) {
-      if (edge.IsRuleRef() || edge.IsRepeatRef()) {
+      if (edge.IsRuleRef() || edge.IsRepeatRef() || edge.IsCaptureStart() || edge.IsCaptureEnd() ||
+          edge.IsBackReference()) {
         return false;
       }
     }

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -50,19 +50,29 @@ Grammar GrammarBuilder::Get(const std::string& root_rule_name) {
 Grammar GrammarBuilder::Get(int32_t root_rule_id) {
   XGRAMMAR_CHECK(root_rule_id >= 0 && root_rule_id < static_cast<int32_t>(grammar_->rules_.size()))
       << "The root rule id " << root_rule_id << " is out of bound.";
+  for (int32_t i = 0; i < static_cast<int32_t>(grammar_->rules_.size()); ++i) {
+    XGRAMMAR_CHECK(grammar_->rules_[i].body_expr_id >= 0)
+        << "The rule with name \"" << grammar_->rules_[i].name << "\" has no body.";
+  }
   grammar_->root_rule_id_ = root_rule_id;
   return Grammar(grammar_);
 }
 
 int32_t GrammarBuilder::AddGrammarExpr(const GrammarExpr& grammar_expr) {
+  XGRAMMAR_CHECK(grammar_expr.data_len >= 0)
+      << "Grammar expression data length cannot be negative.";
   grammar_->grammar_expr_indptr_.push_back(grammar_->grammar_expr_data_.size());
   grammar_->grammar_expr_data_.push_back(static_cast<int32_t>(grammar_expr.type));
   grammar_->grammar_expr_data_.push_back(grammar_expr.data_len);
-  grammar_->grammar_expr_data_.insert(
-      grammar_->grammar_expr_data_.end(),
-      grammar_expr.data,
-      grammar_expr.data + grammar_expr.data_len
-  );
+  if (grammar_expr.data_len > 0) {
+    XGRAMMAR_CHECK(grammar_expr.data != nullptr)
+        << "Grammar expression data cannot be null when data length is positive.";
+    grammar_->grammar_expr_data_.insert(
+        grammar_->grammar_expr_data_.end(),
+        grammar_expr.data,
+        grammar_expr.data + grammar_expr.data_len
+    );
+  }
   return static_cast<int32_t>(grammar_->grammar_expr_indptr_.size()) - 1;
 }
 
@@ -205,6 +215,40 @@ int32_t GrammarBuilder::AddTokenTagDispatch(
   }
   return AddGrammarExpr(
       {GrammarExprType::kTokenTagDispatch, data.data(), static_cast<int32_t>(data.size())}
+  );
+}
+
+int32_t GrammarBuilder::AddDynamicTag(const Grammar::Impl::DynamicTag& dynamic_tag) {
+  XGRAMMAR_CHECK(dynamic_tag.name_rule_id >= 0 && dynamic_tag.name_rule_id < NumRules())
+      << "DynamicTag name_rule_id is out of range";
+  XGRAMMAR_CHECK(dynamic_tag.content_rule_id >= 0 && dynamic_tag.content_rule_id < NumRules())
+      << "DynamicTag content_rule_id is out of range";
+  XGRAMMAR_CHECK(
+      (dynamic_tag.unique_key_scope_rule_id == -1 && dynamic_tag.reserved_names.empty()) ||
+      (dynamic_tag.unique_key_scope_rule_id >= 0 &&
+       dynamic_tag.unique_key_scope_rule_id < NumRules())
+  ) << "DynamicTag unique-key metadata requires a valid scope rule";
+  XGRAMMAR_CHECK(dynamic_tag.unique_key_scope_rule_id == -1 || !dynamic_tag.open_suffix.empty())
+      << "A unique-key DynamicTag requires a non-empty opening suffix";
+  std::vector<int32_t> data = {
+      AddByteString(dynamic_tag.open_prefix),
+      dynamic_tag.name_rule_id,
+      AddByteString(dynamic_tag.open_suffix),
+      dynamic_tag.content_rule_id,
+      AddByteString(dynamic_tag.close_prefix),
+      AddByteString(dynamic_tag.close_suffix)
+  };
+  if (dynamic_tag.unique_key_scope_rule_id >= 0) {
+    data.push_back(dynamic_tag.unique_key_scope_rule_id);
+    std::vector<int32_t> reserved_name_expr_ids;
+    reserved_name_expr_ids.reserve(dynamic_tag.reserved_names.size());
+    for (const auto& name : dynamic_tag.reserved_names) {
+      reserved_name_expr_ids.push_back(AddByteString(name));
+    }
+    data.push_back(AddChoices(reserved_name_expr_ids));
+  }
+  return AddGrammarExpr(
+      {GrammarExprType::kDynamicTag, data.data(), static_cast<int32_t>(data.size())}
   );
 }
 

--- a/cpp/grammar_builder.h
+++ b/cpp/grammar_builder.h
@@ -146,6 +146,12 @@ class GrammarBuilder {
   /*! \brief Encode a TokenTagDispatch struct into a kTokenTagDispatch expr. */
   int32_t AddTokenTagDispatch(const Grammar::Impl::TokenTagDispatch& token_tag_dispatch);
 
+  /*!
+   * \brief Add a paired dynamic tag whose closing name repeats its opening name byte-for-byte.
+   * \note name_rule must be byte-regular; delimiter safety is enforced during FSM compilation.
+   */
+  int32_t AddDynamicTag(const Grammar::Impl::DynamicTag& dynamic_tag);
+
   int32_t AddRepeat(int32_t ref_rule_id, int32_t min_repeat_count, int32_t max_repeat_count);
 
   /*!

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <queue>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -45,7 +46,8 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
       const std::unordered_map<int32_t, DynamicBitset>&
           tag_dispatch_rule_id_to_second_slicing_bitset,
       const TokenizerInfo& tokenizer_info,
-      std::optional<RuleLevelCache>& rule_level_cache
+      std::optional<RuleLevelCache>& rule_level_cache,
+      bool wildcard_backreference = false
   )
       : EarleyParser(grammar, init_state),
         init_rule_id_(init_state.rule_id),
@@ -53,7 +55,8 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
         tag_dispatch_rule_id_to_second_slicing_bitset_(tag_dispatch_rule_id_to_second_slicing_bitset
         ),
         tokenizer_info_(tokenizer_info),
-        rule_level_cache_(rule_level_cache) {}
+        rule_level_cache_(rule_level_cache),
+        wildcard_backreference_(wildcard_backreference) {}
   /*!
    * \brief Get the adaptive token mask for the given ParserState.
    * \param is_root_rule Whether to consider the parent rule. If false, there will be
@@ -102,6 +105,12 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
    */
   void GetFirstCharacterMask(std::bitset<256>& first_character_mask);
 
+  bool AllowWildcardBackReference() const final { return wildcard_backreference_; }
+
+  bool PrepareDynamicTagContent(ParserState* state) final {
+    return !IsUniqueKeyDynamicTagRule(state->rule_id) || wildcard_backreference_;
+  }
+
   /*!
    * \brief Compute sorted vocab indices accepted by token edges at the current FSM state.
    * Token(ids) edges accept listed token IDs.
@@ -130,6 +139,8 @@ class GrammarMatcherForTokenMaskCache : public EarleyParser {
   const TokenizerInfo& tokenizer_info_;
 
   std::optional<RuleLevelCache> rule_level_cache_;
+
+  bool wildcard_backreference_ = false;
 
   // Temporary data for GetAdaptiveTokenMask.
   std::vector<int32_t> tmp_accepted_indices_;
@@ -715,6 +726,8 @@ void GrammarMatcherForTokenMaskCache::GetFirstCharacterMask(std::bitset<256>& fi
       for (int c = edge.min; c <= edge.max; ++c) {
         first_character_mask[c] = true;
       }
+    } else if (wildcard_backreference_ && edge.IsBackReference()) {
+      first_character_mask.set();
     }
   }
 }
@@ -1061,10 +1074,222 @@ class GrammarCompilerSub {
   std::optional<RuleLevelCache> rule_level_cache_;
 };
 
+namespace {
+
+std::vector<bool> FindRulesReachingDynamicTag(const Grammar& grammar) {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  const int32_t num_rules = grammar->NumRules();
+
+  bool has_dynamic_tag = false;
+  for (int32_t expr_id = 0; expr_id < grammar->NumGrammarExprs(); ++expr_id) {
+    if (grammar->GetGrammarExpr(expr_id).type == GrammarExprType::kDynamicTag) {
+      has_dynamic_tag = true;
+      break;
+    }
+  }
+  if (!has_dynamic_tag) {
+    return {};
+  }
+
+  std::vector<bool> reaches_dynamic_tag(num_rules, false);
+  std::vector<std::vector<int32_t>> reverse_dependencies(num_rules);
+  std::vector<int32_t> expr_visit_epoch(grammar->NumGrammarExprs(), -1);
+  std::vector<int32_t> dependency_epoch(num_rules, -1);
+
+  for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
+    auto add_dependency = [&](int32_t dependency) {
+      XGRAMMAR_DCHECK(dependency >= 0 && dependency < num_rules);
+      if (dependency_epoch[dependency] != rule_id) {
+        dependency_epoch[dependency] = rule_id;
+        reverse_dependencies[dependency].push_back(rule_id);
+      }
+    };
+    auto visit_expr = [&](auto&& self, int32_t expr_id) -> void {
+      if (expr_visit_epoch[expr_id] == rule_id) {
+        return;
+      }
+      expr_visit_epoch[expr_id] = rule_id;
+      const auto& expr = grammar->GetGrammarExpr(expr_id);
+      switch (expr.type) {
+        case GrammarExprType::kSequence:
+        case GrammarExprType::kChoices:
+          for (int32_t child_expr_id : expr) {
+            self(self, child_expr_id);
+          }
+          return;
+        case GrammarExprType::kRuleRef:
+        case GrammarExprType::kRepeat:
+          add_dependency(expr[0]);
+          return;
+        case GrammarExprType::kTagDispatch: {
+          for (const auto& [tag, dependency] : grammar->GetTagDispatch(expr).tag_rule_pairs) {
+            static_cast<void>(tag);
+            add_dependency(dependency);
+          }
+          return;
+        }
+        case GrammarExprType::kTokenTagDispatch: {
+          for (const auto& [token_id, dependency] :
+               grammar->GetTokenTagDispatch(expr).trigger_rule_pairs) {
+            static_cast<void>(token_id);
+            add_dependency(dependency);
+          }
+          return;
+        }
+        case GrammarExprType::kDynamicTag: {
+          reaches_dynamic_tag[rule_id] = true;
+          const auto dynamic_tag = grammar->GetDynamicTag(expr);
+          add_dependency(dynamic_tag.name_rule_id);
+          add_dependency(dynamic_tag.content_rule_id);
+          return;
+        }
+        default:
+          return;
+      }
+    };
+
+    const auto& rule = grammar->GetRule(rule_id);
+    visit_expr(visit_expr, rule.body_expr_id);
+    if (rule.lookahead_assertion_id >= 0) {
+      visit_expr(visit_expr, rule.lookahead_assertion_id);
+    }
+    if (const auto* suffix_stop_info = grammar->GetSuffixStopInfo(rule_id);
+        suffix_stop_info != nullptr && suffix_stop_info->body_rule_id >= 0) {
+      add_dependency(suffix_stop_info->body_rule_id);
+    }
+  }
+
+  std::queue<int32_t> pending;
+  for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
+    if (reaches_dynamic_tag[rule_id]) {
+      pending.push(rule_id);
+    }
+  }
+  while (!pending.empty()) {
+    const int32_t dependency = pending.front();
+    pending.pop();
+    for (int32_t dependent : reverse_dependencies[dependency]) {
+      if (!reaches_dynamic_tag[dependent]) {
+        reaches_dynamic_tag[dependent] = true;
+        pending.push(dependent);
+      }
+    }
+  }
+  return reaches_dynamic_tag;
+}
+
+void ValidateUniqueKeyScopeProgress(const Grammar& grammar) {
+  using GrammarExprType = Grammar::Impl::GrammarExprType;
+  const int32_t num_rules = grammar->NumRules();
+  std::vector<int32_t> scope_rule_ids;
+  std::vector<uint8_t> is_scope_rule;
+  for (int32_t expr_id = 0; expr_id < grammar->NumGrammarExprs(); ++expr_id) {
+    const auto& expr = grammar->GetGrammarExpr(expr_id);
+    if (expr.type != GrammarExprType::kDynamicTag) {
+      continue;
+    }
+    const int32_t scope_rule_id = grammar->GetDynamicTagUniqueKeyScopeRuleId(expr);
+    if (scope_rule_id < 0) {
+      continue;
+    }
+    if (is_scope_rule.empty()) {
+      is_scope_rule.assign(num_rules, 0);
+    }
+    if (!is_scope_rule[scope_rule_id]) {
+      is_scope_rule[scope_rule_id] = 1;
+      scope_rule_ids.push_back(scope_rule_id);
+    }
+  }
+  if (scope_rule_ids.empty()) {
+    return;
+  }
+
+  std::vector<uint8_t> is_nullable(num_rules, 0);
+  for (int32_t rule_id : grammar->allow_empty_rule_ids) {
+    is_nullable[rule_id] = 1;
+  }
+
+  std::vector<std::optional<std::vector<int32_t>>> zero_width_callees(num_rules);
+  std::vector<int32_t> state_visit_epoch(grammar->complete_fsm.NumStates(), -1);
+  std::vector<int32_t> callee_visit_epoch(num_rules, -1);
+  auto get_zero_width_callees = [&](int32_t rule_id) -> const std::vector<int32_t>& {
+    if (zero_width_callees[rule_id].has_value()) {
+      return *zero_width_callees[rule_id];
+    }
+    auto& result = zero_width_callees[rule_id].emplace();
+    const auto& rule_fsm = grammar->per_rule_fsms[rule_id].value().GetFsm();
+    const auto& fsm = rule_fsm.GetFsm();
+    std::vector<int32_t> pending{rule_fsm.GetStart()};
+    state_visit_epoch[rule_fsm.GetStart()] = rule_id;
+
+    auto enqueue_state = [&](int32_t state) {
+      if (state_visit_epoch[state] != rule_id) {
+        state_visit_epoch[state] = rule_id;
+        pending.push_back(state);
+      }
+    };
+    auto add_callee = [&](int32_t callee) {
+      if (callee_visit_epoch[callee] != rule_id) {
+        callee_visit_epoch[callee] = rule_id;
+        result.push_back(callee);
+      }
+    };
+
+    for (size_t index = 0; index < pending.size(); ++index) {
+      for (const auto& edge : fsm.GetEdges(pending[index])) {
+        if (edge.IsEpsilon() || edge.IsCaptureStart() || edge.IsCaptureEnd()) {
+          enqueue_state(edge.target);
+        } else if (edge.IsRuleRef()) {
+          const int32_t callee = edge.GetRefRuleId();
+          add_callee(callee);
+          if (is_nullable[callee]) {
+            enqueue_state(edge.target);
+          }
+        } else if (edge.IsRepeatRef()) {
+          const auto repeat = fsm.GetRepeatEdgeInfo(edge.GetAuxIndex());
+          if (repeat.Upper() != 0) {
+            add_callee(repeat.RuleId());
+          }
+          if (repeat.Upper() == 0 || repeat.Lower() == 0 || is_nullable[repeat.RuleId()]) {
+            enqueue_state(edge.target);
+          }
+        }
+      }
+    }
+    return result;
+  };
+
+  std::vector<int32_t> rule_visit_epoch(num_rules, -1);
+  for (int32_t scope_rule_id : scope_rule_ids) {
+    std::vector<int32_t> pending{scope_rule_id};
+    rule_visit_epoch[scope_rule_id] = scope_rule_id;
+    bool has_zero_width_cycle = false;
+    for (size_t index = 0; index < pending.size() && !has_zero_width_cycle; ++index) {
+      for (int32_t callee : get_zero_width_callees(pending[index])) {
+        if (callee == scope_rule_id) {
+          has_zero_width_cycle = true;
+          break;
+        }
+        if (rule_visit_epoch[callee] != scope_rule_id) {
+          rule_visit_epoch[callee] = scope_rule_id;
+          pending.push_back(callee);
+        }
+      }
+    }
+    XGRAMMAR_CHECK(!has_zero_width_cycle)
+        << "unique_key_scope rule '" << grammar->GetRule(scope_rule_id).name
+        << "' can recursively re-enter itself without consuming input; consume at least one byte "
+           "before recursion";
+  }
+}
+
+}  // namespace
+
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
   compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
+  ValidateUniqueKeyScopeProgress(compiled_grammar_impl->grammar);
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
   }
@@ -1075,6 +1300,8 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
   if (rule_level_cache_.has_value()) {
     GrammarFSMHasher().Apply(&compiled_grammar_impl->grammar);
   }
+  const auto rules_reaching_dynamic_tag =
+      FindRulesReachingDynamicTag(compiled_grammar_impl->grammar);
   // Step 3. Compute the adaptive token mask cache
   // The token mask cache is computed for these positions in the grammar:
   // 1. All character class or character class star (with last_utf8_bytes=0, 1, 2, 3)
@@ -1091,21 +1318,115 @@ CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_un
     adaptive_token_mask_cache_mutex.emplace();
   }
 
+  auto store_adaptive_token_mask = [&](const ParserState& state, AdaptiveTokenMask mask) {
+    if (max_threads_ > 1) {
+      std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex.value());
+      compiled_grammar_impl->adaptive_token_mask_cache[state] = std::move(mask);
+    } else {
+      compiled_grammar_impl->adaptive_token_mask_cache[state] = std::move(mask);
+    }
+  };
+
   auto add_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {
+    const bool reaches_dynamic_tag =
+        !rules_reaching_dynamic_tag.empty() && rules_reaching_dynamic_tag[state.rule_id];
+    if (reaches_dynamic_tag) {
+      const auto& rule_fsm =
+          compiled_grammar_impl->grammar->per_rule_fsms[state.rule_id].value().GetFsm();
+      if (rule_fsm.IsBackReferenceOnlyScanableState(state.element_id)) {
+        // The concrete opening name is matcher-local, so this state has no reusable uncertain
+        // token list. GrammarMatcher derives a compact first-byte candidate range at runtime.
+        store_adaptive_token_mask(
+            state,
+            AdaptiveTokenMask(
+                tokenizer_info_.GetVocabSize(),
+                tokenizer_info_.GetSortedDecodedVocab(),
+                /*accepted_indices=*/{},
+                /*uncertain_indices=*/{}
+            )
+        );
+        return;
+      }
+    }
+    std::optional<RuleLevelCache> no_rule_level_cache;
+    auto& cache = reaches_dynamic_tag ? no_rule_level_cache : rule_level_cache_;
     auto grammar_matcher = GrammarMatcherForTokenMaskCache(
         compiled_grammar_impl->grammar,
         state,
         tag_dispatch_rule_id_to_second_slicing_bitset,
         tokenizer_info_,
-        rule_level_cache_
+        cache
     );
     auto cur_adaptive_token_mask_cache = grammar_matcher.GetAdaptiveTokenMask(is_root_rule);
-    if (max_threads_ > 1) {
-      std::lock_guard<std::mutex> lock(adaptive_token_mask_cache_mutex.value());
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
-    } else {
-      compiled_grammar_impl->adaptive_token_mask_cache[state] = cur_adaptive_token_mask_cache;
+    if (reaches_dynamic_tag) {
+      auto wildcard_matcher = GrammarMatcherForTokenMaskCache(
+          compiled_grammar_impl->grammar,
+          state,
+          tag_dispatch_rule_id_to_second_slicing_bitset,
+          tokenizer_info_,
+          no_rule_level_cache,
+          true
+      );
+      auto wildcard_mask = wildcard_matcher.GetAdaptiveTokenMask(is_root_rule);
+      const auto& sorted_vocab = tokenizer_info_.GetSortedDecodedVocab();
+      const int32_t vocab_size = sorted_vocab.size();
+      auto classify = [&](const AdaptiveTokenMask& mask) {
+        std::vector<uint8_t> result(vocab_size);
+        if (mask.store_type == AdaptiveTokenMask::StoreType::kRejected) {
+          std::fill(result.begin(), result.end(), 1);
+          for (int32_t index : mask.rejected_indices) {
+            result[index] = 0;
+          }
+        } else if (mask.store_type == AdaptiveTokenMask::StoreType::kAccepted) {
+          for (int32_t index : mask.accepted_indices) {
+            result[index] = 1;
+          }
+        } else {
+          for (int32_t index = 0; index < vocab_size; ++index) {
+            if (mask.accepted_bitset[sorted_vocab[index].first]) {
+              result[index] = 1;
+            }
+          }
+        }
+        for (int32_t index : mask.uncertain_indices) {
+          result[index] = 2;
+        }
+        return result;
+      };
+      // The baseline rejects runtime-dependent DynamicTag transitions, while the wildcard matcher
+      // admits them. Their difference is the matcher-local region: baseline accepts are definite,
+      // wildcard rejects are definite, and everything else stays uncertain.
+      auto baseline = classify(cur_adaptive_token_mask_cache);
+      auto wildcard = classify(wildcard_mask);
+      std::vector<int32_t> accepted;
+      std::vector<int32_t> rejected;
+      std::vector<int32_t> uncertain;
+      int32_t accepted_count = 0;
+      int32_t uncertain_count = 0;
+      for (int32_t index = 0; index < vocab_size; ++index) {
+        if (baseline[index] == 1) {
+          ++accepted_count;
+        } else if (baseline[index] == 2 || wildcard[index] != 0) {
+          ++uncertain_count;
+        }
+      }
+      accepted.reserve(accepted_count);
+      uncertain.reserve(uncertain_count);
+      rejected.reserve(vocab_size - accepted_count - uncertain_count);
+      for (int32_t index = 0; index < vocab_size; ++index) {
+        if (baseline[index] == 1) {
+          accepted.push_back(index);
+        } else if (baseline[index] == 2 || wildcard[index] != 0) {
+          uncertain.push_back(index);
+        } else {
+          rejected.push_back(index);
+        }
+      }
+      cur_adaptive_token_mask_cache = AdaptiveTokenMask(
+          tokenizer_info_.GetVocabSize(), sorted_vocab, accepted, rejected, uncertain
+      );
     }
+    store_adaptive_token_mask(state, std::move(cur_adaptive_token_mask_cache));
   };
 
   auto add_task_adaptive_token_mask = [&](const ParserState& state, bool is_root_rule) {

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -18,6 +18,8 @@
 #include <stack>
 #include <string>
 #include <tuple>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "compiled_grammar_impl.h"
@@ -35,6 +37,12 @@ namespace xgrammar {
 
 using GrammarExpr = Grammar::Impl::GrammarExpr;
 using ExprType = Grammar::Impl::GrammarExprType;
+
+namespace {
+
+constexpr int32_t kMaxDynamicTagNameStates = 100000;
+
+}  // namespace
 
 /*************************** Impl of grammar constructors ***************************/
 
@@ -117,6 +125,17 @@ class SubGrammarAdderImpl : public GrammarMutator {
     new_ttd.loop_after_dispatch = old_ttd.loop_after_dispatch;
     new_ttd.excludes = old_ttd.excludes;
     return builder_->AddTokenTagDispatch(new_ttd);
+  }
+
+  int32_t VisitDynamicTag(const GrammarExpr& grammar_expr) final {
+    auto dynamic_tag = base_grammar_->GetDynamicTag(grammar_expr);
+    dynamic_tag.name_rule_id = new_rule_ids_names[dynamic_tag.name_rule_id].first;
+    dynamic_tag.content_rule_id = new_rule_ids_names[dynamic_tag.content_rule_id].first;
+    if (dynamic_tag.unique_key_scope_rule_id >= 0) {
+      dynamic_tag.unique_key_scope_rule_id =
+          new_rule_ids_names[dynamic_tag.unique_key_scope_rule_id].first;
+    }
+    return builder_->AddDynamicTag(dynamic_tag);
   }
 
   std::vector<std::pair<int32_t, std::string>> new_rule_ids_names;
@@ -323,6 +342,9 @@ class StructureNormalizerImpl : public GrammarMutator {
       case GrammarExprType::kSubstring:
         XGRAMMAR_LOG(FATAL) << "Substring should not be in lookahead assertion";
         XGRAMMAR_UNREACHABLE();
+      case GrammarExprType::kDynamicTag:
+        XGRAMMAR_LOG(FATAL) << "DynamicTag should not be in lookahead assertion";
+        XGRAMMAR_UNREACHABLE();
       case GrammarExprType::kByteString:
       case GrammarExprType::kCharacterClass:
       case GrammarExprType::kCharacterClassStar:
@@ -366,8 +388,11 @@ class StructureNormalizerImpl : public GrammarMutator {
       }
       case GrammarExprType::kRegex:
       case GrammarExprType::kSubstring:
+      case GrammarExprType::kDynamicTag:
         // A regex or substring is kept as the direct body of the rule, like a tag dispatch.
-        return builder_->AddGrammarExpr(grammar_expr);
+        return grammar_expr.type == GrammarExprType::kDynamicTag
+                   ? VisitDynamicTag(grammar_expr)
+                   : builder_->AddGrammarExpr(grammar_expr);
       default:
         XGRAMMAR_LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(grammar_expr.type);
         XGRAMMAR_UNREACHABLE();
@@ -422,6 +447,12 @@ class StructureNormalizerImpl : public GrammarMutator {
           auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, leaf_expr_id);
           auto new_sequence_id = builder_->AddSequence({builder_->AddRuleRef(new_rule_id)});
           new_choice_ids.push_back(new_sequence_id);
+          break;
+        }
+        case GrammarExprType::kDynamicTag: {
+          auto dynamic_tag_expr_id = VisitDynamicTag(choice_expr);
+          auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, dynamic_tag_expr_id);
+          new_choice_ids.push_back(builder_->AddSequence({builder_->AddRuleRef(new_rule_id)}));
           break;
         }
         default:
@@ -514,6 +545,12 @@ class StructureNormalizerImpl : public GrammarMutator {
         case GrammarExprType::kSubstring: {
           auto leaf_expr_id = builder_->AddGrammarExpr(element_expr);
           auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, leaf_expr_id);
+          new_sequence_ids.push_back(builder_->AddRuleRef(new_rule_id));
+          break;
+        }
+        case GrammarExprType::kDynamicTag: {
+          auto dynamic_tag_expr_id = VisitDynamicTag(element_expr);
+          auto new_rule_id = builder_->AddRuleWithHint(cur_rule_name_, dynamic_tag_expr_id);
           new_sequence_ids.push_back(builder_->AddRuleRef(new_rule_id));
           break;
         }
@@ -726,7 +763,19 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
     int32_t num_rules = builder_.NumRules();
     original_body_expr_ids_.reserve(num_rules);
     for (int32_t rule_id = 0; rule_id < num_rules; ++rule_id) {
-      original_body_expr_ids_.push_back(builder_.GetRule(rule_id).body_expr_id);
+      int32_t body_expr_id = builder_.GetRule(rule_id).body_expr_id;
+      original_body_expr_ids_.push_back(body_expr_id);
+      const auto body = builder_.GetGrammarExpr(body_expr_id);
+      if (body.type != GrammarExprType::kDynamicTag) {
+        continue;
+      }
+      int32_t scope_rule_id = (*grammar_)->GetDynamicTagUniqueKeyScopeRuleId(body);
+      if (scope_rule_id >= 0) {
+        if (is_unique_key_scope_rule_.empty()) {
+          is_unique_key_scope_rule_.assign(num_rules, false);
+        }
+        is_unique_key_scope_rule_[scope_rule_id] = true;
+      }
     }
     can_rule_be_inlined_.assign(num_rules, -1);
   }
@@ -807,7 +856,8 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
     // Inlining a temperature rule would erase the rule its sampling temperature applies to.
     if (rule.max_tokens >= 0 || rule.max_chars >= 0 || !rule.capture_name.empty() ||
         (*grammar_)->GetSuffixStopInfo(rule_id) != nullptr || rule.is_lazy ||
-        rule.temperature.has_value()) {
+        rule.temperature.has_value() ||
+        (!is_unique_key_scope_rule_.empty() && is_unique_key_scope_rule_[rule_id])) {
       can_rule_be_inlined_[rule_id] = false;
       return false;
     }
@@ -844,6 +894,7 @@ class RuleInlinerImpl : public InPlaceGrammarRewriter {
   std::vector<int32_t> original_body_expr_ids_;
   // Per-rule cache of CanRuleBeInlined: -1 unknown, 0 false, 1 true.
   std::vector<int8_t> can_rule_be_inlined_;
+  std::vector<uint8_t> is_unique_key_scope_rule_;
 };
 
 /*!
@@ -895,6 +946,15 @@ class UsedRulesAnalyzer : public GrammarVisitor<std::vector<int32_t>> {
     auto ttd = base_grammar_->GetTokenTagDispatch(grammar_expr);
     for (const auto& [token_id, rule_id] : ttd.trigger_rule_pairs) {
       visit_queue_.push(rule_id);
+    }
+  }
+
+  void VisitDynamicTag(const GrammarExpr& grammar_expr) {
+    auto dynamic_tag = base_grammar_->GetDynamicTag(grammar_expr);
+    visit_queue_.push(dynamic_tag.name_rule_id);
+    visit_queue_.push(dynamic_tag.content_rule_id);
+    if (dynamic_tag.unique_key_scope_rule_id >= 0) {
+      visit_queue_.push(dynamic_tag.unique_key_scope_rule_id);
     }
   }
 
@@ -962,6 +1022,19 @@ class DeadCodeEliminatorImpl : public GrammarMutator {
     return builder_->AddTokenTagDispatch(ttd);
   }
 
+  int32_t VisitDynamicTag(const GrammarExpr& grammar_expr) final {
+    auto dynamic_tag = base_grammar_->GetDynamicTag(grammar_expr);
+    XGRAMMAR_DCHECK(rule_id_map_.count(dynamic_tag.name_rule_id) > 0);
+    XGRAMMAR_DCHECK(rule_id_map_.count(dynamic_tag.content_rule_id) > 0);
+    dynamic_tag.name_rule_id = rule_id_map_[dynamic_tag.name_rule_id];
+    dynamic_tag.content_rule_id = rule_id_map_[dynamic_tag.content_rule_id];
+    if (dynamic_tag.unique_key_scope_rule_id >= 0) {
+      XGRAMMAR_DCHECK(rule_id_map_.count(dynamic_tag.unique_key_scope_rule_id) > 0);
+      dynamic_tag.unique_key_scope_rule_id = rule_id_map_[dynamic_tag.unique_key_scope_rule_id];
+    }
+    return builder_->AddDynamicTag(dynamic_tag);
+  }
+
   int32_t VisitRuleRef(const GrammarExpr& grammar_expr) final {
     XGRAMMAR_DCHECK(rule_id_map_.count(grammar_expr[0]) > 0);
     auto new_rule_id = rule_id_map_[grammar_expr[0]];
@@ -990,7 +1063,8 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
     if (root_grammar_expr.type == GrammarExprType::kTagDispatch ||
         root_grammar_expr.type == GrammarExprType::kTokenTagDispatch ||
         root_grammar_expr.type == GrammarExprType::kRegex ||
-        root_grammar_expr.type == GrammarExprType::kSubstring) {
+        root_grammar_expr.type == GrammarExprType::kSubstring ||
+        root_grammar_expr.type == GrammarExprType::kDynamicTag) {
       return grammar;
     }
     BuildRuleLookaheadInfo();
@@ -1055,6 +1129,12 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
         for (const auto& [token_id, rule_id] : token_tag_dispatch.trigger_rule_pairs) {
           rule_lookahead_infos_[rule_id].is_triggered_by_dispatch = true;
         }
+        continue;
+      }
+      if (grammar_expr.type == GrammarExprType::kDynamicTag) {
+        auto dynamic_tag = base_grammar_->GetDynamicTag(grammar_expr);
+        rule_lookahead_infos_[dynamic_tag.name_rule_id].is_triggered_by_dispatch = true;
+        rule_lookahead_infos_[dynamic_tag.content_rule_id].is_triggered_by_dispatch = true;
         continue;
       }
       if (grammar_expr.type == GrammarExprType::kRegex ||
@@ -1142,6 +1222,12 @@ class RuleRefGraphFinder : public GrammarVisitor<std::vector<std::vector<int32_t
     }
   }
 
+  void VisitDynamicTag(const GrammarExpr& grammar_expr) {
+    auto dynamic_tag = base_grammar_->GetDynamicTag(grammar_expr);
+    rule_visit_graph_[dynamic_tag.name_rule_id].push_back(cur_rule_id_);
+    rule_visit_graph_[dynamic_tag.content_rule_id].push_back(cur_rule_id_);
+  }
+
   // Inversed reference graph: pointing from referee to referer
   std::vector<std::vector<int32_t>> rule_visit_graph_;
   int32_t cur_rule_id_;
@@ -1184,6 +1270,10 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
       if (grammar_expr.type == GrammarExprType::kSubstring) {
         // A substring automaton always accepts the empty string: every state is accepting.
         empty_rule_id_set->insert(i);
+        continue;
+      }
+
+      if (grammar_expr.type == GrammarExprType::kDynamicTag) {
         continue;
       }
 
@@ -1254,6 +1344,9 @@ class AllowEmptyRuleAnalyzerImpl : public GrammarVisitor<std::vector<int32_t>> {
         auto rule = base_grammar_->GetRule(referer_rule_id);
         auto grammar_expr = base_grammar_->GetGrammarExpr(rule.body_expr_id);
 
+        if (grammar_expr.type == GrammarExprType::kDynamicTag) {
+          continue;
+        }
         XGRAMMAR_DCHECK(
             grammar_expr.type != GrammarExprType::kTagDispatch &&
             grammar_expr.type != GrammarExprType::kTokenTagDispatch
@@ -1404,6 +1497,25 @@ class GrammarFSMBuilderImpl {
       int start_state,
       std::vector<int32_t>* end_states
   );
+  void BuildDynamicTag(
+      const Grammar::Impl::DynamicTag& dynamic_tag,
+      const Grammar& grammar,
+      int start_state,
+      std::vector<int32_t>* end_states
+  );
+  Result<FSMWithStartEnd> BuildRegularRuleFSM(const Grammar& grammar, int32_t rule_id);
+  Result<FSMWithStartEnd> ExpandRegularFSM(
+      const Grammar& grammar, int32_t rule_id, const FSMWithStartEnd& raw_fsm
+  );
+  static Result<FSMWithStartEnd> RepeatRegularFSM(
+      const FSMWithStartEnd& child, int32_t lower, int32_t upper, int32_t state_budget
+  );
+  static Result<FSMWithStartEnd> BuildDynamicTagNameConstraint(
+      const std::string& open_prefix,
+      const std::string& open_suffix,
+      const std::string& close_prefix,
+      const std::string& close_suffix
+  );
   void BuildSequence(
       const GrammarExpr& expr,
       const Grammar& grammar,
@@ -1425,6 +1537,8 @@ class GrammarFSMBuilderImpl {
   const std::string* rule_name_;
   // If not null, kRegex expressions may add new rules through this builder; see Apply().
   GrammarBuilder* grammar_builder_ = nullptr;
+  std::unordered_map<int32_t, FSMWithStartEnd> regular_rule_fsm_cache_;
+  std::unordered_set<int32_t> regular_rule_fsm_visiting_;
 };
 
 // This function will add a range [min, max] of unicode characters to the FSM.
@@ -1642,6 +1756,8 @@ void GrammarFSMBuilderImpl::BuildExpression(
       return BuildTagDispatch(grammar->GetTagDispatch(expr), start_state, end_states);
     case ExprType::kTokenTagDispatch:
       return BuildTokenTagDispatch(grammar->GetTokenTagDispatch(expr), start_state, end_states);
+    case ExprType::kDynamicTag:
+      return BuildDynamicTag(grammar->GetDynamicTag(expr), grammar, start_state, end_states);
   }
   XGRAMMAR_UNREACHABLE();
 }
@@ -1912,6 +2028,433 @@ void GrammarFSMBuilderImpl::BuildTokenTagDispatch(
     target_fsm_.AddRuleEdge(dispatch_states[index], dispatch_target, rule_id);
   }
   target_fsm_.AddExcludeTokenEdge(start_state, start_state, excluded_token_ids);
+}
+
+Result<FSMWithStartEnd> GrammarFSMBuilderImpl::RepeatRegularFSM(
+    const FSMWithStartEnd& child, int32_t lower, int32_t upper, int32_t state_budget
+) {
+  XGRAMMAR_DCHECK(lower >= 0 && (upper == -1 || upper >= lower));
+  XGRAMMAR_DCHECK(state_budget >= 0 && state_budget <= kMaxDynamicTagNameStates);
+  const int64_t copies = upper == -1 ? static_cast<int64_t>(lower) + 1 : upper;
+  const int64_t required_states =
+      1 + copies * static_cast<int64_t>(child.NumStates()) + (upper == -1 ? 1 : 0);
+  if (required_states > state_budget) {
+    return ResultErr(
+        "DynamicTag name_rule expands beyond 100000 FSM states; use a regex name rule or a "
+        "smaller repetition bound"
+    );
+  }
+
+  FSM repeated(1);
+  std::vector<int32_t> previous_ends{0};
+  std::vector<int32_t> accepted_ends;
+  if (lower == 0) {
+    accepted_ends.push_back(0);
+  }
+
+  auto append_child = [&]() {
+    std::vector<int> mapping;
+    repeated.AddFSM(child.GetFsm(), &mapping);
+    for (int32_t previous_end : previous_ends) {
+      repeated.AddEpsilonEdge(previous_end, mapping[child.GetStart()]);
+    }
+    previous_ends.clear();
+    previous_ends.reserve(child.GetEnds().size());
+    for (int32_t end : child.GetEnds()) {
+      previous_ends.push_back(mapping[end]);
+    }
+  };
+
+  if (upper != -1) {
+    for (int32_t count = 1; count <= upper; ++count) {
+      append_child();
+      if (count >= lower) {
+        accepted_ends.insert(accepted_ends.end(), previous_ends.begin(), previous_ends.end());
+      }
+    }
+    return ResultOk(FSMWithStartEnd(std::move(repeated), 0, std::move(accepted_ends)));
+  }
+
+  for (int32_t count = 0; count < lower; ++count) {
+    append_child();
+  }
+  int32_t loop_entry = repeated.AddState();
+  for (int32_t previous_end : previous_ends) {
+    repeated.AddEpsilonEdge(previous_end, loop_entry);
+  }
+  std::vector<int> mapping;
+  repeated.AddFSM(child.GetFsm(), &mapping);
+  repeated.AddEpsilonEdge(loop_entry, mapping[child.GetStart()]);
+  for (int32_t end : child.GetEnds()) {
+    repeated.AddEpsilonEdge(mapping[end], loop_entry);
+  }
+  return ResultOk(FSMWithStartEnd(std::move(repeated), 0, {loop_entry}));
+}
+
+Result<FSMWithStartEnd> GrammarFSMBuilderImpl::ExpandRegularFSM(
+    const Grammar& grammar, int32_t rule_id, const FSMWithStartEnd& raw_fsm
+) {
+  auto exceeds_state_budget = [](int64_t current_states, int64_t additional_states) {
+    return current_states + additional_states > kMaxDynamicTagNameStates;
+  };
+  if (exceeds_state_budget(0, raw_fsm.NumStates())) {
+    return ResultErr("DynamicTag name_rule expands beyond 100000 FSM states; simplify the name rule"
+    );
+  }
+  auto is_pure_epsilon_tail = [&](int32_t start) {
+    std::unordered_set<int32_t> closure{start};
+    std::vector<int32_t> pending{start};
+    for (size_t i = 0; i < pending.size(); ++i) {
+      for (const auto& edge : raw_fsm.GetFsm().GetEdges(pending[i])) {
+        if (!edge.IsEpsilon()) {
+          return false;
+        }
+        if (closure.insert(edge.target).second) {
+          pending.push_back(edge.target);
+        }
+      }
+    }
+    return std::any_of(raw_fsm.GetEnds().begin(), raw_fsm.GetEnds().end(), [&](int32_t end) {
+      return closure.count(end) != 0;
+    });
+  };
+  FSM expanded(raw_fsm.NumStates());
+  for (int32_t source = 0; source < raw_fsm.NumStates(); ++source) {
+    for (const auto& edge : raw_fsm.GetFsm().GetEdges(source)) {
+      if (edge.IsCharRange()) {
+        expanded.AddEdge(source, edge.target, edge.min, edge.max);
+      } else if (edge.IsEpsilon()) {
+        expanded.AddEpsilonEdge(source, edge.target);
+      } else if (edge.IsRuleRef()) {
+        if (regular_rule_fsm_visiting_.count(edge.GetRefRuleId()) != 0) {
+          if (edge.GetRefRuleId() != rule_id || !is_pure_epsilon_tail(edge.target)) {
+            return ResultErr("DynamicTag name_rule recursion must be a direct tail recursion");
+          }
+          expanded.AddEpsilonEdge(source, raw_fsm.GetStart());
+          continue;
+        }
+        auto child_result = BuildRegularRuleFSM(grammar, edge.GetRefRuleId());
+        if (child_result.IsErr()) {
+          return ResultErr(std::move(child_result).UnwrapErr());
+        }
+        auto child = std::move(child_result).Unwrap();
+        if (exceeds_state_budget(expanded.NumStates(), child.NumStates())) {
+          return ResultErr(
+              "DynamicTag name_rule expands beyond 100000 FSM states; simplify the name rule"
+          );
+        }
+        std::vector<int> mapping;
+        expanded.AddFSM(child.GetFsm(), &mapping);
+        expanded.AddEpsilonEdge(source, mapping[child.GetStart()]);
+        for (int32_t end : child.GetEnds()) {
+          expanded.AddEpsilonEdge(mapping[end], edge.target);
+        }
+      } else if (edge.IsRepeatRef()) {
+        auto repeat = raw_fsm.GetFsm().GetRepeatEdgeInfo(edge.GetAuxIndex());
+        auto child_result = BuildRegularRuleFSM(grammar, repeat.RuleId());
+        if (child_result.IsErr()) {
+          return ResultErr(std::move(child_result).UnwrapErr());
+        }
+        auto repeated_result = RepeatRegularFSM(
+            std::move(child_result).Unwrap(),
+            repeat.Lower(),
+            repeat.Upper(),
+            kMaxDynamicTagNameStates - expanded.NumStates()
+        );
+        if (repeated_result.IsErr()) {
+          return ResultErr(std::move(repeated_result).UnwrapErr());
+        }
+        auto repeated = std::move(repeated_result).Unwrap();
+        if (exceeds_state_budget(expanded.NumStates(), repeated.NumStates())) {
+          return ResultErr(
+              "DynamicTag name_rule expands beyond 100000 FSM states; simplify the name rule"
+          );
+        }
+        std::vector<int> mapping;
+        expanded.AddFSM(repeated.GetFsm(), &mapping);
+        expanded.AddEpsilonEdge(source, mapping[repeated.GetStart()]);
+        for (int32_t end : repeated.GetEnds()) {
+          expanded.AddEpsilonEdge(mapping[end], edge.target);
+        }
+      } else {
+        return ResultErr(
+            "DynamicTag name_rule must be a byte-regular grammar without Token, "
+            "ExcludeToken, DynamicTag, or EOS transitions"
+        );
+      }
+    }
+  }
+  auto result =
+      FSMWithStartEnd(std::move(expanded), raw_fsm.GetStart(), raw_fsm.GetEnds()).SimplifyEpsilon();
+  return ResultOk(result.MergeEquivalentStates());
+}
+
+Result<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildRegularRuleFSM(
+    const Grammar& grammar, int32_t rule_id
+) {
+  const auto& rule = grammar->GetRule(rule_id);
+  // A rule lookahead is a token-mask boundary hint rather than part of the accepted byte
+  // language. Once the name is inlined, DynamicTag's opening suffix provides that boundary.
+  if (rule.max_tokens >= 0 || rule.max_chars >= 0 || !rule.capture_name.empty() || rule.is_lazy ||
+      rule.temperature.has_value() || grammar->GetSuffixStopInfo(rule_id) != nullptr) {
+    return ResultErr(
+        "DynamicTag name_rule and its dependencies must not use budgets, captures, lazy "
+        "matching, temperature, suffix, or stop metadata"
+    );
+  }
+  auto cached = regular_rule_fsm_cache_.find(rule_id);
+  if (cached != regular_rule_fsm_cache_.end()) {
+    return ResultOk(cached->second.Copy());
+  }
+  if (!regular_rule_fsm_visiting_.insert(rule_id).second) {
+    return ResultErr("DynamicTag name_rule must not contain recursive rule references");
+  }
+
+  auto raw = BuildRuleFSM(grammar, rule_id, grammar_builder_);
+  auto expanded_result = ExpandRegularFSM(grammar, rule_id, raw);
+  regular_rule_fsm_visiting_.erase(rule_id);
+  if (expanded_result.IsErr()) {
+    return ResultErr(std::move(expanded_result).UnwrapErr());
+  }
+  auto expanded = std::move(expanded_result).Unwrap();
+  regular_rule_fsm_cache_.emplace(rule_id, expanded.Copy());
+  return ResultOk(std::move(expanded));
+}
+
+Result<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildDynamicTagNameConstraint(
+    const std::string& open_prefix,
+    const std::string& open_suffix,
+    const std::string& close_prefix,
+    const std::string& close_suffix
+) {
+  std::string forbidden_initial;
+  if (close_prefix.size() > open_prefix.size() &&
+      std::equal(open_prefix.begin(), open_prefix.end(), close_prefix.begin())) {
+    forbidden_initial = close_prefix.substr(open_prefix.size());
+  } else if (open_prefix.size() > close_prefix.size() &&
+             std::equal(close_prefix.begin(), close_prefix.end(), open_prefix.begin())) {
+    forbidden_initial = open_prefix.substr(close_prefix.size());
+  }
+
+  auto build_failure = [](const std::string& delimiter) {
+    std::vector<int32_t> failure(delimiter.size());
+    for (int32_t i = 1, matched = 0; i < static_cast<int32_t>(delimiter.size()); ++i) {
+      while (matched > 0 && delimiter[i] != delimiter[matched]) {
+        matched = failure[matched - 1];
+      }
+      if (delimiter[i] == delimiter[matched]) {
+        ++matched;
+      }
+      failure[i] = matched;
+    }
+    return failure;
+  };
+  const auto open_suffix_failure = build_failure(open_suffix);
+  const auto close_suffix_failure = build_failure(close_suffix);
+
+  using State = std::tuple<int32_t, int32_t, int32_t, bool>;
+  const State start{0, 0, forbidden_initial.empty() ? -1 : 0, false};
+  const auto state_hash = [](const State& state) {
+    return std::apply(
+        [](int32_t open_matched, int32_t close_matched, int32_t initial_matched, bool nonblank) {
+          return static_cast<size_t>(
+              HashCombine(open_matched, close_matched, initial_matched, nonblank)
+          );
+        },
+        state
+    );
+  };
+  std::unordered_map<State, int32_t, decltype(state_hash)> state_ids(0, state_hash);
+  state_ids.emplace(start, 0);
+  std::queue<State> pending;
+  pending.push(start);
+  FSM fsm(1);
+  std::vector<int32_t> ends;
+
+  auto advance_delimiter = [](const std::string& delimiter,
+                              const std::vector<int32_t>& failure,
+                              int32_t matched,
+                              uint8_t byte) -> std::optional<int32_t> {
+    if (delimiter.empty()) {
+      return 0;
+    }
+    while (matched > 0 && byte != static_cast<uint8_t>(delimiter[matched])) {
+      matched = failure[matched - 1];
+    }
+    if (byte == static_cast<uint8_t>(delimiter[matched])) {
+      ++matched;
+      if (matched == static_cast<int32_t>(delimiter.size())) {
+        return std::nullopt;
+      }
+    }
+    return matched;
+  };
+
+  auto has_safe_boundary =
+      [](const std::string& delimiter, const std::vector<int32_t>& failure, int32_t matched) {
+        if (delimiter.empty()) {
+          return true;
+        }
+        for (int32_t index = 0; index < static_cast<int32_t>(delimiter.size()); ++index) {
+          const uint8_t byte = static_cast<uint8_t>(delimiter[index]);
+          while (matched > 0 && byte != static_cast<uint8_t>(delimiter[matched])) {
+            matched = failure[matched - 1];
+          }
+          if (byte == static_cast<uint8_t>(delimiter[matched])) {
+            ++matched;
+            if (matched == static_cast<int32_t>(delimiter.size())) {
+              return index + 1 == static_cast<int32_t>(delimiter.size());
+            }
+          }
+        }
+        XGRAMMAR_UNREACHABLE();
+      };
+
+  auto advance = [&](const State& state, uint8_t byte) -> std::optional<State> {
+    auto [open_suffix_matched, close_suffix_matched, initial_matched, has_non_whitespace] = state;
+    auto next_open = advance_delimiter(open_suffix, open_suffix_failure, open_suffix_matched, byte);
+    auto next_close =
+        advance_delimiter(close_suffix, close_suffix_failure, close_suffix_matched, byte);
+    if (!next_open.has_value() || !next_close.has_value()) {
+      return std::nullopt;
+    }
+    if (initial_matched >= 0) {
+      if (byte == static_cast<uint8_t>(forbidden_initial[initial_matched])) {
+        ++initial_matched;
+        if (initial_matched == static_cast<int32_t>(forbidden_initial.size())) {
+          return std::nullopt;
+        }
+      } else {
+        initial_matched = -1;
+      }
+    }
+    has_non_whitespace = has_non_whitespace || (byte != ' ' && byte != '\t' && byte != '\n' &&
+                                                byte != '\r' && byte != '\f' && byte != '\v');
+    return State{*next_open, *next_close, initial_matched, has_non_whitespace};
+  };
+
+  while (!pending.empty()) {
+    State state = pending.front();
+    pending.pop();
+    const int32_t source = state_ids.at(state);
+    const auto [open_suffix_matched, close_suffix_matched, initial_matched, has_non_whitespace] =
+        state;
+    if (has_non_whitespace &&
+        has_safe_boundary(open_suffix, open_suffix_failure, open_suffix_matched) &&
+        has_safe_boundary(close_suffix, close_suffix_failure, close_suffix_matched)) {
+      ends.push_back(source);
+    }
+
+    std::array<int32_t, 256> targets;
+    targets.fill(-1);
+    for (int32_t byte = 0; byte < 256; ++byte) {
+      auto next = advance(state, static_cast<uint8_t>(byte));
+      if (!next.has_value()) {
+        continue;
+      }
+      auto [it, inserted] = state_ids.emplace(*next, state_ids.size());
+      if (inserted) {
+        if (state_ids.size() > kMaxDynamicTagNameStates) {
+          return ResultErr(
+              "DynamicTag delimiters expand the name constraint beyond 100000 FSM states"
+          );
+        }
+        fsm.AddState();
+        pending.push(*next);
+      }
+      targets[byte] = it->second;
+    }
+    for (int32_t begin = 0; begin < 256;) {
+      if (targets[begin] < 0) {
+        ++begin;
+        continue;
+      }
+      int32_t end = begin;
+      while (end + 1 < 256 && targets[end + 1] == targets[begin]) {
+        ++end;
+      }
+      fsm.AddEdge(source, targets[begin], begin, end);
+      begin = end + 1;
+    }
+  }
+  return ResultOk(FSMWithStartEnd(std::move(fsm), 0, std::move(ends), true));
+}
+
+void GrammarFSMBuilderImpl::BuildDynamicTag(
+    const Grammar::Impl::DynamicTag& dynamic_tag,
+    const Grammar& grammar,
+    int start_state,
+    std::vector<int32_t>* end_states
+) {
+  auto append_literal = [&](int32_t from, const std::string& literal) {
+    int32_t current = from;
+    for (uint8_t byte : literal) {
+      int32_t next = target_fsm_.AddState();
+      target_fsm_.AddEdge(current, next, byte, byte);
+      current = next;
+    }
+    return current;
+  };
+
+  int32_t current = append_literal(start_state, dynamic_tag.open_prefix);
+  int32_t before_name = current;
+  current = target_fsm_.AddState();
+  target_fsm_.AddCaptureStartEdge(before_name, current);
+  auto name_result = BuildRegularRuleFSM(grammar, dynamic_tag.name_rule_id);
+  if (name_result.IsErr()) {
+    XGRAMMAR_LOG(FATAL) << "Cannot compile DynamicTag name_rule \""
+                        << grammar->GetRule(dynamic_tag.name_rule_id).name
+                        << "\": " << std::move(name_result).UnwrapErr().what();
+  }
+  auto name_dfa_result = std::move(name_result).Unwrap().ToDFA(kMaxDynamicTagNameStates);
+  if (name_dfa_result.IsErr()) {
+    XGRAMMAR_LOG(FATAL) << "Cannot determinize DynamicTag name_rule \""
+                        << grammar->GetRule(dynamic_tag.name_rule_id).name
+                        << "\": " << std::move(name_dfa_result).UnwrapErr().what();
+  }
+  auto constraint_result = BuildDynamicTagNameConstraint(
+      dynamic_tag.open_prefix,
+      dynamic_tag.open_suffix,
+      dynamic_tag.close_prefix,
+      dynamic_tag.close_suffix
+  );
+  if (constraint_result.IsErr()) {
+    XGRAMMAR_LOG(FATAL) << "Cannot compile DynamicTag delimiters: "
+                        << std::move(constraint_result).UnwrapErr().what();
+  }
+  auto constrained_name_result = FSMWithStartEnd::Intersect(
+      std::move(name_dfa_result).Unwrap(),
+      std::move(constraint_result).Unwrap(),
+      kMaxDynamicTagNameStates
+  );
+  if (constrained_name_result.IsErr()) {
+    XGRAMMAR_LOG(FATAL) << "Cannot constrain DynamicTag name_rule \""
+                        << grammar->GetRule(dynamic_tag.name_rule_id).name
+                        << "\": " << std::move(constrained_name_result).UnwrapErr().what();
+  }
+  auto constrained_name = std::move(constrained_name_result).Unwrap();
+  if (constrained_name.GetEnds().empty()) {
+    XGRAMMAR_LOG(FATAL) << "Cannot constrain DynamicTag name_rule \""
+                        << grammar->GetRule(dynamic_tag.name_rule_id).name
+                        << "\": the rule has no delimiter-safe nonblank name";
+  }
+  std::vector<int> name_mapping;
+  target_fsm_.AddFSM(constrained_name.GetFsm(), &name_mapping);
+  target_fsm_.AddEpsilonEdge(current, name_mapping[constrained_name.GetStart()]);
+  int32_t after_name = target_fsm_.AddState();
+  for (int32_t end : constrained_name.GetEnds()) {
+    target_fsm_.AddCaptureEndEdge(name_mapping[end], after_name);
+  }
+  current = append_literal(after_name, dynamic_tag.open_suffix);
+
+  int32_t after_content = target_fsm_.AddState();
+  target_fsm_.AddRuleEdge(current, after_content, dynamic_tag.content_rule_id);
+  current = append_literal(after_content, dynamic_tag.close_prefix);
+
+  int32_t after_backreference = target_fsm_.AddState();
+  target_fsm_.AddBackReferenceEdge(current, after_backreference);
+  current = append_literal(after_backreference, dynamic_tag.close_suffix);
+  end_states->assign({current});
 }
 
 std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::BuildTagDispatchFSM(
@@ -3481,7 +4024,8 @@ std::optional<uint64_t> GrammarFSMHasherImpl::HashSequence(
         return std::nullopt;
       }
       case (GrammarExprType::kTagDispatch):
-      case (GrammarExprType::kTokenTagDispatch): {
+      case (GrammarExprType::kTokenTagDispatch):
+      case (GrammarExprType::kDynamicTag): {
         return std::nullopt;
       }
       case (GrammarExprType::kRegex):

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -157,6 +157,8 @@ class GrammarFunctor {
         return VisitRegex(grammar_expr);
       case GrammarExprType::kSubstring:
         return VisitSubstring(grammar_expr);
+      case GrammarExprType::kDynamicTag:
+        return VisitDynamicTag(grammar_expr);
       default:
         XGRAMMAR_LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(grammar_expr.type);
         XGRAMMAR_UNREACHABLE();
@@ -249,6 +251,16 @@ class GrammarFunctor {
 
   virtual T VisitTokenTagDispatch(const GrammarExpr& grammar_expr) {
     return VisitElement(grammar_expr);
+  }
+
+  virtual T VisitDynamicTag(const GrammarExpr& grammar_expr) {
+    if constexpr (std::is_same<T, void>::value) {
+      return;
+    } else if constexpr (std::is_same<T, int32_t>::value) {
+      return builder_->AddDynamicTag(base_grammar_->GetDynamicTag(grammar_expr));
+    } else {
+      return T();
+    }
   }
 
   /*! \brief Visit a regex GrammarExpr. It is a leaf: the pattern string is carried as-is. */

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -196,6 +196,14 @@ class Grammar::Impl {
     // and is carried through the grammar passes as-is; when GrammarFSMBuilder runs, it is
     // compiled into an automaton via a chunk-level suffix automaton (see SuffixAutomata).
     kSubstring,
+    // data format: [open_prefix_expr_id, name_rule_id, open_suffix_expr_id,
+    //               content_rule_id, close_prefix_expr_id, close_suffix_expr_id]
+    // or, when runtime names must be unique within an enclosing object occurrence:
+    //              [..., unique_key_scope_rule_id, reserved_names_choices_expr_id]
+    // Matches a paired tag whose closing name must byte-for-byte equal the runtime-generated
+    // opening name. Structure normalization materializes a nested occurrence as a helper rule,
+    // so every compiled occurrence has an independent rule-local capture scope.
+    kDynamicTag,
   };
 
   /*! \brief The object representing a grammar expr. */
@@ -379,6 +387,84 @@ class Grammar::Impl {
   /*! \brief Get the token tag dispatch from the grammar expr with the given id. */
   TokenTagDispatch GetTokenTagDispatch(int32_t grammar_expr_id) const {
     return GetTokenTagDispatch(GetGrammarExpr(grammar_expr_id));
+  }
+
+  /*!
+   * \brief A paired tag with a runtime-generated name repeated byte-for-byte by its closing tag.
+   *
+   * name_rule must be byte-regular. During compilation it is intersected with the delimiter-safe
+   * tag-name language: names are nonempty and nonblank, cannot contain either suffix or overlap a
+   * suffix across the name boundary, and cannot make the two prefixes indistinguishable.
+   */
+  struct DynamicTag {
+    std::string open_prefix;
+    int32_t name_rule_id;
+    std::string open_suffix;
+    int32_t content_rule_id;
+    std::string close_prefix;
+    std::string close_suffix;
+    int32_t unique_key_scope_rule_id = -1;
+    std::vector<std::string> reserved_names;
+
+    DynamicTag(
+        std::string open_prefix,
+        int32_t name_rule_id,
+        std::string open_suffix,
+        int32_t content_rule_id,
+        std::string close_prefix,
+        std::string close_suffix,
+        int32_t unique_key_scope_rule_id = -1,
+        std::vector<std::string> reserved_names = {}
+    )
+        : open_prefix(std::move(open_prefix)),
+          name_rule_id(name_rule_id),
+          open_suffix(std::move(open_suffix)),
+          content_rule_id(content_rule_id),
+          close_prefix(std::move(close_prefix)),
+          close_suffix(std::move(close_suffix)),
+          unique_key_scope_rule_id(unique_key_scope_rule_id),
+          reserved_names(std::move(reserved_names)) {}
+  };
+
+  DynamicTag GetDynamicTag(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kDynamicTag);
+    XGRAMMAR_DCHECK(grammar_expr.size() == 6 || grammar_expr.size() == 8);
+    DynamicTag result{
+        GetByteString(grammar_expr[0]),
+        grammar_expr[1],
+        GetByteString(grammar_expr[2]),
+        grammar_expr[3],
+        GetByteString(grammar_expr[4]),
+        GetByteString(grammar_expr[5])
+    };
+    if (grammar_expr.size() == 8) {
+      result.unique_key_scope_rule_id = grammar_expr[6];
+      auto reserved_names = GetGrammarExpr(grammar_expr[7]);
+      XGRAMMAR_DCHECK(reserved_names.type == GrammarExprType::kChoices);
+      result.reserved_names.reserve(reserved_names.size());
+      for (int32_t name_expr_id : reserved_names) {
+        result.reserved_names.push_back(GetByteString(name_expr_id));
+      }
+    }
+    return result;
+  }
+
+  DynamicTag GetDynamicTag(int32_t grammar_expr_id) const {
+    return GetDynamicTag(GetGrammarExpr(grammar_expr_id));
+  }
+
+  int32_t GetDynamicTagUniqueKeyScopeRuleId(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kDynamicTag);
+    XGRAMMAR_DCHECK(grammar_expr.size() == 6 || grammar_expr.size() == 8);
+    return grammar_expr.size() == 8 ? grammar_expr[6] : -1;
+  }
+
+  GrammarExpr GetDynamicTagReservedNames(const GrammarExpr& grammar_expr) const {
+    XGRAMMAR_DCHECK(grammar_expr.type == GrammarExprType::kDynamicTag);
+    XGRAMMAR_DCHECK(grammar_expr.size() == 8);
+    auto result = GetGrammarExpr(grammar_expr[7]);
+    XGRAMMAR_DCHECK(result.type == GrammarExprType::kChoices);
+    return result;
   }
 
  private:

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -17,6 +17,7 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -466,7 +467,11 @@ class GrammarMatcher::Impl : public EarleyParser {
       int max_rollback_tokens = -1,
       std::optional<float> default_temperature = std::nullopt
   )
-      : EarleyParser(compiled_grammar->grammar),
+      : EarleyParser(
+            compiled_grammar->grammar,
+            /*initial_state=*/std::nullopt,
+            /*track_unique_key_contexts=*/true
+        ),
         compiled_grammar_(compiled_grammar),
         tokenizer_info_(compiled_grammar->tokenizer_info),
         stop_token_ids_(override_stop_tokens.value_or(tokenizer_info_.GetStopTokenIds())),
@@ -510,6 +515,7 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   void Reset() {
     token_length_history.clear();
+    unique_key_context_history_.clear();
     current_token_index_ = -1;
     budget_enforce_pending_ = false;
     budget_force_close_pending_ = false;
@@ -535,6 +541,26 @@ class GrammarMatcher::Impl : public EarleyParser {
 
  private:
   using StoreType = AdaptiveTokenMask::StoreType;
+
+  class UniqueKeyContextRestoreGuard {
+   public:
+    explicit UniqueKeyContextRestoreGuard(Impl* matcher)
+        : matcher_(matcher->track_unique_key_contexts_ ? matcher : nullptr) {
+      if (matcher_ != nullptr) {
+        snapshot_ = matcher_->SnapshotUniqueKeyContexts();
+      }
+    }
+
+    ~UniqueKeyContextRestoreGuard() {
+      if (matcher_ != nullptr) {
+        matcher_->RestoreUniqueKeyContexts(snapshot_);
+      }
+    }
+
+   private:
+    Impl* matcher_;
+    UniqueKeyContextSnapshot snapshot_;
+  };
 
   /*!
    * \brief If is_uncertain_saved is true, find the next token in uncertain_indices. Otherwise,
@@ -612,6 +638,9 @@ class GrammarMatcher::Impl : public EarleyParser {
       int32_t* bitmask_data_ptr, int index, bool skip_expired, bool debug_print
   );
 
+  /*! \brief Evaluate a pure backreference state over only tokens with the required first byte. */
+  bool FillBitmaskForBackReferenceState(const ParserState& state);
+
   void FillBitmaskForCharBudgetBoundary(
       const AdaptiveTokenMask& adaptive_token_mask, int32_t remaining_chars
   );
@@ -624,8 +653,21 @@ class GrammarMatcher::Impl : public EarleyParser {
 
   /*! \brief Whether byte offsets are needed for captures or budgeted suffix/stop rules. */
   bool ShouldTrackAcceptedBytes() const {
-    return IsCaptureTrackingEnabled() || has_budget_marker_rules_;
+    return IsCaptureTrackingEnabled() || has_budget_marker_rules_ || has_dynamic_tag_rules_;
   }
+
+  bool ShouldTrackTemporaryInput() const {
+    return has_dynamic_tag_rules_ || (has_char_budget_rules_ && has_budget_marker_rules_);
+  }
+
+  std::optional<int64_t> GetInputBytePosition(int32_t row) const;
+
+  std::optional<uint8_t> GetInputByte(int64_t byte_offset) const;
+
+  std::optional<BackReferenceProgress> GetBackReferenceProgress(const ParserState& state
+  ) const final;
+
+  bool PrepareDynamicTagContent(ParserState* state) final;
 
   /*! \brief Whether the bytes consumed by this expired suffix/stop occurrence form a complete
    * match of its body, so max_tokens may end it without consuming the marker. */
@@ -675,20 +717,32 @@ class GrammarMatcher::Impl : public EarleyParser {
     return bitset.Any();
   }
 
+  void CheckCanAppendTrackedBytes(size_t num_bytes) const {
+    constexpr size_t kMaxTrackedBytes = std::numeric_limits<int32_t>::max();
+    XGRAMMAR_CHECK(
+        accepted_bytes_.size() <= kMaxTrackedBytes &&
+        num_bytes <= kMaxTrackedBytes - accepted_bytes_.size()
+    ) << "GrammarMatcher cannot track more than "
+      << kMaxTrackedBytes << " accepted bytes";
+  }
+
   /*! \brief Record that num_rows new input positions were created, each consuming one byte of
    * bytes in order. Used for the byte-by-byte advance paths. */
   void AppendPerByteRows(const std::string& bytes) {
-    for (char c : bytes) {
-      accepted_bytes_.push_back(static_cast<uint8_t>(c));
-      row_byte_end_.push_back(static_cast<int64_t>(accepted_bytes_.size()));
+    CheckCanAppendTrackedBytes(bytes.size());
+    const int32_t previous_size = static_cast<int32_t>(accepted_bytes_.size());
+    accepted_bytes_.insert(accepted_bytes_.end(), bytes.begin(), bytes.end());
+    for (size_t index = 0; index < bytes.size(); ++index) {
+      row_byte_end_.push_back(previous_size + static_cast<int32_t>(index) + 1);
     }
   }
 
   /*! \brief Record that one new input position was created, consuming all bytes of the token.
    * Used for the atomic token advance path. */
   void AppendAtomicRow(const std::string& bytes) {
+    CheckCanAppendTrackedBytes(bytes.size());
     accepted_bytes_.insert(accepted_bytes_.end(), bytes.begin(), bytes.end());
-    row_byte_end_.push_back(static_cast<int64_t>(accepted_bytes_.size()));
+    row_byte_end_.push_back(static_cast<int32_t>(accepted_bytes_.size()));
   }
 
   CompiledGrammar compiled_grammar_;
@@ -698,6 +752,7 @@ class GrammarMatcher::Impl : public EarleyParser {
   std::optional<float> default_temperature_;
   mutable bool has_warned_temperature_conflict_ = false;
   std::deque<int> token_length_history;
+  std::vector<UniqueKeyContextSnapshot> unique_key_context_history_;
 
   /*! \brief Set by the last mask computation when an exhausted budget could be enforced: the
    * next accept commits the same state transition used to compute that mask. */
@@ -728,7 +783,7 @@ class GrammarMatcher::Impl : public EarleyParser {
   std::vector<uint8_t> accepted_bytes_;
   /*! \brief row_byte_end_[i] is the number of accepted bytes after input position i. Aligned
    * with the parser's state history whenever accepted_bytes_ is maintained. */
-  std::vector<int64_t> row_byte_end_{0};
+  std::vector<int32_t> row_byte_end_{0};
   /*! \brief Bytes tentatively consumed by the current token or string advance. */
   std::string temporary_input_bytes_;
   /*! \brief Parser row immediately before temporary_input_bytes_. */
@@ -812,6 +867,161 @@ bool GrammarMatcher::Impl::IsTerminated() const {
 
 bool GrammarMatcher::Impl::IsStopTokenAccepted() const { return stop_token_is_accepted_; }
 
+std::optional<int64_t> GrammarMatcher::Impl::GetInputBytePosition(int32_t row) const {
+  if (row >= 0 && row < static_cast<int32_t>(row_byte_end_.size())) {
+    return row_byte_end_[row];
+  }
+  if (temporary_input_start_row_ >= 0 && row >= temporary_input_start_row_ &&
+      row <= temporary_input_start_row_ + static_cast<int32_t>(temporary_input_bytes_.size())) {
+    return static_cast<int64_t>(accepted_bytes_.size()) + row - temporary_input_start_row_;
+  }
+  return std::nullopt;
+}
+
+std::optional<uint8_t> GrammarMatcher::Impl::GetInputByte(int64_t byte_offset) const {
+  if (byte_offset < 0) {
+    return std::nullopt;
+  }
+  if (byte_offset < static_cast<int64_t>(accepted_bytes_.size())) {
+    return accepted_bytes_[byte_offset];
+  }
+  const int64_t temporary_offset = byte_offset - accepted_bytes_.size();
+  if (temporary_offset < static_cast<int64_t>(temporary_input_bytes_.size())) {
+    return static_cast<uint8_t>(temporary_input_bytes_[temporary_offset]);
+  }
+  return std::nullopt;
+}
+
+std::optional<EarleyParser::BackReferenceProgress> GrammarMatcher::Impl::GetBackReferenceProgress(
+    const ParserState& state
+) const {
+  if (!IsDynamicTagRule(state.rule_id) || state.partial_codepoint < 0 || state.repeat_count < 0) {
+    return std::nullopt;
+  }
+  auto capture_start_byte = GetInputBytePosition(state.sub_element_id);
+  auto capture_end_byte = GetInputBytePosition(state.partial_codepoint);
+  if (!capture_start_byte.has_value() || !capture_end_byte.has_value()) {
+    return std::nullopt;
+  }
+  const int64_t capture_size = *capture_end_byte - *capture_start_byte;
+  if (capture_size <= 0 || state.repeat_count >= capture_size) {
+    return std::nullopt;
+  }
+  auto next_byte = GetInputByte(*capture_start_byte + state.repeat_count);
+  if (!next_byte.has_value()) {
+    return std::nullopt;
+  }
+  return BackReferenceProgress{*next_byte, state.repeat_count + 1 == capture_size};
+}
+
+bool GrammarMatcher::Impl::PrepareDynamicTagContent(ParserState* state) {
+  XGRAMMAR_DCHECK(state != nullptr && IsUniqueKeyDynamicTagRule(state->rule_id));
+  const int32_t scope_rule_id = GetDynamicTagUniqueKeyScopeRuleId(state->rule_id);
+
+  const auto name_start = GetInputBytePosition(state->sub_element_id);
+  const auto name_end = GetInputBytePosition(state->partial_codepoint);
+  if (!name_start.has_value() || !name_end.has_value() || *name_start < 0 ||
+      *name_end <= *name_start || *name_end > std::numeric_limits<int32_t>::max()) {
+    return false;
+  }
+  const int32_t name_start_byte = static_cast<int32_t>(*name_start);
+  const int32_t byte_length = static_cast<int32_t>(*name_end - *name_start);
+
+  const auto semantic_state = GetUniqueKeySemanticState(state->unique_key_state_id);
+  int32_t context_id = semantic_state.current_context_id;
+  const auto& current_context = GetUniqueKeyContext(context_id);
+  if (current_context.kind == UniqueKeyContextNode::Kind::kKey &&
+      current_context.name_start_byte == name_start_byte &&
+      current_context.byte_length == byte_length) {
+    return true;
+  }
+
+  constexpr uint64_t kFNVOffsetBasis = 14695981039346656037ULL;
+  constexpr uint64_t kFNVPrime = 1099511628211ULL;
+  uint64_t hash = kFNVOffsetBasis;
+  for (int32_t offset = 0; offset < byte_length; ++offset) {
+    auto byte = GetInputByte(static_cast<int64_t>(name_start_byte) + offset);
+    if (!byte.has_value()) {
+      return false;
+    }
+    hash = (hash ^ *byte) * kFNVPrime;
+  }
+
+  auto equals_bytes = [&](int32_t lhs_start, int32_t rhs_start, int32_t length) {
+    for (int32_t offset = 0; offset < length; ++offset) {
+      auto lhs = GetInputByte(static_cast<int64_t>(lhs_start) + offset);
+      auto rhs = GetInputByte(static_cast<int64_t>(rhs_start) + offset);
+      if (!lhs.has_value() || !rhs.has_value() || *lhs != *rhs) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const auto body = grammar_->GetGrammarExpr(grammar_->GetRule(state->rule_id).body_expr_id);
+  const auto reserved_names = grammar_->GetDynamicTagReservedNames(body);
+  for (int32_t name_expr_id : reserved_names) {
+    const auto reserved_name = grammar_->GetGrammarExpr(name_expr_id);
+    XGRAMMAR_DCHECK(reserved_name.type == Grammar::Impl::GrammarExprType::kByteString);
+    if (reserved_name.size() != byte_length) {
+      continue;
+    }
+    bool matches = true;
+    for (int32_t offset = 0; offset < byte_length; ++offset) {
+      auto byte = GetInputByte(static_cast<int64_t>(name_start_byte) + offset);
+      if (!byte.has_value() || *byte != static_cast<uint8_t>(reserved_name[offset])) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return false;
+    }
+  }
+
+  const uint64_t bloom_bit_1 = uint64_t{1} << (hash & 63);
+  const uint64_t bloom_bit_2 = uint64_t{1} << ((hash >> 32) & 63);
+  const bool may_be_duplicate = (current_context.name_bloom & bloom_bit_1) != 0 &&
+                                (current_context.name_bloom & bloom_bit_2) != 0;
+  const int32_t scope_context_id = current_context.kind == UniqueKeyContextNode::Kind::kKey
+                                       ? current_context.nearest_scope_context_id
+                                       : context_id;
+  if (may_be_duplicate) {
+    XGRAMMAR_DCHECK(unique_key_context_storage_ != nullptr);
+    const int32_t current_depth = current_context.kind == UniqueKeyContextNode::Kind::kKey
+                                      ? current_context.scope_key_depth
+                                      : 0;
+    const auto candidates =
+        unique_key_context_storage_->key_context_ids_by_scope_and_name_hash.equal_range(
+            HashCombine(scope_context_id, hash)
+        );
+    for (auto it = candidates.first; it != candidates.second; ++it) {
+      const int32_t candidate_id = it->second;
+      const auto& candidate = GetUniqueKeyContext(candidate_id);
+      if (candidate_id > context_id || candidate.nearest_scope_context_id != scope_context_id ||
+          candidate.scope_key_depth > current_depth || candidate.byte_length != byte_length) {
+        continue;
+      }
+      int32_t ancestor_id = context_id;
+      while (GetUniqueKeyContext(ancestor_id).scope_key_depth > candidate.scope_key_depth) {
+        ancestor_id = GetUniqueKeyContext(ancestor_id).parent_id;
+      }
+      if (ancestor_id == candidate_id &&
+          equals_bytes(candidate.name_start_byte, name_start_byte, byte_length)) {
+        return false;
+      }
+    }
+  }
+  const auto& scope = GetUniqueKeyContext(scope_context_id);
+  if (scope.kind != UniqueKeyContextNode::Kind::kScope || scope.scope_rule_id != scope_rule_id) {
+    return false;
+  }
+
+  state->unique_key_state_id =
+      AppendUniqueKey(state->unique_key_state_id, name_start_byte, byte_length, hash);
+  return true;
+}
+
 bool GrammarMatcher::Impl::CanForceCompleteWithoutMarker(
     const ParserState& state, bool use_char_budget
 ) {
@@ -830,18 +1040,12 @@ bool GrammarMatcher::Impl::CanForceCompleteWithoutMarker(
   XGRAMMAR_DCHECK(ShouldTrackAcceptedBytes());
   int32_t start_row =
       state.rule_start_pos == ParserState::kNoPrevInputPos ? 0 : state.rule_start_pos;
-  auto byte_position_for_row = [&](int32_t row) {
-    if (row >= 0 && row < static_cast<int32_t>(row_byte_end_.size())) {
-      return row_byte_end_[row];
-    }
-    XGRAMMAR_DCHECK(temporary_input_start_row_ >= 0);
-    XGRAMMAR_DCHECK(row >= temporary_input_start_row_);
-    XGRAMMAR_DCHECK(
-        row <= temporary_input_start_row_ + static_cast<int32_t>(temporary_input_bytes_.size())
-    );
-    return static_cast<int64_t>(accepted_bytes_.size() + row - temporary_input_start_row_);
-  };
-  int64_t begin = byte_position_for_row(start_row);
+  auto begin_position = GetInputBytePosition(start_row);
+  XGRAMMAR_DCHECK(begin_position.has_value());
+  if (!begin_position.has_value()) {
+    return false;
+  }
+  int64_t begin = *begin_position;
   int64_t end = accepted_bytes_.size() + temporary_input_bytes_.size();
 
   XGRAMMAR_DCHECK(grammar_->per_rule_fsms[suffix_stop_info->body_rule_id].has_value());
@@ -889,7 +1093,7 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
   const auto latest_row = scanable_state_history_[scanable_state_history_.size() - 1];
   std::vector<ParserState> latest_states(latest_row.begin(), latest_row.end());
   std::vector<ParserState> force_completed_states;
-  std::unordered_set<int64_t> force_completed_occurrences;
+  std::unordered_set<std::tuple<int32_t, int32_t, int32_t>> force_completed_occurrences;
 
   tmp_states_visited_in_queue_.Clear();
   tmp_states_to_be_added_.clear();
@@ -904,8 +1108,8 @@ bool GrammarMatcher::Impl::ApplyBudgetEnforcement(bool debug_print) {
     if (!CanForceCompleteWithoutMarker(state, false)) {
       continue;
     }
-    int64_t occurrence =
-        (static_cast<int64_t>(state.rule_id) << 32) | static_cast<uint32_t>(state.rule_start_pos);
+    auto occurrence =
+        std::make_tuple(state.rule_id, state.rule_start_pos, state.unique_key_state_id);
     if (force_completed_occurrences.insert(occurrence).second) {
       force_completed_states.push_back(state);
     }
@@ -975,8 +1179,12 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
   if (capture_tracking_) {
     previous_capture_events = CopyLastCaptureRow();
   }
+  UniqueKeyContextSnapshot previous_unique_key_contexts;
+  if (track_unique_key_contexts_) {
+    previous_unique_key_contexts = SnapshotUniqueKeyContexts();
+  }
   std::vector<ParserState> force_completed_states;
-  std::unordered_set<int64_t> force_completed_occurrences;
+  std::unordered_set<std::tuple<int32_t, int32_t, int32_t>> force_completed_occurrences;
 
   tmp_states_visited_in_queue_.Clear();
   tmp_states_to_be_added_.clear();
@@ -991,8 +1199,8 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
     if (!CanForceCompleteWithoutMarker(state, true)) {
       continue;
     }
-    int64_t occurrence =
-        (static_cast<int64_t>(state.rule_id) << 32) | static_cast<uint32_t>(state.rule_start_pos);
+    auto occurrence =
+        std::make_tuple(state.rule_id, state.rule_start_pos, state.unique_key_state_id);
     if (force_completed_occurrences.insert(occurrence).second) {
       force_completed_states.push_back(state);
     }
@@ -1043,6 +1251,9 @@ bool GrammarMatcher::Impl::ApplyCharacterBudgetEnforcement(bool debug_print) {
     if (capture_tracking_) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(previous_capture_events);
+    }
+    if (track_unique_key_contexts_) {
+      RestoreUniqueKeyContexts(previous_unique_key_contexts);
     }
     return false;
   }
@@ -1100,6 +1311,10 @@ bool GrammarMatcher::Impl::AdvanceWithCharacterBudget(uint8_t byte, bool debug_p
   if (capture_tracking_) {
     previous_capture_events = CopyLastCaptureRow();
   }
+  UniqueKeyContextSnapshot previous_unique_key_contexts;
+  if (track_unique_key_contexts_) {
+    previous_unique_key_contexts = SnapshotUniqueKeyContexts();
+  }
 
   bool enforced = ApplyCharacterBudgetEnforcementToFixedPoint(debug_print);
   if (!enforced && record_char_budget_relaxation_) {
@@ -1115,6 +1330,9 @@ bool GrammarMatcher::Impl::AdvanceWithCharacterBudget(uint8_t byte, bool debug_p
     if (capture_tracking_) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(previous_capture_events);
+    }
+    if (track_unique_key_contexts_) {
+      RestoreUniqueKeyContexts(previous_unique_key_contexts);
     }
   }
   return accepted;
@@ -1138,6 +1356,7 @@ bool GrammarMatcher::Impl::AdvanceAtomicTokenWithCharacterBudget(
   std::vector<std::pair<int32_t, ParserState>> previous_completable_states;
   bool previous_completed = false;
   std::vector<CaptureEvent> previous_capture_events;
+  UniqueKeyContextSnapshot previous_unique_key_contexts;
   bool enforced = false;
   if (has_expired_state) {
     previous_states = GetLatestScanableStates();
@@ -1149,6 +1368,9 @@ bool GrammarMatcher::Impl::AdvanceAtomicTokenWithCharacterBudget(
     previous_completed = IsCompleted();
     if (capture_tracking_) {
       previous_capture_events = CopyLastCaptureRow();
+    }
+    if (track_unique_key_contexts_) {
+      previous_unique_key_contexts = SnapshotUniqueKeyContexts();
     }
     enforced = ApplyCharacterBudgetEnforcementToFixedPoint(debug_print);
     if (!enforced && record_char_budget_relaxation_) {
@@ -1166,6 +1388,9 @@ bool GrammarMatcher::Impl::AdvanceAtomicTokenWithCharacterBudget(
     if (capture_tracking_) {
       capture_event_history_.PopBack(1);
       capture_event_history_.PushBack(previous_capture_events);
+    }
+    if (track_unique_key_contexts_) {
+      RestoreUniqueKeyContexts(previous_unique_key_contexts);
     }
   }
   if (accepted && crosses_budget && record_char_budget_relaxation_) {
@@ -1284,6 +1509,9 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   // Handle the stop token
   if (is_stop_token) {
     bool accepted = AcceptStopToken();
+    if (accepted && track_unique_key_contexts_) {
+      unique_key_context_history_.push_back(SnapshotUniqueKeyContexts());
+    }
     if (debug_print) {
       XGRAMMAR_LOG(INFO) << "The token is an end token. Is accepted: " << accepted;
     }
@@ -1302,6 +1530,10 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   std::vector<ParserState> states_before_token;
   std::vector<std::pair<int32_t, ParserState>> completable_before_token;
   std::vector<CaptureEvent> capture_row_before_token;
+  UniqueKeyContextSnapshot unique_key_contexts_before_token;
+  if (track_unique_key_contexts_) {
+    unique_key_contexts_before_token = SnapshotUniqueKeyContexts();
+  }
   bool completed_before_token = false;
   if (has_char_budget_rules_) {
     states_before_token = GetLatestScanableStates();
@@ -1346,10 +1578,13 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     PopLastStates(1);
   }
   restore_row_before_token();
+  if (!atomic_success && track_unique_key_contexts_) {
+    RestoreUniqueKeyContexts(unique_key_contexts_before_token);
+  }
 
   // Phase 2: Try byte-by-byte path (from the same original state)
   record_char_budget_relaxation_ = true;
-  bool track_temporary_input = has_char_budget_rules_ && has_budget_marker_rules_;
+  bool track_temporary_input = ShouldTrackTemporaryInput();
   if (track_temporary_input) {
     temporary_input_start_row_ = scanable_state_history_.size() - 1;
     temporary_input_bytes_.clear();
@@ -1382,6 +1617,9 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     }
     PopLastStates(pos);
     restore_row_before_token();
+    if (track_unique_key_contexts_) {
+      RestoreUniqueKeyContexts(unique_key_contexts_before_token);
+    }
     record_char_budget_relaxation_ = false;
     char_budget_relaxed_ = false;
     return false;
@@ -1390,6 +1628,9 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   if (atomic_success && !byte_path_success) {
     PopLastStates(pos);
     restore_row_before_token();
+    if (track_unique_key_contexts_) {
+      RestoreUniqueKeyContexts(unique_key_contexts_before_token);
+    }
     char_budget_relaxed_ = false;
     bool accepted =
         has_char_budget_rules_
@@ -1419,6 +1660,37 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
         AppendAtomicRow(token);
       }
     } else {
+      if (has_dynamic_tag_rules_) {
+        const int32_t byte_path_end_row = scanable_state_history_.size() - 1;
+        UniqueKeyRowRemapCache unique_key_remap_cache;
+        auto remap_atomic_end_row = [&](ParserState* state) {
+          if (state->rule_start_pos == size_before_token) {
+            state->rule_start_pos = byte_path_end_row;
+          }
+          if (IsDynamicTagRule(state->rule_id)) {
+            if (state->sub_element_id == size_before_token) {
+              state->sub_element_id = byte_path_end_row;
+            }
+            if (state->partial_codepoint == size_before_token) {
+              state->partial_codepoint = byte_path_end_row;
+            }
+          }
+          state->unique_key_state_id = RemapUniqueKeyStateRows(
+              state->unique_key_state_id,
+              size_before_token,
+              byte_path_end_row,
+              &unique_key_remap_cache
+          );
+        };
+        for (auto& state : atomic_states) {
+          remap_atomic_end_row(&state);
+        }
+        for (auto& [ref_rule_id, state] : atomic_completable) {
+          static_cast<void>(ref_rule_id);
+          remap_atomic_end_row(&state);
+        }
+      }
+
       auto byte_states = GetLatestScanableStates();
       std::vector<ParserState> merged = byte_states;
       StateEqualForParsing state_eq;
@@ -1509,6 +1781,9 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
     // Close exhausted occurrences at the token boundary, including after zero-byte atomic tokens.
     ApplyCharacterBudgetEnforcementToFixedPoint(debug_print);
   }
+  if (track_unique_key_contexts_) {
+    unique_key_context_history_.push_back(unique_key_contexts_before_token);
+  }
   record_char_budget_relaxation_ = false;
   return FinishAccept(consumed_past_deadline);
 }
@@ -1536,6 +1811,10 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
   std::vector<ParserState> states_before_input;
   std::vector<std::pair<int32_t, ParserState>> completable_before_input;
   std::vector<CaptureEvent> capture_row_before_input;
+  UniqueKeyContextSnapshot unique_key_contexts_before_input;
+  if (track_unique_key_contexts_) {
+    unique_key_contexts_before_input = SnapshotUniqueKeyContexts();
+  }
   bool completed_before_input = false;
   if (has_char_budget_rules_) {
     states_before_input = GetLatestScanableStates();
@@ -1547,7 +1826,7 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
     capture_row_before_input = CopyLastCaptureRow();
     completed_before_input = is_completed_.back();
   }
-  bool track_temporary_input = has_char_budget_rules_ && has_budget_marker_rules_;
+  bool track_temporary_input = ShouldTrackTemporaryInput();
   if (track_temporary_input) {
     temporary_input_start_row_ = scanable_state_history_.size() - 1;
     temporary_input_bytes_.clear();
@@ -1573,6 +1852,9 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
           capture_event_history_.PopBack(1);
           capture_event_history_.PushBack(capture_row_before_input);
         }
+      }
+      if (track_unique_key_contexts_) {
+        RestoreUniqueKeyContexts(unique_key_contexts_before_input);
       }
       if (track_temporary_input) {
         temporary_input_start_row_ = -1;
@@ -1602,6 +1884,9 @@ bool GrammarMatcher::Impl::AcceptString(const std::string& input_str, bool debug
   if (track_temporary_input) {
     temporary_input_start_row_ = -1;
     temporary_input_bytes_.clear();
+  }
+  if (track_unique_key_contexts_) {
+    unique_key_context_history_.push_back(unique_key_contexts_before_input);
   }
   record_char_budget_relaxation_ = false;
   FinishCharacterBudgetAccept();
@@ -1645,6 +1930,7 @@ bool GrammarMatcher::Impl::IsTokenBitmaskAllTrue(int32_t* bitmask_data_ptr) {
 bool GrammarMatcher::Impl::FillNextTokenBitmask(
     DLTensor* next_token_bitmask, int index, bool debug_print
 ) {
+  UniqueKeyContextRestoreGuard unique_key_context_guard(this);
   XGRAMMAR_CHECK(!IsStopTokenAccepted())
       << "GrammarMatcher has terminated after accepting the stop token, but is trying to "
          "find the next token mask";
@@ -1827,6 +2113,95 @@ void GrammarMatcher::Impl::FillBitmaskForCharBudgetBoundary(
   temporary_input_bytes_ = std::move(saved_temporary_input_bytes);
 }
 
+bool GrammarMatcher::Impl::FillBitmaskForBackReferenceState(const ParserState& state) {
+  XGRAMMAR_DCHECK(state.rule_id >= 0 && grammar_->per_rule_fsms[state.rule_id].has_value());
+  const auto& rule_fsm = grammar_->per_rule_fsms[state.rule_id]->GetFsm();
+  if (!rule_fsm.IsBackReferenceOnlyScanableState(state.element_id)) {
+    return false;
+  }
+
+  auto progress = GetBackReferenceProgress(state);
+  if (!progress.has_value()) {
+    // A normal matcher should always have the capture at this point. Treat missing history as an
+    // empty accepted set so malformed/restored state cannot weaken the grammar.
+    return true;
+  }
+
+  const auto& vocab = tokenizer_info_.GetSortedDecodedVocab();
+  const auto& subtree_range = tokenizer_info_.GetTrieSubtreeNodesRange();
+  const std::string lower_key(1, static_cast<char>(progress->next_byte));
+  auto begin = std::lower_bound(
+      vocab.begin(),
+      vocab.end(),
+      lower_key,
+      [](const auto& entry, const auto& key) { return entry.second < key; }
+  );
+  auto end = vocab.end();
+  if (progress->next_byte != std::numeric_limits<uint8_t>::max()) {
+    const std::string upper_key(1, static_cast<char>(progress->next_byte + 1));
+    end = std::lower_bound(begin, vocab.end(), upper_key, [](const auto& entry, const auto& key) {
+      return entry.second < key;
+    });
+  }
+
+  PushOneStateToCheck(state);
+  const int32_t saved_temporary_input_start_row = temporary_input_start_row_;
+  std::string saved_temporary_input_bytes = std::move(temporary_input_bytes_);
+  temporary_input_start_row_ = scanable_state_history_.size() - 1;
+  temporary_input_bytes_.clear();
+
+  const std::string* previous_token = nullptr;
+  int32_t previous_matched_size = 0;
+  int32_t rejected_subtree_end = 0;
+  for (auto it = begin; it != end; ++it) {
+    const int32_t vocab_index = static_cast<int32_t>(it - vocab.begin());
+    if (vocab_index < rejected_subtree_end) {
+      continue;
+    }
+    const std::string& token = it->second;
+    bool accepted = true;
+    if (previous_token != nullptr) {
+      const int32_t common_prefix = static_cast<int32_t>(
+          std::mismatch(token.begin(), token.end(), previous_token->begin(), previous_token->end())
+              .first -
+          token.begin()
+      );
+      if (common_prefix > previous_matched_size) {
+        rejected_subtree_end = subtree_range[vocab_index];
+        accepted = false;
+      } else if (common_prefix < previous_matched_size) {
+        PopLastStates(previous_matched_size - common_prefix);
+        temporary_input_bytes_.resize(common_prefix);
+      }
+      previous_matched_size = std::min(previous_matched_size, common_prefix);
+    }
+
+    if (accepted) {
+      for (int32_t i = previous_matched_size; i < static_cast<int32_t>(token.size()); ++i) {
+        const bool byte_accepted = has_char_budget_rules_
+                                       ? AdvanceWithCharacterBudget(static_cast<uint8_t>(token[i]))
+                                       : Advance(static_cast<uint8_t>(token[i]));
+        if (!byte_accepted) {
+          rejected_subtree_end = subtree_range[vocab_index];
+          accepted = false;
+          break;
+        }
+        temporary_input_bytes_.push_back(token[i]);
+        previous_matched_size = i + 1;
+      }
+    }
+    if (accepted) {
+      tmp_accepted_bitset_.Set(it->first, true);
+    }
+    previous_token = &token;
+  }
+
+  PopLastStates(previous_matched_size + 1);
+  temporary_input_start_row_ = saved_temporary_input_start_row;
+  temporary_input_bytes_ = std::move(saved_temporary_input_bytes);
+  return true;
+}
+
 void GrammarMatcher::Impl::FillBitmaskForStates(
     int32_t* bitmask_data_ptr, int index, bool skip_expired, bool debug_print
 ) {
@@ -1862,7 +2237,19 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
       latest_states_with_masks;
 
   for (const auto& state : latest_states) {
-    auto adaptive_token_mask_it = adaptive_token_mask_cache.find(state);
+    ParserState cache_key = state;
+    if (has_dynamic_tag_rules_) {
+      if (FillBitmaskForBackReferenceState(state)) {
+        continue;
+      }
+      if (IsDynamicTagRule(cache_key.rule_id)) {
+        // DynamicTag uses sub_element_id as an occurrence-local capture row. It does not change the
+        // grammar position, so the reusable mask is stored under the normalized value compiled for
+        // this FSM node.
+        cache_key.sub_element_id = 0;
+      }
+    }
+    auto adaptive_token_mask_it = adaptive_token_mask_cache.find(cache_key);
     XGRAMMAR_CHECK(adaptive_token_mask_it != adaptive_token_mask_cache.end()) << state;
     const auto& adaptive_token_mask = adaptive_token_mask_it->second;
     if (state.char_budget_deadline >= 0) {
@@ -1903,7 +2290,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
       atomic_trial_base->capture_recording_ = false;
     }
     PushOneStateToCheck(state);
-    bool track_temporary_input = has_char_budget_rules_ && has_budget_marker_rules_;
+    bool track_temporary_input = ShouldTrackTemporaryInput();
     int32_t saved_temporary_input_start_row = -1;
     std::string saved_temporary_input_bytes;
     if (track_temporary_input) {
@@ -2033,6 +2420,7 @@ void GrammarMatcher::Impl::FillBitmaskForStates(
 }
 
 std::string GrammarMatcher::Impl::FindJumpForwardString() {
+  UniqueKeyContextRestoreGuard unique_key_context_guard(this);
   XGRAMMAR_CHECK(!IsStopTokenAccepted())
       << "GrammarMatcher has terminated after accepting the stop token, but is trying to "
          "get the jump forward string";
@@ -2051,7 +2439,14 @@ std::string GrammarMatcher::Impl::FindJumpForwardString() {
   std::string result;
   int num_accepted_chars = 0;
   bool can_find_next_char = true;
-
+  const bool track_temporary_input = ShouldTrackTemporaryInput();
+  int32_t saved_temporary_input_start_row = temporary_input_start_row_;
+  std::string saved_temporary_input_bytes;
+  if (track_temporary_input) {
+    saved_temporary_input_bytes = std::move(temporary_input_bytes_);
+    temporary_input_start_row_ = scanable_state_history_.size() - 1;
+    temporary_input_bytes_.clear();
+  }
   while (can_find_next_char) {
     const auto& states = scanable_state_history_[scanable_state_history_.size() - 1];
 
@@ -2061,8 +2456,8 @@ std::string GrammarMatcher::Impl::FindJumpForwardString() {
       break;
     }
 
-    // 1. Check that for every leaf ParserState, the next possible char is unique and the same
-    // -1 means not found yet; 0~255 means the next char
+    // 1. Find a byte that is forced by the grammar.
+    // -1 means not found yet; 0~255 means the next char.
     int next_char = -1;
     for (const auto& state : states) {
       if (budget_enforce_pending_ && IsExpiredState(state)) {
@@ -2072,16 +2467,26 @@ std::string GrammarMatcher::Impl::FindJumpForwardString() {
       const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
       const auto& current_edges = fsm.GetFsm().GetFsm().GetEdges(state.element_id);
       for (const auto& edge : current_edges) {
-        if (!edge.IsCharRange()) {
+        int edge_byte = -1;
+        if (edge.IsBackReference()) {
+          auto progress = GetBackReferenceProgress(state);
+          if (!progress.has_value()) {
+            can_find_next_char = false;
+            break;
+          }
+          edge_byte = progress->next_byte;
+        } else if (edge.IsCharRange()) {
+          if (edge.min != edge.max) {
+            can_find_next_char = false;
+            break;
+          }
+          edge_byte = edge.min;
+        } else {
           continue;
         }
-        if (edge.min != edge.max) {
-          can_find_next_char = false;
-          break;
-        }
         if (next_char == -1) {
-          next_char = edge.min;
-        } else if (next_char != edge.min) {
+          next_char = edge_byte;
+        } else if (next_char != edge_byte) {
           can_find_next_char = false;
           break;
         }
@@ -2100,14 +2505,22 @@ std::string GrammarMatcher::Impl::FindJumpForwardString() {
           })) {
         break;
       }
+      const char next_byte = static_cast<char>(next_char);
       result += static_cast<uint8_t>(next_char);
       Advance(next_char);
+      if (track_temporary_input) {
+        temporary_input_bytes_.push_back(next_byte);
+      }
       ++num_accepted_chars;
     }
   }
 
   // Rollback all chars accepted
   PopLastStates(num_accepted_chars);
+  if (track_temporary_input) {
+    temporary_input_start_row_ = saved_temporary_input_start_row;
+    temporary_input_bytes_ = std::move(saved_temporary_input_bytes);
+  }
   return result;
 }
 
@@ -2115,15 +2528,29 @@ void GrammarMatcher::Impl::Rollback(int num_tokens) {
   XGRAMMAR_CHECK(num_tokens <= static_cast<int>(token_length_history.size()))
       << "Intended to rollback " << num_tokens << " tokens, but only the last "
       << token_length_history.size() << " steps of history are saved";
+  XGRAMMAR_DCHECK(
+      !track_unique_key_contexts_ ||
+      unique_key_context_history_.size() == token_length_history.size()
+  );
+  UniqueKeyContextSnapshot rollback_unique_key_contexts;
+  bool restore_unique_key_contexts = false;
   while (num_tokens > 0) {
     int steps = token_length_history.back();
     PopLastStates(steps);
     token_length_history.pop_back();
+    if (track_unique_key_contexts_) {
+      rollback_unique_key_contexts = unique_key_context_history_.back();
+      unique_key_context_history_.pop_back();
+      restore_unique_key_contexts = true;
+    }
     if (ShouldTrackAcceptedBytes() && steps > 0) {
       row_byte_end_.resize(row_byte_end_.size() - steps);
       accepted_bytes_.resize(row_byte_end_.back());
     }
     --num_tokens;
+  }
+  if (restore_unique_key_contexts) {
+    RestoreUniqueKeyContexts(rollback_unique_key_contexts);
   }
   budget_enforce_pending_ = false;
   budget_force_close_pending_ = false;
@@ -2439,12 +2866,20 @@ void GrammarMatcher::Impl::SetTokenBitmask(
       for (int id : tokenizer_info_.GetSpecialTokenIds()) {
         next_token_bitset.Set(id, true);
       }
+    } else {
+      for (int id : tokenizer_info_.GetSpecialTokenIds()) {
+        next_token_bitset.Set(id, false);
+      }
     }
 
     if (can_reach_end) {
       // add end tokens
       for (int id : stop_token_ids_) {
         next_token_bitset.Set(id, true);
+      }
+    } else {
+      for (int id : stop_token_ids_) {
+        next_token_bitset.Set(id, false);
       }
     }
   } else {

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -745,6 +745,7 @@ class EBNFParser {
   int32_t ParseTokenSet();
   int32_t ParseExcludeToken();
   int32_t ParseTokenTagDispatch();
+  int32_t ParseDynamicTag();
   int32_t ParseRegexMacro();
   int32_t ParseSubstringMacro();
 
@@ -800,6 +801,7 @@ const std::unordered_map<std::string, std::function<int32_t(EBNFParser*)>>
         {"TokenTagDispatch", [](EBNFParser* parser) { return parser->ParseTokenTagDispatch(); }},
         {"Regex", [](EBNFParser* parser) { return parser->ParseRegexMacro(); }},
         {"Substring", [](EBNFParser* parser) { return parser->ParseSubstringMacro(); }},
+        {"DynamicTag", [](EBNFParser* parser) { return parser->ParseDynamicTag(); }},
 };
 
 const EBNFParser::Token& EBNFParser::Peek(int delta) const { return *(current_token_ + delta); }
@@ -1264,6 +1266,82 @@ int32_t EBNFParser::ParseTagDispatch() {
   }
 
   return builder_.AddTagDispatch(tag_dispatch);
+}
+
+int32_t EBNFParser::ParseDynamicTag() {
+  Consume();  // Consume DynamicTag operator.
+  auto start = current_token_;
+  auto args = ParseMacroArguments();
+  auto delta_element = start - current_token_;
+  if (args.arguments.size() != 6) {
+    ReportParseError(
+        "DynamicTag expects (open_prefix, name_rule, open_suffix, content_rule, close_prefix, "
+        "close_suffix)",
+        delta_element
+    );
+  }
+  for (const auto& [name, _] : args.named_arguments) {
+    if (name != "unique_key_scope" && name != "reserved_names") {
+      ReportParseError("Unknown DynamicTag argument: " + name, delta_element);
+    }
+  }
+
+  auto get_string = [&](size_t index, const char* name) -> std::string {
+    auto* node = std::get_if<MacroIR::StringNode>(args.arguments[index].get());
+    if (node == nullptr) {
+      ReportParseError(std::string(name) + " must be a string literal", delta_element);
+    }
+    return node->value;
+  };
+  auto get_rule = [&](size_t index, const char* name) -> int32_t {
+    auto* node = std::get_if<MacroIR::IdentifierNode>(args.arguments[index].get());
+    if (node == nullptr) {
+      ReportParseError(std::string(name) + " must be a rule identifier", delta_element);
+    }
+    int32_t rule_id = builder_.GetRuleId(node->name);
+    if (rule_id < 0) {
+      ReportParseError("Rule \"" + node->name + "\" is not defined", delta_element);
+    }
+    return rule_id;
+  };
+
+  Grammar::Impl::DynamicTag dynamic_tag{
+      get_string(0, "open_prefix"),
+      get_rule(1, "name_rule"),
+      get_string(2, "open_suffix"),
+      get_rule(3, "content_rule"),
+      get_string(4, "close_prefix"),
+      get_string(5, "close_suffix")
+  };
+  auto scope_it = args.named_arguments.find("unique_key_scope");
+  auto reserved_it = args.named_arguments.find("reserved_names");
+  if ((scope_it == args.named_arguments.end()) != (reserved_it == args.named_arguments.end())) {
+    ReportParseError(
+        "unique_key_scope and reserved_names must be specified together", delta_element
+    );
+  }
+  if (scope_it != args.named_arguments.end()) {
+    auto* scope = std::get_if<MacroIR::IdentifierNode>(scope_it->second.get());
+    if (scope == nullptr) {
+      ReportParseError("unique_key_scope must be a rule identifier", delta_element);
+    }
+    dynamic_tag.unique_key_scope_rule_id = builder_.GetRuleId(scope->name);
+    if (dynamic_tag.unique_key_scope_rule_id < 0) {
+      ReportParseError("Rule \"" + scope->name + "\" is not defined", delta_element);
+    }
+    auto* names = std::get_if<MacroIR::TupleNode>(reserved_it->second.get());
+    if (names == nullptr) {
+      ReportParseError("reserved_names must be a tuple", delta_element);
+    }
+    for (const auto& element : names->elements) {
+      auto* name = std::get_if<MacroIR::StringNode>(element.get());
+      if (name == nullptr) {
+        ReportParseError("reserved_names must contain only string literals", delta_element);
+      }
+      dynamic_tag.reserved_names.push_back(name->value);
+    }
+  }
+  return builder_.AddDynamicTag(dynamic_tag);
 }
 
 int32_t EBNFParser::ParseRegexMacro() {

--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -110,6 +110,8 @@ std::string GrammarPrinter::PrintGrammarExpr(const GrammarExpr& grammar_expr) {
       return PrintRegex(grammar_expr);
     case GrammarExprType::kSubstring:
       return PrintSubstring(grammar_expr);
+    case GrammarExprType::kDynamicTag:
+      return PrintDynamicTag(grammar_expr);
     default:
       XGRAMMAR_LOG(FATAL) << "Unexpected GrammarExpr type: " << static_cast<int>(grammar_expr.type);
       XGRAMMAR_UNREACHABLE();
@@ -301,6 +303,26 @@ std::string GrammarPrinter::PrintTokenTagDispatch(const GrammarExpr& grammar_exp
   }
   result += ")\n)";
   return result;
+}
+
+std::string GrammarPrinter::PrintDynamicTag(const GrammarExpr& grammar_expr) {
+  auto tag = grammar_->GetDynamicTag(grammar_expr);
+  std::string result = "DynamicTag(" + PrintString(tag.open_prefix) + ", " +
+                       grammar_->GetRule(tag.name_rule_id).name + ", " +
+                       PrintString(tag.open_suffix) + ", " +
+                       grammar_->GetRule(tag.content_rule_id).name + ", " +
+                       PrintString(tag.close_prefix) + ", " + PrintString(tag.close_suffix);
+  if (tag.unique_key_scope_rule_id >= 0) {
+    result += ", unique_key_scope=" + grammar_->GetRule(tag.unique_key_scope_rule_id).name +
+              ", reserved_names=(";
+    for (int32_t i = 0; i < static_cast<int32_t>(tag.reserved_names.size()); ++i) {
+      if (i > 0) result += ", ";
+      result += PrintString(tag.reserved_names[i]);
+    }
+    if (tag.reserved_names.size() == 1) result += ",";
+    result += ")";
+  }
+  return result + ")";
 }
 
 std::string GrammarPrinter::ToString() {

--- a/cpp/grammar_printer.h
+++ b/cpp/grammar_printer.h
@@ -69,6 +69,8 @@ class GrammarPrinter {
   std::string PrintExcludeToken(const GrammarExpr& grammar_expr);
   /*! \brief Print a GrammarExpr for token tag dispatch. */
   std::string PrintTokenTagDispatch(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for a dynamic tag. */
+  std::string PrintDynamicTag(const GrammarExpr& grammar_expr);
   /*! \brief Print a GrammarExpr for regex. */
   std::string PrintRegex(const GrammarExpr& grammar_expr);
   /*! \brief Print a GrammarExpr for substring. */

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -91,9 +91,12 @@ std::string ObjectSpec::ToString() const {
   }
   s +=
       std::string("], allow_additional_properties=") +
-      (allow_additional_properties ? "true" : "false") +
+      (allow_additional_properties ? "true" : "false") + ", has_explicit_additional_properties=" +
+      (has_explicit_additional_properties ? "true" : "false") +
       ", additional_properties_schema=" + (additional_properties_schema ? "SchemaSpec" : "null") +
       ", allow_unevaluated_properties=" + (allow_unevaluated_properties ? "true" : "false") +
+      ", has_explicit_unevaluated_properties=" +
+      (has_explicit_unevaluated_properties ? "true" : "false") +
       ", unevaluated_properties_schema=" + (unevaluated_properties_schema ? "SchemaSpec" : "null") +
       ", property_names=" + (property_names ? "SchemaSpec" : "null") +
       ", min_properties=" + std::to_string(min_properties) +
@@ -1330,6 +1333,7 @@ Result<ObjectSpec, SchemaError> SchemaParser::ParseObject(const picojson::object
 
   spec.allow_additional_properties = !config_.strict_mode;
   if (schema.count("additionalProperties")) {
+    spec.has_explicit_additional_properties = true;
     auto add_props = schema.at("additionalProperties");
     if (add_props.is<bool>()) {
       spec.allow_additional_properties = add_props.get<bool>();
@@ -1345,6 +1349,7 @@ Result<ObjectSpec, SchemaError> SchemaParser::ParseObject(const picojson::object
   if (schema.count("additionalProperties")) {
     spec.allow_unevaluated_properties = spec.allow_additional_properties;
   } else if (schema.count("unevaluatedProperties")) {
+    spec.has_explicit_unevaluated_properties = true;
     auto uneval_props = schema.at("unevaluatedProperties");
     if (uneval_props.is<bool>()) {
       spec.allow_unevaluated_properties = uneval_props.get<bool>();
@@ -1399,7 +1404,10 @@ Result<ObjectSpec, SchemaError> SchemaParser::ParseObject(const picojson::object
             std::to_string(spec.max_properties) + " < " + std::to_string(spec.required.size())
     );
   }
-  if (spec.pattern_properties.empty() && !spec.property_names &&
+  const bool property_names_allow_implicit_properties = spec.property_names &&
+                                                        !spec.has_explicit_additional_properties &&
+                                                        !spec.has_explicit_unevaluated_properties;
+  if (spec.pattern_properties.empty() && !property_names_allow_implicit_properties &&
       !spec.allow_additional_properties && !spec.allow_unevaluated_properties &&
       spec.min_properties > static_cast<int>(spec.properties.size())) {
     return ResultErr<SchemaError>(
@@ -1752,7 +1760,7 @@ Grammar JSONSchemaConverter::Convert(const SchemaSpecPtr& spec) {
   // This allows $ref: "#" to resolve to "root"
   int32_t root_rule_id = builder_.AddEmptyRuleWithHint("root");
   std::string root_rule_name = builder_.GetRule(root_rule_id).name;
-  uri_to_rule_id_["#"] = root_rule_id;
+  uri_to_rule_id_[GetRefCacheKey("#")] = root_rule_id;
 
   // Check if the spec can be directly mapped to an existing rule
   auto cached_rule = GetCache(spec->cache_key);
@@ -2121,6 +2129,13 @@ std::optional<int32_t> JSONSchemaConverter::GetCache(const std::string& key) con
   return rule_cache_manager_.GetCache(key, true);
 }
 
+int JSONSchemaConverter::GetRefCacheDomain() const { return 0; }
+
+std::string JSONSchemaConverter::GetRefCacheKey(const std::string& uri) const {
+  const int domain = GetRefCacheDomain();
+  return domain == 0 ? uri : std::to_string(domain) + ":" + uri;
+}
+
 int32_t JSONSchemaConverter::CreateRule(
     const SchemaSpecPtr& spec, const std::string& rule_name_hint
 ) {
@@ -2477,6 +2492,22 @@ int32_t JSONSchemaConverter::FormatOtherProperty(
     const SchemaSpecPtr& schema
 ) {
   return Sequence({key_pattern_expr, colon_expr_id_, RuleRef(value_rule_id)});
+}
+
+int32_t JSONSchemaConverter::CreatePatternKeyRule(
+    const std::string& pattern, const std::string& rule_name_hint
+) {
+  StringSpec key_spec;
+  key_spec.pattern = pattern;
+  return CreateRule(
+      SchemaSpec::Make(std::move(key_spec), /*cache_key=*/"", rule_name_hint), rule_name_hint
+  );
+}
+
+int32_t JSONSchemaConverter::CreatePropertyNameRule(
+    const SchemaSpecPtr& spec, const std::string& rule_name_hint
+) {
+  return CreateRule(spec, rule_name_hint);
 }
 
 int32_t JSONSchemaConverter::GetPropertyWithNumberConstraints(
@@ -2861,18 +2892,6 @@ int32_t JSONSchemaConverter::GenerateObject(
   bool could_be_empty = false;
   int32_t content = Empty();
 
-  // Build a key rule through GenerateString rather than spelling out a JSON string here. At the
-  // JSON root this still produces `"key"`, while XML-style converters override GenerateString to
-  // produce the unquoted key body expected inside their parameter wrappers.
-  auto create_pattern_key_rule = [&](const std::string& pattern,
-                                     const std::string& rule_name_hint) -> int32_t {
-    StringSpec key_spec;
-    key_spec.pattern = pattern;
-    return CreateRule(
-        SchemaSpec::Make(std::move(key_spec), /*cache_key=*/"", rule_name_hint), rule_name_hint
-    );
-  };
-
   if (!spec.properties.empty() && (!spec.pattern_properties.empty() || spec.property_names)) {
     // Case 1a: properties coexist with patternProperties and/or propertyNames.
     // Use GetPartialRuleForProperties for named properties, and build
@@ -2887,7 +2906,7 @@ int32_t JSONSchemaConverter::GenerateObject(
       for (size_t index = 0; index < spec.pattern_properties.size(); ++index) {
         const auto& pattern_property = spec.pattern_properties[index];
         std::string pattern_suffix = "pp_" + std::to_string(index);
-        int32_t key_rule_id = create_pattern_key_rule(
+        int32_t key_rule_id = CreatePatternKeyRule(
             pattern_property.pattern, rule_name + "_" + pattern_suffix + "_key"
         );
         int32_t value_rule_id =
@@ -2901,7 +2920,7 @@ int32_t JSONSchemaConverter::GenerateObject(
         int32_t value_rule_id =
             CreateRule(effective_additional, rule_name + "_" + effective_suffix);
         patterns.push_back(FormatOtherProperty(
-            KeyPatternExpression(),
+            GetKeyPatternExcluding(spec.properties, rule_name),
             value_rule_id,
             rule_name,
             effective_suffix,
@@ -2917,7 +2936,7 @@ int32_t JSONSchemaConverter::GenerateObject(
       // propertyNames constrains keys of additional properties.
       // Only apply when additional properties are allowed - when additionalProperties
       // is false, no extra keys beyond named properties should be permitted.
-      int32_t key_rule_id = CreateRule(spec.property_names, rule_name + "_name");
+      int32_t key_rule_id = CreatePropertyNameRule(spec.property_names, rule_name + "_name");
       int32_t value_rule_id = CreateRule(effective_additional, rule_name + "_" + effective_suffix);
       additional_override = FormatOtherProperty(
           RuleRef(key_rule_id),
@@ -2950,7 +2969,7 @@ int32_t JSONSchemaConverter::GenerateObject(
         for (size_t index = 0; index < spec.pattern_properties.size(); ++index) {
           const auto& pattern_property = spec.pattern_properties[index];
           std::string pattern_suffix = "prop_" + std::to_string(index);
-          int32_t key_rule_id = create_pattern_key_rule(
+          int32_t key_rule_id = CreatePatternKeyRule(
               pattern_property.pattern, rule_name + "_" + pattern_suffix + "_key"
           );
           int32_t value_rule_id =
@@ -2967,33 +2986,45 @@ int32_t JSONSchemaConverter::GenerateObject(
           ));
         }
       } else {
-        int32_t key_rule_id = CreateRule(spec.property_names, rule_name + "_name");
-        int32_t value_rule_id = builder_.GetRuleId(GetBasicAnyRuleName());
-        XGRAMMAR_DCHECK(value_rule_id != -1);
-        property_choices.push_back(Sequence(
-            {beginning_separator,
-             FormatOtherProperty(
-                 RuleRef(key_rule_id),
-                 value_rule_id,
-                 rule_name,
-                 /*rule_name_suffix=*/"pn",
-                 /*schema=*/nullptr
-             )}
-        ));
+        SchemaSpecPtr property_names_value = additional_property;
+        if (!property_names_value && !spec.has_explicit_additional_properties &&
+            !spec.has_explicit_unevaluated_properties) {
+          // Preserve the established behavior in which propertyNames by itself opts into dynamic
+          // properties, while an explicit false additional/unevaluated policy forbids them.
+          property_names_value = SchemaSpec::Make(AnySpec{}, "", "any");
+        }
+        if (property_names_value) {
+          int32_t key_rule_id = CreatePropertyNameRule(spec.property_names, rule_name + "_name");
+          const std::string value_suffix =
+              additional_suffix.empty() ? "pn_value" : additional_suffix;
+          int32_t value_rule_id = CreateRule(property_names_value, rule_name + "_" + value_suffix);
+          property_choices.push_back(Sequence(
+              {beginning_separator,
+               FormatOtherProperty(
+                   RuleRef(key_rule_id),
+                   value_rule_id,
+                   rule_name,
+                   /*rule_name_suffix=*/"pn",
+                   /*schema=*/nullptr
+               )}
+          ));
+        }
       }
 
-      int32_t property_rule_id =
-          builder_.AddRuleWithHint(rule_name + "_prop", Choice(property_choices));
-      int32_t subsequent_property =
-          Sequence({NextSeparatorExpression(), RuleRef(property_rule_id)});
-      content = Sequence(
-          {RuleRef(property_rule_id),
-           GetPropertyWithNumberConstraints(
-               subsequent_property, spec.min_properties, spec.max_properties, 1, rule_name
-           ),
-           NextSeparatorExpression(true)}
-      );
-      has_content = true;
+      if (!property_choices.empty()) {
+        int32_t property_rule_id =
+            builder_.AddRuleWithHint(rule_name + "_prop", Choice(property_choices));
+        int32_t subsequent_property =
+            Sequence({NextSeparatorExpression(), RuleRef(property_rule_id)});
+        content = Sequence(
+            {RuleRef(property_rule_id),
+             GetPropertyWithNumberConstraints(
+                 subsequent_property, spec.min_properties, spec.max_properties, 1, rule_name
+             ),
+             NextSeparatorExpression(true)}
+        );
+        has_content = true;
+      }
       could_be_empty = spec.min_properties == 0;
     } else {
       could_be_empty = true;
@@ -3092,8 +3123,9 @@ SchemaSpecPtr JSONSchemaConverter::ResolveRefSchema(
 
 int32_t JSONSchemaConverter::GenerateRef(const RefSpec& spec, const std::string& rule_name) {
   // First check if we have a direct URI mapping (for circular references)
-  if (uri_to_rule_id_.count(spec.uri)) {
-    return RuleRef(uri_to_rule_id_[spec.uri]);
+  const std::string ref_cache_key = GetRefCacheKey(spec.uri);
+  if (auto it = uri_to_rule_id_.find(ref_cache_key); it != uri_to_rule_id_.end()) {
+    return RuleRef(it->second);
   }
 
   // Derive rule name from URI path (like original URIToRule) so that the same
@@ -3123,7 +3155,7 @@ int32_t JSONSchemaConverter::GenerateRef(const RefSpec& spec, const std::string&
 
   int32_t allocated_rule_id = builder_.AddEmptyRuleWithHint(rule_name_hint);
   std::string allocated_rule_name = builder_.GetRule(allocated_rule_id).name;
-  uri_to_rule_id_[spec.uri] = allocated_rule_id;
+  uri_to_rule_id_[ref_cache_key] = allocated_rule_id;
   SchemaSpecPtr resolved = ResolveRefSchema(spec, allocated_rule_name);
   builder_.UpdateRuleBody(allocated_rule_id, GenerateFromSpec(resolved, allocated_rule_name));
   if (!resolved->cache_key.empty()) {

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -4092,6 +4092,7 @@ std::optional<JSONFormat> JSONFormatFromString(const std::string& format) {
       {"json", JSONFormat::kJSON},
       {"qwen_xml", JSONFormat::kQwenXML},
       {"minimax_xml", JSONFormat::kMiniMaxXML},
+      {"minimax_m3_xml", JSONFormat::kMiniMaxM3XML},
       {"deepseek_xml", JSONFormat::kDeepSeekXML},
       {"glm_xml", JSONFormat::kGlmXML},
       {"cohere_xml", JSONFormat::kCohereXML},
@@ -4156,6 +4157,17 @@ Grammar JSONSchemaToGrammar(
           max_whitespace_cnt,
           std::move(ref_resolver),
           json_format,
+          any_order
+      );
+      return converter.Convert(spec);
+    }
+    case JSONFormat::kMiniMaxM3XML: {
+      MiniMaxM3XMLToolCallingConverter converter(
+          indent,
+          std::move(separators),
+          any_whitespace,
+          max_whitespace_cnt,
+          std::move(ref_resolver),
           any_order
       );
       return converter.Convert(spec);
@@ -4250,6 +4262,12 @@ std::string JSONSchemaToEBNF(
           ref_resolver,
           json_format,
           any_order
+      );
+      return GrammarNormalizer::Apply(converter.Convert(spec)).ToString();
+    }
+    case JSONFormat::kMiniMaxM3XML: {
+      MiniMaxM3XMLToolCallingConverter converter(
+          indent, separators, any_whitespace, max_whitespace_cnt, ref_resolver, any_order
       );
       return GrammarNormalizer::Apply(converter.Convert(spec)).ToString();
     }

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -201,12 +201,13 @@ enum class JSONFormat : int {
   kGlmXML = 4,
   kCohereXML = 5,
   kKimiK3XML = 6,
+  kMiniMaxM3XML = 7,
 };
 
 /*!
  * \brief Convert a format name to JSONFormat.
- * \param format One of "json", "qwen_xml", "minimax_xml", "deepseek_xml", "glm_xml",
- * "cohere_xml", or "kimi_k3_xml".
+ * \param format One of "json", "qwen_xml", "minimax_xml", "minimax_m3_xml", "deepseek_xml",
+ * "glm_xml", "cohere_xml", or "kimi_k3_xml".
  * \return The corresponding JSONFormat, or std::nullopt if the name is not recognized.
  */
 std::optional<JSONFormat> JSONFormatFromString(const std::string& format);

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -100,8 +100,10 @@ struct ObjectSpec {
   std::unordered_set<std::string> required;
 
   bool allow_additional_properties = false;
+  bool has_explicit_additional_properties = false;
   SchemaSpecPtr additional_properties_schema;
   bool allow_unevaluated_properties = true;
+  bool has_explicit_unevaluated_properties = false;
   SchemaSpecPtr unevaluated_properties_schema;
   SchemaSpecPtr property_names;
 
@@ -352,6 +354,16 @@ class JSONSchemaConverter {
       const SchemaSpecPtr& schema
   );
 
+  /*! \brief Create the grammar for a patternProperties key. */
+  virtual int32_t CreatePatternKeyRule(
+      const std::string& pattern, const std::string& rule_name_hint
+  );
+
+  /*! \brief Create the grammar for a propertyNames schema. */
+  virtual int32_t CreatePropertyNameRule(
+      const SchemaSpecPtr& spec, const std::string& rule_name_hint
+  );
+
   /*! \brief Get the basic string rule name. Override for different formats. */
   virtual std::string GetKeyPattern() const;
 
@@ -372,6 +384,9 @@ class JSONSchemaConverter {
 
   /*! \brief Get cached value by key. Returns std::nullopt if not found. */
   virtual std::optional<int32_t> GetCache(const std::string& key) const;
+
+  /*! \brief Return the encoding domain used to cache resolved references. */
+  virtual int GetRefCacheDomain() const;
 
   // ==================== Helper methods (for subclasses to use) ====================
 
@@ -481,8 +496,10 @@ class JSONSchemaConverter {
 
  private:
   void AddHelperRules();
+  std::string GetRefCacheKey(const std::string& uri) const;
 
-  std::unordered_map<std::string, int32_t> uri_to_rule_id_;  // For circular reference handling
+  // Domain-qualified URI mappings for circular reference handling.
+  std::unordered_map<std::string, int32_t> uri_to_rule_id_;
   RefResolver ref_resolver_;  // Resolves $ref URI to SchemaSpecPtr at generate time
 
   // Trie over property names, for key patterns that exclude specific properties

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -8,6 +8,8 @@
 #include <picojson.h>
 
 #include <algorithm>
+#include <cstdint>
+#include <limits>
 #include <map>
 #include <type_traits>
 #include <unordered_map>
@@ -15,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "support/encoding.h"
 #include "support/logging.h"
 
 namespace xgrammar {
@@ -57,8 +60,297 @@ std::vector<GrammarBuilder::CharacterClassElement> XMLIdentifierContinuationChar
 
 constexpr const char* kStringCacheKey = "{\"type\":\"string\"}";
 constexpr const char* kObjectCacheKey = "{\"type\":\"object\"}";
+constexpr const char* kMiniMaxM3Namespace = "]<]minimax[>[";
+constexpr const char* kMiniMaxM3ArrayItemName = "item";
+
+bool IsASCIIWhitespace(uint8_t byte) {
+  return byte == ' ' || byte == '\t' || byte == '\n' || byte == '\r' || byte == '\f' ||
+         byte == '\v';
+}
+
+bool IsCanonicalUTF8(const std::string& text) {
+  for (size_t offset = 0; offset < text.size();) {
+    auto [codepoint, num_bytes] = ParseNextUTF8(text.data() + offset);
+    if (codepoint == CharHandlingError::kInvalidUTF8 || num_bytes <= 0 ||
+        offset + num_bytes > text.size() || (codepoint >= 0xd800 && codepoint <= 0xdfff) ||
+        codepoint > 0x10ffff || text.compare(offset, num_bytes, CharToUTF8(codepoint)) != 0) {
+      return false;
+    }
+    offset += num_bytes;
+  }
+  return true;
+}
 
 }  // namespace
+
+MiniMaxM3XMLToolCallingConverter::MiniMaxM3XMLToolCallingConverter(
+    std::optional<int> indent,
+    std::optional<std::pair<std::string, std::string>> separators,
+    bool any_whitespace,
+    std::optional<int> max_whitespace_cnt,
+    RefResolver ref_resolver,
+    bool any_order
+)
+    : JSONSchemaConverter(
+          indent, separators, any_whitespace, max_whitespace_cnt, ref_resolver, any_order
+      ) {}
+
+void MiniMaxM3XMLToolCallingConverter::AddBasicRules() {
+  for (const auto& name : {kBasicInteger, kBasicNumber, kBasicString, kBasicBoolean, kBasicNull}) {
+    builder_.AddEmptyRule(name);
+  }
+
+  builder_.UpdateRuleBody(
+      kBasicInteger, JSONSchemaConverter::GenerateInteger(IntegerSpec{}, kBasicInteger)
+  );
+  AddCache("{\"type\":\"integer\"}", builder_.GetRuleId(kBasicInteger));
+
+  builder_.UpdateRuleBody(
+      kBasicNumber, JSONSchemaConverter::GenerateNumber(NumberSpec{}, kBasicNumber)
+  );
+  AddCache("{\"type\":\"number\"}", builder_.GetRuleId(kBasicNumber));
+
+  builder_.UpdateRuleBody(kBasicString, TagDispatch(false, {kMiniMaxM3Namespace}));
+  AddCache(kStringCacheKey, builder_.GetRuleId(kBasicString));
+
+  builder_.UpdateRuleBody(
+      kBasicBoolean, JSONSchemaConverter::GenerateBoolean(BooleanSpec{}, kBasicBoolean)
+  );
+  AddCache("{\"type\":\"boolean\"}", builder_.GetRuleId(kBasicBoolean));
+
+  builder_.UpdateRuleBody(kBasicNull, JSONSchemaConverter::GenerateNull(NullSpec{}, kBasicNull));
+  AddCache("{\"type\":\"null\"}", builder_.GetRuleId(kBasicNull));
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::GenerateString(
+    const StringSpec& spec, const std::string& rule_name
+) {
+  const bool has_known_format =
+      spec.format.has_value() && JSONFormatToRegexPattern(*spec.format).has_value();
+  XGRAMMAR_CHECK(
+      !spec.pattern.has_value() && !has_known_format && spec.min_length == 0 &&
+      spec.max_length == -1
+  ) << "String pattern, recognized format, and length constraints are not supported by "
+       "minimax_m3_xml because they cannot be combined with the namespace-marker exclusion";
+  return RuleRef(kBasicString);
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::GenerateArray(
+    const ArraySpec& spec, const std::string& rule_name
+) {
+  constexpr int64_t kMaxRepeatCount = std::numeric_limits<int32_t>::max();
+  XGRAMMAR_CHECK(
+      spec.min_items <= kMaxRepeatCount &&
+      (spec.max_items == -1 || spec.max_items <= kMaxRepeatCount) &&
+      spec.prefix_items.size() <= static_cast<size_t>(kMaxRepeatCount)
+  ) << "minimax_m3_xml array bounds exceed the supported range";
+  XGRAMMAR_CHECK(!spec.allow_additional_items || spec.additional_items != nullptr)
+      << "minimax_m3_xml requires a fixed schema for array items";
+
+  std::vector<int32_t> prefix_items;
+  prefix_items.reserve(spec.prefix_items.size());
+  for (size_t index = 0; index < spec.prefix_items.size(); ++index) {
+    int32_t item_rule_id =
+        CreateRule(spec.prefix_items[index], rule_name + "_item_" + std::to_string(index));
+    prefix_items.push_back(FormatElement(kMiniMaxM3ArrayItemName, item_rule_id));
+  }
+
+  std::optional<int32_t> additional_item;
+  if (spec.allow_additional_items) {
+    int32_t item_rule_id = CreateRule(spec.additional_items, rule_name + "_additional");
+    additional_item = FormatElement(kMiniMaxM3ArrayItemName, item_rule_id);
+  }
+
+  int32_t empty = Empty();
+  int32_t whitespace = WhitespaceExpression();
+  if (prefix_items.empty()) {
+    if (!additional_item.has_value() || spec.max_items == 0) {
+      return empty;
+    }
+    int32_t min_items = static_cast<int32_t>(spec.min_items);
+    int32_t max_items = spec.max_items == -1 ? -1 : static_cast<int32_t>(spec.max_items);
+    int32_t nonempty = Sequence(
+        {whitespace,
+         *additional_item,
+         Repeat(
+             rule_name + "_items",
+             Sequence({whitespace, *additional_item}),
+             std::max(0, min_items - 1),
+             max_items == -1 ? -1 : std::max(0, max_items - 1)
+         ),
+         whitespace}
+    );
+    return min_items == 0 ? Choice({nonempty, empty}) : nonempty;
+  }
+
+  int32_t prefix_count = static_cast<int32_t>(prefix_items.size());
+  int32_t tail = empty;
+  if (additional_item.has_value()) {
+    int32_t min_additional = std::max(0, static_cast<int32_t>(spec.min_items) - prefix_count);
+    int32_t max_additional = spec.max_items == -1
+                                 ? -1
+                                 : std::max(0, static_cast<int32_t>(spec.max_items) - prefix_count);
+    tail = Repeat(
+        rule_name + "_additional_items",
+        Sequence({whitespace, *additional_item}),
+        min_additional,
+        max_additional
+    );
+  }
+
+  // A prefixItems entry constrains its position but does not make that position mandatory. Build
+  // a linear chain whose suffix can stop once minItems is satisfied.
+  for (int32_t index = prefix_count - 2; index >= 0; --index) {
+    int32_t emitted_count = index + 1;
+    bool can_stop = emitted_count >= spec.min_items;
+    bool can_continue = spec.max_items == -1 || emitted_count < spec.max_items;
+    int32_t body = empty;
+    if (can_continue) {
+      int32_t continuation = Sequence({whitespace, prefix_items[index + 1], tail});
+      body = can_stop ? Choice({continuation, empty}) : continuation;
+    }
+    int32_t tail_rule_id =
+        builder_.AddRuleWithHint(rule_name + "_prefix_tail_" + std::to_string(index), body);
+    tail = RuleRef(tail_rule_id);
+  }
+
+  if (spec.max_items == 0) {
+    return empty;
+  }
+  int32_t nonempty = Sequence({whitespace, prefix_items[0], tail, whitespace});
+  return spec.min_items == 0 ? Choice({nonempty, empty}) : nonempty;
+}
+
+void MiniMaxM3XMLToolCallingConverter::ValidateObject(const ObjectSpec& spec) const {
+  XGRAMMAR_CHECK(
+      !spec.allow_additional_properties && spec.additional_properties_schema == nullptr &&
+      !spec.allow_unevaluated_properties && spec.unevaluated_properties_schema == nullptr &&
+      spec.pattern_properties.empty() && spec.property_names == nullptr
+  ) << "minimax_m3_xml requires fixed object property names; additionalProperties, "
+       "unevaluatedProperties, patternProperties, and propertyNames are not supported";
+
+  std::unordered_set<std::string> property_names;
+  for (const auto& property : spec.properties) {
+    XGRAMMAR_CHECK(property.schema != nullptr)
+        << "minimax_m3_xml property must have a fixed schema: " << property.name;
+    ValidateElementName(property.name);
+    property_names.insert(property.name);
+  }
+  for (const auto& required : spec.required) {
+    XGRAMMAR_CHECK(property_names.count(required) != 0)
+        << "minimax_m3_xml required property has no fixed schema: " << required;
+  }
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::GenerateObject(
+    const ObjectSpec& spec, const std::string& rule_name, bool dummy_need_braces
+) {
+  ValidateObject(spec);
+  bool saved_any_whitespace = any_whitespace_;
+  any_whitespace_ = false;
+  int32_t result = JSONSchemaConverter::GenerateObject(spec, rule_name, /*need_braces=*/false);
+  any_whitespace_ = saved_any_whitespace;
+  return result;
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::GenerateAny(
+    const AnySpec& spec, const std::string& rule_name
+) {
+  XGRAMMAR_LOG(FATAL) << "minimax_m3_xml does not support unconstrained schemas";
+  XGRAMMAR_UNREACHABLE();
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::GenerateLiteral(const picojson::value& value) {
+  if (value.is<std::string>()) {
+    const std::string& text = value.get<std::string>();
+    XGRAMMAR_CHECK(text.find(kMiniMaxM3Namespace) == std::string::npos)
+        << "A minimax_m3_xml string literal cannot contain the namespace marker";
+    return ByteString(text);
+  }
+  if (value.is<picojson::object>()) {
+    const auto& object = value.get<picojson::object>();
+    std::vector<int32_t> properties;
+    properties.reserve(object.size());
+    for (const auto& key : object.ordered_keys()) {
+      int32_t value_expr = GenerateLiteral(object.at(key));
+      int32_t value_rule_id = builder_.AddRuleWithHint("literal_" + key, value_expr);
+      properties.push_back(FormatElement(key, value_rule_id));
+    }
+    return Sequence(properties);
+  }
+  if (value.is<picojson::array>()) {
+    const auto& array = value.get<picojson::array>();
+    std::vector<int32_t> items;
+    items.reserve(array.size());
+    for (size_t index = 0; index < array.size(); ++index) {
+      int32_t value_expr = GenerateLiteral(array[index]);
+      int32_t value_rule_id =
+          builder_.AddRuleWithHint("literal_item_" + std::to_string(index), value_expr);
+      items.push_back(FormatElement(kMiniMaxM3ArrayItemName, value_rule_id));
+    }
+    return Sequence(items);
+  }
+  return ByteString(value.serialize());
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::GenerateConst(
+    const ConstSpec& spec, const std::string& rule_name
+) {
+  picojson::value value;
+  std::string error = picojson::parse(value, spec.json_value);
+  XGRAMMAR_CHECK(error.empty()) << "Invalid const JSON value: " << error;
+  return GenerateLiteral(value);
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::GenerateEnum(
+    const EnumSpec& spec, const std::string& rule_name
+) {
+  XGRAMMAR_DCHECK(!spec.json_values.empty())
+      << "GenerateEnum called with empty enum spec for rule: " << rule_name;
+  std::vector<int32_t> values;
+  values.reserve(spec.json_values.size());
+  for (const auto& json_value : spec.json_values) {
+    picojson::value value;
+    std::string error = picojson::parse(value, json_value);
+    XGRAMMAR_CHECK(error.empty()) << "Invalid enum JSON value: " << error;
+    values.push_back(GenerateLiteral(value));
+  }
+  return Choice(values);
+}
+
+void MiniMaxM3XMLToolCallingConverter::ValidateElementName(const std::string& name) {
+  XGRAMMAR_CHECK(!name.empty() && name.front() != '/' && name.find('>') == std::string::npos)
+      << "Invalid minimax_m3_xml element name: " << name;
+  XGRAMMAR_CHECK(IsCanonicalUTF8(name)) << "minimax_m3_xml element names must be valid UTF-8";
+  XGRAMMAR_CHECK(std::any_of(name.begin(), name.end(), [](unsigned char byte) {
+    return !IsASCIIWhitespace(byte);
+  })) << "minimax_m3_xml element names cannot be blank";
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::FormatElement(
+    const std::string& name, int32_t value_rule_id
+) {
+  ValidateElementName(name);
+  return Sequence(
+      {ByteString(std::string(kMiniMaxM3Namespace) + "<" + name + ">"),
+       RuleRef(value_rule_id),
+       ByteString(std::string(kMiniMaxM3Namespace) + "</" + name + ">")}
+  );
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::FormatProperty(
+    const std::string& key,
+    int32_t value_rule_id,
+    const std::string& rule_name,
+    int64_t idx,
+    const SchemaSpecPtr& schema
+) {
+  return FormatElement(key, value_rule_id);
+}
+
+std::string MiniMaxM3XMLToolCallingConverter::NextSeparator(bool is_end) {
+  return GetWhitespacePattern();
+}
 
 // Static constants
 const std::string XMLToolCallingConverter::kXMLString = "xml_string";

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -62,6 +62,9 @@ constexpr const char* kStringCacheKey = "{\"type\":\"string\"}";
 constexpr const char* kObjectCacheKey = "{\"type\":\"object\"}";
 constexpr const char* kMiniMaxM3Namespace = "]<]minimax[>[";
 constexpr const char* kMiniMaxM3ArrayItemName = "item";
+constexpr const char* kMiniMaxM3DynamicName = "minimax_m3_dynamic_name";
+constexpr const char* kMiniMaxM3AnyObject = "minimax_m3_any_object";
+constexpr const char* kMiniMaxM3AnyArray = "minimax_m3_any_array";
 
 bool IsASCIIWhitespace(uint8_t byte) {
   return byte == ' ' || byte == '\t' || byte == '\n' || byte == '\r' || byte == '\f' ||
@@ -96,7 +99,15 @@ MiniMaxM3XMLToolCallingConverter::MiniMaxM3XMLToolCallingConverter(
       ) {}
 
 void MiniMaxM3XMLToolCallingConverter::AddBasicRules() {
-  for (const auto& name : {kBasicInteger, kBasicNumber, kBasicString, kBasicBoolean, kBasicNull}) {
+  const std::vector<std::string> rule_names = {
+      kBasicInteger,
+      kBasicNumber,
+      kBasicString,
+      kBasicBoolean,
+      kBasicNull,
+      kMiniMaxM3DynamicName,
+  };
+  for (const auto& name : rule_names) {
     builder_.AddEmptyRule(name);
   }
 
@@ -120,11 +131,56 @@ void MiniMaxM3XMLToolCallingConverter::AddBasicRules() {
 
   builder_.UpdateRuleBody(kBasicNull, JSONSchemaConverter::GenerateNull(NullSpec{}, kBasicNull));
   AddCache("{\"type\":\"null\"}", builder_.GetRuleId(kBasicNull));
+
+  builder_.UpdateRuleBody(
+      kMiniMaxM3DynamicName,
+      Sequence(
+          {builder_.AddCharacterClass({{'/', '/'}, {'>', '>'}}, /*is_negative=*/true),
+           builder_.AddCharacterClassStar({{'>', '>'}}, /*is_negative=*/true)}
+      )
+  );
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::GenerateInteger(
+    const IntegerSpec& spec, const std::string& rule_name
+) {
+  XGRAMMAR_CHECK(!generating_property_name_)
+      << "minimax_m3_xml propertyNames must validate strings";
+  return JSONSchemaConverter::GenerateInteger(spec, rule_name);
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::GenerateNumber(
+    const NumberSpec& spec, const std::string& rule_name
+) {
+  XGRAMMAR_CHECK(!generating_property_name_)
+      << "minimax_m3_xml propertyNames must validate strings";
+  return JSONSchemaConverter::GenerateNumber(spec, rule_name);
 }
 
 int32_t MiniMaxM3XMLToolCallingConverter::GenerateString(
     const StringSpec& spec, const std::string& rule_name
 ) {
+  if (generating_property_name_) {
+    if (spec.pattern.has_value()) {
+      return RegexExpression(*spec.pattern, /*json_string=*/false);
+    }
+    if (spec.format.has_value()) {
+      auto regex = JSONFormatToRegexPattern(*spec.format);
+      if (regex.has_value()) {
+        return RegexExpression(*regex, /*json_string=*/false, /*force_cfg_expansion=*/true);
+      }
+    }
+    if (spec.min_length != 0 || spec.max_length != -1) {
+      return Repeat(
+          rule_name + "_characters",
+          builder_.AddCharacterClass({{0, 0x10ffff}}),
+          spec.min_length,
+          spec.max_length
+      );
+    }
+    return RuleRef(kMiniMaxM3DynamicName);
+  }
+
   const bool has_known_format =
       spec.format.has_value() && JSONFormatToRegexPattern(*spec.format).has_value();
   XGRAMMAR_CHECK(
@@ -135,9 +191,27 @@ int32_t MiniMaxM3XMLToolCallingConverter::GenerateString(
   return RuleRef(kBasicString);
 }
 
+int32_t MiniMaxM3XMLToolCallingConverter::GenerateBoolean(
+    const BooleanSpec& spec, const std::string& rule_name
+) {
+  XGRAMMAR_CHECK(!generating_property_name_)
+      << "minimax_m3_xml propertyNames must validate strings";
+  return JSONSchemaConverter::GenerateBoolean(spec, rule_name);
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::GenerateNull(
+    const NullSpec& spec, const std::string& rule_name
+) {
+  XGRAMMAR_CHECK(!generating_property_name_)
+      << "minimax_m3_xml propertyNames must validate strings";
+  return JSONSchemaConverter::GenerateNull(spec, rule_name);
+}
+
 int32_t MiniMaxM3XMLToolCallingConverter::GenerateArray(
     const ArraySpec& spec, const std::string& rule_name
 ) {
+  XGRAMMAR_CHECK(!generating_property_name_)
+      << "minimax_m3_xml propertyNames must validate strings";
   constexpr int64_t kMaxRepeatCount = std::numeric_limits<int32_t>::max();
   XGRAMMAR_CHECK(
       spec.min_items <= kMaxRepeatCount &&
@@ -222,12 +296,26 @@ int32_t MiniMaxM3XMLToolCallingConverter::GenerateArray(
 }
 
 void MiniMaxM3XMLToolCallingConverter::ValidateObject(const ObjectSpec& spec) const {
-  XGRAMMAR_CHECK(
-      !spec.allow_additional_properties && spec.additional_properties_schema == nullptr &&
-      !spec.allow_unevaluated_properties && spec.unevaluated_properties_schema == nullptr &&
-      spec.pattern_properties.empty() && spec.property_names == nullptr
-  ) << "minimax_m3_xml requires fixed object property names; additionalProperties, "
-       "unevaluatedProperties, patternProperties, and propertyNames are not supported";
+  const bool has_pattern_properties = !spec.pattern_properties.empty();
+  const bool has_runtime_fallback =
+      spec.allow_additional_properties || spec.additional_properties_schema != nullptr ||
+      spec.allow_unevaluated_properties || spec.unevaluated_properties_schema != nullptr;
+
+  // The generic converter represents these combinations as alternatives. JSON Schema instead
+  // requires every schema matching a property name to hold, so accepting them here would
+  // under-constrain the generated XML. Keep the initial M3 implementation fail-closed until the
+  // converter has a schema-intersection-aware key partition.
+  XGRAMMAR_CHECK(spec.pattern_properties.size() <= 1)
+      << "minimax_m3_xml does not support multiple patternProperties";
+  XGRAMMAR_CHECK(!has_pattern_properties || spec.properties.empty())
+      << "minimax_m3_xml does not support combining properties with patternProperties";
+  XGRAMMAR_CHECK(!has_pattern_properties || spec.property_names == nullptr)
+      << "minimax_m3_xml does not support combining propertyNames with patternProperties";
+  XGRAMMAR_CHECK(spec.property_names == nullptr || spec.properties.empty())
+      << "minimax_m3_xml does not support combining properties with propertyNames";
+  XGRAMMAR_CHECK(!has_pattern_properties || !has_runtime_fallback)
+      << "minimax_m3_xml does not support combining patternProperties with additional or "
+         "unevaluated properties";
 
   std::unordered_set<std::string> property_names;
   for (const auto& property : spec.properties) {
@@ -245,19 +333,67 @@ void MiniMaxM3XMLToolCallingConverter::ValidateObject(const ObjectSpec& spec) co
 int32_t MiniMaxM3XMLToolCallingConverter::GenerateObject(
     const ObjectSpec& spec, const std::string& rule_name, bool dummy_need_braces
 ) {
+  XGRAMMAR_CHECK(!generating_property_name_)
+      << "minimax_m3_xml propertyNames must validate strings";
   ValidateObject(spec);
+
+  UniqueKeyScopeContext scope;
+  scope.reserved_names.reserve(spec.properties.size());
+  for (const auto& property : spec.properties) {
+    scope.reserved_names.push_back(property.name);
+  }
+  unique_key_scope_stack_.push_back(std::move(scope));
+
   bool saved_any_whitespace = any_whitespace_;
   any_whitespace_ = false;
   int32_t result = JSONSchemaConverter::GenerateObject(spec, rule_name, /*need_braces=*/false);
   any_whitespace_ = saved_any_whitespace;
+
+  scope = std::move(unique_key_scope_stack_.back());
+  unique_key_scope_stack_.pop_back();
+  if (scope.rule_id >= 0) {
+    builder_.UpdateRuleBody(scope.rule_id, result);
+    result = RuleRef(scope.rule_id);
+  }
   return result;
 }
 
 int32_t MiniMaxM3XMLToolCallingConverter::GenerateAny(
     const AnySpec& spec, const std::string& rule_name
 ) {
-  XGRAMMAR_LOG(FATAL) << "minimax_m3_xml does not support unconstrained schemas";
-  XGRAMMAR_UNREACHABLE();
+  if (generating_property_name_) {
+    return RuleRef(kMiniMaxM3DynamicName);
+  }
+  EnsureAnyRules();
+  return RuleRef(kBasicAny);
+}
+
+void MiniMaxM3XMLToolCallingConverter::EnsureAnyRules() {
+  if (any_rules_initialized_) {
+    return;
+  }
+  any_rules_initialized_ = true;
+
+  builder_.AddEmptyRule(kBasicAny);
+  int32_t object_rule_id = builder_.AddEmptyRuleWithHint(kMiniMaxM3AnyObject);
+  int32_t array_rule_id = builder_.AddEmptyRuleWithHint(kMiniMaxM3AnyArray);
+
+  int32_t dynamic_element = FormatRuntimeElement(
+      builder_.GetRuleId(kMiniMaxM3DynamicName), builder_.GetRuleId(kBasicAny), object_rule_id
+  );
+  builder_.UpdateRuleBody(
+      object_rule_id, Repeat(kMiniMaxM3AnyObject + std::string("_elements"), dynamic_element, 1, -1)
+  );
+
+  int32_t array_item = FormatElement(kMiniMaxM3ArrayItemName, builder_.GetRuleId(kBasicAny));
+  builder_.UpdateRuleBody(
+      array_rule_id, Repeat(kMiniMaxM3AnyArray + std::string("_items"), array_item, 1, -1)
+  );
+
+  builder_.UpdateRuleBody(
+      kBasicAny, Choice({RuleRef(kBasicString), RuleRef(object_rule_id), RuleRef(array_rule_id)})
+  );
+  AddCache("{}", builder_.GetRuleId(kBasicAny));
 }
 
 int32_t MiniMaxM3XMLToolCallingConverter::GenerateLiteral(const picojson::value& value) {
@@ -299,6 +435,13 @@ int32_t MiniMaxM3XMLToolCallingConverter::GenerateConst(
   picojson::value value;
   std::string error = picojson::parse(value, spec.json_value);
   XGRAMMAR_CHECK(error.empty()) << "Invalid const JSON value: " << error;
+  if (generating_property_name_) {
+    XGRAMMAR_CHECK(value.is<std::string>())
+        << "minimax_m3_xml propertyNames const must be a string";
+    const std::string& name = value.get<std::string>();
+    ValidateElementName(name);
+    return ByteString(name);
+  }
   return GenerateLiteral(value);
 }
 
@@ -313,7 +456,15 @@ int32_t MiniMaxM3XMLToolCallingConverter::GenerateEnum(
     picojson::value value;
     std::string error = picojson::parse(value, json_value);
     XGRAMMAR_CHECK(error.empty()) << "Invalid enum JSON value: " << error;
-    values.push_back(GenerateLiteral(value));
+    if (generating_property_name_) {
+      XGRAMMAR_CHECK(value.is<std::string>())
+          << "minimax_m3_xml propertyNames enum values must be strings";
+      const std::string& name = value.get<std::string>();
+      ValidateElementName(name);
+      values.push_back(ByteString(name));
+    } else {
+      values.push_back(GenerateLiteral(value));
+    }
   }
   return Choice(values);
 }
@@ -338,6 +489,24 @@ int32_t MiniMaxM3XMLToolCallingConverter::FormatElement(
   );
 }
 
+int32_t MiniMaxM3XMLToolCallingConverter::FormatRuntimeElement(
+    int32_t name_rule_id,
+    int32_t content_rule_id,
+    int32_t unique_key_scope_rule_id,
+    const std::vector<std::string>& reserved_names
+) {
+  return builder_.AddDynamicTag(
+      {std::string(kMiniMaxM3Namespace) + "<",
+       name_rule_id,
+       ">",
+       content_rule_id,
+       std::string(kMiniMaxM3Namespace) + "</",
+       ">",
+       unique_key_scope_rule_id,
+       reserved_names}
+  );
+}
+
 int32_t MiniMaxM3XMLToolCallingConverter::FormatProperty(
     const std::string& key,
     int32_t value_rule_id,
@@ -346,6 +515,68 @@ int32_t MiniMaxM3XMLToolCallingConverter::FormatProperty(
     const SchemaSpecPtr& schema
 ) {
   return FormatElement(key, value_rule_id);
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::FormatOtherProperty(
+    int32_t key_pattern_expr,
+    int32_t value_rule_id,
+    const std::string& rule_name,
+    const std::string& rule_name_suffix,
+    const SchemaSpecPtr& schema
+) {
+  XGRAMMAR_DCHECK(!unique_key_scope_stack_.empty());
+  int32_t name_rule_id =
+      builder_.AddRuleWithHint(rule_name + "_" + rule_name_suffix + "_name", key_pattern_expr);
+  auto& scope = unique_key_scope_stack_.back();
+  if (scope.rule_id < 0) {
+    scope.rule_id = builder_.AddEmptyRuleWithHint(rule_name + "_unique_keys");
+  }
+  return FormatRuntimeElement(name_rule_id, value_rule_id, scope.rule_id, scope.reserved_names);
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::CreatePatternKeyRule(
+    const std::string& pattern, const std::string& rule_name_hint
+) {
+  return builder_.AddRuleWithHint(rule_name_hint, RegexExpression(pattern, /*json_string=*/false));
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::CreatePropertyNameRule(
+    const SchemaSpecPtr& spec, const std::string& rule_name_hint
+) {
+  int32_t rule_id = builder_.AddEmptyRuleWithHint(rule_name_hint);
+  std::string rule_name = builder_.GetRule(rule_id).name;
+  bool saved_generating_property_name = generating_property_name_;
+  generating_property_name_ = true;
+  builder_.UpdateRuleBody(rule_id, GenerateFromSpec(spec, rule_name));
+  generating_property_name_ = saved_generating_property_name;
+  return rule_id;
+}
+
+std::string MiniMaxM3XMLToolCallingConverter::GetKeyPattern() const {
+  return kMiniMaxM3DynamicName;
+}
+
+int32_t MiniMaxM3XMLToolCallingConverter::GetKeyPatternExcluding(
+    const std::vector<ObjectSpec::Property>& properties, const std::string& rule_name
+) {
+  return RuleRef(kMiniMaxM3DynamicName);
+}
+
+void MiniMaxM3XMLToolCallingConverter::AddCache(const std::string& key, int32_t rule_id) {
+  if (!key.empty()) {
+    rule_cache_manager_.AddCache(key, !generating_property_name_, rule_id);
+  }
+}
+
+std::optional<int32_t> MiniMaxM3XMLToolCallingConverter::GetCache(const std::string& key) const {
+  if (key.empty()) {
+    return std::nullopt;
+  }
+  return rule_cache_manager_.GetCache(key, !generating_property_name_);
+}
+
+int MiniMaxM3XMLToolCallingConverter::GetRefCacheDomain() const {
+  return generating_property_name_ ? 1 : 0;
 }
 
 std::string MiniMaxM3XMLToolCallingConverter::NextSeparator(bool is_end) {
@@ -758,6 +989,8 @@ std::optional<int32_t> XMLToolCallingConverter::GetCache(const std::string& key)
   }
   return rule_cache_manager_.GetCache(key, nested_object_level_ > 1);
 }
+
+int XMLToolCallingConverter::GetRefCacheDomain() const { return std::min(nested_object_level_, 2); }
 
 CohereXMLToolCallingConverter::CohereXMLToolCallingConverter(
     std::optional<int> indent,
@@ -1232,5 +1465,7 @@ std::optional<int32_t> CohereXMLToolCallingConverter::GetCache(const std::string
   }
   return rule_cache_manager_.GetCache(key, nested_object_level_ > 1 && !InCohereValueContext());
 }
+
+int CohereXMLToolCallingConverter::GetRefCacheDomain() const { return 0; }
 
 }  // namespace xgrammar

--- a/cpp/json_schema_converter_ext.h
+++ b/cpp/json_schema_converter_ext.h
@@ -21,9 +21,8 @@ namespace xgrammar {
 /*!
  * \brief Converter for MiniMax M3's recursive namespace-prefixed XML format.
  *
- * This initial implementation supports schemas whose object property names are
- * known when the grammar is built. Schemas requiring runtime element names are
- * rejected explicitly.
+ * Runtime property names are represented by DynamicTag expressions so their
+ * closing tags repeat the generated opening names byte-for-byte.
  */
 class MiniMaxM3XMLToolCallingConverter : public JSONSchemaConverter {
  public:
@@ -37,7 +36,11 @@ class MiniMaxM3XMLToolCallingConverter : public JSONSchemaConverter {
   );
 
  protected:
+  int32_t GenerateInteger(const IntegerSpec& spec, const std::string& rule_name) override;
+  int32_t GenerateNumber(const NumberSpec& spec, const std::string& rule_name) override;
   int32_t GenerateString(const StringSpec& spec, const std::string& rule_name) override;
+  int32_t GenerateBoolean(const BooleanSpec& spec, const std::string& rule_name) override;
+  int32_t GenerateNull(const NullSpec& spec, const std::string& rule_name) override;
   int32_t GenerateArray(const ArraySpec& spec, const std::string& rule_name) override;
   int32_t GenerateObject(
       const ObjectSpec& spec, const std::string& rule_name, bool dummy_need_braces = false
@@ -53,14 +56,48 @@ class MiniMaxM3XMLToolCallingConverter : public JSONSchemaConverter {
       int64_t idx,
       const SchemaSpecPtr& schema
   ) override;
+  int32_t FormatOtherProperty(
+      int32_t key_pattern_expr,
+      int32_t value_rule_id,
+      const std::string& rule_name,
+      const std::string& rule_name_suffix,
+      const SchemaSpecPtr& schema
+  ) override;
+  int32_t CreatePatternKeyRule(const std::string& pattern, const std::string& rule_name_hint)
+      override;
+  int32_t CreatePropertyNameRule(const SchemaSpecPtr& spec, const std::string& rule_name_hint)
+      override;
+  std::string GetKeyPattern() const override;
+  int32_t GetKeyPatternExcluding(
+      const std::vector<ObjectSpec::Property>& properties, const std::string& rule_name
+  ) override;
   std::string NextSeparator(bool is_end = false) override;
   void AddBasicRules() override;
+  void AddCache(const std::string& key, int32_t rule_id) override;
+  std::optional<int32_t> GetCache(const std::string& key) const override;
+  int GetRefCacheDomain() const override;
 
  private:
+  struct UniqueKeyScopeContext {
+    int32_t rule_id = -1;
+    std::vector<std::string> reserved_names;
+  };
+
   int32_t FormatElement(const std::string& name, int32_t value_rule_id);
+  int32_t FormatRuntimeElement(
+      int32_t name_rule_id,
+      int32_t content_rule_id,
+      int32_t unique_key_scope_rule_id,
+      const std::vector<std::string>& reserved_names = {}
+  );
   int32_t GenerateLiteral(const picojson::value& value);
+  void EnsureAnyRules();
   void ValidateObject(const ObjectSpec& spec) const;
   static void ValidateElementName(const std::string& name);
+
+  bool generating_property_name_ = false;
+  bool any_rules_initialized_ = false;
+  std::vector<UniqueKeyScopeContext> unique_key_scope_stack_;
 };
 
 /*!
@@ -126,6 +163,7 @@ class XMLToolCallingConverter : public JSONSchemaConverter {
 
   void AddCache(const std::string& key, int32_t rule_id) override;
   std::optional<int32_t> GetCache(const std::string& key) const override;
+  int GetRefCacheDomain() const override;
 
  protected:
   // Wrapper strings for XML parameter tags (key prefix/suffix, value prefix, closing suffix)
@@ -223,6 +261,7 @@ class CohereXMLToolCallingConverter : public XMLToolCallingConverter {
 
   void AddCache(const std::string& key, int32_t rule_id) override;
   std::optional<int32_t> GetCache(const std::string& key) const override;
+  int GetRefCacheDomain() const override;
 
  private:
   struct XMLIdentifierTrieNode {

--- a/cpp/json_schema_converter_ext.h
+++ b/cpp/json_schema_converter_ext.h
@@ -19,6 +19,51 @@
 namespace xgrammar {
 
 /*!
+ * \brief Converter for MiniMax M3's recursive namespace-prefixed XML format.
+ *
+ * This initial implementation supports schemas whose object property names are
+ * known when the grammar is built. Schemas requiring runtime element names are
+ * rejected explicitly.
+ */
+class MiniMaxM3XMLToolCallingConverter : public JSONSchemaConverter {
+ public:
+  MiniMaxM3XMLToolCallingConverter(
+      std::optional<int> indent,
+      std::optional<std::pair<std::string, std::string>> separators,
+      bool any_whitespace,
+      std::optional<int> max_whitespace_cnt,
+      RefResolver ref_resolver = nullptr,
+      bool any_order = false
+  );
+
+ protected:
+  int32_t GenerateString(const StringSpec& spec, const std::string& rule_name) override;
+  int32_t GenerateArray(const ArraySpec& spec, const std::string& rule_name) override;
+  int32_t GenerateObject(
+      const ObjectSpec& spec, const std::string& rule_name, bool dummy_need_braces = false
+  ) override;
+  int32_t GenerateAny(const AnySpec& spec, const std::string& rule_name) override;
+  int32_t GenerateConst(const ConstSpec& spec, const std::string& rule_name) override;
+  int32_t GenerateEnum(const EnumSpec& spec, const std::string& rule_name) override;
+
+  int32_t FormatProperty(
+      const std::string& key,
+      int32_t value_rule_id,
+      const std::string& rule_name,
+      int64_t idx,
+      const SchemaSpecPtr& schema
+  ) override;
+  std::string NextSeparator(bool is_end = false) override;
+  void AddBasicRules() override;
+
+ private:
+  int32_t FormatElement(const std::string& name, int32_t value_rule_id);
+  int32_t GenerateLiteral(const picojson::value& value);
+  void ValidateObject(const ObjectSpec& spec) const;
+  static void ValidateElementName(const std::string& name);
+};
+
+/*!
  * \brief Converter for XML Tool Calling format (e.g., Qwen style).
  *
  * This converter generates a grammar where:

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -552,11 +552,11 @@ Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
     if (it != obj.end() && it->second.is<std::string>()) {
       style = it->second.get<std::string>();
       if (style != "json" && style != "qwen_xml" && style != "minimax_xml" &&
-          style != "deepseek_xml" && style != "glm_xml" && style != "cohere_xml" &&
-          style != "kimi_k3_xml") {
+          style != "minimax_m3_xml" && style != "deepseek_xml" && style != "glm_xml" &&
+          style != "cohere_xml" && style != "kimi_k3_xml") {
         return ResultErr<ISTError>(
-            "style must be \"json\", \"qwen_xml\", \"minimax_xml\", \"deepseek_xml\", "
-            "\"glm_xml\", \"cohere_xml\", or \"kimi_k3_xml\""
+            "style must be \"json\", \"qwen_xml\", \"minimax_xml\", \"minimax_m3_xml\", "
+            "\"deepseek_xml\", \"glm_xml\", \"cohere_xml\", or \"kimi_k3_xml\""
         );
       }
     }

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -83,7 +83,8 @@ struct ConstStringFormat {
 struct JSONSchemaFormat {
   static constexpr const char* type = "json_schema";
   std::string json_schema;
-  // "json","qwen_xml","minimax_xml","deepseek_xml","glm_xml","cohere_xml","kimi_k3_xml"
+  // "json","qwen_xml","minimax_xml","minimax_m3_xml","deepseek_xml","glm_xml","cohere_xml",
+  // "kimi_k3_xml"
   std::string style = "json";
   // Whether to allow object properties to appear in any order. See
   // Grammar::FromJSONSchema / JSONSchemaToEBNF for the semantics.

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -62,7 +62,7 @@ class SerializeVersion {
    * \brief The current serialization version. When the serialization result of any object in
    * XGrammar is changed, this version should be bumped.
    */
-  static constexpr const char kXGrammarSerializeVersion[] = "v16";
+  static constexpr const char kXGrammarSerializeVersion[] = "v17";
 };
 
 /*!

--- a/docs/defining_structures/ebnf_grammar.md
+++ b/docs/defining_structures/ebnf_grammar.md
@@ -455,6 +455,41 @@ The chunk list is compiled into a suffix automaton, so the number of automaton s
 linearly with the number of chunks. This is also the compiled form of the Lark
 `%regex {"substring_chunks": ...}` and `%regex {"substring_chars": ...}` extensions.
 
+### `DynamicTag`
+
+`DynamicTag` captures a name from an opening tag and requires the closing tag to reproduce the
+same bytes:
+
+```text
+root ::= DynamicTag("<", name, ">", content, "</", ">")
+name ::= [a-z_]+
+content ::= [A-Z]*
+```
+
+This grammar accepts `<key>VALUE</key>` but rejects `<key>VALUE</other>`. The six positional
+arguments are the opening prefix, name rule, opening suffix, content rule, closing prefix, and
+closing suffix. The name and content arguments must reference defined rules.
+
+The name rule must describe a byte-regular language. During compilation, XGrammar also constrains
+it to non-empty, nonblank names that cannot consume or overlap either suffix delimiter, or make
+the opening and closing prefixes indistinguishable. A name rule that cannot be converted to this
+bounded finite-state form fails closed at compilation time.
+
+Structured-data converters can additionally specify both `unique_key_scope` and
+`reserved_names`:
+
+```text
+object ::= dynamic_property*
+dynamic_property ::= DynamicTag(
+    "<", name, ">", content, "</", ">",
+    unique_key_scope=object,
+    reserved_names=("fixed",)
+)
+```
+
+Within each active occurrence of `object`, this rejects duplicate runtime names and names listed
+in `reserved_names`. The two named arguments must be supplied together.
+
 ### `TagDispatch`
 
 `TagDispatch` implements the common tool-calling pattern: the model produces free text until a

--- a/docs/structural_tag/structural_tag.md
+++ b/docs/structural_tag/structural_tag.md
@@ -162,7 +162,7 @@ Matches content that conforms to a JSON Schema.
 - `"json"`: standard JSON
 - `"qwen_xml"`: Qwen-style XML parameters, such as `<parameter=name>value</parameter>`
 - `"minimax_xml"`: MiniMax-style XML parameters, such as `<parameter name="name">value</parameter>`
-- `"minimax_m3_xml"`: MiniMax M3 namespace-prefixed XML. Fixed-name objects and arrays are encoded recursively, for example `]<]minimax[>[<city>Paris]<]minimax[>[</city>`. Schemas requiring runtime property names—for example schemas that permit `additionalProperties` or use `patternProperties` / `propertyNames`—and unconstrained schemas are rejected. String pattern, recognized format, and length constraints are also unsupported because string bodies must exclude the namespace marker.
+- `"minimax_m3_xml"`: MiniMax M3 namespace-prefixed XML. Objects and arrays are encoded recursively, for example `]<]minimax[>[<city>Paris]<]minimax[>[</city>`. Fixed property names produce fixed tags. Runtime property names from `additionalProperties`, a single standalone `patternProperties`, or standalone `propertyNames` are captured from the opening tag and reproduced byte-for-byte in the closing tag. Unsafe combinations whose property-name schemas would require intersection are rejected. Runtime name grammars must be byte-regular and delimiter-safe. String pattern, recognized format, and length constraints remain unsupported because string bodies must exclude the namespace marker.
 - `"deepseek_xml"`: DeepSeek-v3.2 XML parameter format
 - `"glm_xml"`: GLM-style XML parameter format, such as `<arg_key>name</arg_key><arg_value>value</arg_value>`
 - `"cohere_xml"`: Cohere-style XML values, such as `<cofl:value name="name" type="raw">value</cofl:value>`

--- a/docs/structural_tag/structural_tag.md
+++ b/docs/structural_tag/structural_tag.md
@@ -152,7 +152,7 @@ Matches content that conforms to a JSON Schema.
 | Field | Type | Default |
 | --- | --- | --- |
 | `json_schema` | `object` | (required) |
-| `style` | `"json"` \| `"qwen_xml"` \| `"minimax_xml"` \| `"deepseek_xml"` \| `"glm_xml"` \| `"cohere_xml"` \| `"kimi_k3_xml"` | `"json"` |
+| `style` | `"json"` \| `"qwen_xml"` \| `"minimax_xml"` \| `"minimax_m3_xml"` \| `"deepseek_xml"` \| `"glm_xml"` \| `"cohere_xml"` \| `"kimi_k3_xml"` | `"json"` |
 | `any_order` | `bool` | `false` |
 
 - **Use it when**: the structured part is naturally expressed as schema-constrained data
@@ -162,6 +162,7 @@ Matches content that conforms to a JSON Schema.
 - `"json"`: standard JSON
 - `"qwen_xml"`: Qwen-style XML parameters, such as `<parameter=name>value</parameter>`
 - `"minimax_xml"`: MiniMax-style XML parameters, such as `<parameter name="name">value</parameter>`
+- `"minimax_m3_xml"`: MiniMax M3 namespace-prefixed XML. Fixed-name objects and arrays are encoded recursively, for example `]<]minimax[>[<city>Paris]<]minimax[>[</city>`. Schemas requiring runtime property names—for example schemas that permit `additionalProperties` or use `patternProperties` / `propertyNames`—and unconstrained schemas are rejected. String pattern, recognized format, and length constraints are also unsupported because string bodies must exclude the namespace marker.
 - `"deepseek_xml"`: DeepSeek-v3.2 XML parameter format
 - `"glm_xml"`: GLM-style XML parameter format, such as `<arg_key>name</arg_key><arg_value>value</arg_value>`
 - `"cohere_xml"`: Cohere-style XML values, such as `<cofl:value name="name" type="raw">value</cofl:value>`

--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -13,7 +13,7 @@ The `tool_choice` parameter controls how tool calls and text are mixed:
 - **Forced** (named choice): exactly one specified tool must be called.
 - **None** (`"none"`): tool calls are disabled; only text and reasoning are allowed.
 
-The `reasoning` parameter controls whether the model-specific reasoning section is enabled.
+The `reasoning` parameter controls the model-specific reasoning section.
 
 ## Basic API: `get_model_structural_tag`
 
@@ -23,13 +23,14 @@ Use it when you need to constrain the model to output in a fixed pattern such as
 
 ### Parameters
 
-- **model** (`str`): The structural-tag style. Valid values are `"llama"`, `"qwen_3"`, `"qwen_3_5"`, `"qwen_3_coder"`, `"kimi"`, `"kimi_k3"`, `"deepseek_r1"`, `"deepseek_v3_1"`, `"harmony"`, `"deepseek_v3_2"`, `"minimax"`, `"glm_4_7"`, `"deepseek_v4"`, `"cohere"`, `"exaone"`.
+- **model** (`str`): The structural-tag style. Valid values are `"llama"`, `"qwen_3"`, `"qwen_3_5"`, `"qwen_3_coder"`, `"kimi"`, `"kimi_k3"`, `"deepseek_r1"`, `"deepseek_v3_1"`, `"harmony"`, `"deepseek_v3_2"`, `"minimax"`, `"minimax_m3"`, `"glm_4_7"`, `"deepseek_v4"`, `"cohere"`, `"exaone"`.
 - **tools** (`List[ToolParam | dict]`, optional): Function and builtin tools available to the model. The list can contain two kinds of tools:
   - **Function tools** use the OpenAI Chat Completions shape:
     ```json
     {"type": "function", "function": {"name": "...", "parameters": {...}}}
     ```
     The `"parameters"` field accepts a JSON Schema dict, `True` (any JSON), or can be omitted (unconstrained). When `"strict"` is `False`, the parameters constraint is skipped.
+    MiniMax M3 currently requires fixed property names and rejects unconstrained parameters and schemas with runtime-named properties.
   - **Builtin tools** use a compact shape with XGrammar-specific fields:
     ```json
     {"type": "web_search_preview", "name": "browser.search", "parameters": {...}}
@@ -47,11 +48,11 @@ Use it when you need to constrain the model to output in a fixed pattern such as
   - `{"type": "function", "function": {"name": ...}}`: forces one function tool.
   - `{"type": <builtin_type>}`: forces one builtin tool (matched by `type`).
   - `{"type": "allowed_tools", "allowed_tools": {"mode": ..., "tools": [...]}}`: limits available tools before applying its `mode`. The `tools` list may contain both function refs and builtin refs (matched by `type`).
-- **reasoning** (`bool`, optional): Whether to enable reasoning mode (`<think>`/`</think>` tags or model-specific equivalents). Default `True`.
+- **reasoning** (`bool | "enabled" | "disabled" | "auto"`, optional): Controls the model-specific reasoning section. `True` and `False` are equivalent to `"enabled"` and `"disabled"`, respectively. For models with a leading reasoning block, `"auto"` means that the prompt does not prefill its opener, and the model may emit one complete block or answer/call a tool directly. Default `True` in `get_model_structural_tag`; the model-specific `get_minimax_m3_structural_tag` defaults to `"auto"`. For MiniMax M3, these modes must be paired with the chat template's `enabled`, `disabled`, and `adaptive` thinking modes. Boolean aliases are supported only by `get_model_structural_tag`; model-specific builders take the three explicit string modes.
 - **any_order** (`bool`, optional): When `True`, applies `any_order=True` to every `JSONSchemaFormat` in the generated structural tag, so each tool's arguments may be emitted in any property order (see [`JSONSchemaFormat`](structural_tag) for the exact semantics). Default `False`, which keeps the declared property order with full validation.
 - **max_whitespace_cnt** (`Optional[int]`, optional): Caps the number of consecutive whitespace characters. Setting it (e.g. `2`) bounds runs of whitespace, which avoids the unbounded-whitespace outputs some models emit in bad cases that would otherwise blow up grammar compilation/matching.
 
-Passing an unsupported `model` or an invalid `tool_choice` will raise `ValueError`.
+Passing an unsupported `model`, invalid `tool_choice`, or invalid `reasoning` mode will raise `ValueError`.
 
 ### Returns
 
@@ -119,14 +120,22 @@ grammar = Grammar.from_structural_tag(structural_tag)
 
 ### Reasoning mode
 
-For formats that support reasoning (like Qwen3, DeepSeek-R1, Kimi-K2), pass `reasoning` to enable/disable:
+For formats that support reasoning (like Qwen3, DeepSeek-R1, Kimi-K2), use a boolean or its corresponding explicit mode:
 
 ```python
 structural_tag = get_model_structural_tag("qwen_3", tools=tools, reasoning=True)
 grammar = Grammar.from_structural_tag(structural_tag)
 ```
 
-If `reasoning` is not passed, reasoning mode is enabled by default.
+If `reasoning` is omitted, reasoning is enabled by default. Adaptive reasoning must be requested explicitly:
+
+```python
+structural_tag = get_model_structural_tag(
+    "qwen_3", tools=tools, reasoning="auto"
+)
+```
+
+The model-specific `get_minimax_m3_structural_tag` builder is the exception: its direct-call default is `reasoning="auto"`.
 
 ### Tool choice
 
@@ -202,6 +211,7 @@ The `model` argument of `get_model_structural_tag` accepts the style names below
 | `"harmony"` | gpt-oss |
 | `"deepseek_v3_2"` | DeepSeek-V3.2 |
 | `"minimax"` | MiniMax-M2.5 |
+| `"minimax_m3"` | MiniMax-M3 |
 | `"glm_4_7"` | GLM-5, GLM-4.7 |
 | `"deepseek_v4"` | DeepSeek-V4 |
 | `"cohere"` | Cohere Command models using XML tool calls |

--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -30,7 +30,7 @@ Use it when you need to constrain the model to output in a fixed pattern such as
     {"type": "function", "function": {"name": "...", "parameters": {...}}}
     ```
     The `"parameters"` field accepts a JSON Schema dict, `True` (any JSON), or can be omitted (unconstrained). When `"strict"` is `False`, the parameters constraint is skipped.
-    MiniMax M3 currently requires fixed property names and rejects unconstrained parameters and schemas with runtime-named properties.
+    MiniMax M3 normalizes unconstrained parameters to an object with runtime-named properties. Its XML grammar captures each runtime name from the opening tag and requires the closing tag to reproduce it byte-for-byte. Object schemas whose fixed, pattern, or property-name constraints overlap in ways that require schema intersection are rejected.
   - **Builtin tools** use a compact shape with XGrammar-specific fields:
     ```json
     {"type": "web_search_preview", "name": "browser.search", "parameters": {...}}

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -214,8 +214,7 @@ def get_model_structural_tag(
     -----
     If a tool's ``parameters`` field is omitted or ``None``, its generated
     arguments are unconstrained JSON. If a function tool has ``strict=False``,
-    its ``parameters`` schema is also treated as unconstrained. MiniMax M3's
-    fixed-name XML converter currently rejects such unconstrained schemas.
+    its ``parameters`` schema is also treated as unconstrained.
 
     Returns
     -------
@@ -1975,19 +1974,25 @@ def get_minimax_m3_structural_tag(
     if builtin_tools:
         raise ValueError("MiniMax M3 does not support builtin tools.")
 
-    invoke_tags = [
-        TagFormat(
-            begin=INVOKE_BEGIN_PREFIX + tool.function.name + INVOKE_BEGIN_SUFFIX,
-            content=JSONSchemaFormat(
-                json_schema=_get_function_parameters(tool.function),
-                style=XML_STYLE,
-                any_order=any_order,
-                max_whitespace_cnt=max_whitespace_cnt,
-            ),
-            end=INVOKE_END,
+    invoke_tags = []
+    for tool in tools:
+        parameters = _get_function_parameters(tool.function)
+        # Tool arguments are always an object. Preserve that outer shape when the
+        # function declaration leaves its members unconstrained.
+        if parameters is True:
+            parameters = {"type": "object", "additionalProperties": True}
+        invoke_tags.append(
+            TagFormat(
+                begin=INVOKE_BEGIN_PREFIX + tool.function.name + INVOKE_BEGIN_SUFFIX,
+                content=JSONSchemaFormat(
+                    json_schema=parameters,
+                    style=XML_STYLE,
+                    any_order=any_order,
+                    max_whitespace_cnt=max_whitespace_cnt,
+                ),
+                end=INVOKE_END,
+            )
         )
-        for tool in tools
-    ]
 
     def make_tool_call_tag(tags: List[TagFormat], *, allow_multiple: bool = True) -> TagFormat:
         content = (

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -15,6 +15,7 @@ from .openai_tool_call_schema import (
 from .structural_tag import (
     AnyTextFormat,
     ConstStringFormat,
+    Format,
     JSONSchemaFormat,
     OptionalFormat,
     RegexFormat,
@@ -32,7 +33,7 @@ def get_model_structural_tag(
     model: str,
     tools: Optional[List[Union[ToolParam, dict]]] = None,
     tool_choice: Union[ToolChoiceOptionParam, dict, None] = "auto",
-    reasoning: bool = True,
+    reasoning: Union[bool, Literal["enabled", "disabled", "auto"]] = True,
     force_reasoning: bool = False,
     any_order: bool = False,
     exclude_special_tokens: bool = True,
@@ -177,12 +178,13 @@ def get_model_structural_tag(
           available tools before applying its ``mode``. Its ``tools`` list may
           contain both function refs and builtin refs. Builtin refs are matched
           by ``type``.
-    reasoning : bool
-        Whether to enable the reasoning part. Some models, such as Qwen 3.6
-        and DeepSeek V4, support both reasoning and non-reasoning modes. If
-        ``False``, use the non-reasoning mode. For models that do not support
-        reasoning, this has no effect. For models that only support reasoning,
-        ``False`` means reasoning with empty content.
+    reasoning : Union[bool, Literal["enabled", "disabled", "auto"]]
+        Controls the model-specific reasoning section. ``True`` and ``False``
+        are equivalent to ``"enabled"`` and ``"disabled"``, respectively.
+        For models with a leading reasoning block, ``"auto"`` allows either a
+        complete block or a direct response/tool call. Defaults to ``True``.
+        Boolean aliases are supported by this dispatcher; model-specific
+        builders accept the three explicit string modes.
     force_reasoning : bool
         Deprecated. Control whether to keep the reasoning part but leave its content empty.
         Now we will embed the model's specific behavior into the structural tag function, so
@@ -212,7 +214,8 @@ def get_model_structural_tag(
     -----
     If a tool's ``parameters`` field is omitted or ``None``, its generated
     arguments are unconstrained JSON. If a function tool has ``strict=False``,
-    its ``parameters`` schema is also treated as unconstrained.
+    its ``parameters`` schema is also treated as unconstrained. MiniMax M3's
+    fixed-name XML converter currently rejects such unconstrained schemas.
 
     Returns
     -------
@@ -222,7 +225,7 @@ def get_model_structural_tag(
     Raises
     ------
     ValueError
-        If tool lists, tool choices, or required tool availability are invalid.
+        If tool lists, tool choices, reasoning modes, or required tool availability are invalid.
     """
 
     func = _structural_tag_registry.get(model)
@@ -234,11 +237,20 @@ def get_model_structural_tag(
         tools, tool_choice
     )
 
+    if isinstance(reasoning, bool):
+        reasoning_mode = "enabled" if reasoning else "disabled"
+    elif isinstance(reasoning, str) and reasoning in ("enabled", "disabled", "auto"):
+        reasoning_mode = reasoning
+    else:
+        raise ValueError(
+            "The 'reasoning' argument must be a bool or one of: " "'enabled', 'disabled', 'auto'."
+        )
+
     return func(
         function_tools,
         builtin_tools,
         simplified_tool_choice,
-        reasoning,
+        reasoning_mode,
         any_order=any_order,
         exclude_special_tokens=exclude_special_tokens,
         max_whitespace_cnt=max_whitespace_cnt,
@@ -345,7 +357,7 @@ def normalize_tool_choice(
             function_tools,
             builtin_tools,
             tool_choice,
-            reasoning=True,
+            reasoning="enabled",
         )
     """
 
@@ -451,6 +463,53 @@ def _text_excludes(exclude_special_tokens: bool, tokens: List[str]) -> List[str]
     return list(tokens) if exclude_special_tokens else []
 
 
+def _build_reasoning_prefix(
+    *,
+    reasoning_mode: Literal["enabled", "disabled", "auto"],
+    think_tag_begin: str,
+    think_tag_end: str,
+    exclude_special_tokens: bool,
+    reasoning_exclude_tokens: List[str],
+    prompt_end_with_think: bool = True,
+    reasoning_suffix: str = "",
+) -> Optional[Format]:
+    """Build a conventional leading reasoning block.
+
+    ``enabled`` continues an opener already present in the prompt by default.
+    ``auto`` makes a complete reasoning block optional. ``disabled`` omits the
+    block. Models with a different protocol keep their model-specific assembly.
+    """
+
+    if reasoning_mode not in ("enabled", "disabled", "auto"):
+        raise ValueError(
+            "The 'reasoning_mode' argument must be one of: 'enabled', 'disabled', 'auto'."
+        )
+    if reasoning_mode == "disabled":
+        return None
+
+    begin = "" if reasoning_mode == "enabled" and prompt_end_with_think else think_tag_begin
+    prefix: Format = TagFormat(
+        begin=begin,
+        content=AnyTextFormat(
+            excludes=_text_excludes(exclude_special_tokens, reasoning_exclude_tokens)
+        ),
+        end=think_tag_end,
+    )
+    if reasoning_suffix:
+        prefix = SequenceFormat(elements=[prefix, ConstStringFormat(value=reasoning_suffix)])
+    if reasoning_mode == "auto":
+        prefix = OptionalFormat(content=prefix)
+    return prefix
+
+
+def _assemble_structural_tag(prefix: Optional[Format], suffix: Format) -> StructuralTag:
+    """Assemble an optional reasoning prefix and a model-specific suffix."""
+
+    if prefix is None:
+        return StructuralTag(format=suffix)
+    return StructuralTag(format=SequenceFormat(elements=[prefix, suffix]))
+
+
 def _filter_allowed_tools(
     tools: List[FunctionToolParam],
     builtin_tools: List[BuiltinToolParam],
@@ -505,7 +564,7 @@ def register_model_structural_tag(name: str):
         @register_model_structural_tag("my_model")
         def get_my_model_structural_tag(
             tools=None, builtin_tools=None, tool_choice="auto",
-            reasoning=True, **kwargs,
+            reasoning="enabled", **kwargs,
         ):
             ...
     """
@@ -525,7 +584,7 @@ def get_llama_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -641,7 +700,7 @@ def get_kimi_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -658,8 +717,9 @@ def get_kimi_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a ``function``
       object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode. If ``False``, remove
-      the reasoning part and constrain only the following part.
+    - ``reasoning``: ``"enabled"`` keeps the reasoning part,
+      ``"disabled"`` removes it, and ``"auto"`` makes a complete reasoning
+      block optional.
 
     Supported models:
 
@@ -679,6 +739,7 @@ def get_kimi_structural_tag(
     TOOL_CALL_END = "<|tool_call_end|>"
     TOOL_CALLS_SECTION_BEGIN = "<|tool_calls_section_begin|>"
     TOOL_CALLS_SECTION_END = "<|tool_calls_section_end|>"
+    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
 
@@ -782,11 +843,14 @@ def get_kimi_structural_tag(
             ]
         )
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=THINK_EXCLUDE_TOKENS,
+    )
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
 
 
 @register_model_structural_tag("kimi_k3")
@@ -794,7 +858,7 @@ def get_kimi_k3_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -836,8 +900,8 @@ def get_kimi_k3_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a ``function``
       object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode. If ``False``, remove
-      the leading think block and constrain only the following part.
+    - ``reasoning``: selects ``"enabled"``, ``"disabled"``, or adaptive
+      ``"auto"`` reasoning.
 
     Supported models:
 
@@ -852,6 +916,7 @@ def get_kimi_k3_structural_tag(
     OPEN = "<|open|>"
     CLOSE = "<|close|>"
     SEP = "<|sep|>"
+    THINK_BEGIN = f"{OPEN}think{SEP}"
     THINK_END = f"{CLOSE}think{SEP}"
     RESPONSE_BEGIN = f"{OPEN}response{SEP}"
     RESPONSE_END = f"{CLOSE}response{SEP}"
@@ -923,20 +988,19 @@ def get_kimi_k3_structural_tag(
     # The generation prompt already emitted the first block's opening marker, so the
     # constrained output starts inside its body: the think body in reasoning mode, the
     # response body otherwise. Only the remaining markers are generated by the model.
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_BEGIN,
+        think_tag_end=THINK_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=SPECIAL_EXCLUDE_TOKENS,
+    )
     elements: List[Any] = []
-    if reasoning:
-        elements.append(
-            TagFormat(
-                begin="",
-                content=AnyTextFormat(
-                    excludes=_text_excludes(exclude_special_tokens, SPECIAL_EXCLUDE_TOKENS)
-                ),
-                end=THINK_END,
-            )
-        )
+    if prefix_tag is not None:
+        elements.append(prefix_tag)
     elements.append(
         TagFormat(
-            begin=RESPONSE_BEGIN if reasoning else "",
+            begin="" if reasoning == "disabled" else RESPONSE_BEGIN,
             content=AnyTextFormat(
                 excludes=_text_excludes(exclude_special_tokens, SPECIAL_EXCLUDE_TOKENS)
             ),
@@ -956,7 +1020,7 @@ def get_deepseek_r1_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -980,6 +1044,7 @@ def get_deepseek_r1_structural_tag(
     TOOL_SEP = "<｜tool▁sep｜>"
     JSON_RENDER_BEGIN = "\n```json\n"
     JSON_RENDER_END = "\n```"
+    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
 
@@ -1053,12 +1118,14 @@ def get_deepseek_r1_structural_tag(
         inner_tool_calls = TagsWithSeparatorFormat(tags=tags, separator="\n", at_least_one=True)
         suffix_tag = TagFormat(begin=TOOL_CALLS_BEGIN, content=inner_tool_calls, end=TOOL_CALLS_END)
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
-
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=THINK_EXCLUDE_TOKENS,
+    )
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
 
 
 @register_model_structural_tag("deepseek_v3_1")
@@ -1066,7 +1133,7 @@ def get_deepseek_v3_1_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -1088,6 +1155,7 @@ def get_deepseek_v3_1_structural_tag(
     TOOL_CALL_BEGIN = "<｜tool▁call▁begin｜>"
     TOOL_CALL_END = "<｜tool▁call▁end｜>"
     TOOL_SEP = "<｜tool▁sep｜>"
+    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
 
@@ -1161,12 +1229,14 @@ def get_deepseek_v3_1_structural_tag(
         inner_tool_calls = TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
         suffix_tag = TagFormat(begin=TOOL_CALLS_BEGIN, content=inner_tool_calls, end=TOOL_CALLS_END)
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
-
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=THINK_EXCLUDE_TOKENS,
+    )
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
 
 
 @register_model_structural_tag("qwen_3_5")
@@ -1175,7 +1245,7 @@ def get_qwen_3_5_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -1192,8 +1262,8 @@ def get_qwen_3_5_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a ``function``
       object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to add the ``</think>`` reasoning prefix before
-      the tool/text suffix.
+    - ``reasoning``: controls whether the reasoning prefix is required,
+      omitted, or optional before the tool/text suffix.
 
     Supported models:
 
@@ -1211,6 +1281,7 @@ def get_qwen_3_5_structural_tag(
     TOOL_CALL_BEGIN_SUFFIX = ">\n"
     TOOL_CALL_END = "\n</function>\n</tool_call>"
     TOOL_CALL_TRIGGER = "<tool_call>\n<function="
+    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
     THINK_SUFFIX = "\n\n"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
@@ -1288,16 +1359,15 @@ def get_qwen_3_5_structural_tag(
             at_least_one=True,
         )
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = SequenceFormat(
-        elements=[
-            TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END),
-            ConstStringFormat(value=THINK_SUFFIX),
-        ]
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=THINK_EXCLUDE_TOKENS,
+        reasoning_suffix=THINK_SUFFIX,
     )
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
 
 
 get_qwen_3_coder_structural_tag = get_qwen_3_5_structural_tag
@@ -1309,7 +1379,7 @@ def get_qwen_3_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -1326,8 +1396,8 @@ def get_qwen_3_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a ``function``
       object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode. If ``False``, remove
-      the reasoning part.
+    - ``reasoning``: controls whether the reasoning block is required,
+      omitted, or optional.
 
     Supported models:
 
@@ -1344,6 +1414,7 @@ def get_qwen_3_structural_tag(
     ARGUMENTS_FIELD_PREFIX = '", "arguments": '
     TOOL_CALL_END = "}\n</tool_call>"
     TOOL_CALL_TRIGGER = "<tool_call>"
+    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
     THINK_SUFFIX = "\n\n"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
@@ -1418,16 +1489,15 @@ def get_qwen_3_structural_tag(
             at_least_one=True,
         )
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = SequenceFormat(
-        elements=[
-            TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END),
-            ConstStringFormat(value=THINK_SUFFIX),
-        ]
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=THINK_EXCLUDE_TOKENS,
+        reasoning_suffix=THINK_SUFFIX,
     )
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
 
 
 @register_model_structural_tag("harmony")
@@ -1435,7 +1505,7 @@ def get_harmony_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -1455,7 +1525,7 @@ def get_harmony_structural_tag(
       object containing ``name`` and ``parameters`` fields.
     - ``builtin_tools``: a list of builtin tools. Each builtin tool should
       provide ``type``, optional ``name``, and ``parameters`` fields.
-    - ``reasoning``: whether to enable the analysis channel.
+    - ``reasoning``: controls whether the analysis channel is available.
 
     Supported models:
 
@@ -1559,7 +1629,7 @@ def get_harmony_structural_tag(
             tags.extend(_function_tool_tags(function.name, parameters))
         assert len(tags) > 0
 
-    if reasoning:
+    if reasoning != "disabled":
         analysis_tag = TagFormat(begin=ANALYSIS_BEGIN, content=AnyTextFormat(), end=FINAL_END)
         tags.append(analysis_tag)
 
@@ -1572,7 +1642,7 @@ def get_deepseek_v3_2_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -1599,6 +1669,7 @@ def get_deepseek_v3_2_structural_tag(
     FUNCTION_CALLS_BEGIN = "<｜DSML｜function_calls>\n"
     FUNCTION_CALLS_END = "</｜DSML｜function_calls>"
     FUNCTION_CALLS_TRIGGER = "<｜DSML｜function_calls>"
+    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
     XML_STYLE = "deepseek_xml"
@@ -1693,13 +1764,14 @@ def get_deepseek_v3_2_structural_tag(
             ]
         )
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
-
-    sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
-    return StructuralTag(format=sequence_format)
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=THINK_EXCLUDE_TOKENS,
+    )
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
 
 
 @register_model_structural_tag("minimax")
@@ -1707,7 +1779,7 @@ def get_minimax_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -1733,6 +1805,7 @@ def get_minimax_structural_tag(
     TOOL_CALL_BEGIN = "<minimax:tool_call>\n"
     TOOL_CALL_END = "</minimax:tool_call>"
     TOOL_CALL_TRIGGER = "<minimax:tool_call>"
+    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
     THINK_SUFFIX = "\n\n"
     EMPTY_THINK_CONTENT = "\n</think>\n\n"
@@ -1827,15 +1900,143 @@ def get_minimax_structural_tag(
             ]
         )
 
-    if reasoning:
-        think_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
-    else:
-        think_tag = ConstStringFormat(value=EMPTY_THINK_CONTENT)
-    return StructuralTag(
-        format=SequenceFormat(
-            elements=[think_tag, ConstStringFormat(value=THINK_SUFFIX), suffix_tag]
+    if reasoning == "disabled":
+        return StructuralTag(
+            format=SequenceFormat(
+                elements=[
+                    ConstStringFormat(value=EMPTY_THINK_CONTENT),
+                    ConstStringFormat(value=THINK_SUFFIX),
+                    suffix_tag,
+                ]
+            )
         )
+
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=[] if reasoning == "enabled" else THINK_EXCLUDE_TOKENS,
+        reasoning_suffix=THINK_SUFFIX,
     )
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
+
+
+@register_model_structural_tag("minimax_m3")
+def get_minimax_m3_structural_tag(
+    tools: Optional[List[FunctionToolParam]] = None,
+    builtin_tools: Optional[List[BuiltinToolParam]] = None,
+    tool_choice: Literal["auto", "required", "forced"] = "auto",
+    reasoning: Literal["enabled", "disabled", "auto"] = "auto",
+    any_order: bool = False,
+    exclude_special_tokens: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
+    **kwargs: Any,
+) -> StructuralTag:
+    """Get MiniMax-M3 style structural tag format.
+
+    MiniMax M3 recursively encodes tool arguments as namespace-prefixed XML.
+    With ``reasoning="enabled"``, the matching generation prompt has
+    already emitted ``<mm:think>`` and constrained output starts inside its
+    body. ``"disabled"`` starts directly at the response body after the matching
+    prompt. ``"auto"`` matches the ``adaptive`` prompt and accepts
+    either a complete reasoning block or a direct response/tool call. ``"auto"``
+    is the default for this model-specific builder.
+
+    Corresponding model key: ``"minimax_m3"``.
+
+    Supported models:
+
+    - MiniMax-M3
+
+    Returns
+    -------
+    StructuralTag
+        A structural tag for MiniMax M3 reasoning and function calling.
+    """
+    NAMESPACE = "]<]minimax[>["
+    INVOKE_BEGIN_PREFIX = NAMESPACE + '<invoke name="'
+    INVOKE_BEGIN_SUFFIX = '">'
+    INVOKE_END = NAMESPACE + "</invoke>\n"
+    TOOL_CALL_BEGIN = NAMESPACE + "<tool_call>\n"
+    TOOL_CALL_END = NAMESPACE + "</tool_call>"
+    TOOL_CALL_TRIGGER = NAMESPACE + "<tool_call>"
+    THINK_TAG_BEGIN = "<mm:think>"
+    THINK_TAG_END = "</mm:think>"
+    XML_STYLE = "minimax_m3_xml"
+
+    # Do not exclude the bare namespace: every M3 element and the tool-call trigger share it.
+    stray_tool_markers = [TOOL_CALL_END, NAMESPACE + "<invoke", NAMESPACE + "</invoke>"]
+    suffix_excludes = [THINK_TAG_BEGIN, THINK_TAG_END, *stray_tool_markers]
+    reasoning_excludes = [TOOL_CALL_TRIGGER, *suffix_excludes]
+
+    tools = tools or []
+    builtin_tools = builtin_tools or []
+    if builtin_tools:
+        raise ValueError("MiniMax M3 does not support builtin tools.")
+
+    invoke_tags = [
+        TagFormat(
+            begin=INVOKE_BEGIN_PREFIX + tool.function.name + INVOKE_BEGIN_SUFFIX,
+            content=JSONSchemaFormat(
+                json_schema=_get_function_parameters(tool.function),
+                style=XML_STYLE,
+                any_order=any_order,
+                max_whitespace_cnt=max_whitespace_cnt,
+            ),
+            end=INVOKE_END,
+        )
+        for tool in tools
+    ]
+
+    def make_tool_call_tag(tags: List[TagFormat], *, allow_multiple: bool = True) -> TagFormat:
+        content = (
+            TagsWithSeparatorFormat(tags=tags, separator="", at_least_one=True)
+            if allow_multiple
+            else tags[0]
+        )
+        return TagFormat(begin=TOOL_CALL_BEGIN, content=content, end=TOOL_CALL_END)
+
+    if tool_choice == "auto":
+        if invoke_tags:
+            suffix_tag = TriggeredTagsFormat(
+                triggers=[TOOL_CALL_TRIGGER],
+                tags=[make_tool_call_tag(invoke_tags)],
+                excludes=_text_excludes(exclude_special_tokens, suffix_excludes),
+            )
+        else:
+            suffix_tag = AnyTextFormat(
+                excludes=_text_excludes(
+                    exclude_special_tokens, [TOOL_CALL_TRIGGER, *suffix_excludes]
+                )
+            )
+    elif tool_choice == "forced":
+        if not invoke_tags:
+            raise ValueError("Forced tool choice must resolve to exactly one tool.")
+        suffix_tag = make_tool_call_tag([invoke_tags[0]], allow_multiple=False)
+    elif tool_choice == "required":
+        if not invoke_tags:
+            raise ValueError("Required tool choice needs at least one function tool.")
+        suffix_tag = TriggeredTagsFormat(
+            triggers=[TOOL_CALL_TRIGGER],
+            tags=[make_tool_call_tag(invoke_tags)],
+            excludes=_text_excludes(exclude_special_tokens, suffix_excludes),
+            at_least_one=True,
+        )
+    else:
+        raise ValueError(f"Unsupported tool choice: {tool_choice}")
+
+    # The generation prompt already emitted the first block's opening marker, so the
+    # constrained output starts inside its body: the think body in reasoning mode, the
+    # response body otherwise. Only the remaining markers are generated by the model.
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=reasoning_excludes,
+    )
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
 
 
 @register_model_structural_tag("glm_4_7")
@@ -1843,7 +2044,7 @@ def get_glm_4_7_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -1863,8 +2064,7 @@ def get_glm_4_7_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a ``function``
       object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode. If ``False``, use the
-      non-reasoning mode.
+    - ``reasoning``: selects enabled, disabled, or automatic reasoning mode.
 
     Supported models:
 
@@ -1879,6 +2079,7 @@ def get_glm_4_7_structural_tag(
     TOOL_CALL_BEGIN_PREFIX = "<tool_call>"
     TOOL_CALL_END = "</tool_call>"
     TOOL_CALL_TRIGGER = "<tool_call>"
+    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
     XML_STYLE = "glm_xml"
@@ -1966,16 +2167,14 @@ def get_glm_4_7_structural_tag(
             at_least_one=True,
         )
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = TagFormat(
-        begin="",
-        content=AnyTextFormat(excludes=_text_excludes(exclude_special_tokens, REASONING_EXCLUDES)),
-        end=THINK_TAG_END,
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=REASONING_EXCLUDES,
     )
-
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
 
 
 # TODO: We are dropping Gemma support because its parameter format is special and not supported
@@ -1985,7 +2184,7 @@ def _get_gemma_4_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -2009,8 +2208,8 @@ def _get_gemma_4_structural_tag(
 
     - ``tools``: a list of function tools. Each tool should have a
       ``function`` object containing ``name`` and ``parameters`` fields.
-    - ``reasoning``: whether to enable reasoning mode. If ``False``, the
-      reasoning channel is omitted.
+    - ``reasoning``: controls whether the reasoning channel is required,
+      omitted, or optional.
     - ``tool_choice``: ``"auto"`` or ``"required"``. ``"required"`` forces at
       least one tool call.
 
@@ -2104,11 +2303,15 @@ def _get_gemma_4_structural_tag(
             at_least_one=True,
         )
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = TagFormat(begin=THINK_TAG_BEGIN, content=AnyTextFormat(), end=THINK_TAG_END)
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=GEMMA4_EXCLUDE_TOKENS,
+        prompt_end_with_think=False,
+    )
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
 
 
 @register_model_structural_tag("deepseek_v4")
@@ -2116,7 +2319,7 @@ def get_deepseek_v4_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -2141,6 +2344,7 @@ def get_deepseek_v4_structural_tag(
     FUNCTION_CALLS_BEGIN = "<｜DSML｜tool_calls>\n"
     FUNCTION_CALLS_END = "</｜DSML｜tool_calls>"
     FUNCTION_CALLS_TRIGGER = "<｜DSML｜tool_calls>"
+    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
     XML_STYLE = "deepseek_xml"
@@ -2235,13 +2439,14 @@ def get_deepseek_v4_structural_tag(
             ]
         )
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
-
-    sequence_format = SequenceFormat(elements=[prefix_tag, suffix_tag])
-    return StructuralTag(format=sequence_format)
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=THINK_EXCLUDE_TOKENS,
+    )
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
 
 
 @register_model_structural_tag("cohere")
@@ -2249,7 +2454,7 @@ def get_cohere_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -2271,6 +2476,7 @@ def get_cohere_structural_tag(
     TOOL_CALLS_BEGIN = "<cofl:tool_calls>"
     TOOL_CALLS_END = "</cofl:tool_calls>"
     TOOL_CALLS_TRIGGER = "<cofl:tool_calls>"
+    THINK_TAG_BEGIN = "<|START_THINKING|>"
     THINK_TAG_END = "<|END_THINKING|>"
     THINK_EXCLUDE_TOKENS = ["<|START_THINKING|>", "<|END_THINKING|>"]
     XML_STYLE = "cohere_xml"
@@ -2338,11 +2544,14 @@ def get_cohere_structural_tag(
             ]
         )
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END)
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=[] if reasoning == "enabled" else THINK_EXCLUDE_TOKENS,
+    )
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
 
 
 @register_model_structural_tag("exaone")
@@ -2350,7 +2559,7 @@ def get_exaone_structural_tag(
     tools: Optional[List[FunctionToolParam]] = None,
     builtin_tools: Optional[List[BuiltinToolParam]] = None,
     tool_choice: Literal["auto", "required", "forced"] = "auto",
-    reasoning: bool = True,
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
     any_order: bool = False,
     exclude_special_tokens: bool = True,
     max_whitespace_cnt: Optional[int] = None,
@@ -2371,6 +2580,7 @@ def get_exaone_structural_tag(
     ARGUMENTS_FIELD_PREFIX = '", "arguments": '
     TOOL_CALL_END = "}</tool_call>"
     TOOL_CALL_TRIGGER = "<tool_call>"
+    THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
     THINK_SUFFIX = "\n\n"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
@@ -2445,16 +2655,15 @@ def get_exaone_structural_tag(
             at_least_one=True,
         )
 
-    if not reasoning:
-        return StructuralTag(format=suffix_tag)
-
-    prefix_tag = SequenceFormat(
-        elements=[
-            TagFormat(begin="", content=AnyTextFormat(), end=THINK_TAG_END),
-            ConstStringFormat(value=THINK_SUFFIX),
-        ]
+    prefix_tag = _build_reasoning_prefix(
+        reasoning_mode=reasoning,
+        think_tag_begin=THINK_TAG_BEGIN,
+        think_tag_end=THINK_TAG_END,
+        exclude_special_tokens=exclude_special_tokens,
+        reasoning_exclude_tokens=[] if reasoning == "enabled" else THINK_EXCLUDE_TOKENS,
+        reasoning_suffix=THINK_SUFFIX,
     )
-    return StructuralTag(format=SequenceFormat(elements=[prefix_tag, suffix_tag]))
+    return _assemble_structural_tag(prefix_tag, suffix_tag)
 
 
 # Backward-compatible alias

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -32,10 +32,19 @@ class JSONSchemaFormat(BaseModel):
     json_schema: Union[bool, Dict[str, Any]]
     """The JSON schema."""
     style: Literal[
-        "json", "qwen_xml", "minimax_xml", "deepseek_xml", "glm_xml", "cohere_xml", "kimi_k3_xml"
+        "json",
+        "qwen_xml",
+        "minimax_xml",
+        "minimax_m3_xml",
+        "deepseek_xml",
+        "glm_xml",
+        "cohere_xml",
+        "kimi_k3_xml",
     ] = "json"
     """How to parse the content. Valid values: \"json\" (standard JSON), \"qwen_xml\" (Qwen XML:
-    <parameter=key>value</parameter>), \"minimax_xml\" (MiniMax XML: <parameter name=\"key\">value</parameter>),
+    <parameter=key>value</parameter>), \"minimax_xml\" (MiniMax XML:
+    <parameter name=\"key\">value</parameter>), \"minimax_m3_xml\" (MiniMax M3 recursive
+    namespace XML: ]<]minimax[>[<key>value]<]minimax[>[</key>),
     \"deepseek_xml\" (DeepSeek XML(DeepSeek-v3.2): <{dsml_token}parameter name=\"key\" string=\"true|false\">value</{dsml_token}parameter>),
     \"glm_xml\" (GLM XML: <arg_key>key</arg_key><arg_value>value</arg_value>),
     \"cohere_xml\" (Cohere XML: <cofl:value name=\"key\" type=\"raw|json|dict|list\">value</cofl:value>),

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -68,8 +68,8 @@ def _json_schema_to_ebnf(
     json_format : str, default: "json"
         The generated grammar format. One of "json", "qwen_xml", "minimax_xml",
         "minimax_m3_xml", "deepseek_xml", "glm_xml", "cohere_xml", or "kimi_k3_xml".
-        MiniMax M3 encodes fixed-name nested objects and arrays recursively; the other XML
-        styles use their existing model-specific encodings.
+        MiniMax M3 encodes nested objects and arrays recursively and supports fixed or runtime
+        property names; the other XML styles use their existing model-specific encodings.
 
     Returns
     -------

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -25,7 +25,14 @@ def _json_schema_to_ebnf(
     max_whitespace_cnt: Optional[int] = None,
     strict_mode: bool = True,
     json_format: Literal[
-        "json", "qwen_xml", "minimax_xml", "deepseek_xml", "glm_xml", "cohere_xml", "kimi_k3_xml"
+        "json",
+        "qwen_xml",
+        "minimax_xml",
+        "minimax_m3_xml",
+        "deepseek_xml",
+        "glm_xml",
+        "cohere_xml",
+        "kimi_k3_xml",
     ] = "json",
     any_order: bool = False,
 ) -> str:
@@ -59,9 +66,10 @@ def _json_schema_to_ebnf(
         It should be a positive integer.
 
     json_format : str, default: "json"
-        The root format of the generated grammar. One of "json", "qwen_xml", "minimax_xml",
-        "deepseek_xml", "glm_xml", "cohere_xml", "kimi_k3_xml". Formats other than "json" generate an
-        XML-style root object for tool calling, while the inner values remain JSON-style.
+        The generated grammar format. One of "json", "qwen_xml", "minimax_xml",
+        "minimax_m3_xml", "deepseek_xml", "glm_xml", "cohere_xml", or "kimi_k3_xml".
+        MiniMax M3 encodes fixed-name nested objects and arrays recursively; the other XML
+        styles use their existing model-specific encodings.
 
     Returns
     -------

--- a/tests/cpp/test_dynamic_tag_matcher.cc
+++ b/tests/cpp/test_dynamic_tag_matcher.cc
@@ -1,0 +1,1078 @@
+#include <dlpack/dlpack.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <future>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "xgrammar/xgrammar.h"
+
+namespace xgrammar {
+namespace {
+
+constexpr int kNumThreads = 8;
+constexpr int kThreadIterations = 100;
+
+Grammar BasicDynamicTagGrammar() {
+  return Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, ">", content, "</", ">")
+    name ::= [a-z_][a-z0-9_]*
+    content ::= [A-Z]*
+  )");
+}
+
+Grammar UniqueKeyDynamicTagGrammar() {
+  return Grammar::FromEBNF(R"(
+    root ::= scope
+    scope ::= element+
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=("fixed",)
+    )
+    name ::= [a-z_][a-z0-9_]*
+    content ::= [A-Z]* | scope
+  )");
+}
+
+CompiledGrammar Compile(
+    const Grammar& grammar,
+    const TokenizerInfo& tokenizer_info = TokenizerInfo(std::vector<std::string>{})
+) {
+  return GrammarCompiler(tokenizer_info, 4, false).CompileGrammar(grammar);
+}
+
+bool Accepts(const CompiledGrammar& compiled, const std::string& input) {
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+  return matcher.AcceptString(input) && matcher.IsCompleted();
+}
+
+std::vector<int> GetMaskedTokens(
+    GrammarMatcher* matcher, const TokenizerInfo& tokenizer_info, int32_t batch_size = 1
+) {
+  const int32_t bitmask_size = GetBitmaskSize(tokenizer_info.GetVocabSize());
+  std::vector<int32_t> bitmask_data(batch_size * bitmask_size);
+  int64_t shape[2] = {batch_size, bitmask_size};
+  DLTensor bitmask{};
+  bitmask.data = bitmask_data.data();
+  bitmask.device = DLDevice{kDLCPU, 0};
+  bitmask.ndim = 2;
+  bitmask.dtype = GetBitmaskDLType();
+  bitmask.shape = shape;
+  matcher->FillNextTokenBitmask(&bitmask);
+
+  std::vector<int> masked;
+  _DebugGetMaskedTokensFromBitmask(&masked, bitmask, tokenizer_info.GetVocabSize());
+  return masked;
+}
+
+TEST(DynamicTagGrammarTest, MatchesOpeningNameAtTheClosingTag) {
+  const auto compiled = Compile(BasicDynamicTagGrammar());
+
+  EXPECT_TRUE(Accepts(compiled, "<key>VALUE</key>"));
+  EXPECT_TRUE(Accepts(compiled, "<other_2></other_2>"));
+  EXPECT_FALSE(Accepts(compiled, "<key>VALUE</other>"));
+  EXPECT_FALSE(Accepts(compiled, "<key>lowercase</key>"));
+}
+
+TEST(DynamicTagGrammarTest, AcceptStringPreservesCaptureAcrossChunks) {
+  const auto compiled = Compile(BasicDynamicTagGrammar());
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+
+  ASSERT_TRUE(matcher.AcceptString("<run"));
+  ASSERT_TRUE(matcher.AcceptString("time_1>VALUE</run"));
+  EXPECT_FALSE(matcher.AcceptString("wrong>"));
+  ASSERT_TRUE(matcher.AcceptString("time_1>"));
+  EXPECT_TRUE(matcher.IsCompleted());
+}
+
+TEST(DynamicTagGrammarTest, ConstraintIsScopedToTheSelectedUnionBranch) {
+  const auto dynamic = BasicDynamicTagGrammar();
+  const auto plain = Grammar::FromEBNF(R"(root ::= "plain")");
+  const auto compiled = Compile(Grammar::Union({plain, dynamic}));
+
+  EXPECT_TRUE(Accepts(compiled, "plain"));
+  EXPECT_TRUE(Accepts(compiled, "<key>VALUE</key>"));
+  EXPECT_FALSE(Accepts(compiled, "<key>VALUE</other>"));
+}
+
+TEST(DynamicTagGrammarTest, SurvivesGrammarConcatenation) {
+  const auto prefix = Grammar::FromEBNF(R"(root ::= "prefix:")");
+  const auto suffix = Grammar::FromEBNF(R"(root ::= ":suffix")");
+  const auto grammar = Grammar::Concat({prefix, BasicDynamicTagGrammar(), suffix});
+  const auto compiled = Compile(grammar);
+
+  EXPECT_TRUE(Accepts(compiled, "prefix:<key>VALUE</key>:suffix"));
+  EXPECT_FALSE(Accepts(compiled, "prefix:<key>VALUE</wrong>:suffix"));
+}
+
+TEST(DynamicTagGrammarTest, SupportsNestedAndSiblingOccurrences) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= element
+    element ::= DynamicTag("<", name, ">", content, "</", ">")
+    name ::= [a-z]+
+    content ::= [A-Z]* | element+
+  )");
+  const auto compiled = Compile(grammar);
+
+  EXPECT_TRUE(Accepts(compiled, "<outer><left>A</left><right>B</right></outer>"));
+  EXPECT_TRUE(Accepts(compiled, "<a><b><c>X</c></b></a>"));
+  EXPECT_FALSE(Accepts(compiled, "<outer><inner>X</outer></inner>"));
+  EXPECT_FALSE(Accepts(compiled, "<outer><inner>X</wrong></outer>"));
+}
+
+TEST(DynamicTagGrammarTest, UniqueKeyScopeRejectsSiblingAndReservedNames) {
+  const auto compiled = Compile(UniqueKeyDynamicTagGrammar());
+
+  EXPECT_TRUE(Accepts(compiled, "<a>A</a><b>B</b>"));
+  EXPECT_FALSE(Accepts(compiled, "<a>A</a><a>B</a>"));
+  EXPECT_FALSE(Accepts(compiled, "<fixed>A</fixed>"));
+}
+
+TEST(DynamicTagGrammarTest, UniqueKeyScopeIsOccurrenceLocalForNestedObjects) {
+  const auto compiled = Compile(UniqueKeyDynamicTagGrammar());
+
+  EXPECT_TRUE(Accepts(compiled, "<left><x>A</x></left><right><x>B</x></right>"));
+  EXPECT_FALSE(Accepts(compiled, "<outer><x>A</x><x>B</x></outer>"));
+}
+
+TEST(DynamicTagGrammarTest, UniqueKeyIndexStaysScopeLocalAfterBloomSaturation) {
+  const auto compiled = Compile(UniqueKeyDynamicTagGrammar());
+  constexpr int32_t kNumKeys = 128;
+
+  std::string nested_left = "<left>";
+  std::string nested_right = "<right>";
+  std::string flat;
+  for (int32_t i = 0; i < kNumKeys; ++i) {
+    const std::string name = "key_" + std::to_string(i);
+    const std::string left_tag = "<" + name + ">A</" + name + ">";
+    const std::string right_tag = "<" + name + ">B</" + name + ">";
+    nested_left += left_tag;
+    nested_right += right_tag;
+    flat += left_tag;
+  }
+  nested_left += "</left>";
+  nested_right += "</right>";
+
+  EXPECT_TRUE(Accepts(compiled, nested_left + nested_right));
+  EXPECT_TRUE(Accepts(compiled, flat));
+  EXPECT_FALSE(Accepts(compiled, flat + "<key_0>B</key_0>"));
+  EXPECT_FALSE(Accepts(compiled, flat + "<key_127>B</key_127>"));
+
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+  ASSERT_TRUE(matcher.AcceptString(flat));
+  matcher.Reset();
+  EXPECT_TRUE(matcher.AcceptString(flat));
+}
+
+TEST(DynamicTagGrammarTest, UniqueKeyStateIsDerivationLocalAcrossAmbiguousLiteralBranch) {
+  const auto with_literal = Grammar::FromEBNF(R"(
+    root ::= scope
+    scope ::= (element | "<a>X</a>") element
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=()
+    )
+    name ::= [a-z]+
+    content ::= "X"
+  )");
+  const auto without_literal = Grammar::FromEBNF(R"(
+    root ::= scope
+    scope ::= element element
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=()
+    )
+    name ::= [a-z]+
+    content ::= "X"
+  )");
+  const std::string input = "<a>X</a><a>X</a>";
+  const TokenizerInfo tokenizer_info({input}, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto with_literal_compiled = Compile(with_literal, tokenizer_info);
+  const auto without_literal_compiled = Compile(without_literal, tokenizer_info);
+
+  EXPECT_TRUE(Accepts(with_literal_compiled, input));
+  EXPECT_FALSE(Accepts(without_literal_compiled, input));
+
+  GrammarMatcher with_literal_matcher(with_literal_compiled, std::nullopt, true);
+  const auto with_literal_masked = GetMaskedTokens(&with_literal_matcher, tokenizer_info);
+  EXPECT_EQ(
+      std::find(with_literal_masked.begin(), with_literal_masked.end(), 0),
+      with_literal_masked.end()
+  );
+  EXPECT_TRUE(with_literal_matcher.AcceptToken(0));
+  EXPECT_TRUE(with_literal_matcher.IsCompleted());
+
+  GrammarMatcher without_literal_matcher(without_literal_compiled, std::nullopt, true);
+  const auto without_literal_masked = GetMaskedTokens(&without_literal_matcher, tokenizer_info);
+  EXPECT_NE(
+      std::find(without_literal_masked.begin(), without_literal_masked.end(), 0),
+      without_literal_masked.end()
+  );
+  EXPECT_FALSE(without_literal_matcher.AcceptToken(0));
+}
+
+TEST(DynamicTagGrammarTest, RightRecursionPreservesBranchLocalUniqueKeyState) {
+  const auto with_literal = Grammar::FromEBNF(R"(
+    root ::= scope
+    scope ::= (wrapped | "<a>X</a>") tail
+    wrapped ::= element
+    tail ::= wrapped tail | ""
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=()
+    )
+    name ::= [a-z]+
+    content ::= "X"
+  )");
+  const auto without_literal = Grammar::FromEBNF(R"(
+    root ::= scope
+    scope ::= wrapped tail
+    wrapped ::= element
+    tail ::= wrapped tail | ""
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=()
+    )
+    name ::= [a-z]+
+    content ::= "X"
+  )");
+  constexpr const char* kInput = "<a>X</a><a>X</a><b>X</b>";
+  const TokenizerInfo tokenizer_info(
+      {kInput}, VocabType::RAW, std::nullopt, std::vector<int32_t>{}
+  );
+  const auto with_literal_compiled = Compile(with_literal, tokenizer_info);
+  const auto without_literal_compiled = Compile(without_literal, tokenizer_info);
+
+  EXPECT_TRUE(Accepts(with_literal_compiled, kInput));
+  EXPECT_FALSE(Accepts(without_literal_compiled, kInput));
+
+  GrammarMatcher with_literal_matcher(with_literal_compiled, std::nullopt, true);
+  EXPECT_EQ(GetMaskedTokens(&with_literal_matcher, tokenizer_info), std::vector<int>{});
+  EXPECT_TRUE(with_literal_matcher.AcceptToken(0));
+  EXPECT_TRUE(with_literal_matcher.IsCompleted());
+
+  GrammarMatcher without_literal_matcher(without_literal_compiled, std::nullopt, true);
+  EXPECT_EQ(GetMaskedTokens(&without_literal_matcher, tokenizer_info), std::vector<int>{0});
+  EXPECT_FALSE(without_literal_matcher.AcceptToken(0));
+}
+
+TEST(DynamicTagGrammarTest, UniqueKeyScopeRightRecursionKeepsOccurrencesSeparate) {
+  const auto nested_scopes = Grammar::FromEBNF(R"(
+    root ::= scope
+    scope ::= element scope | ""
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=()
+    )
+    name ::= [a-z]+
+    content ::= "X"
+  )");
+  const auto one_scope = Grammar::FromEBNF(R"(
+    root ::= scope
+    scope ::= element tail
+    tail ::= element tail | ""
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=()
+    )
+    name ::= [a-z]+
+    content ::= "X"
+  )");
+  constexpr const char* kInput = "<a>X</a><a>X</a>";
+
+  EXPECT_TRUE(Accepts(Compile(nested_scopes), kInput));
+  EXPECT_FALSE(Accepts(Compile(one_scope), kInput));
+}
+
+TEST(DynamicTagGrammarTest, RejectsZeroWidthRecursiveUniqueKeyScope) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= scope
+    scope ::= scope | element
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=()
+    )
+    name ::= [a-z]+
+    content ::= "X"
+  )");
+
+  EXPECT_ANY_THROW(Compile(grammar));
+}
+
+TEST(DynamicTagGrammarTest, RejectsIndirectNullableUniqueKeyScopeCycle) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= scope
+    scope ::= bridge | element
+    bridge ::= empty scope
+    empty ::= ""
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=()
+    )
+    name ::= [a-z]+
+    content ::= "X"
+  )");
+
+  EXPECT_ANY_THROW(Compile(grammar));
+}
+
+TEST(DynamicTagGrammarTest, AllowsNullableUniqueKeyScopeWithoutZeroWidthRecursion) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= scope
+    scope ::= "" | element+
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=()
+    )
+    name ::= [a-z]+
+    content ::= "X"
+  )");
+  const auto compiled = Compile(grammar);
+
+  EXPECT_TRUE(Accepts(compiled, ""));
+  EXPECT_TRUE(Accepts(compiled, "<a>X</a><b>X</b>"));
+}
+
+TEST(DynamicTagGrammarTest, UniqueKeyScopePreservesAmbiguousAncestorOccurrences) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= scope
+    scope ::= element | "x" element | "x" scope
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=()
+    )
+    name ::= [a-z]+
+    content ::= "X"
+  )");
+  const std::vector<std::string> inputs = {"<a>X</a>", "x<a>X</a>", "xx<a>X</a>"};
+  const TokenizerInfo tokenizer_info(inputs, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto compiled = Compile(grammar, tokenizer_info);
+
+  for (const auto& input : inputs) {
+    EXPECT_TRUE(Accepts(compiled, input));
+  }
+
+  GrammarMatcher mask_matcher(compiled, std::nullopt, true);
+  const auto masked = GetMaskedTokens(&mask_matcher, tokenizer_info);
+  for (int32_t token_id = 0; token_id < static_cast<int32_t>(inputs.size()); ++token_id) {
+    EXPECT_EQ(std::find(masked.begin(), masked.end(), token_id), masked.end());
+    GrammarMatcher matcher(compiled, std::nullopt, true);
+    EXPECT_TRUE(matcher.AcceptToken(token_id));
+    EXPECT_TRUE(matcher.IsCompleted());
+  }
+}
+
+TEST(DynamicTagGrammarTest, UniqueKeyTokenMaskAndRollbackUseMatcherLocalState) {
+  const std::vector<std::string> vocab = {"a>", "b>", "fixed>"};
+  const TokenizerInfo tokenizer_info(vocab, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto compiled = Compile(UniqueKeyDynamicTagGrammar(), tokenizer_info);
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+  ASSERT_TRUE(matcher.AcceptString("<a>A</a><"));
+
+  auto masked = GetMaskedTokens(&matcher, tokenizer_info);
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 0), masked.end());
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 1), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 2), masked.end());
+  EXPECT_FALSE(matcher.AcceptToken(0));
+
+  ASSERT_TRUE(matcher.AcceptToken(1));
+  matcher.Rollback();
+  masked = GetMaskedTokens(&matcher, tokenizer_info);
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 1), masked.end());
+  EXPECT_TRUE(matcher.AcceptToken(1));
+}
+
+TEST(DynamicTagGrammarTest, UniqueKeyForksDetachBeforeMutationAndRollback) {
+  const auto compiled = Compile(UniqueKeyDynamicTagGrammar());
+  GrammarMatcher original(compiled, std::nullopt, true);
+  ASSERT_TRUE(original.AcceptString("<a>A</a>"));
+  auto fork = original.Fork();
+
+  ASSERT_TRUE(original.AcceptString("<b>B</b>"));
+  ASSERT_TRUE(fork.AcceptString("<c>C</c>"));
+
+  fork.Rollback();
+  EXPECT_FALSE(original.AcceptString("<b>B</b>"));
+  ASSERT_TRUE(original.AcceptString("<c>C</c>"));
+  original.Rollback();
+
+  ASSERT_TRUE(fork.AcceptString("<c>C</c>"));
+  fork.Rollback();
+  EXPECT_TRUE(fork.AcceptString("<b>B</b>"));
+
+  original.Rollback();
+  EXPECT_TRUE(original.AcceptString("<b>B</b>"));
+}
+
+TEST(DynamicTagGrammarTest, RollbackCommittedUniqueKeyMakesNameReusable) {
+  const auto compiled = Compile(UniqueKeyDynamicTagGrammar());
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+
+  ASSERT_TRUE(matcher.AcceptString("<key>A</key>"));
+  matcher.Rollback();
+  EXPECT_TRUE(matcher.AcceptString("<key>B</key>"));
+}
+
+TEST(DynamicTagGrammarTest, RejectedAcceptStringDoesNotLeakUniqueKey) {
+  const auto compiled = Compile(UniqueKeyDynamicTagGrammar());
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+  ASSERT_TRUE(matcher.AcceptString("<committed>A</committed>"));
+
+  EXPECT_FALSE(matcher.AcceptString("<retry>B</wrong>"));
+  EXPECT_TRUE(matcher.AcceptString("<retry>B</retry>"));
+}
+
+TEST(DynamicTagGrammarTest, UniqueKeyScopeMustBeAnActiveAncestor) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= scope | element
+    scope ::= "literal"
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=()
+    )
+    name ::= [a-z]+
+    content ::= [A-Z]*
+  )");
+  const auto compiled = Compile(grammar);
+
+  EXPECT_TRUE(Accepts(compiled, "literal"));
+  EXPECT_FALSE(Accepts(compiled, "<a>A</a>"));
+}
+
+TEST(DynamicTagGrammarTest, UniqueKeyStateSurvivesAtomicAndBytePathMerge) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= "<" Token(0) "atomic" | scope
+    scope ::= element+
+    element ::= DynamicTag(
+      "<", name, ">", content, "</", ">",
+      unique_key_scope=scope,
+      reserved_names=()
+    )
+    name ::= [a-z]+
+    content ::= [A-Z]*
+  )");
+  const TokenizerInfo tokenizer_info({"a>"}, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto compiled = Compile(grammar, tokenizer_info);
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+
+  ASSERT_TRUE(matcher.AcceptString("<"));
+  ASSERT_TRUE(matcher.AcceptToken(0));
+  EXPECT_FALSE(matcher.AcceptString("A</a><a>B</a>"));
+}
+
+TEST(DynamicTagGrammarTest, CapturesUtf8NamesByteForByte) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("]<]minimax[>[<", name, ">", content, "]<]minimax[>[</", ">")
+    name ::= [^>/]+
+    content ::= [^<]*
+  )");
+  const auto compiled = Compile(grammar);
+  const std::string ns = "]<]minimax[>[";
+
+  EXPECT_TRUE(Accepts(compiled, ns + "<城市>HANGZHOU" + ns + "</城市>"));
+  EXPECT_FALSE(Accepts(compiled, ns + "<城市>HANGZHOU" + ns + "</天气>"));
+}
+
+TEST(DynamicTagGrammarTest, SupportsEmptyFixedDelimiters) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("", name, ":", content, "/", "")
+    name ::= [a-z]+
+    content ::= [A-Z]*
+  )");
+  const auto compiled = Compile(grammar);
+
+  EXPECT_TRUE(Accepts(compiled, "key:VALUE/key"));
+  EXPECT_FALSE(Accepts(compiled, "key:VALUE/other"));
+}
+
+TEST(DynamicTagGrammarTest, RejectsAmbiguousOrEmptyRuntimeNames) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, ">", content, "</", ">")
+    name ::= [^]*
+    content ::= [A-Z]*
+  )");
+  const auto compiled = Compile(grammar);
+
+  EXPECT_TRUE(Accepts(compiled, "<key with space>VALUE</key with space>"));
+  EXPECT_FALSE(Accepts(compiled, "<>VALUE</>"));
+  EXPECT_FALSE(Accepts(compiled, "< \t>VALUE</ \t>"));
+  EXPECT_FALSE(Accepts(compiled, "<a>b>VALUE</a>b>"));
+  EXPECT_FALSE(Accepts(compiled, "</bad>VALUE<//bad>"));
+}
+
+TEST(DynamicTagGrammarTest, RejectsNameLanguageWithoutAnySafeName) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, ">", content, "</", ">")
+    name ::= "" | [ \t]+
+    content ::= "VALUE"
+  )");
+
+  EXPECT_ANY_THROW(Compile(grammar));
+}
+
+TEST(DynamicTagGrammarTest, MultiByteDelimiterHasAnUnambiguousCaptureBoundary) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, "::", content, "</", ">")
+    name ::= [^]*
+    content ::= [A-Z]*
+  )");
+  const auto compiled = Compile(grammar);
+
+  EXPECT_TRUE(Accepts(compiled, "<a:b::VALUE</a:b>"));
+  EXPECT_FALSE(Accepts(compiled, "<a:::VALUE</a:>"));
+  EXPECT_FALSE(Accepts(compiled, "<a::b::VALUE</a::b>"));
+}
+
+TEST(DynamicTagGrammarTest, BothOpeningAndClosingSuffixesBoundTheName) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, ":", content, "</", ">")
+    name ::= [^]*
+    content ::= "VALUE"
+  )");
+  const auto compiled = Compile(grammar);
+
+  EXPECT_TRUE(Accepts(compiled, "<key:VALUE</key>"));
+  EXPECT_FALSE(Accepts(compiled, "<a>b:VALUE</a>b>"));
+}
+
+TEST(DynamicTagGrammarTest, MultiByteSuffixOnlyRejectsActualBoundaryOverlap) {
+  const auto safe = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, "ab", content, "</", "ab")
+    name ::= [^]*
+    content ::= "VALUE"
+  )");
+  EXPECT_TRUE(Accepts(Compile(safe), "<aabVALUE</aab"));
+
+  const auto overlapping = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, "aa", content, "</", "aa")
+    name ::= [^]*
+    content ::= "VALUE"
+  )");
+  EXPECT_FALSE(Accepts(Compile(overlapping), "<aaaVALUE</aaa"));
+}
+
+TEST(DynamicTagGrammarTest, OpeningAndClosingPrefixesAreDistinguishableSymmetrically) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("</", name, ">", content, "<", ">")
+    name ::= [^>]+
+    content ::= "VALUE"
+  )");
+  const auto compiled = Compile(grammar);
+
+  EXPECT_TRUE(Accepts(compiled, "</key>VALUE<key>"));
+  EXPECT_FALSE(Accepts(compiled, "<//key>VALUE</key>"));
+}
+
+TEST(DynamicTagGrammarTest, DelimiterSafetyMatchesTheDocumentedNameLanguage) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, "ab", content, "</", ">")
+    name ::= [^]*
+    content ::= "VALUE"
+  )");
+  const auto compiled = Compile(grammar);
+  const std::string alphabet = "ab/x ";
+
+  std::vector<std::string> names{""};
+  for (int length = 1; length <= 4; ++length) {
+    const size_t begin = names.size();
+    std::vector<std::string> next;
+    if (length == 1) {
+      next.push_back("");
+    } else {
+      for (size_t index = begin; index-- > 0;) {
+        if (names[index].size() == static_cast<size_t>(length - 1)) {
+          next.push_back(names[index]);
+        }
+      }
+    }
+    for (const auto& prefix : next) {
+      for (char byte : alphabet) {
+        names.push_back(prefix + byte);
+      }
+    }
+  }
+
+  for (const std::string& name : names) {
+    const bool has_non_whitespace =
+        std::any_of(name.begin(), name.end(), [](char byte) { return byte != ' '; });
+    const bool expected = !name.empty() && has_non_whitespace && name.front() != '/' &&
+                          name.find("ab") == std::string::npos;
+    EXPECT_EQ(Accepts(compiled, "<" + name + "abVALUE</" + name + ">"), expected) << name;
+  }
+}
+
+TEST(DynamicTagGrammarTest, ExpandsLargeRegularNameRepetitions) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, ">", content, "</", ">")
+    name ::= [a-z]{1, 1200}
+    content ::= "VALUE"
+  )");
+  const auto compiled = Compile(grammar);
+  const std::string name(1200, 'a');
+
+  EXPECT_TRUE(Accepts(compiled, "<" + name + ">VALUE</" + name + ">"));
+  EXPECT_FALSE(Accepts(compiled, "<" + name + ">VALUE</short>"));
+}
+
+TEST(DynamicTagGrammarTest, RejectsCumulativeNameNfaExpansionBeyondTheStateLimit) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, ">", content, "</", ">")
+    name ::= part part part part part part
+    part ::= [a-z]{1, 20000}
+    content ::= "VALUE"
+  )");
+
+  EXPECT_ANY_THROW(Compile(grammar));
+}
+
+TEST(DynamicTagGrammarTest, PreservesBoundedRepetitionLanguageForCompoundNames) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, ">", content, "</", ">")
+    name ::= part{2, 4}
+    part ::= "a" | "bc"
+    content ::= "VALUE"
+  )");
+  const auto compiled = Compile(grammar);
+
+  EXPECT_TRUE(Accepts(compiled, "<abc>VALUE</abc>"));
+  EXPECT_TRUE(Accepts(compiled, "<bcbcbcbc>VALUE</bcbcbcbc>"));
+  EXPECT_FALSE(Accepts(compiled, "<a>VALUE</a>"));
+  EXPECT_FALSE(Accepts(compiled, "<aaaaa>VALUE</aaaaa>"));
+}
+
+TEST(DynamicTagGrammarTest, RejectsNonRegularNameRecursion) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, ">", content, "</", ">")
+    name ::= "x" | "a" name "b"
+    content ::= "VALUE"
+  )");
+
+  EXPECT_ANY_THROW(Compile(grammar));
+}
+
+TEST(DynamicTagGrammarTest, RejectsRuntimeMetadataOnNameRules) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, ">", content, "</", ">")
+    name[max_tokens=1, max_chars=2, lazy, capture="name", temperature=0.5] ::= [a-z]+
+    content ::= "VALUE"
+  )");
+
+  EXPECT_ANY_THROW(Compile(grammar));
+}
+
+TEST(DynamicTagGrammarTest, TokenMaskHandlesTokensCrossingEveryBoundary) {
+  const std::vector<std::string> vocab = {
+      "<key>VALUE</key>", "<key>VALUE</wrong>", "<other></other>"
+  };
+  const TokenizerInfo tokenizer_info(vocab, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto compiled = Compile(BasicDynamicTagGrammar(), tokenizer_info);
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+
+  const auto masked = GetMaskedTokens(&matcher, tokenizer_info);
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 0), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 1), masked.end());
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 2), masked.end());
+  EXPECT_TRUE(matcher.AcceptToken(0));
+  EXPECT_TRUE(matcher.IsCompleted());
+}
+
+TEST(DynamicTagGrammarTest, TokenMaskCrossesAnOrdinaryParentRule) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= "prefix:" element ":suffix"
+    element ::= DynamicTag("<", name, ">", content, "</", ">")
+    name ::= [a-z_][a-z0-9_]*
+    content ::= [A-Z]*
+  )");
+  const std::vector<std::string> vocab = {
+      "prefix:<key>VALUE</key>:suffix", "prefix:<key>VALUE</wrong>:suffix"
+  };
+  const TokenizerInfo tokenizer_info(vocab, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto compiled = Compile(grammar, tokenizer_info);
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+
+  const auto masked = GetMaskedTokens(&matcher, tokenizer_info);
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 0), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 1), masked.end());
+  EXPECT_TRUE(matcher.AcceptToken(0));
+  EXPECT_TRUE(matcher.IsCompleted());
+}
+
+TEST(DynamicTagGrammarTest, CaptureStartSurvivesAtomicAndBytePathMerge) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= Token(0) element | "<trigger>NO"
+    element ::= DynamicTag("", name, ":", content, "/", "")
+    name ::= [a-z]+
+    content ::= [A-Z]*
+  )");
+  const TokenizerInfo tokenizer_info(
+      {"<trigger>"}, VocabType::RAW, std::nullopt, std::vector<int32_t>{}
+  );
+  const auto compiled = Compile(grammar, tokenizer_info);
+
+  GrammarMatcher matching(compiled, std::nullopt, true);
+  ASSERT_TRUE(matching.AcceptToken(0));
+  EXPECT_TRUE(matching.AcceptString("key:VALUE/key"));
+  EXPECT_TRUE(matching.IsCompleted());
+
+  GrammarMatcher mismatching(compiled, std::nullopt, true);
+  ASSERT_TRUE(mismatching.AcceptToken(0));
+  EXPECT_FALSE(mismatching.AcceptString("key:VALUE/wrong"));
+}
+
+TEST(DynamicTagGrammarTest, ParentCompletionSurvivesAtomicAndBytePathMerge) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= Token(0) element "!" | "<trigger>NO"
+    element ::= DynamicTag("", name, ":", content, "/", "")
+    name ::= [a-z]+
+    content ::= [A-Z]*
+  )");
+  const TokenizerInfo tokenizer_info(
+      {"<trigger>"}, VocabType::RAW, std::nullopt, std::vector<int32_t>{}
+  );
+  const auto compiled = Compile(grammar, tokenizer_info);
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+
+  ASSERT_TRUE(matcher.AcceptToken(0));
+  ASSERT_TRUE(matcher.AcceptString("key:VALUE/key"));
+  EXPECT_TRUE(matcher.AcceptString("!"));
+  EXPECT_TRUE(matcher.IsCompleted());
+}
+
+TEST(DynamicTagGrammarTest, TokenMaskKeepsDynamicEqualityBranchLocalAcrossUnion) {
+  const auto grammar =
+      Grammar::Union({Grammar::FromEBNF(R"(root ::= "plain")"), BasicDynamicTagGrammar()});
+  const std::vector<std::string> vocab = {"plain", "<key>VALUE</key>", "<key>VALUE</wrong>"};
+  const TokenizerInfo tokenizer_info(vocab, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto compiled = Compile(grammar, tokenizer_info);
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+
+  const auto masked = GetMaskedTokens(&matcher, tokenizer_info);
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 0), masked.end());
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 1), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 2), masked.end());
+}
+
+TEST(DynamicTagGrammarTest, TokenMaskTracksNestedCapturesInsideOneToken) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= element
+    element ::= DynamicTag("<", name, ">", content, "</", ">")
+    name ::= [a-z]+
+    content ::= [A-Z]* | element+
+  )");
+  const std::vector<std::string> vocab = {
+      "<outer><left>A</left><right>B</right></outer>",
+      "<outer><left>A</wrong><right>B</right></outer>",
+      "<outer><left>A</left><right>B</right></wrong>"
+  };
+  const TokenizerInfo tokenizer_info(vocab, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto compiled = Compile(grammar, tokenizer_info);
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+
+  const auto masked = GetMaskedTokens(&matcher, tokenizer_info);
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 0), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 1), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 2), masked.end());
+}
+
+TEST(DynamicTagGrammarTest, TokenMaskUsesTheOccurrenceLocalCapturedName) {
+  const std::vector<std::string> vocab = {"alpha>", "beta>", "wrong>"};
+  const TokenizerInfo tokenizer_info(vocab, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto compiled = Compile(BasicDynamicTagGrammar(), tokenizer_info);
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+  ASSERT_TRUE(matcher.AcceptString("<alpha>VALUE</"));
+
+  const auto masked = GetMaskedTokens(&matcher, tokenizer_info);
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 0), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 1), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 2), masked.end());
+}
+
+TEST(DynamicTagGrammarTest, BackReferenceMaskSlicesTheCompleteByteAlphabetSafely) {
+  std::vector<std::string> vocab;
+  vocab.reserve(258);
+  for (int32_t byte = 0; byte < 256; ++byte) {
+    vocab.push_back(std::string(1, static_cast<char>(byte)) + "suffix");
+  }
+  const int32_t matching_token = vocab.size();
+  vocab.push_back("x>");
+  const int32_t wrong_same_prefix_token = vocab.size();
+  vocab.push_back("xwrong>");
+
+  const TokenizerInfo tokenizer_info(vocab, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto compiled = Compile(BasicDynamicTagGrammar(), tokenizer_info);
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+  ASSERT_TRUE(matcher.AcceptString("<x>VALUE</"));
+
+  const auto masked = GetMaskedTokens(&matcher, tokenizer_info);
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), matching_token), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), wrong_same_prefix_token), masked.end());
+  for (int32_t token_id = 0; token_id < 256; ++token_id) {
+    EXPECT_NE(std::find(masked.begin(), masked.end(), token_id), masked.end()) << token_id;
+  }
+}
+
+TEST(DynamicTagGrammarTest, BackReferenceMaskSlicesUtf8FirstBytesSafely) {
+  const std::vector<std::string> vocab = {"城市>", "天气>", "城wrong>", "x>"};
+  const TokenizerInfo tokenizer_info(vocab, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, ">", content, "</", ">")
+    name ::= [^>/]+
+    content ::= "VALUE"
+  )");
+  const auto compiled = Compile(grammar, tokenizer_info);
+  GrammarMatcher matcher(compiled, std::nullopt, true);
+  ASSERT_TRUE(matcher.AcceptString("<城市>VALUE</"));
+
+  const auto masked = GetMaskedTokens(&matcher, tokenizer_info);
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 0), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 1), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 2), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 3), masked.end());
+}
+
+TEST(DynamicTagGrammarTest, BackReferenceFastPathNeverAdmitsStopOrSpecialTokensEarly) {
+  const std::vector<std::string> vocab = {"key>", "<stop>", ""};
+  const TokenizerInfo tokenizer_info(vocab, VocabType::RAW, std::nullopt, std::vector<int32_t>{1});
+  const auto compiled = Compile(BasicDynamicTagGrammar(), tokenizer_info);
+  GrammarMatcher matcher(compiled, std::nullopt, false);
+  ASSERT_TRUE(matcher.AcceptString("<key>VALUE</"));
+
+  const auto masked = GetMaskedTokens(&matcher, tokenizer_info);
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 0), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 1), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 2), masked.end());
+}
+
+TEST(DynamicTagGrammarTest, RejectsTokenizerDependentNameGrammar) {
+  const auto grammar = Grammar::FromEBNF(R"(
+    root ::= DynamicTag("<", name, ">", content, "</", ">")
+    name ::= Token(0) | [a-z]+
+    content ::= "VALUE"
+  )");
+  const TokenizerInfo tokenizer_info(
+      {"alpha"}, VocabType::RAW, std::nullopt, std::vector<int32_t>{}
+  );
+  EXPECT_ANY_THROW(Compile(grammar, tokenizer_info));
+}
+
+TEST(DynamicTagGrammarTest, ForkAndRollbackKeepIndependentCaptureState) {
+  const std::vector<std::string> vocab = {"alpha>", "beta>"};
+  const TokenizerInfo tokenizer_info(vocab, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto compiled = Compile(BasicDynamicTagGrammar(), tokenizer_info);
+  GrammarMatcher original(compiled, std::nullopt, true);
+  ASSERT_TRUE(original.AcceptString("<alpha>VALUE</"));
+
+  auto fork = original.Fork();
+  EXPECT_TRUE(fork.AcceptToken(0));
+  EXPECT_TRUE(fork.IsCompleted());
+  fork.Rollback();
+  EXPECT_TRUE(fork.AcceptToken(0));
+  EXPECT_FALSE(original.AcceptToken(1));
+  EXPECT_TRUE(original.AcceptToken(0));
+}
+
+TEST(DynamicTagGrammarTest, GrammarAndCompiledGrammarRoundTrip) {
+  const auto grammar = BasicDynamicTagGrammar();
+  const std::string printed = grammar.ToString();
+  EXPECT_NE(printed.find("DynamicTag("), std::string::npos);
+  const auto reparsed = Grammar::FromEBNF(printed);
+  EXPECT_TRUE(Accepts(Compile(reparsed), "<key>VALUE</key>"));
+  EXPECT_FALSE(Accepts(Compile(reparsed), "<key>VALUE</wrong>"));
+
+  auto grammar_result = Grammar::DeserializeJSON(grammar.SerializeJSON());
+  ASSERT_TRUE(std::holds_alternative<Grammar>(grammar_result));
+  const auto recovered_grammar = std::get<Grammar>(grammar_result);
+  EXPECT_EQ(recovered_grammar.SerializeJSON(), grammar.SerializeJSON());
+
+  const TokenizerInfo tokenizer_info(
+      {"key>", "wrong>"}, VocabType::RAW, std::nullopt, std::vector<int32_t>{}
+  );
+  const auto compiled = Compile(recovered_grammar, tokenizer_info);
+  auto compiled_result = CompiledGrammar::DeserializeJSON(compiled.SerializeJSON(), tokenizer_info);
+  ASSERT_TRUE(std::holds_alternative<CompiledGrammar>(compiled_result));
+  const auto recovered_compiled = std::get<CompiledGrammar>(compiled_result);
+  EXPECT_EQ(recovered_compiled.SerializeJSON(), compiled.SerializeJSON());
+
+  GrammarMatcher matcher(recovered_compiled, std::nullopt, true);
+  ASSERT_TRUE(matcher.AcceptString("<key>VALUE</"));
+  const auto masked = GetMaskedTokens(&matcher, tokenizer_info);
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 0), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 1), masked.end());
+}
+
+TEST(DynamicTagGrammarTest, UniqueKeyMetadataSurvivesGrammarAndCompiledGrammarRoundTrip) {
+  const auto grammar = UniqueKeyDynamicTagGrammar();
+  const std::string printed = grammar.ToString();
+  const auto reparsed = Grammar::FromEBNF(printed);
+  EXPECT_TRUE(Accepts(Compile(reparsed), "<a>A</a><b>B</b>"));
+  EXPECT_FALSE(Accepts(Compile(reparsed), "<a>A</a><a>B</a>"));
+  EXPECT_FALSE(Accepts(Compile(reparsed), "<fixed>A</fixed>"));
+
+  auto grammar_result = Grammar::DeserializeJSON(grammar.SerializeJSON());
+  ASSERT_TRUE(std::holds_alternative<Grammar>(grammar_result));
+  const auto recovered_grammar = std::get<Grammar>(grammar_result);
+  EXPECT_EQ(recovered_grammar.SerializeJSON(), grammar.SerializeJSON());
+  EXPECT_TRUE(Accepts(Compile(recovered_grammar), "<a>A</a><b>B</b>"));
+  EXPECT_FALSE(Accepts(Compile(recovered_grammar), "<a>A</a><a>B</a>"));
+  EXPECT_FALSE(Accepts(Compile(recovered_grammar), "<fixed>A</fixed>"));
+
+  const TokenizerInfo tokenizer_info(
+      {"a>", "b>", "fixed>"}, VocabType::RAW, std::nullopt, std::vector<int32_t>{}
+  );
+  const auto compiled = Compile(recovered_grammar, tokenizer_info);
+  auto compiled_result = CompiledGrammar::DeserializeJSON(compiled.SerializeJSON(), tokenizer_info);
+  ASSERT_TRUE(std::holds_alternative<CompiledGrammar>(compiled_result));
+  const auto recovered_compiled = std::get<CompiledGrammar>(compiled_result);
+  EXPECT_EQ(recovered_compiled.SerializeJSON(), compiled.SerializeJSON());
+
+  GrammarMatcher matcher(recovered_compiled, std::nullopt, true);
+  ASSERT_TRUE(matcher.AcceptString("<a>A</a><"));
+  const auto masked = GetMaskedTokens(&matcher, tokenizer_info);
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 0), masked.end());
+  EXPECT_EQ(std::find(masked.begin(), masked.end(), 1), masked.end());
+  EXPECT_NE(std::find(masked.begin(), masked.end(), 2), masked.end());
+  ASSERT_TRUE(matcher.AcceptToken(1));
+  EXPECT_TRUE(matcher.AcceptString("B</b>"));
+  EXPECT_TRUE(matcher.IsCompleted());
+}
+
+TEST(DynamicTagGrammarTest, SharedCompiledGrammarIsThreadSafe) {
+  const std::vector<std::string> vocab = {"alpha>", "beta>", "wrong>"};
+  const TokenizerInfo tokenizer_info(vocab, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto compiled = Compile(BasicDynamicTagGrammar(), tokenizer_info);
+  std::vector<std::future<bool>> futures;
+  futures.reserve(kNumThreads);
+
+  for (int thread_id = 0; thread_id < kNumThreads; ++thread_id) {
+    futures.push_back(std::async(std::launch::async, [compiled, thread_id] {
+      const std::string name = thread_id % 2 == 0 ? "alpha" : "beta";
+      for (int iteration = 0; iteration < kThreadIterations; ++iteration) {
+        GrammarMatcher matcher(compiled, std::nullopt, true);
+        if (!matcher.AcceptString("<" + name + ">VALUE</" + name + ">") || !matcher.IsCompleted()) {
+          return false;
+        }
+        GrammarMatcher invalid(compiled, std::nullopt, true);
+        if (invalid.AcceptString("<" + name + ">VALUE</wrong>")) {
+          return false;
+        }
+      }
+      return true;
+    }));
+  }
+
+  for (auto& future : futures) {
+    EXPECT_TRUE(future.get());
+  }
+}
+
+TEST(DynamicTagGrammarTest, UniqueKeyStateIsThreadLocal) {
+  const auto compiled = Compile(UniqueKeyDynamicTagGrammar());
+  std::vector<std::future<bool>> futures;
+  futures.reserve(kNumThreads);
+
+  for (int thread_id = 0; thread_id < kNumThreads; ++thread_id) {
+    futures.push_back(std::async(std::launch::async, [compiled, thread_id] {
+      const std::string first = thread_id % 2 == 0 ? "alpha" : "beta";
+      for (int iteration = 0; iteration < kThreadIterations; ++iteration) {
+        GrammarMatcher valid(compiled, std::nullopt, true);
+        if (!valid.AcceptString("<" + first + ">A</" + first + "><other>B</other>") ||
+            !valid.IsCompleted()) {
+          return false;
+        }
+        GrammarMatcher duplicate(compiled, std::nullopt, true);
+        if (duplicate.AcceptString(
+                "<" + first + ">A</" + first + "><" + first + ">B</" + first + ">"
+            )) {
+          return false;
+        }
+      }
+      return true;
+    }));
+  }
+
+  for (auto& future : futures) {
+    EXPECT_TRUE(future.get());
+  }
+}
+
+TEST(DynamicTagGrammarTest, ConcurrentForksDetachUniqueKeyStorageBeforeMutation) {
+  const auto compiled = Compile(UniqueKeyDynamicTagGrammar());
+  GrammarMatcher original(compiled, std::nullopt, true);
+  ASSERT_TRUE(original.AcceptString("<seed>A</seed>"));
+
+  std::vector<std::future<bool>> futures;
+  futures.reserve(kNumThreads);
+  for (int thread_id = 0; thread_id < kNumThreads; ++thread_id) {
+    auto fork = original.Fork();
+    futures.push_back(std::async(std::launch::async, [fork = std::move(fork), thread_id]() mutable {
+      for (int iteration = 0; iteration < kThreadIterations; ++iteration) {
+        const std::string name =
+            "thread_" + std::to_string(thread_id) + "_key_" + std::to_string(iteration);
+        if (!fork.AcceptString("<" + name + ">B</" + name + ">")) {
+          return false;
+        }
+      }
+      return fork.IsCompleted() && !fork.AcceptString("<seed>B</seed>");
+    }));
+  }
+
+  for (auto& future : futures) {
+    EXPECT_TRUE(future.get());
+  }
+  EXPECT_TRUE(original.AcceptString("<base>B</base>"));
+  EXPECT_FALSE(original.AcceptString("<seed>B</seed>"));
+}
+
+TEST(DynamicTagGrammarTest, BatchMaskingUsesOnlyMatcherLocalCaptureState) {
+  const std::vector<std::string> vocab = {"alpha>", "beta>", "wrong>"};
+  const TokenizerInfo tokenizer_info(vocab, VocabType::RAW, std::nullopt, std::vector<int32_t>{});
+  const auto compiled = Compile(BasicDynamicTagGrammar(), tokenizer_info);
+  std::vector<GrammarMatcher> matchers;
+  for (int index = 0; index < 16; ++index) {
+    const std::string name = index % 2 == 0 ? "alpha" : "beta";
+    GrammarMatcher matcher(compiled, std::nullopt, true);
+    EXPECT_TRUE(matcher.AcceptString("<" + name + ">VALUE</"));
+    matchers.push_back(std::move(matcher));
+  }
+
+  const int32_t bitmask_size = GetBitmaskSize(tokenizer_info.GetVocabSize());
+  std::vector<int32_t> bitmask_data(matchers.size() * bitmask_size);
+  int64_t shape[2] = {static_cast<int64_t>(matchers.size()), bitmask_size};
+  DLTensor bitmask{};
+  bitmask.data = bitmask_data.data();
+  bitmask.device = DLDevice{kDLCPU, 0};
+  bitmask.ndim = 2;
+  bitmask.dtype = GetBitmaskDLType();
+  bitmask.shape = shape;
+
+  BatchGrammarMatcher batch_matcher(4);
+  batch_matcher.BatchFillNextTokenBitmask(&matchers, &bitmask);
+  for (int index = 0; index < static_cast<int>(matchers.size()); ++index) {
+    std::vector<int> masked;
+    _DebugGetMaskedTokensFromBitmask(&masked, bitmask, tokenizer_info.GetVocabSize(), index);
+    const int expected = index % 2;
+    EXPECT_EQ(std::find(masked.begin(), masked.end(), expected), masked.end());
+    EXPECT_NE(std::find(masked.begin(), masked.end(), 1 - expected), masked.end());
+    EXPECT_NE(std::find(masked.begin(), masked.end(), 2), masked.end());
+  }
+}
+
+}  // namespace
+}  // namespace xgrammar

--- a/tests/cpp/test_fsm.cc
+++ b/tests/cpp/test_fsm.cc
@@ -282,6 +282,44 @@ TEST(XGrammarFSMTest, FunctionTest) {
   std::cout << "--------- Function Test Passed! -----------" << std::endl;
 }
 
+TEST(XGrammarFSMTest, IntersectRejectsTokenDependentEdges) {
+  FSM token_fsm(2);
+  token_fsm.AddTokenEdge(0, 1, {7});
+  FSM byte_fsm(2);
+  byte_fsm.AddEdge(0, 1, 'a', 'z');
+
+  auto result = FSMWithStartEnd::Intersect(
+      FSMWithStartEnd(std::move(token_fsm), 0, {1}), FSMWithStartEnd(std::move(byte_fsm), 0, {1})
+  );
+  ASSERT_TRUE(result.IsErr());
+  EXPECT_EQ(
+      std::string(std::move(result).UnwrapErr().what()), "Intersect only supports byte-regular FSMs"
+  );
+}
+
+TEST(XGrammarFSMTest, ToDFAEnforcesResultStateLimit) {
+  // This three-state NFA has four reachable DFA subsets: {0}, {0, 1}, {0, 2}, and {0, 1, 2}.
+  FSM nfa(3);
+  nfa.AddEdge(0, 0, 'a', 'b');
+  nfa.AddEdge(0, 1, 'a', 'a');
+  nfa.AddEdge(1, 2, 'a', 'b');
+  FSMWithStartEnd grammar(std::move(nfa), 0, {2});
+
+  EXPECT_TRUE(grammar.ToDFA(/*max_num_states=*/3).IsErr());
+  auto dfa = grammar.ToDFA(/*max_num_states=*/4);
+  ASSERT_TRUE(dfa.IsOk()) << std::move(dfa).UnwrapErr().what();
+  EXPECT_EQ(std::move(dfa).Unwrap().NumStates(), 4);
+}
+
+TEST(XGrammarFSMTest, RegularTransformationsRejectRuntimeDependentEdges) {
+  FSM runtime_fsm(2);
+  runtime_fsm.AddCaptureStartEdge(0, 1);
+  FSMWithStartEnd grammar(std::move(runtime_fsm), 0, {1});
+
+  EXPECT_TRUE(grammar.ToDFA().IsErr());
+  EXPECT_TRUE(grammar.MinimizeDFA().IsErr());
+}
+
 TEST(XGrammarFSMTest, EfficiencyTest) {
   std::cout << "--------- Efficiency Test Starts! -----------" << std::endl;
   // i.e ([a-z]0123456789){10}. Use this way to test the performance.

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -2333,6 +2333,41 @@ def test_minimax_m3_auto_without_tools_forbids_tool_calls_but_not_namespace_text
         check_stag_with_instance(structural_tag, _M3_SEARCH_CALL, False)
 
 
+@pytest.mark.parametrize(
+    "function",
+    [
+        {"name": "dynamic"},
+        {
+            "name": "dynamic",
+            "strict": False,
+            "parameters": {
+                "type": "object",
+                "properties": {"fixed": {"type": "integer"}},
+                "required": ["fixed"],
+                "additionalProperties": False,
+            },
+        },
+    ],
+)
+def test_minimax_m3_unconstrained_tool_parameters_keep_object_shape(function: Dict[str, Any]):
+    structural_tag = get_model_structural_tag(
+        "minimax_m3",
+        tools=[{"type": "function", "function": function}],
+        tool_choice="required",
+        reasoning=False,
+    )
+    assert _collect_json_schema_values(structural_tag) == [
+        {"type": "object", "additionalProperties": True}
+    ]
+
+    grammar = xgr.Grammar.from_structural_tag(structural_tag)
+    assert _is_grammar_accept_string(
+        grammar, _m3_tool_call(_m3_invoke("dynamic", _m3_element("runtime", "value")))
+    )
+    assert not _is_grammar_accept_string(grammar, _m3_tool_call(_m3_invoke("dynamic", "value")))
+    assert _is_grammar_accept_string(grammar, _m3_tool_call(_m3_invoke("dynamic", "")))
+
+
 # ---------- Test: any_order propagation ----------
 
 

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -2,7 +2,7 @@
 
 import re
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import pytest
 from transformers import AutoTokenizer
@@ -19,6 +19,7 @@ from xgrammar.builtin_structural_tag import (
     get_kimi_k3_structural_tag,
     get_kimi_structural_tag,
     get_llama_structural_tag,
+    get_minimax_m3_structural_tag,
     get_minimax_structural_tag,
     get_model_structural_tag,
     get_qwen_3_5_structural_tag,
@@ -27,7 +28,14 @@ from xgrammar.builtin_structural_tag import (
     normalize_tool_choice,
 )
 from xgrammar.openai_tool_call_schema import BuiltinToolParam, FunctionToolParam
-from xgrammar.structural_tag import JSONSchemaFormat, StructuralTag, TagFormat
+from xgrammar.structural_tag import (
+    ConstStringFormat,
+    JSONSchemaFormat,
+    OptionalFormat,
+    SequenceFormat,
+    StructuralTag,
+    TagFormat,
+)
 from xgrammar.testing import _is_grammar_accept_string
 
 
@@ -58,7 +66,7 @@ def _input_dict_to_get_stag_kwargs(format_type: str, input_dict: Dict[str, Any])
     return {
         "model": format_type,
         "tools": tools,
-        "reasoning": input_dict.get("reasoning", input_dict.get("reasoning", True)),
+        "reasoning": input_dict.get("reasoning", True),
         "tool_choice": tool_choice,
     }
 
@@ -201,6 +209,7 @@ _builtin_harmony = make_tools(["analysis_tool"])
 _tools_deepseek_v3_2 = make_tools(["search"])
 _tools_deepseek_v4 = make_tools(["search"])
 _tools_minimax = make_tools(["search"])
+_tools_minimax_m3 = make_tools(["search"])
 _tools_glm_4_7 = make_tools(["search"])
 _tools_cohere = make_tools(["search"])
 
@@ -212,6 +221,7 @@ _tools_deepseek_pair = make_tools(["search", "alt"])
 _tools_deepseek_v3_2_pair = make_tools(["search", "alt"])
 _tools_deepseek_v4_pair = make_tools(["search", "alt"])
 _tools_minimax_pair = make_tools(["search", "alt"])
+_tools_minimax_m3_pair = make_tools(["search", "alt"])
 _tools_qwen_3_coder_pair = make_tools(["run_sql", "run_py"])
 _tools_qwen_3_pair = make_tools(["t1", "t2"])
 _tools_qwen_3_5_pair = make_tools(["run_sql", "run_py"])
@@ -243,6 +253,81 @@ def test_unknown_format_is_checked_before_tool_inputs():
 
 
 # ---------- Test: input validation errors ----------
+
+
+@pytest.mark.parametrize(("boolean_value", "mode"), [(True, "enabled"), (False, "disabled")])
+def test_reasoning_boolean_aliases(boolean_value: bool, mode: Literal["enabled", "disabled"]):
+    by_boolean = get_model_structural_tag("qwen_3", tools=[], reasoning=boolean_value)
+    by_mode = get_model_structural_tag("qwen_3", tools=[], reasoning=mode)
+    assert by_boolean == by_mode
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "llama",
+        "kimi",
+        "kimi_k3",
+        "deepseek_r1",
+        "deepseek_v3_1",
+        "qwen_3_5",
+        "qwen_3_coder",
+        "qwen_3",
+        "harmony",
+        "deepseek_v3_2",
+        "minimax",
+        "minimax_m3",
+        "glm_4_7",
+        "deepseek_v4",
+        "cohere",
+        "exaone",
+    ],
+)
+def test_reasoning_auto_builds_for_every_model(model: str):
+    structural_tag = get_model_structural_tag(model, tools=[], reasoning="auto")
+    xgr.Grammar.from_structural_tag(structural_tag)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "kimi",
+        "kimi_k3",
+        "deepseek_r1",
+        "deepseek_v3_1",
+        "qwen_3_5",
+        "qwen_3_coder",
+        "qwen_3",
+        "deepseek_v3_2",
+        "minimax",
+        "minimax_m3",
+        "glm_4_7",
+        "deepseek_v4",
+        "cohere",
+        "exaone",
+    ],
+)
+def test_reasoning_auto_uses_an_optional_complete_prefix(model: str):
+    structural_tag = get_model_structural_tag(model, tools=[], reasoning="auto")
+    assert isinstance(structural_tag.format, SequenceFormat)
+    assert isinstance(structural_tag.format.elements[0], OptionalFormat)
+
+
+@pytest.mark.parametrize(
+    "model", ["kimi", "deepseek_r1", "deepseek_v3_1", "deepseek_v3_2", "deepseek_v4", "glm_4_7"]
+)
+def test_standard_reasoning_auto_accepts_complete_reasoning_or_direct_response(model: str):
+    structural_tag = get_model_structural_tag(model, tools=[], reasoning="auto")
+    grammar = xgr.Grammar.from_structural_tag(structural_tag)
+    assert _is_grammar_accept_string(grammar, "answer")
+    assert _is_grammar_accept_string(grammar, "<think>plan</think>answer")
+    assert not _is_grammar_accept_string(grammar, "plan</think>answer")
+
+
+def test_invalid_reasoning_mode_is_rejected():
+    with pytest.raises(ValueError, match="enabled.*disabled.*auto"):
+        get_model_structural_tag("qwen_3", tools=[], reasoning="invalid")  # type: ignore[arg-type]
+
 
 # (format_type, input_dict, substring that must appear in the error message)
 input_validation_error_cases: List[Tuple[str, Dict[str, Any], str]] = [
@@ -782,6 +867,20 @@ def test_kimi_k3_reasoning_false_starts_inside_the_response_block():
     )
 
 
+def test_kimi_k3_reasoning_auto_starts_before_think_or_response_block():
+    """Adaptive prompts have not opened either block, so both complete paths are legal."""
+
+    structural_tag = get_model_structural_tag("kimi_k3", tools=[], reasoning="auto")
+    response = "<|open|>response<|sep|>answer<|close|>response<|sep|><|close|>message<|sep|>"
+    check_stag_with_instance(structural_tag, response, True)
+    check_stag_with_instance(
+        structural_tag, "<|open|>think<|sep|>plan<|close|>think<|sep|>" + response, True
+    )
+    check_stag_with_instance(
+        structural_tag, "answer<|close|>response<|sep|><|close|>message<|sep|>", False
+    )
+
+
 def test_kimi_k3_no_tools_rejects_tools_section():
     """Without tools the grammar must not admit a tools section at all."""
 
@@ -1103,6 +1202,40 @@ def test_cohere_reasoning_prefix_uses_end_thinking_token():
 
 
 @pytest.mark.parametrize(
+    ("model", "reasoning_output", "direct_output"),
+    [
+        ("minimax", "<think>plan</think>\n\nanswer", "answer"),
+        ("cohere", "<|START_THINKING|>plan<|END_THINKING|>answer", "answer"),
+        ("exaone", "<think>plan</think>\n\nanswer", "answer"),
+    ],
+)
+def test_custom_reasoning_auto_accepts_complete_reasoning_or_direct_response(
+    model: str, reasoning_output: str, direct_output: str
+):
+    structural_tag = get_model_structural_tag(model, tools=[], reasoning="auto")
+    check_stag_with_instance(structural_tag, reasoning_output, True)
+    check_stag_with_instance(structural_tag, direct_output, True)
+
+
+@pytest.mark.parametrize("model", ["qwen_3", "qwen_3_5"])
+def test_qwen_reasoning_suffix_stays_inside_the_optional_prefix(model: str):
+    structural_tag = get_model_structural_tag(model, tools=[], reasoning="auto")
+    assert isinstance(structural_tag.format, SequenceFormat)
+
+    optional_prefix = structural_tag.format.elements[0]
+    assert isinstance(optional_prefix, OptionalFormat)
+    assert isinstance(optional_prefix.content, SequenceFormat)
+    assert isinstance(optional_prefix.content.elements[0], TagFormat)
+    assert optional_prefix.content.elements[0].end == "</think>"
+    assert optional_prefix.content.elements[1] == ConstStringFormat(value="\n\n")
+
+    grammar = xgr.Grammar.from_structural_tag(structural_tag)
+    assert _is_grammar_accept_string(grammar, "answer")
+    assert _is_grammar_accept_string(grammar, "<think>reasoning</think>\n\nanswer")
+    assert not _is_grammar_accept_string(grammar, "<think>reasoning</think>answer")
+
+
+@pytest.mark.parametrize(
     "structural_tag_fn",
     [
         get_llama_structural_tag,
@@ -1186,7 +1319,7 @@ def test_specific_functions_cases(structural_tag_fn, case: Dict[str, Any]):
         tools=case["tools"],
         builtin_tools=case["builtin_tools"],
         tool_choice=case["tool_choice"],
-        reasoning=True,
+        reasoning="enabled",
     )
     assert isinstance(structural_tag, StructuralTag)
     xgr.Grammar.from_structural_tag(structural_tag)
@@ -2110,6 +2243,96 @@ def test_required_allows_termination_with_trailing_text(stag_key, one_call, two_
     ), f"{stag_key}: tool call + trailing text rejected"
 
 
+# ---------- Test: MiniMax M3 ----------
+
+_M3_NS = "]<]minimax[>["
+
+
+def _m3_element(name: str, value: str) -> str:
+    return f"{_M3_NS}<{name}>{value}{_M3_NS}</{name}>"
+
+
+def _m3_invoke(name: str, body: str) -> str:
+    return f'{_M3_NS}<invoke name="{name}">{body}{_M3_NS}</invoke>\n'
+
+
+def _m3_tool_call(*invokes: str) -> str:
+    return f"{_M3_NS}<tool_call>\n{''.join(invokes)}{_M3_NS}</tool_call>"
+
+
+_M3_SEARCH_CALL = _m3_tool_call(_m3_invoke("search", _m3_element("q", "weather")))
+
+
+def test_minimax_m3_reasoning_modes():
+    enabled = get_model_structural_tag("minimax_m3", tools=_tools_minimax_m3, reasoning="enabled")
+    check_stag_with_instance(enabled, "plan</mm:think>answer", True)
+    check_stag_with_instance(enabled, "plan</mm:think>" + _M3_SEARCH_CALL, True)
+    check_stag_with_instance(enabled, "answer", False)
+    check_stag_with_instance(enabled, "<mm:think>plan</mm:think>answer", False)
+
+    disabled = get_model_structural_tag("minimax_m3", tools=_tools_minimax_m3, reasoning="disabled")
+    check_stag_with_instance(disabled, "answer", True)
+    check_stag_with_instance(disabled, _M3_SEARCH_CALL, True)
+    check_stag_with_instance(disabled, "plan</mm:think>answer", False)
+
+    adaptive = get_model_structural_tag("minimax_m3", tools=_tools_minimax_m3, reasoning="auto")
+    check_stag_with_instance(adaptive, "answer", True)
+    check_stag_with_instance(adaptive, _M3_SEARCH_CALL, True)
+    check_stag_with_instance(adaptive, "<mm:think>plan</mm:think>answer", True)
+    check_stag_with_instance(adaptive, "<mm:think>plan</mm:think>" + _M3_SEARCH_CALL, True)
+    check_stag_with_instance(adaptive, "plan</mm:think>answer", False)
+
+
+def test_minimax_m3_reasoning_defaults_and_validation():
+    default_enabled = get_model_structural_tag("minimax_m3", tools=[])
+    assert default_enabled == get_model_structural_tag("minimax_m3", tools=[], reasoning="enabled")
+    assert default_enabled == get_model_structural_tag("minimax_m3", tools=[], reasoning=True)
+
+    direct_auto = get_minimax_m3_structural_tag(tools=[])
+    assert direct_auto == get_minimax_m3_structural_tag(tools=[], reasoning="auto")
+    assert isinstance(direct_auto.format, SequenceFormat)
+    assert isinstance(direct_auto.format.elements[0], OptionalFormat)
+
+    direct_disabled = get_minimax_m3_structural_tag(tools=[], reasoning="disabled")
+    assert not isinstance(direct_disabled.format, SequenceFormat)
+
+    with pytest.raises(ValueError, match="reasoning"):
+        get_minimax_m3_structural_tag(tools=[], reasoning="invalid")  # type: ignore[arg-type]
+
+
+def test_minimax_m3_required_and_forced_tool_choice():
+    required = get_model_structural_tag(
+        "minimax_m3", tools=_tools_minimax_m3_pair, tool_choice="required", reasoning=False
+    )
+    search = _m3_invoke("search", _m3_element("q", "weather"))
+    alt = _m3_invoke("alt", _m3_element("q", "time"))
+    check_stag_with_instance(required, "plain text", False)
+    check_stag_with_instance(required, _m3_tool_call(search), True)
+    check_stag_with_instance(required, _m3_tool_call(search, alt), True)
+    check_stag_with_instance(required, _m3_tool_call(search + "\n", alt), False)
+    check_stag_with_instance(required, _m3_tool_call(search) + " done", True)
+
+    forced = get_model_structural_tag(
+        "minimax_m3",
+        tools=_tools_minimax_m3_pair,
+        tool_choice={"type": "function", "function": {"name": "alt"}},
+        reasoning=False,
+    )
+    check_stag_with_instance(forced, _m3_tool_call(alt), True)
+    check_stag_with_instance(forced, _m3_tool_call(search), False)
+    check_stag_with_instance(forced, _m3_tool_call(alt, alt), False)
+
+
+def test_minimax_m3_auto_without_tools_forbids_tool_calls_but_not_namespace_text():
+    no_tools = get_model_structural_tag("minimax_m3", tools=[], reasoning=False)
+    choice_none = get_model_structural_tag(
+        "minimax_m3", tools=_tools_minimax_m3, tool_choice="none", reasoning=False
+    )
+    for structural_tag in (no_tools, choice_none):
+        check_stag_with_instance(structural_tag, "plain " + _M3_NS + " text", True)
+        check_stag_with_instance(structural_tag, _M3_SEARCH_CALL, False)
+
+
 # ---------- Test: any_order propagation ----------
 
 
@@ -2134,6 +2357,7 @@ _ANY_ORDER_MODELS = [
     "deepseek_v3_2",
     "deepseek_v4",
     "minimax",
+    "minimax_m3",
     "glm_4_7",
     "harmony",
     "exaone",

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -2452,7 +2452,76 @@ def test_true_schema():
     assert not _is_grammar_accept_string(ebnf_grammar, "anything")
 
 
-# ---------- MiniMax M3 fixed-name recursive XML ----------
+ROOT_SELF_REF_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "child": {"anyOf": [{"type": "null"}, {"$ref": "#"}]},
+    },
+    "required": ["name", "child"],
+    "additionalProperties": False,
+}
+
+
+@pytest.mark.parametrize(
+    "json_format, nested_json, nested_xml",
+    [
+        (
+            "qwen_xml",
+            '<parameter=name>root</parameter><parameter=child>{"name": "leaf", "child": null}</parameter>',
+            "<parameter=name>root</parameter><parameter=child>"
+            "<parameter=name>leaf</parameter><parameter=child>null</parameter></parameter>",
+        ),
+        (
+            "minimax_xml",
+            '<parameter name="name">root</parameter><parameter name="child">'
+            '{"name": "leaf", "child": null}</parameter>',
+            '<parameter name="name">root</parameter><parameter name="child">'
+            '<parameter name="name">leaf</parameter><parameter name="child">null</parameter>'
+            "</parameter>",
+        ),
+        (
+            "deepseek_xml",
+            '<｜DSML｜parameter name="name" string="true">root</｜DSML｜parameter>'
+            '<｜DSML｜parameter name="child" string="false">'
+            '{"name": "leaf", "child": null}</｜DSML｜parameter>',
+            '<｜DSML｜parameter name="name" string="true">root</｜DSML｜parameter>'
+            '<｜DSML｜parameter name="child" string="false">'
+            '<｜DSML｜parameter name="name" string="true">leaf</｜DSML｜parameter>'
+            '<｜DSML｜parameter name="child" string="false">null</｜DSML｜parameter>'
+            "</｜DSML｜parameter>",
+        ),
+        (
+            "glm_xml",
+            "<arg_key>name</arg_key><arg_value>root</arg_value>"
+            '<arg_key>child</arg_key><arg_value>{"name": "leaf", "child": null}</arg_value>',
+            "<arg_key>name</arg_key><arg_value>root</arg_value>"
+            "<arg_key>child</arg_key><arg_value>"
+            "<arg_key>name</arg_key><arg_value>leaf</arg_value>"
+            "<arg_key>child</arg_key><arg_value>null</arg_value></arg_value>",
+        ),
+        (
+            "kimi_k3_xml",
+            '<|open|>argument key="name" type="string"<|sep|>root<|close|>argument<|sep|>'
+            '<|open|>argument key="child" type="object"<|sep|>'
+            '{"name": "leaf", "child": null}<|close|>argument<|sep|>',
+            '<|open|>argument key="name" type="string"<|sep|>root<|close|>argument<|sep|>'
+            '<|open|>argument key="child" type="object"<|sep|>'
+            '<|open|>argument key="name" type="string"<|sep|>leaf<|close|>argument<|sep|>'
+            '<|open|>argument key="child" type="null"<|sep|>null<|close|>argument<|sep|>'
+            "<|close|>argument<|sep|>",
+        ),
+    ],
+)
+def test_root_only_xml_self_ref_uses_nested_json_domain(
+    json_format: str, nested_json: str, nested_xml: str
+):
+    grammar = _json_schema_to_ebnf(ROOT_SELF_REF_SCHEMA, json_format=json_format)
+    assert _is_grammar_accept_string(grammar, nested_json)
+    assert not _is_grammar_accept_string(grammar, nested_xml)
+
+
+# ---------- MiniMax M3 recursive XML ----------
 
 M3_NS = "]<]minimax[>["
 
@@ -2705,32 +2774,201 @@ def test_minimax_m3_rejects_unparseable_element_names(key: str):
 
 
 @pytest.mark.parametrize(
+    "schema, accepted, rejected",
+    [
+        (
+            {"type": "object", "additionalProperties": {"type": "string"}},
+            _m3_element("runtime key/城市", "value"),
+            _m3_element("runtime key/城市", "value").replace("</runtime key/城市>", "</other>"),
+        ),
+        (
+            {
+                "type": "object",
+                "patternProperties": {"^x_[a-z]+$": {"type": "integer"}},
+                "additionalProperties": False,
+            },
+            _m3_element("x_count", "2"),
+            _m3_element("y_count", "2"),
+        ),
+        (
+            {
+                "type": "object",
+                "propertyNames": {"pattern": "^[a-z]+$"},
+                "additionalProperties": {"type": "string"},
+            },
+            _m3_element("runtime", "value"),
+            _m3_element("runtime_1", "value"),
+        ),
+        ({}, _m3_element("runtime", _m3_element("nested", "value")), None),
+    ],
+)
+def test_minimax_m3_dynamic_property_schemas(schema: dict, accepted: str, rejected):
+    grammar = _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
+    assert _is_grammar_accept_string(grammar, accepted)
+    if rejected is not None:
+        assert not _is_grammar_accept_string(grammar, rejected)
+
+
+def test_minimax_m3_property_names_preserves_dynamic_value_policy():
+    schema = {
+        "type": "object",
+        "propertyNames": {"pattern": "^[a-z]+$"},
+        "additionalProperties": {"type": "string"},
+    }
+    grammar = _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
+    assert _is_grammar_accept_string(grammar, _m3_element("runtime", "value"))
+    assert not _is_grammar_accept_string(
+        grammar, _m3_element("runtime", _m3_element("nested", "value"))
+    )
+
+    forbidden = _json_schema_to_ebnf(
+        {"type": "object", "propertyNames": {"pattern": "^[a-z]+$"}, "additionalProperties": False},
+        json_format="minimax_m3_xml",
+    )
+    assert _is_grammar_accept_string(forbidden, "")
+    assert not _is_grammar_accept_string(forbidden, _m3_element("runtime", "value"))
+
+
+@pytest.mark.parametrize(
     "schema",
     [
-        {"type": "object", "additionalProperties": True},
-        {"type": "object", "additionalProperties": {"type": "string"}},
         {
             "type": "object",
-            "patternProperties": {"^x.*": {"type": "string"}},
+            "properties": {"x": {"type": "string"}},
+            "patternProperties": {"^x$": {"type": "integer"}},
             "additionalProperties": False,
         },
-        {"type": "object", "propertyNames": {"pattern": "^[a-z]+$"}, "additionalProperties": False},
         {
             "type": "object",
-            "properties": {"runtime": {}},
-            "required": ["runtime"],
+            "patternProperties": {"^x": {"type": "integer"}, "x$": {"type": "string"}},
             "additionalProperties": False,
+        },
+        {
+            "type": "object",
+            "properties": {"X": {"type": "string"}},
+            "propertyNames": {"pattern": "^[a-z]+$"},
+            "additionalProperties": False,
+        },
+        {
+            "type": "object",
+            "propertyNames": {"pattern": "^[a-z]+$"},
+            "patternProperties": {".*": {"type": "string"}},
+            "additionalProperties": False,
+        },
+        {
+            "type": "object",
+            "patternProperties": {"^x$": {"type": "integer"}},
+            "additionalProperties": {"type": "string"},
         },
     ],
 )
-def test_minimax_m3_rejects_runtime_property_schemas(schema: dict):
-    with pytest.raises(RuntimeError, match="fixed object property names|unconstrained schemas"):
+def test_minimax_m3_rejects_overlapping_object_name_constraints(schema: dict):
+    with pytest.raises(RuntimeError, match="minimax_m3_xml does not support"):
         _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
 
 
-def test_minimax_m3_strict_false_rejected():
-    with pytest.raises(RuntimeError, match="fixed object property names"):
-        _json_schema_to_ebnf({"type": "object"}, json_format="minimax_m3_xml", strict_mode=False)
+@pytest.mark.parametrize("any_order", [False, True])
+def test_minimax_m3_dynamic_names_are_unique_and_cannot_shadow_fixed_names(any_order: bool):
+    schema = {
+        "type": "object",
+        "properties": {"fixed": {"const": "value"}},
+        "required": ["fixed"],
+        "additionalProperties": {"type": "string"},
+    }
+    grammar = _json_schema_to_ebnf(schema, json_format="minimax_m3_xml", any_order=any_order)
+    fixed = _m3_element("fixed", "value")
+    assert _is_grammar_accept_string(
+        grammar, fixed + _m3_element("left", "a") + _m3_element("right", "b")
+    )
+    assert not _is_grammar_accept_string(
+        grammar, fixed + _m3_element("same", "a") + _m3_element("same", "b")
+    )
+    assert not _is_grammar_accept_string(grammar, fixed + _m3_element("fixed", "again"))
+
+
+def test_minimax_m3_dynamic_name_uniqueness_is_object_local():
+    schema = {
+        "type": "object",
+        "additionalProperties": {"type": "object", "additionalProperties": {"type": "string"}},
+    }
+    grammar = _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
+    assert _is_grammar_accept_string(
+        grammar,
+        _m3_element("left", _m3_element("same", "a"))
+        + _m3_element("right", _m3_element("same", "b")),
+    )
+    assert not _is_grammar_accept_string(
+        grammar, _m3_element("outer", _m3_element("same", "a") + _m3_element("same", "b"))
+    )
+
+
+def test_minimax_m3_recursive_ref_keeps_dynamic_scopes_occurrence_local():
+    schema = {
+        "$defs": {
+            "node": {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+                "additionalProperties": {"$ref": "#/$defs/node"},
+            }
+        },
+        "type": "object",
+        "properties": {"root": {"$ref": "#/$defs/node"}},
+        "required": ["root"],
+        "additionalProperties": False,
+    }
+    grammar = _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
+    nested = _m3_element("value", "parent") + _m3_element("child", _m3_element("value", "leaf"))
+    assert _is_grammar_accept_string(grammar, _m3_element("root", nested))
+    duplicate_children = nested + _m3_element("child", _m3_element("value", "second leaf"))
+    assert not _is_grammar_accept_string(grammar, _m3_element("root", duplicate_children))
+
+
+def test_minimax_m3_any_distinguishes_objects_from_repeated_item_arrays():
+    grammar = _json_schema_to_ebnf(
+        {"type": "object", "additionalProperties": True}, json_format="minimax_m3_xml"
+    )
+    assert _is_grammar_accept_string(
+        grammar,
+        _m3_element(
+            "array",
+            _m3_element("item", "first") + _m3_element("item", _m3_element("nested", "second")),
+        ),
+    )
+    assert not _is_grammar_accept_string(
+        grammar, _m3_element("object", _m3_element("same", "a") + _m3_element("same", "b"))
+    )
+
+
+@pytest.mark.parametrize(
+    "schema, instance",
+    [
+        ({"type": "object"}, _m3_element("runtime", _m3_element("nested", "value"))),
+        (
+            {"type": "array"},
+            _m3_element("item", "value") + _m3_element("item", _m3_element("nested", "value")),
+        ),
+    ],
+)
+def test_minimax_m3_strict_false_supports_dynamic_containers(schema: dict, instance: str):
+    grammar = _json_schema_to_ebnf(schema, json_format="minimax_m3_xml", strict_mode=False)
+    assert _is_grammar_accept_string(grammar, instance)
+
+
+def test_minimax_m3_property_name_refs_use_an_independent_cache_domain():
+    schema = {
+        "$defs": {"text": {"type": "string"}},
+        "type": "object",
+        "propertyNames": {"$ref": "#/$defs/text"},
+        "additionalProperties": {"$ref": "#/$defs/text"},
+    }
+    grammar = _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
+    assert _is_grammar_accept_string(grammar, _m3_element("runtime", "a>b"))
+
+
+def test_minimax_m3_fixed_only_schema_does_not_emit_dynamic_tag():
+    grammar = _json_schema_to_ebnf(M3_FIXED_SCHEMA, json_format="minimax_m3_xml")
+    assert "DynamicTag(" not in str(grammar)
 
 
 @pytest.mark.parametrize(

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -2452,5 +2452,305 @@ def test_true_schema():
     assert not _is_grammar_accept_string(ebnf_grammar, "anything")
 
 
+# ---------- MiniMax M3 fixed-name recursive XML ----------
+
+M3_NS = "]<]minimax[>["
+
+
+def _m3_element(name: str, value: str) -> str:
+    return f"{M3_NS}<{name}>{value}{M3_NS}</{name}>"
+
+
+M3_FIXED_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "count": {"type": "integer"},
+        "active": {"type": "boolean"},
+        "details": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "scores": {
+                    "type": "array",
+                    "items": {"type": "number"},
+                    "minItems": 1,
+                    "maxItems": 2,
+                },
+            },
+            "required": ["city", "scores"],
+            "additionalProperties": False,
+        },
+        "stops": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"label": {"type": "string"}},
+                "required": ["label"],
+                "additionalProperties": False,
+            },
+            "minItems": 1,
+            "maxItems": 2,
+        },
+        "note": {"enum": ["short", "long"]},
+    },
+    "required": ["name", "count", "active", "details", "stops"],
+    "additionalProperties": False,
+}
+
+M3_DETAILS = _m3_element(
+    "details",
+    _m3_element("city", "Hangzhou")
+    + _m3_element("scores", _m3_element("item", "1.5") + _m3_element("item", "2")),
+)
+M3_STOPS = _m3_element(
+    "stops",
+    _m3_element("item", _m3_element("label", "West Lake"))
+    + _m3_element("item", _m3_element("label", "Lingyin")),
+)
+M3_FIXED_INSTANCE = (
+    _m3_element("name", "Alice")
+    + _m3_element("count", "2")
+    + _m3_element("active", "true")
+    + M3_DETAILS
+    + M3_STOPS
+)
+
+
+@pytest.mark.parametrize(
+    "instance, accepted",
+    [
+        (M3_FIXED_INSTANCE, True),
+        (M3_FIXED_INSTANCE + _m3_element("note", "short"), True),
+        (M3_FIXED_INSTANCE.replace(f"{M3_NS}</name>", f"{M3_NS}</wrong>", 1), False),
+        (M3_FIXED_INSTANCE.replace(M3_DETAILS, _m3_element("details", '{"city":"x"}')), False),
+        (M3_FIXED_INSTANCE.replace(_m3_element("active", "true"), ""), False),
+        (
+            M3_FIXED_INSTANCE.replace(
+                M3_STOPS,
+                _m3_element(
+                    "stops",
+                    _m3_element("item", _m3_element("label", "A"))
+                    + _m3_element("item", _m3_element("label", "B"))
+                    + _m3_element("item", _m3_element("label", "C")),
+                ),
+            ),
+            False,
+        ),
+        (
+            M3_FIXED_INSTANCE.replace(
+                _m3_element("scores", _m3_element("item", "1.5") + _m3_element("item", "2")),
+                _m3_element("scores", ""),
+            ),
+            False,
+        ),
+        (
+            M3_FIXED_INSTANCE.replace(
+                _m3_element("name", "Alice"),
+                _m3_element("name", f"A{M3_NS}<unexpected>x{M3_NS}</unexpected>"),
+            ),
+            False,
+        ),
+    ],
+)
+def test_minimax_m3_fixed_nested_schema(instance: str, accepted: bool):
+    grammar = _json_schema_to_ebnf(M3_FIXED_SCHEMA, json_format="minimax_m3_xml")
+    assert _is_grammar_accept_string(grammar, instance) == accepted
+
+
+def test_minimax_m3_any_order_and_ref():
+    schema = {
+        "$defs": {
+            "point": {
+                "type": "object",
+                "properties": {"x": {"type": "integer"}, "y": {"type": "integer"}},
+                "required": ["x", "y"],
+                "additionalProperties": False,
+            }
+        },
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "point": {"$ref": "#/$defs/point"}},
+        "required": ["name", "point"],
+        "additionalProperties": False,
+    }
+    reordered = _m3_element("point", _m3_element("y", "2") + _m3_element("x", "1"))
+    reordered += _m3_element("name", "p")
+    ordered = _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
+    any_order = _json_schema_to_ebnf(schema, json_format="minimax_m3_xml", any_order=True)
+    assert not _is_grammar_accept_string(ordered, reordered)
+    assert _is_grammar_accept_string(any_order, reordered)
+
+
+def test_minimax_m3_empty_values_const_and_unknown_string_format():
+    schema = {
+        "type": "object",
+        "properties": {
+            "empty_object": {"type": "object", "properties": {}, "additionalProperties": False},
+            "empty_array": {"type": "array", "items": False, "maxItems": 0},
+            "fixed": {"const": {"x": [1, True]}},
+            "vendor": {"type": "string", "format": "vendor-custom"},
+        },
+        "required": ["empty_object", "empty_array", "fixed", "vendor"],
+        "additionalProperties": False,
+    }
+    grammar = _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
+    fixed = _m3_element(
+        "fixed", _m3_element("x", _m3_element("item", "1") + _m3_element("item", "true"))
+    )
+    instance = (
+        _m3_element("empty_object", "")
+        + _m3_element("empty_array", "")
+        + fixed
+        + _m3_element("vendor", "plain text")
+    )
+    assert _is_grammar_accept_string(grammar, instance)
+    assert not _is_grammar_accept_string(
+        grammar, instance.replace(_m3_element("empty_object", ""), _m3_element("empty_object", " "))
+    )
+    assert not _is_grammar_accept_string(
+        grammar, instance.replace(fixed, _m3_element("fixed", "{}"))
+    )
+    assert not _is_grammar_accept_string(
+        grammar,
+        instance.replace(
+            _m3_element("vendor", "plain text"),
+            _m3_element("vendor", f"text{M3_NS}<nested>x{M3_NS}</nested>"),
+        ),
+    )
+
+
+def test_minimax_m3_self_ref_stays_recursive_xml():
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "child": {"anyOf": [{"type": "null"}, {"$ref": "#"}]},
+        },
+        "required": ["name", "child"],
+        "additionalProperties": False,
+    }
+    grammar = _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
+    recursive_xml = _m3_element("name", "root") + _m3_element(
+        "child", _m3_element("name", "leaf") + _m3_element("child", "null")
+    )
+    nested_json = _m3_element("name", "root") + _m3_element("child", '{"name":"leaf","child":null}')
+    assert _is_grammar_accept_string(grammar, recursive_xml)
+    assert not _is_grammar_accept_string(grammar, nested_json)
+
+
+def test_minimax_m3_rejects_array_bounds_outside_repeat_range():
+    with pytest.raises(RuntimeError, match="array bounds exceed the supported range"):
+        _json_schema_to_ebnf(
+            {"type": "array", "items": {"type": "string"}, "maxItems": 2**31},
+            json_format="minimax_m3_xml",
+        )
+
+
+def test_minimax_m3_prefix_items_and_whitespace_limit():
+    array_schema = {
+        "type": "array",
+        "prefixItems": [{"type": "string"}, {"type": "integer"}],
+        "items": False,
+    }
+    array_grammar = _json_schema_to_ebnf(array_schema, json_format="minimax_m3_xml")
+    valid = _m3_element("item", "alpha") + _m3_element("item", "2")
+    assert _is_grammar_accept_string(array_grammar, "")
+    assert _is_grammar_accept_string(array_grammar, _m3_element("item", "alpha"))
+    assert _is_grammar_accept_string(array_grammar, valid)
+    assert not _is_grammar_accept_string(array_grammar, valid + _m3_element("item", "extra"))
+
+    required_prefix_grammar = _json_schema_to_ebnf(
+        {**array_schema, "minItems": 2}, json_format="minimax_m3_xml"
+    )
+    assert not _is_grammar_accept_string(required_prefix_grammar, "")
+    assert not _is_grammar_accept_string(required_prefix_grammar, _m3_element("item", "alpha"))
+    assert _is_grammar_accept_string(required_prefix_grammar, valid)
+
+    object_schema = {
+        "type": "object",
+        "properties": {"a": {"type": "string"}, "b": {"type": "string"}},
+        "required": ["a", "b"],
+        "additionalProperties": False,
+    }
+    object_grammar = _json_schema_to_ebnf(
+        object_schema, json_format="minimax_m3_xml", max_whitespace_cnt=1
+    )
+    first, second = _m3_element("a", "x"), _m3_element("b", "y")
+    assert _is_grammar_accept_string(object_grammar, first + "\n" + second)
+    assert not _is_grammar_accept_string(object_grammar, first + "\n\n" + second)
+
+
+def test_minimax_m3_fixed_element_names_are_escaped_as_grammar_literals():
+    key = 'line\n"quoted"\\key'
+    schema = {
+        "type": "object",
+        "properties": {key: {"type": "string"}},
+        "required": [key],
+        "additionalProperties": False,
+    }
+    grammar = _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
+    assert _is_grammar_accept_string(grammar, _m3_element(key, "value"))
+
+
+@pytest.mark.parametrize("key", ["", "/closing", "has>delimiter", " \t\n", "\ud800"])
+def test_minimax_m3_rejects_unparseable_element_names(key: str):
+    schema = {
+        "type": "object",
+        "properties": {key: {"type": "string"}},
+        "required": [key],
+        "additionalProperties": False,
+    }
+    with pytest.raises(RuntimeError, match="element name|cannot be blank|Failed to parse JSON"):
+        _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"type": "object", "additionalProperties": True},
+        {"type": "object", "additionalProperties": {"type": "string"}},
+        {
+            "type": "object",
+            "patternProperties": {"^x.*": {"type": "string"}},
+            "additionalProperties": False,
+        },
+        {"type": "object", "propertyNames": {"pattern": "^[a-z]+$"}, "additionalProperties": False},
+        {
+            "type": "object",
+            "properties": {"runtime": {}},
+            "required": ["runtime"],
+            "additionalProperties": False,
+        },
+    ],
+)
+def test_minimax_m3_rejects_runtime_property_schemas(schema: dict):
+    with pytest.raises(RuntimeError, match="fixed object property names|unconstrained schemas"):
+        _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
+
+
+def test_minimax_m3_strict_false_rejected():
+    with pytest.raises(RuntimeError, match="fixed object property names"):
+        _json_schema_to_ebnf({"type": "object"}, json_format="minimax_m3_xml", strict_mode=False)
+
+
+@pytest.mark.parametrize(
+    "string_schema",
+    [
+        {"type": "string", "pattern": ".*"},
+        {"type": "string", "format": "email"},
+        {"type": "string", "minLength": 1},
+    ],
+)
+def test_minimax_m3_rejects_constrained_strings(string_schema: dict):
+    schema = {
+        "type": "object",
+        "properties": {"value": string_schema},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    with pytest.raises(RuntimeError, match="String pattern, recognized format, and length"):
+        _json_schema_to_ebnf(schema, json_format="minimax_m3_xml")
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3106,6 +3106,22 @@ def test_pattern_properties_extra_key():
     )
 
 
+def test_additional_property_branch_cannot_repeat_fixed_key_with_pattern_properties():
+    schema = {
+        "type": "object",
+        "properties": {"fixed": {"type": "string"}},
+        "required": ["fixed"],
+        "patternProperties": {"^x_.*$": {"type": "integer"}},
+        "additionalProperties": {"type": "string"},
+    }
+    grammar = xgr.Grammar.from_json_schema(
+        json.dumps(schema), any_whitespace=False, separators=(",", ":")
+    )
+
+    assert _is_grammar_accept_string(grammar, '{"fixed":"a","x_key":1,"other":"b"}')
+    assert not _is_grammar_accept_string(grammar, '{"fixed":"a","fixed":"b"}')
+
+
 def test_pattern_properties_additional_false():
     """Regression test for #487: additionalProperties=false with both properties and patternProperties."""
     schema = {

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -44,7 +44,7 @@ def construct_compiled_grammar():
 
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
-    assert xgr.get_serialization_version() == "v16"
+    assert xgr.get_serialization_version() == "v17"
 
 
 def test_serialize_grammar():
@@ -68,7 +68,7 @@ def test_serialize_grammar():
         "per_rule_fsms": [],
         "allow_empty_rule_ids": [],
         "optimized": False,
-        "__VERSION__": "v16",
+        "__VERSION__": "v17",
     }
     # The fsms are the same one, but the start state and end states are different.
     assert json.loads(serialized) == expected_json
@@ -92,14 +92,14 @@ def test_serialize_grammar_exception():
         "allow_empty_rule_ids": [],
         "complete_fsm": None,
         "per_rule_fsms": [],
-        "__VERSION__": "v16",
+        "__VERSION__": "v17",
     }
 
     expected_json["__VERSION__"] = "v1"  # Change version to trigger error
     with pytest.raises(xgr.DeserializeVersionError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
 
-    expected_json["__VERSION__"] = "v16"
+    expected_json["__VERSION__"] = "v17"
     expected_json.pop("rules")  # Remove required field to trigger error
     with pytest.raises(xgr.DeserializeFormatError):
         xgr.Grammar.deserialize_json(json.dumps(expected_json))
@@ -151,7 +151,7 @@ def test_serialize_tokenizer_info():
         '"decoded_vocab":["1","212","a","A","b","\\u00e4\\u00b8\\u0080","-","aBc","abc"],'
         '"sorted_decoded_vocab":[[6,"-"],[3,"A"],[2,"a"],[7,"aBc"],[8,"abc"],[4,"b"],[5,"\\u00e4\\u00b8\\u0080"]],'
         '"trie_subtree_nodes_range":[1,2,5,4,5,6,7],'
-        '"__VERSION__":"v16"}'
+        '"__VERSION__":"v17"}'
     )
     assert json.loads(serialized) == json.loads(expected_json)
 
@@ -270,7 +270,7 @@ def test_serialize_compiled_grammar():
             "add_prefix_space": True,
             "stop_token_ids": [0, 1],
         },
-        "__VERSION__": "v16",
+        "__VERSION__": "v17",
     }
 
     class AdaptiveTokenMask(BaseModel):

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -1108,6 +1108,31 @@ def test_json_schema_style_kimi_k3_xml_const_enum_and_nullable_values():
     )
 
 
+def test_json_schema_style_minimax_m3_xml_fixed_nested_values():
+    namespace = "]<]minimax[>["
+
+    def element(name: str, value: str) -> str:
+        return f"{namespace}<{name}>{value}{namespace}</{name}>"
+
+    structural_tag = StructuralTag(
+        format=JSONSchemaFormat(
+            json_schema={
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "days": {"type": "array", "items": {"type": "integer"}},
+                },
+                "required": ["city", "days"],
+                "additionalProperties": False,
+            },
+            style="minimax_m3_xml",
+        )
+    )
+    valid = element("city", "Paris") + element("days", element("item", "1") + element("item", "2"))
+    check_stag_with_instance(structural_tag, valid, True)
+    check_stag_with_instance(structural_tag, valid.replace("</days>", "</wrong>"), False)
+
+
 ebnf_grammar_stag_grammar = [
     (
         {
@@ -3263,7 +3288,7 @@ json_format_error_test_data = [
     ),
     (
         '{"type": "structural_tag", "format": {"type": "json_schema", "json_schema": {"type": "string"}, "style": "not_string"}}',
-        'style must be "json", "qwen_xml", "minimax_xml", "deepseek_xml", "glm_xml", "cohere_xml", or "kimi_k3_xml"',
+        'style must be "json", "qwen_xml", "minimax_xml", "minimax_m3_xml", "deepseek_xml", "glm_xml", "cohere_xml", or "kimi_k3_xml"',
     ),
     # RepeatFormat Errors - illegal min/max
     (

--- a/web/src/structural_tag.ts
+++ b/web/src/structural_tag.ts
@@ -12,7 +12,14 @@ export interface ConstStringFormat {
 export interface JSONSchemaFormat {
   type: "json_schema";
   json_schema: JSONSchemaValue;
-  style?: "json" | "qwen_xml" | "minimax_xml" | "deepseek_xml" | "glm_xml" | "cohere_xml";
+  style?:
+    | "json"
+    | "qwen_xml"
+    | "minimax_xml"
+    | "minimax_m3_xml"
+    | "deepseek_xml"
+    | "glm_xml"
+    | "cohere_xml";
 }
 
 export interface QwenXMLParameterFormat {

--- a/web/tests/grammar.test.ts
+++ b/web/tests/grammar.test.ts
@@ -253,6 +253,53 @@ d_1 ::= ("" | ("d"))
     compiledGrammar2.dispose();
     compiler.dispose();
   });
+
+  test("Test MiniMax M3 fixed-name structural tag", async () => {
+    const ns = "]<]minimax[>[";
+    const structuralTag = {
+      type: "structural_tag" as const,
+      format: {
+        type: "json_schema" as const,
+        json_schema: {
+          type: "object",
+          properties: {
+            city: { type: "string" },
+            days: { type: "array", items: { type: "integer" } },
+          },
+          required: ["city", "days"],
+          additionalProperties: false,
+        },
+        style: "minimax_m3_xml" as const,
+      },
+    };
+    const element = (name: string, value: string) =>
+      `${ns}<${name}>${value}${ns}</${name}>`;
+    const valid = element("city", "Paris") + element(
+      "days",
+      element("item", "1") + element("item", "2"),
+    );
+
+    const tokenizerInfo = await TokenizerInfo.createTokenizerInfo(["x"], "byte_level", false);
+    const compiler = await GrammarCompiler.createGrammarCompiler(tokenizerInfo);
+    const compiledGrammar = await compiler.compileStructuralTag(structuralTag);
+
+    const matching = await GrammarMatcher.createGrammarMatcher(compiledGrammar, undefined, true);
+    expect(matching._acceptString(valid)).toEqual(true);
+    expect(matching.isCompleted()).toEqual(true);
+
+    const mismatching = await GrammarMatcher.createGrammarMatcher(
+      compiledGrammar,
+      undefined,
+      true,
+    );
+    expect(mismatching._acceptString(valid.replace("</days>", "</wrong>"))).toEqual(false);
+
+    matching.dispose();
+    mismatching.dispose();
+    compiledGrammar.dispose();
+    compiler.dispose();
+    tokenizerInfo.dispose();
+  });
 });
 
 // Identical to tests in `test_grammar_matcher.py`


### PR DESCRIPTION
## Summary

Depends on #713.

This follow-up adds generic runtime-named `DynamicTag` support and integrates it with the MiniMax M3 recursive XML format.

While #713 supports schemas with fixed property names, this PR adds exact support for runtime-generated property names used by `additionalProperties`, supported `patternProperties` and `propertyNames` schemas, and unconstrained tool-argument objects.

## What changed

- Add a generic `DynamicTag(...)` grammar expression.
- Capture runtime opening-tag names and require closing tags to reproduce them byte-for-byte.
- Keep runtime-name and uniqueness state local to each grammar derivation.
- Preserve the semantics across token masking, rollback, fork, grammar composition, and atomic-token paths.
- Preserve dynamic-tag metadata through `Grammar` and `CompiledGrammar` serialization and EBNF print/parse.
- Extend `minimax_m3_xml` with runtime property names, duplicate-name rejection, and fixed-name collision prevention.
- Reject unsupported or non-byte-regular name grammars fail-closed.
- Keep ordinary grammars on explicit fast paths so they do not pay the dynamic-tag matching cost.

This PR is intentionally stacked on #713 and can be rebased onto `main` after #713 is merged.

## Verification

- C++ tests: 123/123 passed
- Python tests: 3550 passed, 718 skipped
- Pre-commit checks: passed
- Web lint: passed