### PR TITLE
Skip deriving a lookahead with a non-atom suffix element

### DIFF
--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -1075,6 +1075,25 @@ class LookaheadAssertionAnalyzerImpl : public GrammarMutator {
     if (!CanUseDerivedLookahead(rule_id)) {
       return -1;
     }
+    // The lookahead assertion is matched by EarleyParser::Predict/Scan on the expr path, which
+    // only handles atom elements. A composite element such as a choices expr (which a
+    // non-normalized rule body may leave inside a sequence) would abort the parser, so skip
+    // deriving a lookahead in that case. The derived lookahead is only an optimization, so
+    // skipping it never changes the accepted language.
+    for (int32_t element_id : rule_lookahead_infos_[rule_id].suffix_after_first_occurrence) {
+      switch (base_grammar_->GetGrammarExpr(element_id).type) {
+        case GrammarExprType::kByteString:
+        case GrammarExprType::kCharacterClass:
+        case GrammarExprType::kCharacterClassStar:
+        case GrammarExprType::kRuleRef:
+        case GrammarExprType::kRepeat:
+        case GrammarExprType::kToken:
+        case GrammarExprType::kExcludeToken:
+          break;
+        default:
+          return -1;
+      }
+    }
     return builder_->AddSequence(rule_lookahead_infos_[rule_id].suffix_after_first_occurrence);
   }
 

--- a/tests/python/test_grammar_compiler.py
+++ b/tests/python/test_grammar_compiler.py
@@ -12,7 +12,11 @@ from pydantic import BaseModel
 from transformers import AutoTokenizer
 
 import xgrammar as xgr
-from xgrammar.testing import _get_allow_empty_rule_ids, bitmask_to_bool_mask
+from xgrammar.testing import (
+    _ebnf_to_grammar_no_normalization,
+    _get_allow_empty_rule_ids,
+    bitmask_to_bool_mask,
+)
 
 
 @pytest.mark.parametrize(
@@ -638,6 +642,31 @@ def test_limited_compiler_cache_evicts_value_that_crosses_limit():
     compiled = compiler.compile_builtin_json_grammar()
     assert compiler.get_cache_size_bytes() <= cache_limit
     assert _compiled_accepts(compiled, '{"a": 1}')
+
+
+def test_derived_lookahead_skips_non_atom_suffix():
+    # A non-normalized rule body may leave a choices expr inside a sequence.
+    # LookaheadAssertionAnalyzer derives a lookahead for `sub` (its single
+    # non-last occurrence) whose suffix would then include that choices expr.
+    # The Earley lookahead matcher only handles atom elements, so deriving such
+    # a lookahead used to abort compilation with a fatal "element type is not
+    # supported" error. The analyzer must skip deriving a lookahead in that case
+    # while still accepting the same language.
+    #
+    # The vocabulary contains tokens that straddle the end of `sub` into the
+    # following choices (e.g. "xa", "ax"). Those become uncertain tokens whose
+    # mask is resolved by matching the derived lookahead at compile time, which
+    # is exactly the path that reached the fatal error.
+    tokenizer_info = xgr.TokenizerInfo(["ax", "a", "bb", "z", "xa", "aa", "xbb"], stop_token_ids=[])
+    grammar = _ebnf_to_grammar_no_normalization(
+        'root ::= sub ("a" | "bb") "z"\n' 'sub ::= inner "x" | inner inner\n' "inner ::= [a-z]"
+    )
+    compiled = xgr.GrammarCompiler(
+        tokenizer_info, max_threads=1, cache_enabled=False
+    ).compile_grammar(grammar)
+    assert _compiled_accepts(compiled, "axaz")
+    assert _compiled_accepts(compiled, "aabbz")
+    assert not _compiled_accepts(compiled, "axz")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A rule compiled through the Earley path can carry a *derived* lookahead assertion: `LookaheadAssertionAnalyzer` builds one from the suffix that follows the rule’s single non-last occurrence. The Earley lookahead matcher (`EarleyParser::Predict`/`Scan` on the expr path) only handles atom elements — byte string, character class, character class star, rule reference, repeat, token, exclude token.

When the derived suffix contains a composite element such as a `kChoices` expr, the parser hits `The element type is not supported! The type is: 6` and throws. A non-normalized rule body can leave a choices expr inside a sequence, which then flows straight into the derived suffix. Because the adaptive-mask computation that matches the lookahead runs on the compiler thread pool, with `max_threads > 1` the fatal error is thrown from a worker thread and `std::terminate` brings down the whole process:

```
terminate called after throwing an instance of 'xgrammar::LogFatalError'
```

The fix makes `DetectLookaheadAssertion` skip deriving a lookahead when the suffix contains any non-atom element. The derived lookahead is purely an optimization, so skipping it never changes the accepted language; grammars whose suffix is entirely atoms (the normalized path) are unaffected.