### PR TITLE
Fix segfaults from invalid arguments, corrupted serialized data and worker-thread errors

### DIFF
--- a/cpp/compiled_grammar.cc
+++ b/cpp/compiled_grammar.cc
@@ -5,7 +5,12 @@
 
 #include <xgrammar/compiler.h>
 
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
 #include "compiled_grammar_impl.h"
+#include "support/json_parse.h"
 #include "support/json_serializer.h"
 #include "testing.h"
 #include "tokenizer_info_impl.h"
@@ -185,7 +190,12 @@ std::optional<SerializationError> DeserializeJSONValue(
   if (object.find("grammar") == object.end()) {
     return ConstructDeserializeError("Expect a 'grammar' field", type_name);
   }
-  AutoDeserializeJSONValue(&(impl->grammar), object["grammar"], type_name);
+  if (auto error = AutoDeserializeJSONValue(&(impl->grammar), object["grammar"], type_name)) {
+    return error;
+  }
+  if (impl->grammar.IsNull()) {
+    return ConstructDeserializeError("Expect a non-null grammar", type_name);
+  }
   if (object.find("tokenizer_metadata") == object.end()) {
     return ConstructDeserializeError("Expect a 'tokenizer_metadata' field", type_name);
   }
@@ -199,7 +209,33 @@ std::optional<SerializationError> DeserializeJSONValue(
   if (object.find("adaptive_token_mask_cache") == object.end()) {
     return ConstructDeserializeError("Expect a 'adaptive_token_mask_cache' field", type_name);
   }
-  AutoDeserializeJSONValue(&(impl->adaptive_token_mask_cache), object["adaptive_token_mask_cache"]);
+  if (auto error = AutoDeserializeJSONValue(
+          &(impl->adaptive_token_mask_cache), object["adaptive_token_mask_cache"], type_name
+      )) {
+    return error;
+  }
+  // The masks index sorted_decoded_vocab and are OR-ed into a vocab_size-bit bitset, so their
+  // contents must match the tokenizer they are deserialized with.
+  const int64_t num_sorted_tokens = tokenizer_info.GetSortedDecodedVocab().size();
+  auto indices_ok = [&](const std::vector<int32_t>& indices) {
+    return std::all_of(indices.begin(), indices.end(), [&](int32_t index) {
+      return index >= 0 && index < num_sorted_tokens;
+    });
+  };
+  for (const auto& [state, mask] : impl->adaptive_token_mask_cache) {
+    using StoreType = AdaptiveTokenMask::StoreType;
+    const bool store_type_ok = mask.store_type == StoreType::kAccepted ||
+                               mask.store_type == StoreType::kRejected ||
+                               mask.store_type == StoreType::kAcceptedBitset;
+    const bool bitset_ok = mask.store_type != StoreType::kAcceptedBitset ||
+                           mask.accepted_bitset.Size() == tokenizer_info.GetVocabSize();
+    if (!store_type_ok || !bitset_ok || !indices_ok(mask.accepted_indices) ||
+        !indices_ok(mask.rejected_indices) || !indices_ok(mask.uncertain_indices)) {
+      return ConstructDeserializeError(
+          "adaptive_token_mask_cache contains a mask that does not match the tokenizer", type_name
+      );
+    }
+  }
   return std::nullopt;
 }
 
@@ -223,7 +259,7 @@ std::variant<CompiledGrammar, SerializationError> CompiledGrammar::DeserializeJS
     const std::string& json_string, const TokenizerInfo& tokenizer_info
 ) {
   picojson::value json_value;
-  if (auto error = picojson::parse(json_value, json_string); !error.empty()) {
+  if (auto error = ParseJSON(json_value, json_string); !error.empty()) {
     return InvalidJSONError("Failed to parse JSON: " + error);
   }
   if (!json_value.is<picojson::object>()) {

--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -593,6 +593,40 @@ class CompactFSM::Impl : public FSMImplBase<Compact2DArray<FSMEdge>> {
 
   size_t GetNumEdges() const { return edge_num_; }
 
+  /*!
+   * \brief Check that every edge target and every auxiliary data reference is in range. Used after
+   * deserialization, where the fields are restored verbatim.
+   * \return An error message if the FSM is malformed.
+   */
+  std::optional<std::string> Validate() const {
+    const int64_t aux_size = edge_aux_data_.size();
+    for (int state = 0; state < NumStates(); ++state) {
+      for (const auto& edge : edges_[state]) {
+        if (edge.target < 0 || edge.target >= NumStates()) {
+          return "Edge target " + std::to_string(edge.target) + " is out of range";
+        }
+        if (!edge.IsAuxEdge()) {
+          continue;
+        }
+        // A repeat edge owns 3 aux elements; a token edge owns a count followed by count ids.
+        const int64_t idx = edge.max;
+        bool in_range = idx >= 0 && idx < aux_size;
+        if (in_range && edge.IsRepeatRef()) {
+          in_range = idx + 3 <= aux_size;
+        } else if (in_range) {
+          in_range = edge_aux_data_[idx] >= 0 && idx + 1 + edge_aux_data_[idx] <= aux_size;
+        }
+        if (!in_range) {
+          return "Edge aux index " + std::to_string(idx) + " is out of range";
+        }
+      }
+    }
+    if (edge_num_ != ComputeEdgeNum(edges_)) {
+      return "edge_num does not match the number of edges";
+    }
+    return std::nullopt;
+  }
+
   size_t edge_num_ = 0;
 
   friend std::size_t MemorySize(const Impl& impl) {
@@ -847,6 +881,17 @@ struct CompactFSMWithStartEndSerializeHelper {
         edge_num(compact_fsm_with_se.edge_num_) {}
 
   CompactFSMWithStartEndSerializeHelper() = default;
+
+  std::optional<std::string> Validate() const {
+    if (fsm.IsNull()) {
+      return "Expect a non-null fsm";
+    }
+    auto in_range = [&](int32_t state) { return state >= 0 && state < fsm.NumStates(); };
+    if (!in_range(start) || !std::all_of(end_index.begin(), end_index.end(), in_range)) {
+      return "The start or end state is out of range";
+    }
+    return std::nullopt;
+  }
 };
 
 XGRAMMAR_MEMBER_ARRAY(

--- a/cpp/grammar.cc
+++ b/cpp/grammar.cc
@@ -5,6 +5,9 @@
 
 #include <xgrammar/grammar.h>
 
+#include <algorithm>
+#include <cstdint>
+#include <optional>
 #include <string>
 
 #include "grammar_functor.h"
@@ -182,6 +185,165 @@ Grammar Grammar::Concat(const std::vector<Grammar>& grammars) {
 std::ostream& operator<<(std::ostream& os, const Grammar& grammar) {
   os << grammar.ToString();
   return os;
+}
+
+std::optional<std::string> Grammar::Impl::Validate() const {
+  const int64_t num_rules = rules_.size();
+  const int64_t num_exprs = grammar_expr_indptr_.size();
+  const int64_t data_size = grammar_expr_data_.size();
+  auto rule_ok = [&](int64_t id) { return id >= 0 && id < num_rules; };
+  auto expr_ok = [&](int64_t id) { return id >= 0 && id < num_exprs; };
+
+  // Pass 1: every expr must fit in grammar_expr_data_ before any expr can be read.
+  for (int64_t expr_id = 0; expr_id < num_exprs; ++expr_id) {
+    const int64_t start = grammar_expr_indptr_[expr_id];
+    if (start < 0 || start + 2 > data_size) {
+      return "grammar_expr_indptr[" + std::to_string(expr_id) + "] is out of range";
+    }
+    const int64_t type = grammar_expr_data_[start];
+    const int64_t len = grammar_expr_data_[start + 1];
+    if (len < 0 || start + 2 + len > data_size) {
+      return "The length of grammar expr " + std::to_string(expr_id) + " is out of range";
+    }
+    if (type < 0 || type > static_cast<int64_t>(GrammarExprType::kSubstring)) {
+      return "Unknown type of grammar expr " + std::to_string(expr_id);
+    }
+  }
+
+  // Pass 2: the ids stored inside each expr must refer to existing rules and exprs.
+  for (int64_t expr_id = 0; expr_id < num_exprs; ++expr_id) {
+    const auto expr = GetGrammarExpr(expr_id);
+    const int64_t size = expr.size();
+    bool ok = true;
+    switch (expr.type) {
+      case GrammarExprType::kByteString:
+      case GrammarExprType::kEmptyStr:
+      case GrammarExprType::kToken:
+      case GrammarExprType::kExcludeToken:
+        break;
+      case GrammarExprType::kCharacterClass:
+      case GrammarExprType::kCharacterClassStar:
+        // [is_negative, lower0, upper0, ...]
+        ok = size >= 1 && size % 2 == 1;
+        break;
+      case GrammarExprType::kRuleRef:
+        ok = size == 1 && rule_ok(expr[0]);
+        break;
+      case GrammarExprType::kSequence:
+      case GrammarExprType::kChoices:
+        ok = std::all_of(expr.begin(), expr.end(), expr_ok);
+        break;
+      case GrammarExprType::kTagDispatch: {
+        // [tag_expr0, rule_id0, ..., loop_after_dispatch, excluded_str_expr_id]
+        const int64_t extra = TagDispatch::kTagDispatchExtraParameter;
+        ok = size >= extra && (size - extra) % 2 == 0;
+        for (int64_t i = 0; ok && i < size - extra; i += 2) {
+          ok = expr_ok(expr[i]) && rule_ok(expr[i + 1]);
+        }
+        // The excluded strings are read as a kChoices expr of byte string exprs.
+        ok = ok && expr_ok(expr[size - 1]) &&
+             GetGrammarExpr(expr[size - 1]).type == GrammarExprType::kChoices;
+        break;
+      }
+      case GrammarExprType::kRepeat:
+        ok = size == 3 && rule_ok(expr[0]);
+        break;
+      case GrammarExprType::kTokenTagDispatch: {
+        // [trigger_cnt, (token_id, rule_id) x N, loop_after_dispatch, exclude_cnt, token_id x M]
+        const int64_t trigger_cnt = size >= 1 ? expr[0] : -1;
+        ok = trigger_cnt >= 0 && 1 + 2 * trigger_cnt + 2 <= size;
+        for (int64_t i = 0; ok && i < trigger_cnt; ++i) {
+          ok = rule_ok(expr[2 + 2 * i]);
+        }
+        if (ok) {
+          const int64_t exclude_cnt = expr[1 + 2 * trigger_cnt + 1];
+          ok = exclude_cnt >= 0 && 1 + 2 * trigger_cnt + 2 + exclude_cnt == size;
+        }
+        break;
+      }
+      case GrammarExprType::kRegex:
+        ok = size >= 1;
+        break;
+      case GrammarExprType::kSubstring:
+        // [chunk0_len, byte0_0, ..., chunk1_len, ...]
+        for (int64_t i = 0; ok && i < size;) {
+          const int64_t chunk_len = expr[i++];
+          ok = chunk_len >= 0 && i + chunk_len <= size;
+          i += chunk_len;
+        }
+        break;
+    }
+    if (!ok) {
+      return "Grammar expr " + std::to_string(expr_id) + " is malformed";
+    }
+  }
+
+  for (int64_t rule_id = 0; rule_id < num_rules; ++rule_id) {
+    const auto& rule = rules_[rule_id];
+    if (!expr_ok(rule.body_expr_id) ||
+        (rule.lookahead_assertion_id != -1 && !expr_ok(rule.lookahead_assertion_id))) {
+      return "Rule " + std::to_string(rule_id) + " refers to a grammar expr out of range";
+    }
+  }
+  if (!rule_ok(root_rule_id_)) {
+    return "root_rule_id " + std::to_string(root_rule_id_) + " is out of range";
+  }
+  for (const auto& info : suffix_stop_infos_) {
+    if (!rule_ok(info.rule_id) || (info.body_rule_id != -1 && !rule_ok(info.body_rule_id)) ||
+        (info.marker_rule_id != -1 && !rule_ok(info.marker_rule_id))) {
+      return "suffix_stop_infos refers to a rule out of range";
+    }
+  }
+  if (!std::all_of(allow_empty_rule_ids.begin(), allow_empty_rule_ids.end(), rule_ok)) {
+    return "allow_empty_rule_ids refers to a rule out of range";
+  }
+
+  // The FSMs are internally consistent (see CompactFSM::Impl::Validate); check the rule ids they
+  // refer to. The parser reads the repeat info of a per-rule FSM edge from complete_fsm, so the
+  // aux indices of per-rule repeat edges must also be valid for complete_fsm.
+  auto fsm_rules_ok = [&](const CompactFSM& fsm) {
+    const auto& aux = fsm.GetEdgeAuxData();
+    for (int state = 0; state < fsm.NumStates(); ++state) {
+      for (const auto& edge : fsm.GetEdges(state)) {
+        if ((edge.IsRuleRef() && !rule_ok(edge.max)) ||
+            (edge.IsRepeatRef() && !rule_ok(aux[edge.max]))) {
+          return false;
+        }
+      }
+    }
+    return true;
+  };
+  if (!complete_fsm.IsNull() && !fsm_rules_ok(complete_fsm)) {
+    return "complete_fsm refers to a rule out of range";
+  }
+  if (optimized &&
+      (complete_fsm.IsNull() || static_cast<int64_t>(per_rule_fsms.size()) != num_rules)) {
+    return "An optimized grammar must have complete_fsm and one FSM per rule";
+  }
+  for (int64_t rule_id = 0; rule_id < static_cast<int64_t>(per_rule_fsms.size()); ++rule_id) {
+    if (!per_rule_fsms[rule_id].has_value()) {
+      if (optimized) {
+        return "Rule " + std::to_string(rule_id) + " has no FSM in an optimized grammar";
+      }
+      continue;
+    }
+    const CompactFSM& fsm = per_rule_fsms[rule_id]->GetFsm().GetFsm();
+    if (!fsm_rules_ok(fsm)) {
+      return "The FSM of rule " + std::to_string(rule_id) + " refers to a rule out of range";
+    }
+    const int64_t complete_aux_size =
+        complete_fsm.IsNull() ? 0 : complete_fsm.GetEdgeAuxData().size();
+    for (int state = 0; state < fsm.NumStates(); ++state) {
+      for (const auto& edge : fsm.GetEdges(state)) {
+        if (edge.IsRepeatRef() && (static_cast<int64_t>(edge.max) + 3 > complete_aux_size ||
+                                   !rule_ok(complete_fsm.GetEdgeAuxData()[edge.max]))) {
+          return "The FSM of rule " + std::to_string(rule_id) +
+                 " has a repeat edge that is out of range of complete_fsm";
+        }
+      }
+    }
+  }
+  return std::nullopt;
 }
 
 std::string Grammar::SerializeJSON() const { return AutoSerializeJSON(*this, true); }

--- a/cpp/grammar_builder.cc
+++ b/cpp/grammar_builder.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -55,6 +56,11 @@ Grammar GrammarBuilder::Get(int32_t root_rule_id) {
 }
 
 int32_t GrammarBuilder::AddGrammarExpr(const GrammarExpr& grammar_expr) {
+  // Offsets into grammar_expr_data_ are stored as int32.
+  XGRAMMAR_CHECK(
+      grammar_->grammar_expr_data_.size() + 2 + grammar_expr.data_len <=
+      static_cast<size_t>(std::numeric_limits<int32_t>::max())
+  ) << "The grammar is too large: the grammar expr data exceeds 2^31 elements";
   grammar_->grammar_expr_indptr_.push_back(grammar_->grammar_expr_data_.size());
   grammar_->grammar_expr_data_.push_back(static_cast<int32_t>(grammar_expr.type));
   grammar_->grammar_expr_data_.push_back(grammar_expr.data_len);

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -734,6 +734,12 @@ const std::vector<int32_t>& GrammarMatcherForTokenMaskCache::GetTokenEdgeAccepte
   const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
   int32_t sorted_size = static_cast<int32_t>(sorted_decoded_vocab.size());
   const auto& tid_to_sorted = tokenizer_info_.ImplPtr()->GetTokenIdToSortedVocabIndex();
+  // Out-of-vocabulary ids are rejected before compilation starts (CheckTokenIdsInVocab); guard
+  // here as well because this runs on worker threads, where an out-of-bounds read cannot be
+  // reported as an error.
+  auto sorted_index = [&](int32_t tid) {
+    return tid >= 0 && tid < static_cast<int32_t>(tid_to_sorted.size()) ? tid_to_sorted[tid] : -1;
+  };
 
   bool has_exclude_token = false;
 
@@ -741,20 +747,16 @@ const std::vector<int32_t>& GrammarMatcherForTokenMaskCache::GetTokenEdgeAccepte
     if (edge.IsToken()) {
       auto info = fsm.GetFsm().GetFsm().GetTokenEdgeInfo(edge.GetAuxIndex());
       for (int32_t i = 0; i < info.Count(); ++i) {
-        int32_t tid = info.TokenIds()[i];
-        XGRAMMAR_DCHECK(tid >= 0 && tid < static_cast<int32_t>(tid_to_sorted.size()));
-        if (tid_to_sorted[tid] >= 0) {
-          tmp_token_edge_accepted_.push_back(tid_to_sorted[tid]);
+        if (int32_t index = sorted_index(info.TokenIds()[i]); index >= 0) {
+          tmp_token_edge_accepted_.push_back(index);
         }
       }
     } else if (edge.IsExcludeToken()) {
       has_exclude_token = true;
       auto info = fsm.GetFsm().GetFsm().GetExcludeTokenEdgeInfo(edge.GetAuxIndex());
       for (int32_t i = 0; i < info.Count(); ++i) {
-        int32_t tid = info.TokenIds()[i];
-        XGRAMMAR_DCHECK(tid >= 0 && tid < static_cast<int32_t>(tid_to_sorted.size()));
-        if (tid_to_sorted[tid] >= 0) {
-          tmp_token_edge_excluded_.push_back(tid_to_sorted[tid]);
+        if (int32_t index = sorted_index(info.TokenIds()[i]); index >= 0) {
+          tmp_token_edge_excluded_.push_back(index);
         }
       }
     }
@@ -1066,10 +1068,34 @@ class GrammarCompilerSub {
   std::optional<RuleLevelCache> rule_level_cache_;
 };
 
+/*!
+ * \brief Check that every token id written in Token(...), ExcludeToken(...) and TokenTagDispatch
+ * exists in the vocabulary. They are used as indices into per-token arrays during compilation,
+ * which runs on worker threads where an error cannot be reported.
+ */
+static void CheckTokenIdsInVocab(const Grammar& grammar, int vocab_size) {
+  const CompactFSM& fsm = grammar->complete_fsm;
+  for (int state = 0; state < fsm.NumStates(); ++state) {
+    for (const auto& edge : fsm.GetEdges(state)) {
+      if (!edge.IsToken() && !edge.IsExcludeToken()) {
+        continue;
+      }
+      // Token and exclude-token edges share the [count, token_id_0, ...] aux layout.
+      const auto info = fsm.GetTokenEdgeInfo(edge.GetAuxIndex());
+      for (int32_t i = 0; i < info.Count(); ++i) {
+        XGRAMMAR_CHECK(info.TokenIds()[i] >= 0 && info.TokenIds()[i] < vocab_size)
+            << "Token id " << info.TokenIds()[i]
+            << " in the grammar is out of the vocabulary range [0, " << vocab_size << ")";
+      }
+    }
+  }
+}
+
 CompiledGrammar GrammarCompilerSub::MultiThreadCompileGrammar(Grammar grammar_unoptimized) {
   auto compiled_grammar_impl = std::make_shared<CompiledGrammar::Impl>();
   compiled_grammar_impl->grammar = GrammarOptimizer::Apply(grammar_unoptimized);
   compiled_grammar_impl->tokenizer_info = tokenizer_info_;
+  CheckTokenIdsInVocab(compiled_grammar_impl->grammar, tokenizer_info_.GetVocabSize());
   if (tokenizer_info_.GetVocabSize() == 0) {
     return CompiledGrammar(compiled_grammar_impl);
   }

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -2159,8 +2159,8 @@ int32_t RepetitionRangeExpanderImpl::ExpandRepetitionRange(
     const std::string& cur_rule_name, int32_t grammar_expr_id, int64_t lower, int64_t upper
 ) {
   static const int64_t kUnzipThreshold = 128;
-  XGRAMMAR_DCHECK(lower >= 0);
-  XGRAMMAR_DCHECK(upper == -1 || upper >= lower);
+  XGRAMMAR_CHECK(lower >= 0 && (upper == -1 || upper >= lower))
+      << "Invalid repetition range {" << lower << ", " << upper << "}";
 
   // Case 1.1 small upper (<=threshold), unzip the repetition.
   // Case 1.2 unbounded upper, and lower is also small (<=threshold), unzip the lower part.

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -154,6 +154,13 @@ class Grammar::Impl {
     return rules_[root_rule_id_];
   }
 
+  /*!
+   * \brief Check that every id and offset stored in the grammar is in range. Used after
+   * deserialization, where the fields are restored verbatim and none of the builder checks run.
+   * \return An error message if the grammar is malformed.
+   */
+  std::optional<std::string> Validate() const;
+
   /*! \brief The type of the grammar expr. */
   enum class GrammarExprType : int32_t {
     // data format: [byte0, byte1, ...]

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -481,8 +481,16 @@ class GrammarMatcher::Impl : public EarleyParser {
         terminate_without_stop_token_(terminate_without_stop_token),
         default_temperature_(default_temperature),
         tmp_accepted_bitset_(tokenizer_info_.GetVocabSize()) {
-    XGRAMMAR_CHECK(!override_stop_tokens.has_value() || !override_stop_tokens->empty())
-        << "The override_stop_tokens should not be empty";
+    if (override_stop_tokens.has_value()) {
+      XGRAMMAR_CHECK(!override_stop_tokens->empty())
+          << "The override_stop_tokens should not be empty";
+      // Stop token ids are written into the token bitmask, so they must be in range.
+      for (int id : *override_stop_tokens) {
+        XGRAMMAR_CHECK(id >= 0 && id < tokenizer_info_.GetVocabSize())
+            << "The override stop token id " << id << " is out of the vocabulary range [0, "
+            << tokenizer_info_.GetVocabSize() << ")";
+      }
+    }
     if (has_budget_rules_ || has_char_budget_rules_) {
       for (int32_t rule_id = 0; rule_id < grammar_->NumRules(); ++rule_id) {
         const auto& rule = grammar_->GetRule(rule_id);
@@ -1226,8 +1234,8 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   const auto& special_token_ids = tokenizer_info_.GetSpecialTokenIds();
   if (!is_stop_token && std::find(special_token_ids.begin(), special_token_ids.end(), token_id) !=
                             special_token_ids.end()) {
-    // Padding ids in [vocab_size beyond the real tokens) are special ids too, but they have no
-    // entry in decoded_vocab_, so only decode ids that are backed by a real token.
+    // Padding ids, i.e. ids in [decoded_vocab.size(), vocab_size), are registered as special ids
+    // too, but they have no entry in decoded_vocab, so only decode ids backed by a real token.
     const auto& decoded_vocab = tokenizer_info_.GetDecodedVocab();
     XGRAMMAR_LOG(WARNING) << "GrammarMatcher cannot accept special token id " << token_id << ": "
                           << (token_id < static_cast<int32_t>(decoded_vocab.size())
@@ -2682,9 +2690,13 @@ bool GrammarMatcher::TraverseDraftTree(
 
   // The traversal follows retrieve_next_token / retrieve_next_sibling as node indices; a value
   // outside [-1, num_nodes) would recurse into an out-of-bounds position, so validate them upfront.
+  // The edges must also form a tree: the root is never a target, and every other node is the
+  // child or next sibling of at most one node. A node targeted twice (a cycle or a shared node)
+  // would otherwise make the traversal recurse without bound.
   int64_t num_nodes = retrieve_next_token->shape[0];
   const int64_t* next_token_data = reinterpret_cast<const int64_t*>(retrieve_next_token->data);
   const int64_t* next_sibling_data = reinterpret_cast<const int64_t*>(retrieve_next_sibling->data);
+  std::vector<int32_t> in_degree(num_nodes, 0);
   for (int64_t i = 0; i < num_nodes; ++i) {
     XGRAMMAR_CHECK(next_token_data[i] >= -1 && next_token_data[i] < num_nodes)
         << "retrieve_next_token[" << i << "] = " << next_token_data[i]
@@ -2692,6 +2704,19 @@ bool GrammarMatcher::TraverseDraftTree(
     XGRAMMAR_CHECK(next_sibling_data[i] >= -1 && next_sibling_data[i] < num_nodes)
         << "retrieve_next_sibling[" << i << "] = " << next_sibling_data[i]
         << " is out of bounds: it should be in [-1, " << num_nodes << ").";
+    if (next_token_data[i] != -1) {
+      ++in_degree[next_token_data[i]];
+    }
+    if (next_sibling_data[i] != -1) {
+      ++in_degree[next_sibling_data[i]];
+    }
+  }
+  XGRAMMAR_CHECK(in_degree[0] == 0) << "The root node must not be the child or sibling of a node";
+  for (int64_t i = 1; i < num_nodes; ++i) {
+    XGRAMMAR_CHECK(in_degree[i] <= 1)
+        << "Node " << i << " is the target of " << in_degree[i]
+        << " retrieve_next_token / retrieve_next_sibling entries; the draft tree must not contain "
+           "cycles or shared nodes.";
   }
 
   return details::TraverseDraftTreeRecursive(

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -344,6 +344,14 @@ void ApplyTokenBitmaskInplaceCPU(
         << "When indices is not provided, the logits's batch size should be equal to the "
            "bitmask's batch size, but got "
         << logits_shape.first << " vs " << bitmask_shape.first;
+  } else {
+    // Each index selects a row of both logits and bitmask; an out-of-range index would lead to
+    // an out-of-bounds access, so validate every index against both batch sizes here.
+    for (int idx : indices.value()) {
+      XGRAMMAR_CHECK(idx >= 0 && idx < logits_shape.first && idx < bitmask_shape.first)
+          << "The provided index " << idx << " is out of bounds: it should be in [0, "
+          << std::min(logits_shape.first, bitmask_shape.first) << ").";
+    }
   }
 
   // Apply mask
@@ -1218,8 +1226,13 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   const auto& special_token_ids = tokenizer_info_.GetSpecialTokenIds();
   if (!is_stop_token && std::find(special_token_ids.begin(), special_token_ids.end(), token_id) !=
                             special_token_ids.end()) {
+    // Padding ids in [vocab_size beyond the real tokens) are special ids too, but they have no
+    // entry in decoded_vocab_, so only decode ids that are backed by a real token.
+    const auto& decoded_vocab = tokenizer_info_.GetDecodedVocab();
     XGRAMMAR_LOG(WARNING) << "GrammarMatcher cannot accept special token id " << token_id << ": "
-                          << tokenizer_info_.GetDecodedVocab()[token_id]
+                          << (token_id < static_cast<int32_t>(decoded_vocab.size())
+                                  ? decoded_vocab[token_id]
+                                  : "<padding>")
                           << ". Rejecting the token.";
     return false;
   }
@@ -2666,6 +2679,20 @@ bool GrammarMatcher::TraverseDraftTree(
       << "The draft tree must not be empty";
   XGRAMMAR_CHECK(reinterpret_cast<const int64_t*>(retrieve_next_sibling->data)[0] == -1)
       << "The root node must not have siblings";
+
+  // The traversal follows retrieve_next_token / retrieve_next_sibling as node indices; a value
+  // outside [-1, num_nodes) would recurse into an out-of-bounds position, so validate them upfront.
+  int64_t num_nodes = retrieve_next_token->shape[0];
+  const int64_t* next_token_data = reinterpret_cast<const int64_t*>(retrieve_next_token->data);
+  const int64_t* next_sibling_data = reinterpret_cast<const int64_t*>(retrieve_next_sibling->data);
+  for (int64_t i = 0; i < num_nodes; ++i) {
+    XGRAMMAR_CHECK(next_token_data[i] >= -1 && next_token_data[i] < num_nodes)
+        << "retrieve_next_token[" << i << "] = " << next_token_data[i]
+        << " is out of bounds: it should be in [-1, " << num_nodes << ").";
+    XGRAMMAR_CHECK(next_sibling_data[i] >= -1 && next_sibling_data[i] < num_nodes)
+        << "retrieve_next_sibling[" << i << "] = " << next_sibling_data[i]
+        << " is out of bounds: it should be in [-1, " << num_nodes << ").";
+  }
 
   return details::TraverseDraftTreeRecursive(
       0,

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -1151,7 +1151,12 @@ EBNFParser::MacroIR::NodePtr EBNFParser::ParseMacroValue() {
     Consume();
     return std::make_unique<MacroIR::Node>(MacroIR::IdentifierNode{name});
   } else if (Peek().type == TokenType::LParen) {
-    // Tuple value
+    // Tuple value. Nested tuples recurse once per layer, so guard the depth the same way the
+    // ordinary parenthesis path does to avoid a stack overflow on deeply nested input.
+    nest_layer_guard_++;
+    if (nest_layer_guard_ > max_nest_layer_) {
+      ReportParseError("Nest layer exceeded the maximum limit", -1);
+    }
     Consume();  // Consume (
 
     MacroIR::TupleNode tuple;
@@ -1175,6 +1180,7 @@ EBNFParser::MacroIR::NodePtr EBNFParser::ParseMacroValue() {
     }
 
     Consume();  // Consume )
+    nest_layer_guard_--;
     return std::make_unique<MacroIR::Node>(std::move(tuple));
   } else {
     ReportParseError("Expect string, integer, boolean, or tuple in macro argument");

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -29,6 +29,7 @@
 #include "grammar_functor.h"
 #include "json_schema_converter_ext.h"
 #include "regex_converter.h"
+#include "support/json_parse.h"
 #include "support/logging.h"
 
 namespace xgrammar {
@@ -1113,10 +1114,15 @@ Result<StringSpec, SchemaError> SchemaParser::ParseString(const picojson::object
   StringSpec spec;
   if (schema.count("format")) spec.format = schema.at("format").get<std::string>();
   if (schema.count("pattern")) spec.pattern = schema.at("pattern").get<std::string>();
+  // Lengths become int32 repetition bounds. A minimum beyond int32 can never be satisfied; a
+  // maximum beyond it is unbounded in practice. Neither may wrap around when converted.
+  constexpr int64_t kMaxBound = std::numeric_limits<int32_t>::max();
   if (schema.count("minLength")) {
-    if (!schema.at("minLength").is<int64_t>()) {
+    if (!schema.at("minLength").is<int64_t>() ||
+        schema.at("minLength").get<int64_t>() > kMaxBound) {
       return ResultErr<SchemaError>(
-          SchemaErrorType::kInvalidSchema, "minLength must be an integer"
+          SchemaErrorType::kInvalidSchema,
+          "minLength must be an integer not exceeding " + std::to_string(kMaxBound)
       );
     }
     spec.min_length = static_cast<int>(schema.at("minLength").get<int64_t>());
@@ -1127,7 +1133,9 @@ Result<StringSpec, SchemaError> SchemaParser::ParseString(const picojson::object
           SchemaErrorType::kInvalidSchema, "maxLength must be an integer"
       );
     }
-    spec.max_length = static_cast<int>(schema.at("maxLength").get<int64_t>());
+    if (schema.at("maxLength").get<int64_t>() <= kMaxBound) {
+      spec.max_length = static_cast<int>(schema.at("maxLength").get<int64_t>());
+    }
   }
   if (spec.max_length != -1 && spec.min_length > spec.max_length) {
     return ResultErr<SchemaError>(
@@ -1231,6 +1239,17 @@ Result<ArraySpec, SchemaError> SchemaParser::ParseArray(const picojson::object& 
       );
     }
     spec.max_items = schema.at("maxItems").get<int64_t>();
+  }
+  // Item counts become int32 repetition bounds, see ParseString for the rationale.
+  constexpr int64_t kMaxBound = std::numeric_limits<int32_t>::max();
+  if (spec.min_items > kMaxBound) {
+    return ResultErr<SchemaError>(
+        SchemaErrorType::kInvalidSchema,
+        "minItems and minContains must not exceed " + std::to_string(kMaxBound)
+    );
+  }
+  if (spec.max_items > kMaxBound) {
+    spec.max_items = -1;
   }
 
   if (spec.max_items != -1 && spec.min_items > spec.max_items) {
@@ -2033,7 +2052,7 @@ int32_t JSONSchemaConverter::FormattingExpression(const std::string& expression)
   }
 
   picojson::value value;
-  std::string error = picojson::parse(value, expression);
+  std::string error = ParseJSON(value, expression);
   XGRAMMAR_CHECK(error.empty() && value.is<std::string>())
       << "Unsupported indentation expression: " << expression;
   return ByteString(value.get<std::string>());
@@ -4146,7 +4165,7 @@ Grammar JSONSchemaToGrammar(
     JSONFormat json_format
 ) {
   picojson::value schema_value;
-  std::string error = picojson::parse(schema_value, schema);
+  std::string error = ParseJSON(schema_value, schema);
   XGRAMMAR_CHECK(error.empty()) << "Failed to parse JSON: " << error
                                 << ". The JSON string is:" << schema;
   SchemaParser parser(schema_value, {strict_mode, json_format});
@@ -4219,7 +4238,7 @@ std::string JSONSchemaToEBNF(
     bool any_order
 ) {
   picojson::value schema_value;
-  std::string err = picojson::parse(schema_value, schema);
+  std::string err = ParseJSON(schema_value, schema);
   XGRAMMAR_CHECK(err.empty()) << "Failed to parse JSON: " << err
                               << ". The JSON string is:" << schema;
   return JSONSchemaToEBNF(

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "support/json_parse.h"
 #include "support/logging.h"
 
 namespace xgrammar {
@@ -108,7 +109,7 @@ Grammar XMLToolCallingConverter::Convert(const SchemaSpecPtr& spec) {
 
 std::string XMLToolCallingConverter::XMLValue(const std::string& json_value) const {
   picojson::value value;
-  std::string error = picojson::parse(value, json_value);
+  std::string error = ParseJSON(value, json_value);
   if (error.empty() && value.is<std::string>()) {
     return value.get<std::string>();
   }
@@ -149,7 +150,7 @@ std::optional<std::string> XMLToolCallingConverter::KimiK3TypeAttr(const SchemaS
   // The type name a single JSON value is rendered with, following the model's _xtml_type.
   auto type_of_json_value = [](const std::string& json_value) -> std::optional<std::string> {
     picojson::value value;
-    if (!picojson::parse(value, json_value).empty()) {
+    if (!ParseJSON(value, json_value).empty()) {
       return std::nullopt;
     }
     if (value.is<std::string>()) return "string";
@@ -498,7 +499,7 @@ int32_t CohereXMLToolCallingConverter::FormatCohereValue(int32_t value_rule_id) 
 
 std::string CohereXMLToolCallingConverter::CohereTypeForJSONLiteral(const std::string& json_value) {
   picojson::value value;
-  std::string error = picojson::parse(value, json_value);
+  std::string error = ParseJSON(value, json_value);
   // Const/enum object and array literals are emitted as JSON text today, not recursive Cohere
   // dict/list bodies, so only JSON strings get the raw Cohere type.
   return error.empty() && value.is<std::string>() ? "raw" : "json";

--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -1024,7 +1024,8 @@ class LarkParser {
   }
 
   // Groups recurse ParseChoice -> ParseSequence -> ParseExpr -> ParseAtom once per level, so bound
-  // the depth like the EBNF parser does instead of overflowing the stack.
+  // the depth instead of overflowing the stack. Each level uses a few KB of stack; the limit keeps
+  // a wide margin below the 1 MB main-thread stack of Windows.
   Node ParseGroupBody(const Token& open) {
     if (group_depth_ >= kMaxGroupDepth) {
       RaiseLarkError(
@@ -1166,7 +1167,7 @@ class LarkParser {
   std::vector<Token> tokens_;
   size_t position_ = 0;
   int group_depth_ = 0;
-  static constexpr int kMaxGroupDepth = 1000;
+  static constexpr int kMaxGroupDepth = 200;
 };
 
 const std::unordered_map<std::string, std::string>& CommonRegexes() {

--- a/cpp/lark_converter.cc
+++ b/cpp/lark_converter.cc
@@ -28,6 +28,7 @@
 #include "grammar_builder.h"
 #include "grammar_functor.h"
 #include "support/encoding.h"
+#include "support/json_parse.h"
 #include "support/logging.h"
 
 namespace xgrammar {
@@ -469,7 +470,7 @@ class LarkLexer {
     auto end = source_.end();
     picojson::value value;
     std::string error;
-    auto parsed_end = picojson::parse(value, begin, end, &error);
+    auto parsed_end = ParseJSON(value, begin, end, &error);
     if (!error.empty() || parsed_end == begin) {
       RaiseLarkError(
           source_, location, "failed to parse JSON value after " + directive + ": " + error
@@ -713,7 +714,7 @@ class LarkParser {
   void ParseOptions(Document* document) {
     Token token = Consume(TokenType::kGrammarOptions, "expected %grammar_options");
     picojson::value value;
-    std::string error = picojson::parse(value, token.text);
+    std::string error = ParseJSON(value, token.text);
     if (!error.empty()) {
       RaiseLarkError(source_, token.location, "invalid %grammar_options value: " + error);
     }
@@ -1022,15 +1023,31 @@ class LarkParser {
     return repeat;
   }
 
+  // Groups recurse ParseChoice -> ParseSequence -> ParseExpr -> ParseAtom once per level, so bound
+  // the depth like the EBNF parser does instead of overflowing the stack.
+  Node ParseGroupBody(const Token& open) {
+    if (group_depth_ >= kMaxGroupDepth) {
+      RaiseLarkError(
+          source_,
+          open.location,
+          "groups are nested deeper than " + std::to_string(kMaxGroupDepth) + " levels"
+      );
+    }
+    ++group_depth_;
+    Node result = ParseChoice();
+    --group_depth_;
+    return result;
+  }
+
   Node ParseAtom() {
     Token token = Peek();
     if (Match(TokenType::kLParen)) {
-      Node result = ParseChoice();
+      Node result = ParseGroupBody(token);
       Consume(TokenType::kRParen, "expected ')' after group");
       return result;
     }
     if (Match(TokenType::kLBracket)) {
-      Node inner = ParseChoice();
+      Node inner = ParseGroupBody(token);
       Consume(TokenType::kRBracket, "expected ']' after optional group");
       Node result;
       result.kind = Node::Kind::kRepeat;
@@ -1133,7 +1150,7 @@ class LarkParser {
       json_string.pop_back();
     }
     picojson::value value;
-    std::string error = picojson::parse(value, json_string);
+    std::string error = ParseJSON(value, json_string);
     if (!error.empty() || !value.is<std::string>()) {
       RaiseLarkError(source_, token.location, "invalid string literal: " + error);
     }
@@ -1148,6 +1165,8 @@ class LarkParser {
   const std::string& source_;
   std::vector<Token> tokens_;
   size_t position_ = 0;
+  int group_depth_ = 0;
+  static constexpr int kMaxGroupDepth = 1000;
 };
 
 const std::unordered_map<std::string, std::string>& CommonRegexes() {
@@ -1846,7 +1865,7 @@ class LarkCompiler {
 
   std::vector<std::string> ParseStructuredRegexChunks(const Node& node) const {
     picojson::value value;
-    std::string error = picojson::parse(value, node.text);
+    std::string error = ParseJSON(value, node.text);
     if (!error.empty()) {
       RaiseLarkError(source_, node.location, "failed to parse %regex: " + error);
     }

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -20,6 +20,7 @@
 #include "grammar_functor.h"
 #include "grammar_impl.h"
 #include "json_schema_converter.h"
+#include "support/json_parse.h"
 #include "support/logging.h"
 #include "support/recursion_guard.h"
 #include "support/utils.h"
@@ -94,7 +95,7 @@ picojson::value JSONSchemaFormat::ToJSON() const {
   picojson::object obj;
   obj["type"] = picojson::value(type);
   picojson::value schema_val;
-  if (picojson::parse(schema_val, json_schema).empty()) {
+  if (ParseJSON(schema_val, json_schema).empty()) {
     obj["json_schema"] = schema_val;
   } else {
     obj["json_schema"] = picojson::value(json_schema);
@@ -371,7 +372,7 @@ class StructuralTagParser {
 
 Result<StructuralTag, StructuralTagError> StructuralTagParser::FromJSON(const std::string& json) {
   picojson::value value;
-  std::string err = picojson::parse(value, json);
+  std::string err = ParseJSON(value, json);
   if (!err.empty()) {
     return ResultErr<InvalidJSONError>("Failed to parse JSON: " + err);
   }
@@ -405,6 +406,14 @@ Result<StructuralTag, ISTError> StructuralTagParser::ParseStructuralTag(const pi
 
 Result<Format, ISTError> StructuralTagParser::ParseFormat(const picojson::value& value) {
   RecursionGuard guard(&parse_format_recursion_depth_);
+  // The global recursion limit is far deeper than the native stack allows for the recursive passes
+  // over the format tree, so cap the nesting of formats explicitly.
+  static constexpr int kMaxFormatDepth = 1000;
+  if (parse_format_recursion_depth_ > kMaxFormatDepth) {
+    return ResultErr<ISTError>(
+        "Formats are nested deeper than " + std::to_string(kMaxFormatDepth) + " levels"
+    );
+  }
   if (!value.is<picojson::object>()) {
     return ResultErr<ISTError>("Format must be an object");
   }

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -407,8 +407,9 @@ Result<StructuralTag, ISTError> StructuralTagParser::ParseStructuralTag(const pi
 Result<Format, ISTError> StructuralTagParser::ParseFormat(const picojson::value& value) {
   RecursionGuard guard(&parse_format_recursion_depth_);
   // The global recursion limit is far deeper than the native stack allows for the recursive passes
-  // over the format tree, so cap the nesting of formats explicitly.
-  static constexpr int kMaxFormatDepth = 1000;
+  // over the format tree (a few KB per level, and Windows has a 1 MB main-thread stack), so cap
+  // the nesting of formats explicitly.
+  static constexpr int kMaxFormatDepth = 100;
   if (parse_format_recursion_depth_ > kMaxFormatDepth) {
     return ResultErr<ISTError>(
         "Formats are nested deeper than " + std::to_string(kMaxFormatDepth) + " levels"

--- a/cpp/support/compact_2d_array.h
+++ b/cpp/support/compact_2d_array.h
@@ -7,9 +7,12 @@
 
 #include <picojson.h>
 
+#include <algorithm>
 #include <climits>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -153,6 +156,20 @@ class Compact2DArray {
 
   /*! \brief Get the number of rows in the Compact2DArray. */
   int32_t size() const { return static_cast<int32_t>(indptr_.size()) - 1; }
+
+  /*!
+   * \brief Check the CSR invariants after deserialization: indptr starts with 0, is non-decreasing
+   * and ends with the data size. Otherwise row accesses would read out of bounds.
+   * \return An error message if the invariants are violated.
+   */
+  std::optional<std::string> Validate() const {
+    if (indptr_.empty() || indptr_.front() != 0 ||
+        indptr_.back() != static_cast<int32_t>(data_.size()) ||
+        !std::is_sorted(indptr_.begin(), indptr_.end())) {
+      return "Invalid indptr: it must start with 0, be non-decreasing and end with the data size";
+    }
+    return std::nullopt;
+  }
 
   friend std::size_t MemorySize(const Compact2DArray<DataType>& arr) {
     return MemorySize(arr.data_) + MemorySize(arr.indptr_);

--- a/cpp/support/dynamic_bitset.h
+++ b/cpp/support/dynamic_bitset.h
@@ -261,9 +261,14 @@ class DynamicBitset {
       return ConstructDeserializeError("Expect an integer for buffer_size", type_name);
     }
     int buffer_size = static_cast<int>(arr[1].get<int64_t>());
-    if (buffer_size != GetBufferSize(size)) {
+    if (size < 0 || buffer_size != GetBufferSize(size)) {
       return ConstructDeserializeError(
           "Invalid buffer_size. Buffer size should be ceil(size / 32)", type_name
+      );
+    }
+    if (static_cast<int64_t>(arr.size()) != static_cast<int64_t>(buffer_size) + 2) {
+      return ConstructDeserializeError(
+          "Expect exactly buffer_size + 2 elements in the array", type_name
       );
     }
 

--- a/cpp/support/json_parse.h
+++ b/cpp/support/json_parse.h
@@ -1,0 +1,85 @@
+/*!
+ *  Copyright (c) 2025 by Contributors
+ * \file xgrammar/support/json_parse.h
+ * \brief picojson::parse wrappers that reject inputs nested deeper than the recursion limit.
+ * picojson recurses once per nesting level and has no depth limit of its own, so a deeply nested
+ * input would overflow the stack before any of the recursion guards in xgrammar run.
+ */
+#ifndef XGRAMMAR_SUPPORT_JSON_PARSE_H_
+#define XGRAMMAR_SUPPORT_JSON_PARSE_H_
+
+#include <picojson.h>
+
+#include <optional>
+#include <string>
+
+#include "recursion_guard.h"
+
+namespace xgrammar {
+
+namespace detail {
+
+/*!
+ * \brief Check that the JSON value starting at begin is not nested deeper than the maximum
+ * recursion depth. Scanning stops at the end of the first top-level array or object.
+ * \return The error message if the nesting is too deep.
+ */
+template <typename Iter>
+inline std::optional<std::string> CheckJSONNestingDepth(Iter begin, Iter end) {
+  const int max_depth = RecursionGuard::GetMaxRecursionDepth();
+  int depth = 0;
+  bool in_string = false;
+  for (Iter it = begin; it != end; ++it) {
+    const char c = *it;
+    if (in_string) {
+      if (c == '\\') {
+        if (++it == end) break;
+      } else if (c == '"') {
+        in_string = false;
+      }
+    } else if (c == '"') {
+      in_string = true;
+    } else if (c == '[' || c == '{') {
+      if (++depth > max_depth) {
+        return "JSON is nested deeper than the maximum recursion depth " +
+               std::to_string(max_depth);
+      }
+    } else if ((c == ']' || c == '}') && --depth <= 0) {
+      break;
+    }
+  }
+  return std::nullopt;
+}
+
+}  // namespace detail
+
+/*!
+ * \brief Parse a JSON string. Same as picojson::parse(out, json), but rejects inputs nested
+ * deeper than the maximum recursion depth.
+ * \return The error message, empty on success.
+ */
+inline std::string ParseJSON(picojson::value& out, const std::string& json) {
+  if (auto error = detail::CheckJSONNestingDepth(json.begin(), json.end())) {
+    return *error;
+  }
+  return picojson::parse(out, json);
+}
+
+/*!
+ * \brief Parse the JSON value at the start of [begin, end). Same as
+ * picojson::parse(out, begin, end, err), but rejects inputs nested deeper than the maximum
+ * recursion depth.
+ * \return The iterator past the parsed value; begin if the nesting check failed.
+ */
+template <typename Iter>
+inline Iter ParseJSON(picojson::value& out, Iter begin, Iter end, std::string* err) {
+  if (auto error = detail::CheckJSONNestingDepth(begin, end)) {
+    *err = *error;
+    return begin;
+  }
+  return picojson::parse(out, begin, end, err);
+}
+
+}  // namespace xgrammar
+
+#endif  // XGRAMMAR_SUPPORT_JSON_PARSE_H_

--- a/cpp/support/json_parse.h
+++ b/cpp/support/json_parse.h
@@ -1,7 +1,7 @@
 /*!
  *  Copyright (c) 2025 by Contributors
  * \file xgrammar/support/json_parse.h
- * \brief picojson::parse wrappers that reject inputs nested deeper than the recursion limit.
+ * \brief picojson::parse wrappers whose nesting depth is bounded by RecursionGuard.
  * picojson recurses once per nesting level and has no depth limit of its own, so a deeply nested
  * input would overflow the stack before any of the recursion guards in xgrammar run.
  */
@@ -10,9 +10,10 @@
 
 #include <picojson.h>
 
-#include <optional>
+#include <cstdint>
 #include <string>
 
+#include "logging.h"
 #include "recursion_guard.h"
 
 namespace xgrammar {
@@ -20,64 +21,96 @@ namespace xgrammar {
 namespace detail {
 
 /*!
- * \brief Check that the JSON value starting at begin is not nested deeper than the maximum
- * recursion depth. Scanning stops at the end of the first top-level array or object.
- * \return The error message if the nesting is too deep.
+ * \brief A picojson parse context that behaves like picojson::default_parse_context, but counts
+ * every nested array or object in a RecursionGuard. The maximum recursion depth of xgrammar thus
+ * applies while parsing, and exceeding it throws before the stack overflows.
  */
-template <typename Iter>
-inline std::optional<std::string> CheckJSONNestingDepth(Iter begin, Iter end) {
-  const int max_depth = RecursionGuard::GetMaxRecursionDepth();
-  int depth = 0;
-  bool in_string = false;
-  for (Iter it = begin; it != end; ++it) {
-    const char c = *it;
-    if (in_string) {
-      if (c == '\\') {
-        if (++it == end) break;
-      } else if (c == '"') {
-        in_string = false;
-      }
-    } else if (c == '"') {
-      in_string = true;
-    } else if (c == '[' || c == '{') {
-      if (++depth > max_depth) {
-        return "JSON is nested deeper than the maximum recursion depth " +
-               std::to_string(max_depth);
-      }
-    } else if ((c == ']' || c == '}') && --depth <= 0) {
-      break;
-    }
+class DepthGuardedParseContext {
+ public:
+  DepthGuardedParseContext(picojson::value* out, int* depth) : out_(out), depth_(depth) {}
+  DepthGuardedParseContext(const DepthGuardedParseContext&) = delete;
+  DepthGuardedParseContext& operator=(const DepthGuardedParseContext&) = delete;
+
+  bool set_null() {
+    *out_ = picojson::value();
+    return true;
   }
-  return std::nullopt;
-}
+  bool set_bool(bool b) {
+    *out_ = picojson::value(b);
+    return true;
+  }
+  bool set_int64(int64_t i) {
+    *out_ = picojson::value(i);
+    return true;
+  }
+  bool set_number(double f) {
+    *out_ = picojson::value(f);
+    return true;
+  }
+  template <typename Iter>
+  bool parse_string(picojson::input<Iter>& in) {
+    *out_ = picojson::value(picojson::string_type, false);
+    return picojson::_parse_string(out_->get<std::string>(), in);
+  }
+  bool parse_array_start() {
+    *out_ = picojson::value(picojson::array_type, false);
+    return true;
+  }
+  template <typename Iter>
+  bool parse_array_item(picojson::input<Iter>& in, size_t) {
+    picojson::array& a = out_->get<picojson::array>();
+    a.push_back(picojson::value());
+    RecursionGuard guard(depth_);
+    DepthGuardedParseContext child(&a.back(), depth_);
+    return picojson::_parse(child, in);
+  }
+  bool parse_array_stop(size_t) { return true; }
+  bool parse_object_start() {
+    *out_ = picojson::value(picojson::object_type, false);
+    return true;
+  }
+  template <typename Iter>
+  bool parse_object_item(picojson::input<Iter>& in, const std::string& key) {
+    picojson::object& o = out_->get<picojson::object>();
+    RecursionGuard guard(depth_);
+    DepthGuardedParseContext child(&o[key], depth_);
+    return picojson::_parse(child, in);
+  }
+
+ private:
+  picojson::value* out_;
+  int* depth_;
+};
 
 }  // namespace detail
 
 /*!
- * \brief Parse a JSON string. Same as picojson::parse(out, json), but rejects inputs nested
- * deeper than the maximum recursion depth.
- * \return The error message, empty on success.
- */
-inline std::string ParseJSON(picojson::value& out, const std::string& json) {
-  if (auto error = detail::CheckJSONNestingDepth(json.begin(), json.end())) {
-    return *error;
-  }
-  return picojson::parse(out, json);
-}
-
-/*!
  * \brief Parse the JSON value at the start of [begin, end). Same as
- * picojson::parse(out, begin, end, err), but rejects inputs nested deeper than the maximum
- * recursion depth.
- * \return The iterator past the parsed value; begin if the nesting check failed.
+ * picojson::parse(out, begin, end, err), but the nesting depth is bounded by the maximum
+ * recursion depth (see RecursionGuard).
+ * \return The iterator past the parsed value; begin if the depth limit was exceeded.
  */
 template <typename Iter>
 inline Iter ParseJSON(picojson::value& out, Iter begin, Iter end, std::string* err) {
-  if (auto error = detail::CheckJSONNestingDepth(begin, end)) {
-    *err = *error;
+  int depth = 0;
+  detail::DepthGuardedParseContext ctx(&out, &depth);
+  try {
+    return picojson::_parse(ctx, begin, end, err);
+  } catch (const LogFatalError& error) {
+    *err = error.what();
     return begin;
   }
-  return picojson::parse(out, begin, end, err);
+}
+
+/*!
+ * \brief Parse a JSON string. Same as picojson::parse(out, json), but the nesting depth is bounded
+ * by the maximum recursion depth (see RecursionGuard).
+ * \return The error message, empty on success.
+ */
+inline std::string ParseJSON(picojson::value& out, const std::string& json) {
+  std::string err;
+  ParseJSON(out, json.begin(), json.end(), &err);
+  return err;
 }
 
 }  // namespace xgrammar

--- a/cpp/support/json_serializer.h
+++ b/cpp/support/json_serializer.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "encoding.h"
+#include "json_parse.h"
 #include "logging.h"
 #include "reflection.h"
 #include "utils.h"
@@ -96,7 +97,10 @@ std::string AutoSerializeJSON(const T& value, bool add_version = false);
  * \details It supports STL types, PImpl types, reflection-based types (whose members are defined
  * through XGRAMMAR_MEMBER_TABLE or XGRAMMAR_MEMBER_ARRAY), and types who have defined a global
  * DeserializeJSONValue function. For reflection-based types, the deserialization logic is
- * automatically generated from the defined members.
+ * automatically generated from the defined members. If a reflection-based type also defines
+ * `std::optional<std::string> Validate() const`, it is called after all members are deserialized,
+ * and a returned message is reported as a deserialization error. This is where a type checks the
+ * invariants (index ranges, CSR layout, ...) that the constructors normally guarantee.
  * \param result The pointer to the result to be deserialized.
  * \param value The JSON value to be deserialized.
  * \param type_name The name of the type to be deserialized. Used for error message.
@@ -198,6 +202,31 @@ struct has_deserialize_json_global<
       "global deserializer can only apply to a default constructible type"
   );
 };
+
+template <typename, typename = void>
+struct has_validate : std::false_type {};
+
+template <typename T>
+struct has_validate<T, std::void_t<decltype(std::declval<const T&>().Validate())>>
+    : std::true_type {
+  static_assert(
+      std::is_same_v<decltype(std::declval<const T&>().Validate()), std::optional<std::string>>,
+      "Validate must be a const member function returning std::optional<std::string>"
+  );
+};
+
+/*! \brief Runs T::Validate() on a deserialized value if the type defines one. */
+template <typename T>
+inline std::optional<SerializationError> ValidateDeserialized(
+    const T& value, const std::string& type_name
+) {
+  if constexpr (has_validate<T>::value) {
+    if (auto error = value.Validate()) {
+      return ConstructDeserializeError(*error, type_name);
+    }
+  }
+  return std::nullopt;
+}
 
 template <typename>
 inline constexpr bool false_v = false;
@@ -439,7 +468,10 @@ inline std::optional<SerializationError> AutoDeserializeJSONValue(
   } else if constexpr (is_pimpl_class<T>::value) {
     return detail::json_serializer::AutoDeserializeJSONValuePImpl(result, value, type_name);
   } else if constexpr (member_trait<T>::value != member_type::kNone) {
-    return detail::json_serializer::TraitDeserializeJSONValue(result, value, type_name);
+    if (auto error = detail::json_serializer::TraitDeserializeJSONValue(result, value, type_name)) {
+      return error;
+    }
+    return detail::json_serializer::ValidateDeserialized(*result, type_name);
   } else if constexpr (std::is_same_v<T, bool>) {
     if (!value.is<bool>()) {
       return ConstructDeserializeError("Expect a boolean", type_name);
@@ -591,7 +623,7 @@ inline std::optional<SerializationError> AutoDeserializeJSON(
     T* result, const std::string& json_string, bool check_version, const std::string& type_name
 ) {
   picojson::value json_value;
-  if (auto error = picojson::parse(json_value, json_string); !error.empty()) {
+  if (auto error = ParseJSON(json_value, json_string); !error.empty()) {
     return InvalidJSONError(error);
   }
   if (check_version) {

--- a/cpp/support/logging.h
+++ b/cpp/support/logging.h
@@ -25,6 +25,48 @@
 
 namespace xgrammar {
 
+/*!
+ * \brief Error type for errors from XGRAMMAR_CHECK, XGRAMMAR_ICHECK, and XGRAMMAR_LOG(FATAL). This
+ * error contains a backtrace of where it occurred.
+ */
+class LogFatalError : public std::runtime_error {
+ public:
+  /*! \brief Construct an error. Not recommended to use directly. Instead use XGRAMMAR_LOG(FATAL).
+   *
+   * \param file The file where the error occurred.
+   * \param lineno The line number where the error occurred.
+   * \param message The error message to display.
+   * \param time The time at which the error occurred. This should be in local time.
+   */
+  LogFatalError(
+      const std::string& file,
+      int lineno,
+      const std::string& message,
+      std::time_t time = std::time(nullptr)
+  )
+      : std::runtime_error(message), file_(file), lineno_(lineno), time_(time) {
+    std::ostringstream s;
+    s << "[" << std::put_time(std::localtime(&time), "%H:%M:%S") << "] " << file << ":" << lineno
+      << ": " << message << "\n";
+    full_message_ = s.str();
+  }
+
+  /*! \return The file in which the error occurred. */
+  const std::string& file() const { return file_; }
+  /*! \return The time at which this error occurred. */
+  const std::time_t& time() const { return time_; }
+  /*! \return The line number at which this error occurred. */
+  int lineno() const { return lineno_; }
+  /*! \return The error message. */
+  const char* what() const noexcept override { return full_message_.c_str(); }
+
+ private:
+  std::string file_;
+  int lineno_;
+  std::time_t time_;
+  std::string full_message_;
+};
+
 // Provide support for customized logging.
 #if XGRAMMAR_LOG_CUSTOMIZE
 /*!
@@ -83,48 +125,6 @@ class LogMessage {
 };
 
 #else  // if XGRAMMAR_LOG_CUSTOMIZE
-
-/*!
- * \brief Error type for errors from XGRAMMAR_CHECK, XGRAMMAR_ICHECK, and XGRAMMAR_LOG(FATAL). This
- * error contains a backtrace of where it occurred.
- */
-class LogFatalError : public std::runtime_error {
- public:
-  /*! \brief Construct an error. Not recommended to use directly. Instead use XGRAMMAR_LOG(FATAL).
-   *
-   * \param file The file where the error occurred.
-   * \param lineno The line number where the error occurred.
-   * \param message The error message to display.
-   * \param time The time at which the error occurred. This should be in local time.
-   */
-  LogFatalError(
-      const std::string& file,
-      int lineno,
-      const std::string& message,
-      std::time_t time = std::time(nullptr)
-  )
-      : std::runtime_error(message), file_(file), lineno_(lineno), time_(time) {
-    std::ostringstream s;
-    s << "[" << std::put_time(std::localtime(&time), "%H:%M:%S") << "] " << file << ":" << lineno
-      << ": " << message << "\n";
-    full_message_ = s.str();
-  }
-
-  /*! \return The file in which the error occurred. */
-  const std::string& file() const { return file_; }
-  /*! \return The time at which this error occurred. */
-  const std::time_t& time() const { return time_; }
-  /*! \return The line number at which this error occurred. */
-  int lineno() const { return lineno_; }
-  /*! \return The error message. */
-  const char* what() const noexcept override { return full_message_.c_str(); }
-
- private:
-  std::string file_;
-  int lineno_;
-  std::time_t time_;
-  std::string full_message_;
-};
 
 /*!
  * \brief Class to accumulate an error message and throw it. Do not use

--- a/cpp/support/thread_pool.h
+++ b/cpp/support/thread_pool.h
@@ -7,6 +7,7 @@
 #define XGRAMMAR_SUPPORT_THREAD_POOL_H_
 
 #include <condition_variable>
+#include <exception>
 #include <functional>
 #include <future>
 #include <mutex>
@@ -51,7 +52,14 @@ class ThreadPool {
             task = std::move(task_queue_.front());
             task_queue_.pop();
           }
-          task();
+          try {
+            task();
+          } catch (...) {
+            std::unique_lock<std::mutex> lock(queue_mutex_);
+            if (!first_exception_) {
+              first_exception_ = std::current_exception();
+            }
+          }
           TaskComplete();
         }
       });
@@ -111,9 +119,17 @@ class ThreadPool {
     queue_condition_.notify_one();
   }
 
+  /*!
+   * \brief Wait until all submitted tasks have finished.
+   * \note If a task submitted with Execute threw, the first such exception is rethrown here on the
+   * calling thread. An exception escaping a worker thread would otherwise terminate the process.
+   */
   void Wait() {
-    std::unique_lock<std::mutex> lock(queue_mutex_);
-    tasks_done_condition_.wait(lock, [this] { return unfinished_task_count_ == 0; });
+    {
+      std::unique_lock<std::mutex> lock(queue_mutex_);
+      tasks_done_condition_.wait(lock, [this] { return unfinished_task_count_ == 0; });
+    }
+    RethrowTaskException();
   }
 
   /*!
@@ -122,8 +138,27 @@ class ThreadPool {
    * Sets shutdown flag and waits for all threads to complete their current tasks
    * before destroying the pool. Any remaining tasks in the queue will be executed
    * before shutdown completes.
+   * \note If a task submitted with Execute threw, the first such exception is rethrown here on the
+   * calling thread. An exception escaping a worker thread would otherwise terminate the process.
    */
   void Join() {
+    Shutdown();
+    RethrowTaskException();
+  }
+
+  /*!
+   * \brief Destructor that ensures graceful shutdown of the thread pool.
+   */
+  ~ThreadPool() { Shutdown(); }
+
+  // Prevent copying or moving of the thread pool
+  ThreadPool(const ThreadPool&) = delete;
+  ThreadPool(ThreadPool&&) = delete;
+  ThreadPool& operator=(const ThreadPool&) = delete;
+  ThreadPool& operator=(ThreadPool&&) = delete;
+
+ private:
+  void Shutdown() {
     {
       std::unique_lock<std::mutex> lock(queue_mutex_);
       if (shutdown_) return;  // Already shut down
@@ -136,18 +171,17 @@ class ThreadPool {
     }
   }
 
-  /*!
-   * \brief Destructor that ensures graceful shutdown of the thread pool.
-   */
-  ~ThreadPool() { Join(); }
+  void RethrowTaskException() {
+    std::exception_ptr exception;
+    {
+      std::unique_lock<std::mutex> lock(queue_mutex_);
+      std::swap(exception, first_exception_);
+    }
+    if (exception) {
+      std::rethrow_exception(exception);
+    }
+  }
 
-  // Prevent copying or moving of the thread pool
-  ThreadPool(const ThreadPool&) = delete;
-  ThreadPool(ThreadPool&&) = delete;
-  ThreadPool& operator=(const ThreadPool&) = delete;
-  ThreadPool& operator=(ThreadPool&&) = delete;
-
- private:
   void TaskComplete() {
     std::unique_lock<std::mutex> lock(queue_mutex_);
     --unfinished_task_count_;
@@ -170,6 +204,8 @@ class ThreadPool {
   bool shutdown_ = false;
   /*! \brief Number of unfinished tasks */
   int unfinished_task_count_ = 0;
+  /*! \brief The first exception thrown by a task, rethrown by Wait() or Join() */
+  std::exception_ptr first_exception_ = nullptr;
 };
 
 inline void ParallelFor(int low, int high, int num_threads, std::function<void(int)> f) {

--- a/cpp/testing.cc
+++ b/cpp/testing.cc
@@ -45,6 +45,8 @@ Grammar _EBNFToGrammarNoNormalization(
 }
 
 std::string _PrintGrammarFSMs(const Grammar& grammar) {
+  XGRAMMAR_CHECK(static_cast<int>(grammar->per_rule_fsms.size()) == grammar->NumRules())
+      << "The grammar has no per-rule FSMs; build them first";
   std::string result;
   for (int i = 0; i < grammar->NumRules(); i++) {
     result += "Rule " + std::to_string(i) + ": " + grammar->GetRule(i).name + ", FSM: ";

--- a/cpp/tokenizer_info.cc
+++ b/cpp/tokenizer_info.cc
@@ -274,6 +274,11 @@ TokenizerInfo::Impl::Impl(
     : vocab_type_(vocab_type),
       vocab_size_(vocab_size.value_or(encoded_vocab.size())),
       add_prefix_space_(add_prefix_space) {
+  // vocab_size only ever pads the encoded vocab with special ids; a value below the number of
+  // real tokens would leave token ids without a slot and corrupt the id -> index table below.
+  XGRAMMAR_CHECK(vocab_size_ >= static_cast<int>(encoded_vocab.size()))
+      << "vocab_size (" << vocab_size_ << ") must be at least the number of tokens in the vocab ("
+      << encoded_vocab.size() << ").";
   decoded_vocab_.reserve(encoded_vocab.size());
   sorted_decoded_vocab_.reserve(encoded_vocab.size());
   for (int i = 0; i < static_cast<int>(encoded_vocab.size()); ++i) {

--- a/cpp/tokenizer_info.cc
+++ b/cpp/tokenizer_info.cc
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "support/encoding.h"
+#include "support/json_parse.h"
 #include "support/json_serializer.h"
 #include "support/logging.h"
 #include "tokenizer_info_impl.h"
@@ -326,6 +327,28 @@ TokenizerInfo::Impl::Impl(
   BuildTokenCharData();
 }
 
+std::optional<std::string> TokenizerInfo::Impl::Validate() const {
+  const int64_t num_tokens = decoded_vocab_.size();
+  if (vocab_size_ < num_tokens) {
+    return "vocab_size " + std::to_string(vocab_size_) + " is smaller than the number of tokens " +
+           std::to_string(num_tokens);
+  }
+  for (const auto& [token_id, token] : sorted_decoded_vocab_) {
+    if (token_id < 0 || token_id >= num_tokens) {
+      return "sorted_decoded_vocab contains token id " + std::to_string(token_id) + " out of range";
+    }
+  }
+  if (trie_subtree_nodes_range_.size() != sorted_decoded_vocab_.size()) {
+    return "trie_subtree_nodes_range must have one entry per sorted token";
+  }
+  auto id_ok = [&](int32_t token_id) { return token_id >= 0 && token_id < vocab_size_; };
+  if (!std::all_of(stop_token_ids_.begin(), stop_token_ids_.end(), id_ok) ||
+      !std::all_of(special_token_ids_.begin(), special_token_ids_.end(), id_ok)) {
+    return "stop_token_ids or special_token_ids contains a token id out of range";
+  }
+  return std::nullopt;
+}
+
 void TokenizerInfo::Impl::BuildTokenIdToSortedVocabIndex() {
   token_id_to_sorted_vocab_index_.assign(vocab_size_, -1);
   for (int32_t i = 0; i < static_cast<int32_t>(sorted_decoded_vocab_.size()); ++i) {
@@ -429,7 +452,7 @@ std::shared_ptr<TokenizerInfo::Impl> TokenizerInfo::Impl::FromVocabAndMetadata(
     const std::vector<std::string>& encoded_vocab, const std::string& metadata
 ) {
   picojson::value v;
-  std::string err = picojson::parse(v, metadata);
+  std::string err = ParseJSON(v, metadata);
   XGRAMMAR_CHECK(err.empty()) << "Failed to parse metadata: " << err;
 
   const picojson::object& obj = v.get<picojson::object>();
@@ -463,7 +486,7 @@ std::shared_ptr<TokenizerInfo::Impl> TokenizerInfo::Impl::FromVocabAndMetadata(
 
 std::string TokenizerInfo::Impl::DetectMetadataFromHF(const std::string& backend_str) {
   picojson::value v;
-  std::string err = picojson::parse(v, backend_str);
+  std::string err = ParseJSON(v, backend_str);
   XGRAMMAR_CHECK(err.empty() && v.is<picojson::object>()) << "Failed to parse JSON object: " << err;
   const picojson::object& obj = v.get<picojson::object>();
   VocabType vocab_type = HFTokenizerAnalyzer::DetectVocabType(obj);
@@ -530,6 +553,7 @@ std::variant<TokenizerInfo, SerializationError> TokenizerInfo::DeserializeJSON(
   if (auto err = AutoDeserializeJSON(&tokenizer_info, json_string, true, "TokenizerInfo")) {
     return err.value();
   }
+  // Derived per-token arrays are not serialized; rebuild them like the constructor does.
   tokenizer_info->BuildTokenIdToSortedVocabIndex();
   tokenizer_info->BuildTokenCharData();
   return tokenizer_info;

--- a/cpp/tokenizer_info_impl.h
+++ b/cpp/tokenizer_info_impl.h
@@ -4,6 +4,7 @@
 #include <picojson.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -43,6 +44,13 @@ class TokenizerInfo::Impl {
   int32_t GetMaxTokenChars() const;
   void BuildTokenIdToSortedVocabIndex();
   void BuildTokenCharData();
+
+  /*!
+   * \brief Check that the token ids and per-token arrays are consistent with the vocabulary. Used
+   * after deserialization, where the fields are restored verbatim.
+   * \return An error message if the tokenizer info is malformed.
+   */
+  std::optional<std::string> Validate() const;
 
   std::string DumpMetadata() const;
   picojson::value DumpMetadataValue() const;

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -926,8 +926,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           "xgrammar.tvm_ffi_binding.testing._is_rule_fsm_accept_string",
           [](O grammar_ref, int64_t rule_id, ffi::String input) {
             const auto& grammar = grammar_ref.as<GrammarObj>()->value;
-            XGRAMMAR_CHECK(rule_id >= 0 && rule_id < grammar->NumRules())
-                << "Rule id is out of range: " << rule_id;
+            XGRAMMAR_CHECK(
+                rule_id >= 0 && rule_id < static_cast<int64_t>(grammar->per_rule_fsms.size())
+            ) << "Rule id is out of range or the grammar has no per-rule FSMs: "
+              << rule_id;
             const auto& rule_fsm = grammar->per_rule_fsms[rule_id];
             XGRAMMAR_CHECK(rule_fsm.has_value())
                 << "Rule " << rule_id << " does not have a finite-state machine";

--- a/tests/python/test_grammar_matcher_basic.py
+++ b/tests/python/test_grammar_matcher_basic.py
@@ -907,5 +907,29 @@ def test_batch_fill_next_token_bitmask_pressure_shuffled():
         )
 
 
+def test_override_stop_tokens_out_of_range_raises():
+    # Stop token ids are written into the token bitmask, so an id outside the vocabulary must be
+    # rejected instead of corrupting memory.
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c"], vocab_size=8)
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(xgr.Grammar.from_regex("a+"))
+    with pytest.raises(RuntimeError):
+        xgr.GrammarMatcher(compiled, override_stop_tokens=[2**28])
+
+
+def test_batch_fill_next_token_bitmask_terminated_matcher_raises():
+    # An error raised by a matcher inside the thread pool must surface on the calling thread instead
+    # of terminating the process.
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "</s>"], stop_token_ids=[2])
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_grammar(xgr.Grammar.from_regex("a"))
+    terminated = xgr.GrammarMatcher(compiled)
+    assert terminated.accept_token(0)
+    assert terminated.accept_token(2)
+    assert terminated.is_terminated()
+    matchers = [xgr.GrammarMatcher(compiled), terminated]
+    bitmask = xgr.allocate_token_bitmask(len(matchers), tokenizer_info.vocab_size)
+    with pytest.raises(RuntimeError):
+        xgr.BatchGrammarMatcher(2).batch_fill_next_token_bitmask(matchers, bitmask)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3533,5 +3533,27 @@ def test_prefix_items_no_additional_items_allows_shorter():
     check_schema_with_instance(schema, '["a", 1, true]', is_accepted=False)
 
 
+def test_bounds_beyond_int32():
+    # Bounds become int32 repetition ranges: a maximum beyond int32 is unbounded in practice and a
+    # minimum beyond it can never be satisfied. Neither may wrap around and crash the converter.
+    schema = {
+        "type": "array",
+        "items": {"type": "string", "maxLength": 2**32},
+        "maxItems": 2**31 + 1,
+    }
+    grammar = xgr.Grammar.from_json_schema(json.dumps(schema))
+    assert _is_grammar_accept_string(grammar, '["a", "b"]')
+    with pytest.raises(RuntimeError):
+        xgr.Grammar.from_json_schema(json.dumps({"type": "array", "minItems": 2**31 + 1}))
+    with pytest.raises(RuntimeError):
+        xgr.Grammar.from_json_schema(json.dumps({"type": "string", "minLength": 2**31 + 1}))
+
+
+def test_deeply_nested_json_rejected():
+    # The JSON parser recurses once per nesting level, so the depth must be bounded.
+    with pytest.raises(RuntimeError):
+        xgr.Grammar.from_json_schema("[" * 30000 + "]" * 30000)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3550,9 +3550,15 @@ def test_bounds_beyond_int32():
 
 
 def test_deeply_nested_json_rejected():
-    # The JSON parser recurses once per nesting level, so the depth must be bounded.
-    with pytest.raises(RuntimeError):
-        xgr.Grammar.from_json_schema("[" * 30000 + "]" * 30000)
+    # The JSON parser recurses once per nesting level; the depth is bounded by the maximum
+    # recursion depth instead of overflowing the stack.
+    def schema(depth: int) -> str:
+        return '{"unused": ' + "[" * depth + "0" + "]" * depth + "}"
+
+    with xgr.max_recursion_depth(50):
+        xgr.Grammar.from_json_schema(schema(40))
+        with pytest.raises(RuntimeError, match="Maximum recursion depth exceeded"):
+            xgr.Grammar.from_json_schema(schema(60))
 
 
 if __name__ == "__main__":

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -3549,6 +3549,7 @@ def test_bounds_beyond_int32():
         xgr.Grammar.from_json_schema(json.dumps({"type": "string", "minLength": 2**31 + 1}))
 
 
+@pytest.mark.thread_unsafe
 def test_deeply_nested_json_rejected():
     # The JSON parser recurses once per nesting level; the depth is bounded by the maximum
     # recursion depth instead of overflowing the stack.

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -3168,3 +3168,10 @@ def test_lark_suffix_stop_body_must_be_terminal_but_supports_bounded_regex(attri
         ["ab!", "abcde!"],
         ["a!", "abcdef!", "ab!!"],
     )
+
+
+def test_deeply_nested_groups_rejected():
+    # Group parsing recurses once per level; the depth must be bounded instead of overflowing the
+    # stack.
+    assert xgr.Grammar.from_lark("start: " + "(" * 100 + '"a"' + ")" * 100) is not None
+    _assert_lark_error("start: " + "(" * 2000 + '"a"' + ")" * 2000, "nested deeper than")

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -3177,6 +3177,7 @@ def test_deeply_nested_groups_rejected():
     _assert_lark_error("start: " + "(" * 2000 + '"a"' + ")" * 2000, "nested deeper than")
 
 
+@pytest.mark.thread_unsafe
 def test_json_directive_depth_is_bounded_per_value():
     # The %json value is parsed on its own: brackets in the rest of the grammar must not count
     # towards its nesting depth, while the value itself is bounded by the maximum recursion depth.

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -3175,3 +3175,13 @@ def test_deeply_nested_groups_rejected():
     # stack.
     assert xgr.Grammar.from_lark("start: " + "(" * 100 + '"a"' + ")" * 100) is not None
     _assert_lark_error("start: " + "(" * 2000 + '"a"' + ")" * 2000, "nested deeper than")
+
+
+def test_json_directive_depth_is_bounded_per_value():
+    # The %json value is parsed on its own: brackets in the rest of the grammar must not count
+    # towards its nesting depth, while the value itself is bounded by the maximum recursion depth.
+    with xgr.max_recursion_depth(50):
+        assert xgr.Grammar.from_lark("start: %json true\n# " + "[" * 100) is not None
+        _assert_lark_error(
+            "start: %json " + "[" * 60 + "]" * 60, "Maximum recursion depth exceeded"
+        )

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -3177,7 +3177,6 @@ def test_deeply_nested_groups_rejected():
     _assert_lark_error("start: " + "(" * 2000 + '"a"' + ")" * 2000, "nested deeper than")
 
 
-@pytest.mark.thread_unsafe
 def test_json_directive_depth_is_bounded_per_value():
     # The %json value is parsed on its own: brackets in the rest of the grammar must not count
     # towards its nesting depth, while the value itself is bounded by the maximum recursion depth.

--- a/tests/python/test_recursion_depth.py
+++ b/tests/python/test_recursion_depth.py
@@ -52,5 +52,13 @@ def test_recursion_exceed():
         matcher.accept_string(input_str)
 
 
+def test_deeply_nested_macro_tuple_does_not_overflow():
+    # Nested tuples inside a macro argument recurse once per layer; without a depth guard this
+    # overflows the stack. It must instead be rejected with a parser error.
+    grammar_str = "root ::= Token(" + "(" * 500000
+    with pytest.raises(RuntimeError):
+        xgr.Grammar.from_ebnf(grammar_str)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_recursion_depth.py
+++ b/tests/python/test_recursion_depth.py
@@ -54,8 +54,8 @@ def test_recursion_exceed():
 
 def test_deeply_nested_macro_tuple_does_not_overflow():
     # Nested tuples inside a macro argument recurse once per layer; without a depth guard this
-    # overflows the stack. It must instead be rejected with a parser error.
-    grammar_str = "root ::= Token(" + "(" * 500000
+    # overflows the stack. Exceeding the 1000-layer guard must be rejected with a parser error.
+    grammar_str = "root ::= Token(" + "(" * 2000
     with pytest.raises(RuntimeError):
         xgr.Grammar.from_ebnf(grammar_str)
 

--- a/tests/python/test_recursion_depth.py
+++ b/tests/python/test_recursion_depth.py
@@ -10,7 +10,7 @@ from xgrammar.testing import _get_matcher_from_grammar
 def test_set_get_recursion_depth():
     """Test getting default recursion depth"""
     default_depth = xgr.get_max_recursion_depth()
-    assert default_depth == 10000
+    assert default_depth == 50
 
     xgr.set_max_recursion_depth(1000)
     new_depth = xgr.get_max_recursion_depth()
@@ -21,7 +21,7 @@ def test_set_get_recursion_depth():
 @pytest.mark.thread_unsafe
 def test_recursion_depth_context():
     """Test recursion depth context manager"""
-    assert xgr.get_max_recursion_depth() == 10000
+    assert xgr.get_max_recursion_depth() == 50
     with xgr.max_recursion_depth(1000):
         depth = xgr.get_max_recursion_depth()
         assert depth == 1000

--- a/tests/python/test_recursion_depth.py
+++ b/tests/python/test_recursion_depth.py
@@ -10,7 +10,7 @@ from xgrammar.testing import _get_matcher_from_grammar
 def test_set_get_recursion_depth():
     """Test getting default recursion depth"""
     default_depth = xgr.get_max_recursion_depth()
-    assert default_depth == 50
+    assert default_depth == 10000
 
     xgr.set_max_recursion_depth(1000)
     new_depth = xgr.get_max_recursion_depth()
@@ -21,7 +21,7 @@ def test_set_get_recursion_depth():
 @pytest.mark.thread_unsafe
 def test_recursion_depth_context():
     """Test recursion depth context manager"""
-    assert xgr.get_max_recursion_depth() == 50
+    assert xgr.get_max_recursion_depth() == 10000
     with xgr.max_recursion_depth(1000):
         depth = xgr.get_max_recursion_depth()
         assert depth == 1000

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -552,7 +552,6 @@ def test_deserialized_tokenizer_info_compiles_token_edges():
     assert masks[0] == masks[1]
 
 
-@pytest.mark.thread_unsafe
 def test_deserialize_deeply_nested_json_rejected():
     # The JSON parser recurses once per nesting level; the depth is bounded by the maximum
     # recursion depth and reported as an invalid JSON error.

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -552,6 +552,7 @@ def test_deserialized_tokenizer_info_compiles_token_edges():
     assert masks[0] == masks[1]
 
 
+@pytest.mark.thread_unsafe
 def test_deserialize_deeply_nested_json_rejected():
     # The JSON parser recurses once per nesting level; the depth is bounded by the maximum
     # recursion depth and reported as an invalid JSON error.

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -552,5 +552,13 @@ def test_deserialized_tokenizer_info_compiles_token_edges():
     assert masks[0] == masks[1]
 
 
+def test_deserialize_deeply_nested_json_rejected():
+    # The JSON parser recurses once per nesting level; the depth is bounded by the maximum
+    # recursion depth and reported as an invalid JSON error.
+    with xgr.max_recursion_depth(50):
+        with pytest.raises(xgr.InvalidJSONError, match="Maximum recursion depth exceeded"):
+            xgr.Grammar.deserialize_json("[" * 60 + "]" * 60)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -42,6 +42,13 @@ def construct_compiled_grammar():
     return grammar_compiler.compile_grammar(grammar), tokenizer_info
 
 
+def _set_path(obj, path, value):
+    """Set obj[path[0]][path[1]]... = value on a parsed JSON object."""
+    for key in path[:-1]:
+        obj = obj[key]
+    obj[path[-1]] = value
+
+
 def test_get_serialization_version():
     """Test the version of the serialized JSON string."""
     assert xgr.get_serialization_version() == "v16"
@@ -441,6 +448,108 @@ def test_serialized_output_survives_pickle():
     )
     assert result.returncode == 0, f"returncode={result.returncode}\n{result.stderr[-2000:]}"
     assert "PICKLE_OK" in result.stdout
+
+
+# The reflection-based deserializer restores fields verbatim, so corrupted ids and offsets used to
+# be dereferenced later and crash the process. They must be rejected at deserialization time.
+@pytest.mark.parametrize(
+    "path, value",
+    [
+        (["root_rule_id"], 2**31 - 1),
+        (["grammar_expr_indptr"], [10**9]),
+        (["grammar_expr_data"], []),
+        (["rules", 0, 1], 10**6),  # body_expr_id
+        (["allow_empty_rule_ids"], [10**6]),
+    ],
+)
+def test_deserialize_grammar_rejects_out_of_range(path, value):
+    obj = json.loads(construct_grammar().serialize_json())
+    _set_path(obj, path, value)
+    with pytest.raises(xgr.DeserializeFormatError):
+        xgr.Grammar.deserialize_json(json.dumps(obj))
+
+
+def test_deserialize_grammar_rejects_rule_ref_out_of_range():
+    obj = json.loads(construct_grammar().serialize_json())
+    data, indptr = obj["grammar_expr_data"], obj["grammar_expr_indptr"]
+    # Every expr is stored as [type, length, data...]; type 4 is a rule reference.
+    rule_ref_starts = [start for start in indptr if data[start] == 4]
+    assert rule_ref_starts
+    data[rule_ref_starts[0] + 2] = 10**6
+    with pytest.raises(xgr.DeserializeFormatError):
+        xgr.Grammar.deserialize_json(json.dumps(obj))
+
+
+@pytest.mark.parametrize(
+    "path, value",
+    [
+        (["grammar", "per_rule_fsms"], []),  # optimized grammar without per-rule FSMs
+        (["grammar", "complete_fsm"], None),
+        (["grammar", "complete_fsm", "edges", "data_", 0, 2], 10**6),  # edge target
+        (["grammar", "complete_fsm", "edges", "indptr_"], [0]),  # CSR does not cover the data
+        (["grammar", "complete_fsm", "edge_num"], 0),
+        (["grammar", "per_rule_fsms", 0, 0, 1], 10**6),  # start state
+        (["grammar", "per_rule_fsms", 0, 0, 2], [10**6]),  # end states
+    ],
+)
+def test_deserialize_compiled_grammar_rejects_corrupted_fsm(path, value):
+    compiled_grammar, tokenizer_info = construct_compiled_grammar()
+    obj = json.loads(compiled_grammar.serialize_json())
+    _set_path(obj, path, value)
+    with pytest.raises(xgr.DeserializeFormatError):
+        xgr.CompiledGrammar.deserialize_json(json.dumps(obj), tokenizer_info)
+
+
+@pytest.mark.parametrize(
+    "fields",
+    [
+        {"accepted_indices": [10**6]},
+        {"rejected_indices": [-1]},
+        {"uncertain_indices": [10**6]},
+        {"store_type": 7},
+        {"accepted_bitset": [64, 2]},  # declares 2 words but provides none
+        {"store_type": 2, "accepted_bitset": [1, 1, 0]},  # bitset smaller than vocab_size
+    ],
+)
+def test_deserialize_compiled_grammar_rejects_corrupted_mask(fields):
+    compiled_grammar, tokenizer_info = construct_compiled_grammar()
+    obj = json.loads(compiled_grammar.serialize_json())
+    obj["adaptive_token_mask_cache"][0][1].update(fields)
+    with pytest.raises(xgr.DeserializeFormatError):
+        xgr.CompiledGrammar.deserialize_json(json.dumps(obj), tokenizer_info)
+
+
+@pytest.mark.parametrize(
+    "path, value",
+    [
+        (["vocab_size"], 3),  # smaller than the number of real tokens
+        (["sorted_decoded_vocab", 0, 0], 10**6),
+        (["trie_subtree_nodes_range"], []),
+        (["stop_token_ids"], [10**6]),
+        (["special_token_ids"], [-1]),
+    ],
+)
+def test_deserialize_tokenizer_info_rejects_out_of_range(path, value):
+    obj = json.loads(construct_tokenizer_info().serialize_json())
+    _set_path(obj, path, value)
+    with pytest.raises(xgr.DeserializeFormatError):
+        xgr.TokenizerInfo.deserialize_json(json.dumps(obj))
+
+
+def test_deserialized_tokenizer_info_compiles_token_edges():
+    # token_id_to_sorted_vocab_index is derived data that is not serialized; compiling a grammar
+    # with Token() edges against a deserialized TokenizerInfo used to read the missing array.
+    tokenizer_info = construct_tokenizer_info()
+    recovered = xgr.TokenizerInfo.deserialize_json(tokenizer_info.serialize_json())
+    grammar = xgr.Grammar.from_ebnf('root ::= Token(2, 3) "a"\n')
+    masks = []
+    for info in (tokenizer_info, recovered):
+        matcher = xgr.GrammarMatcher(xgr.GrammarCompiler(info).compile_grammar(grammar))
+        mask = xgr.allocate_token_bitmask(1, info.vocab_size)
+        matcher.fill_next_token_bitmask(mask)
+        masks.append(mask.tolist())
+        assert matcher.accept_token(2)
+    assert masks[0] == masks[1]
 
 
 if __name__ == "__main__":

--- a/tests/python/test_speculative_decoding.py
+++ b/tests/python/test_speculative_decoding.py
@@ -240,8 +240,19 @@ def test_traverse_draft_tree_out_of_bounds_edge(compiled_grammar):
         torch.tensor([-1], dtype=torch.int64),  # next_sibling: root has none (passes the check)
         torch.tensor([3], dtype=torch.int64),  # draft tokens
     )
-    with pytest.raises(Exception):
+    with pytest.raises(RuntimeError):
         _run_traverse(compiled_grammar, bad_tree)
+
+
+def test_traverse_draft_tree_cyclic_edge(compiled_grammar):
+    # Node 1 is its own child: the traversal would recurse forever, so the edges must be rejected.
+    cyclic_tree = (
+        torch.tensor([1, 1, -1], dtype=torch.int64),
+        torch.tensor([-1, -1, -1], dtype=torch.int64),
+        torch.tensor([3, 6, 4], dtype=torch.int64),
+    )
+    with pytest.raises(RuntimeError):
+        _run_traverse(compiled_grammar, cyclic_tree)
 
 
 if __name__ == "__main__":

--- a/tests/python/test_speculative_decoding.py
+++ b/tests/python/test_speculative_decoding.py
@@ -232,5 +232,17 @@ def test_traverse_draft_tree_timeout_triggers():
     assert bitmask[0].any(), "Root bitmask should still be computed even when timed out"
 
 
+def test_traverse_draft_tree_out_of_bounds_edge(compiled_grammar):
+    # An edge index outside [-1, num_nodes) would make the traversal recurse into an out-of-bounds
+    # node; it must be rejected instead of crashing.
+    bad_tree = (
+        torch.tensor([1000000], dtype=torch.int64),  # next_token points to a non-existent node
+        torch.tensor([-1], dtype=torch.int64),  # next_sibling: root has none (passes the check)
+        torch.tensor([3], dtype=torch.int64),  # draft tokens
+    )
+    with pytest.raises(Exception):
+        _run_traverse(compiled_grammar, bad_tree)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -4973,5 +4973,19 @@ def test_structural_tag_max_whitespace_cnt_compile_cache():
     assert not _is_grammar_accept_string(g_bounded, _ws_instance(5))
 
 
+def test_deeply_nested_formats_rejected():
+    # Formats are walked by several recursive passes; the nesting depth must be bounded instead of
+    # overflowing the stack.
+    def nested(depth: int) -> Dict[str, Any]:
+        fmt: Dict[str, Any] = {"type": "const_string", "value": "a"}
+        for _ in range(depth):
+            fmt = {"type": "sequence", "elements": [fmt]}
+        return fmt
+
+    xgr.Grammar.from_structural_tag({"type": "structural_tag", "format": nested(100)})
+    with pytest.raises(Exception, match="nested deeper than"):
+        xgr.Grammar.from_structural_tag({"type": "structural_tag", "format": nested(2000)})
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -4975,16 +4975,16 @@ def test_structural_tag_max_whitespace_cnt_compile_cache():
 
 def test_deeply_nested_formats_rejected():
     # Formats are walked by several recursive passes; the nesting depth must be bounded instead of
-    # overflowing the stack.
-    def nested(depth: int) -> Dict[str, Any]:
-        fmt: Dict[str, Any] = {"type": "const_string", "value": "a"}
-        for _ in range(depth):
-            fmt = {"type": "sequence", "elements": [fmt]}
-        return fmt
+    # overflowing the stack. The JSON is built as a string so that Python's own recursion limit is
+    # not the thing under test.
+    def nested(depth: int) -> str:
+        fmt = '{"type": "sequence", "elements": [' * depth
+        fmt += '{"type": "const_string", "value": "a"}' + "]}" * depth
+        return '{"type": "structural_tag", "format": ' + fmt + "}"
 
-    xgr.Grammar.from_structural_tag({"type": "structural_tag", "format": nested(100)})
+    xgr.Grammar.from_structural_tag(nested(50))
     with pytest.raises(Exception, match="nested deeper than"):
-        xgr.Grammar.from_structural_tag({"type": "structural_tag", "format": nested(2000)})
+        xgr.Grammar.from_structural_tag(nested(300))
 
 
 if __name__ == "__main__":

--- a/tests/python/test_token_bitmask_operations.py
+++ b/tests/python/test_token_bitmask_operations.py
@@ -366,6 +366,16 @@ def test_apply_token_bitmask_inplace_indices(
         torch.testing.assert_close(logits, logits_expected)
 
 
+@pytest.mark.parametrize("bad_index", [5, -1])
+def test_apply_token_bitmask_inplace_indices_out_of_bounds(bad_index: int):
+    # An index that is out of range for the logits/bitmask batch would cause an out-of-bounds
+    # write; it must be rejected instead of crashing.
+    logits = torch.ones(2, 128, dtype=torch.float32)
+    bitmask = torch.zeros(2, 4, dtype=torch.int32)
+    with pytest.raises(Exception):
+        xgr.apply_token_bitmask_inplace(logits, bitmask, indices=[bad_index])
+
+
 def test_bitmask_to_boolmask():
     # 0xFFFF0000, 0x0000FFFF
     bitmask = torch.tensor([[-65536, 65535]], dtype=torch.int32)

--- a/tests/python/test_token_edge.py
+++ b/tests/python/test_token_edge.py
@@ -1632,5 +1632,14 @@ def test_stag_any_tokens_exclude_redispatch():
     assert m.is_terminated()
 
 
+def test_token_edge_id_out_of_vocab_raises():
+    # Token ids index per-token arrays during compilation, so an id outside the vocabulary must be
+    # rejected with an error instead of being read out of bounds.
+    tokenizer_info = xgr.TokenizerInfo(["a", "b", "c", "d"])
+    grammar = xgr.Grammar.from_ebnf('root ::= Token(2147483647) "c"\n')
+    with pytest.raises(RuntimeError):
+        xgr.GrammarCompiler(tokenizer_info).compile_grammar(grammar)
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/python/test_tokenizer_info.py
+++ b/tests/python/test_tokenizer_info.py
@@ -303,5 +303,22 @@ def test_model_vocab_size_smaller_than_tokenizer(tokenizer_path: str, model_voca
     print(len(tokenizer_info.decoded_vocab))
 
 
+def test_tokenizer_info_vocab_size_smaller_than_vocab_raises():
+    # vocab_size only ever pads the vocab; a value below the number of real tokens leaves token ids
+    # without a slot and used to corrupt an internal table. It must be rejected.
+    vocab = [str(i) for i in range(100)]
+    with pytest.raises(RuntimeError):
+        xgr.TokenizerInfo(vocab, vocab_size=1)
+
+
+def test_matcher_accept_padding_token_id():
+    # With a padded vocab, ids in [len(vocab), vocab_size) are padding/special ids with no decoded
+    # token. Accepting one must be rejected gracefully instead of reading out of bounds.
+    tokenizer_info = xgr.TokenizerInfo(["a", "b"], vocab_size=1000, stop_token_ids=[])
+    compiled = xgr.GrammarCompiler(tokenizer_info).compile_builtin_json_grammar()
+    matcher = xgr.GrammarMatcher(compiled)
+    assert matcher.accept_token(500) is False
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)


### PR DESCRIPTION
## Summary

Hardens the C++ boundary so that invalid arguments, corrupted or incomplete serialized data, and errors raised on worker threads surface as Python exceptions instead of crashing the process. Every fix comes with a subprocess-verified reproducer turned into a regression test.

### Out-of-range arguments to the public API

- `apply_token_bitmask_inplace(..., indices=[...])`: validate every index against both the logits and the bitmask batch size (`ApplyTokenBitmaskInplaceCPU` only checked the no-indices path, so an out-of-range index wrote through a wild pointer).
- `TokenizerInfo(vocab, vocab_size=N)` with `N < len(vocab)`: reject in the constructor (`token_id_to_sorted_vocab_index_` was allocated with `vocab_size` and written with real token ids).
- `accept_token(padding_id)`: padding ids pass the range check because it uses the padded vocab size, but the special-token warning indexed `decoded_vocab` with them; only decode ids backed by a real token.
- `traverse_draft_tree`: validate that every `retrieve_next_token` / `retrieve_next_sibling` value is in `[-1, num_nodes)` and that the edges form a tree (root has no incoming edge, every other node at most one). Out-of-range values recursed into arbitrary memory; cycles or shared nodes recursed without bound.
- EBNF macro arguments: nested tuples in `ParseMacroValue` bypassed `nest_layer_guard_`, so `Token((((...` overflowed the stack.
- Token ids written in `Token(...)`, `ExcludeToken(...)` and token tag dispatch must exist in the vocabulary. They are used as indices into per-token arrays on compiler worker threads, so they are checked on the calling thread before compilation starts (and skipped defensively on the worker path).
- `GrammarMatcher(override_stop_tokens=[...])`: every id must be in `[0, vocab_size)`; the ids are written into the token bitmask.

### Integer truncation and unbounded recursion in the grammar front-ends

- JSON schema `minLength` / `maxLength` / `minItems` / `minContains` / `maxItems` beyond int32 were truncated when converted to repetition bounds; a negative upper bound made `LegacyHandleRepetitionRange` call `back()` on an empty vector. Maxima beyond int32 are now unbounded, minima beyond it are rejected, and `ExpandRepetitionRange` checks its range.
- The Lark parser had no nesting limit for groups; it now stops at 200 levels (each level uses a few KB of stack; the limit leaves a wide margin below the 1 MB main-thread stack on Windows).
- Structural tag formats are limited to 100 nesting levels; the global recursion limit is far deeper than the native stack allows for the passes over the format tree.
- `picojson::parse` recurses once per nesting level with no limit. All call sites go through `ParseJSON` (`cpp/support/json_parse.h`), which parses with a picojson context that counts every nested array or object in a `RecursionGuard`, so the maximum recursion depth applies while parsing and a too-deep input is reported as a JSON parse error.
- `GrammarBuilder::AddGrammarExpr` checks that the grammar expr data stays addressable by int32 offsets (reachable with a huge `indent`).
- The `xgrammar.testing` FSM helpers check `per_rule_fsms` before indexing it.

### Deserialization of corrupted or incomplete data

The reflection-based deserializer restored CSR arrays, ids and bitsets verbatim and never re-ran the invariants that the constructors guarantee, so corrupted JSON crashed on first use (`root_rule_id`, `grammar_expr_indptr`, FSM edges, mask indices, ...). It also never rebuilt `token_id_to_sorted_vocab_index_`, so compiling any grammar with token edges against a *legitimately* deserialized `TokenizerInfo` segfaulted.

- `AutoDeserializeJSONValue` now calls `std::optional<std::string> Validate() const` on reflection-based types that define it, after all members are deserialized, and reports the message as a `DeserializeFormatError`. `Validate()` is implemented for `Compact2DArray`, `CompactFSM::Impl`, the `CompactFSMWithStartEnd` serialization helper, `Grammar::Impl` and `TokenizerInfo::Impl`.
- `DynamicBitset` deserialization checks the array length before reading the words.
- `CompiledGrammar` deserialization propagates the errors of its `grammar` and `adaptive_token_mask_cache` sub-objects (they were ignored) and checks that every mask matches the tokenizer.
- `TokenizerInfo::DeserializeJSON` rebuilds `token_id_to_sorted_vocab_index_`.

The serialization format is unchanged.

### Errors on worker threads

`ThreadPool::Execute` tasks that threw (a terminated matcher or an out-of-range index in `BatchGrammarMatcher.batch_fill_next_token_bitmask`, or any check failing during multi-threaded compilation) escaped the worker thread and called `std::terminate`. The pool now records the first exception and rethrows it from `Wait()` / `Join()` on the calling thread.

