### PR TITLE
feat: add canonical recursive Any support for Cohere XML

### DIFF
--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -66,6 +66,8 @@ const std::string XMLToolCallingConverter::kXMLString = "xml_string";
 const std::string XMLToolCallingConverter::kXMLAny = "xml_any";
 const std::string XMLToolCallingConverter::kXMLObject = "xml_object";
 const std::string XMLToolCallingConverter::kXMLVariableName = "xml_variable_name";
+const std::string CohereXMLToolCallingConverter::kCohereAnyScalar = "cohere_any_scalar";
+const std::string CohereXMLToolCallingConverter::kCohereAnyList = "cohere_any_list";
 const std::unordered_map<JSONFormat, XMLToolCallingConverter::XMLWrapper>
     XMLToolCallingConverter::kKeyWrapperMap = {
         {JSONFormat::kQwenXML, {"<parameter=", ">", "", "</parameter>"}},
@@ -486,6 +488,28 @@ CohereXMLToolCallingConverter::CohereXMLToolCallingConverter(
           any_order
       ) {}
 
+void CohereXMLToolCallingConverter::AddBasicRules() {
+  // The recursive Any bodies must have stable targets before kXMLAny and kXMLObject are built.
+  builder_.AddEmptyRule(kCohereAnyScalar);
+  builder_.AddEmptyRule(kCohereAnyList);
+
+  XMLToolCallingConverter::AddBasicRules();
+
+  builder_.UpdateRuleBody(
+      kCohereAnyScalar, Choice({RuleRef(kBasicNumber), RuleRef(kBasicBoolean), RuleRef(kBasicNull)})
+  );
+  // kXMLObject already provides named_any_value* through its dynamic-property formatting.
+  // Lists need the corresponding recursive sequence of unnamed Any wrappers explicitly.
+  int32_t unnamed_any_value = FormatAnyCohereParam(std::nullopt, std::nullopt);
+  builder_.UpdateRuleBody(
+      kCohereAnyList, Repeat("cohere_any_list_items", unnamed_any_value, 0, -1)
+  );
+}
+
+bool CohereXMLToolCallingConverter::AtCohereRoot() const {
+  return nested_object_level_ == 0 && object_stack_.empty() && cohere_array_level_ == 0;
+}
+
 bool CohereXMLToolCallingConverter::InCohereValueContext() const {
   return nested_object_level_ <= 1 || !object_stack_.empty() || cohere_array_level_ > 0;
 }
@@ -595,6 +619,17 @@ int32_t CohereXMLToolCallingConverter::FormatSingleCohereParam(
     const SchemaSpecPtr& schema,
     int32_t value_rule_id
 ) {
+  return FormatCohereParamWithType(
+      name, key_pattern_expr, GetCohereTypePattern(schema), value_rule_id
+  );
+}
+
+int32_t CohereXMLToolCallingConverter::FormatCohereParamWithType(
+    const std::optional<std::string>& name,
+    const std::optional<int32_t>& key_pattern_expr,
+    int32_t type_expression,
+    int32_t value_rule_id
+) {
   std::vector<int32_t> elements = {ByteString(xml_wrapper_.key_wrapper_prefix)};
   if (name.has_value()) {
     elements.push_back(ByteString(" name=\"" + *name + "\""));
@@ -604,7 +639,7 @@ int32_t CohereXMLToolCallingConverter::FormatSingleCohereParam(
     elements.push_back(ByteString("\""));
   }
   elements.push_back(ByteString(" type=\""));
-  elements.push_back(GetCohereTypePattern(schema));
+  elements.push_back(type_expression);
   elements.push_back(ByteString("\"" + xml_wrapper_.key_wrapper_suffix));
 
   if (!xml_wrapper_.value_wrapper_prefix.empty()) {
@@ -613,6 +648,27 @@ int32_t CohereXMLToolCallingConverter::FormatSingleCohereParam(
   elements.push_back(FormatCohereValue(value_rule_id));
   elements.push_back(ByteString(xml_wrapper_.parameter_suffix));
   return Sequence(elements);
+}
+
+int32_t CohereXMLToolCallingConverter::FormatAnyCohereParam(
+    const std::optional<std::string>& name, const std::optional<int32_t>& key_pattern_expr
+) {
+  // kXMLAny is the aggregate body-only union. Wrapping it under every type would create a
+  // type/body cross product, so each wrapper deliberately references its matching component.
+  return Choice(
+      {FormatCohereParamWithType(
+           name, key_pattern_expr, ByteString("raw"), builder_.GetRuleId(kXMLString)
+       ),
+       FormatCohereParamWithType(
+           name, key_pattern_expr, ByteString("json"), builder_.GetRuleId(kCohereAnyScalar)
+       ),
+       FormatCohereParamWithType(
+           name, key_pattern_expr, ByteString("dict"), builder_.GetRuleId(kXMLObject)
+       ),
+       FormatCohereParamWithType(
+           name, key_pattern_expr, ByteString("list"), builder_.GetRuleId(kCohereAnyList)
+       )}
+  );
 }
 
 int32_t CohereXMLToolCallingConverter::FormatCohereParam(
@@ -635,6 +691,18 @@ int32_t CohereXMLToolCallingConverter::FormatCohereParam(
       resolved_schema = ResolveRefSchema(*ref, value_rule_name);
       ref = std::get_if<RefSpec>(&resolved_schema->spec);
     } while (ref != nullptr);
+  }
+
+  // CreateRule may return any aggregate rule (cached or freshly generated), but the schema is
+  // retained along this object-property call path so Any can select correlated wrappers here.
+  if (std::holds_alternative<AnySpec>(resolved_schema->spec)) {
+    return FormatAnyCohereParam(name, key_pattern_expr);
+  }
+  if (const auto* all_of = std::get_if<AllOfSpec>(&resolved_schema->spec);
+      all_of != nullptr && all_of->schemas.size() != 1) {
+    // The base converter intentionally falls back to Any while multi-branch allOf support is
+    // incomplete. Keep that fallback canonical instead of wrapping its aggregate body as json.
+    return FormatAnyCohereParam(name, key_pattern_expr);
   }
 
   auto options = GetCohereCompositeOptions(resolved_schema);
@@ -690,10 +758,12 @@ int32_t CohereXMLToolCallingConverter::GenerateAny(
   if (!InCohereValueContext()) {
     return JSONSchemaConverter::GenerateAny(spec, rule_name);
   }
-  if (nested_object_level_ == 0) {
+  if (AtCohereRoot()) {
     return RuleRef(kXMLObject);
   }
-  return JSONSchemaConverter::GenerateAny(spec, rule_name);
+  return Choice(
+      {RuleRef(kXMLString), RuleRef(kCohereAnyScalar), RuleRef(kXMLObject), RuleRef(kCohereAnyList)}
+  );
 }
 
 int32_t CohereXMLToolCallingConverter::GenerateConst(
@@ -938,6 +1008,11 @@ void CohereXMLToolCallingConverter::AddCache(const std::string& key, int32_t rul
 std::optional<int32_t> CohereXMLToolCallingConverter::GetCache(const std::string& key) const {
   if (key.empty()) {
     return std::nullopt;
+  }
+  // true and {} are equivalent schemas. At the tool-arguments root both are unrestricted
+  // dictionaries, while nested {} keeps using the aggregate Any body rule.
+  if (AtCohereRoot() && key == "{}") {
+    return builder_.GetRuleId(kXMLObject);
   }
   return rule_cache_manager_.GetCache(key, nested_object_level_ > 1 && !InCohereValueContext());
 }

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -8,6 +8,7 @@
 #include <picojson.h>
 
 #include <algorithm>
+#include <array>
 #include <map>
 #include <type_traits>
 #include <unordered_map>
@@ -15,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+#include "support/encoding.h"
 #include "support/json_parse.h"
 #include "support/logging.h"
 
@@ -22,38 +24,77 @@ namespace xgrammar {
 
 namespace {
 
-bool IsXMLIdentifierChar(char c, bool is_first) {
-  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' ||
-         (!is_first && c >= '0' && c <= '9');
+constexpr std::array<std::pair<TCodepoint, const char*>, 4> kCohereKeyEntities = {
+    std::pair<TCodepoint, const char*>{'&', "&amp;"},
+    std::pair<TCodepoint, const char*>{'<', "&lt;"},
+    std::pair<TCodepoint, const char*>{'>', "&gt;"},
+    std::pair<TCodepoint, const char*>{'"', "&quot;"},
+};
+
+std::string SerializeCohereKeyCodepoint(TCodepoint codepoint) {
+  for (const auto& [entity_codepoint, entity] : kCohereKeyEntities) {
+    if (codepoint == entity_codepoint) {
+      return entity;
+    }
+  }
+  return CharToUTF8(codepoint);
+}
+
+std::vector<TCodepoint> ParseCohereKeyCodepoints(const std::string& key) {
+  XGRAMMAR_CHECK(key.find('\0') == std::string::npos) << "Cohere property names cannot contain NUL";
+  auto codepoints = ParseUTF8(key.c_str());
+  XGRAMMAR_CHECK(codepoints.size() != 1 || codepoints[0] != CharHandlingError::kInvalidUTF8)
+      << "Cohere property names must be valid UTF-8";
+  return codepoints;
+}
+
+std::string SerializeCohereKey(const std::string& key) {
+  std::string serialized;
+  for (TCodepoint codepoint : ParseCohereKeyCodepoints(key)) {
+    serialized += SerializeCohereKeyCodepoint(codepoint);
+  }
+  return serialized;
 }
 
 template <typename Children>
-std::vector<GrammarBuilder::CharacterClassElement> XMLIdentifierCharClassExcluding(
-    const Children& children, bool is_first
+std::vector<GrammarBuilder::CharacterClassElement> CohereOrdinaryKeyRangesExcluding(
+    const Children& children
 ) {
-  std::vector<GrammarBuilder::CharacterClassElement> chars;
-  auto add_if_missing = [&](char c) {
-    if (!children.count(c)) {
-      chars.push_back({c, c});
-    }
-  };
-  for (char c = 'A'; c <= 'Z'; ++c) {
-    add_if_missing(c);
-  }
-  add_if_missing('_');
-  for (char c = 'a'; c <= 'z'; ++c) {
-    add_if_missing(c);
-  }
-  if (!is_first) {
-    for (char c = '0'; c <= '9'; ++c) {
-      add_if_missing(c);
-    }
-  }
-  return chars;
-}
+  constexpr TCodepoint kMaxUnicodeCodepoint = 0x10FFFF;
 
-std::vector<GrammarBuilder::CharacterClassElement> XMLIdentifierContinuationChars() {
-  return {{'a', 'z'}, {'A', 'Z'}, {'0', '9'}, {'_', '_'}};
+  // Ordinary key characters must not consume NUL, XML-sensitive characters (which are
+  // represented by entity alternatives), or a codepoint handled by a child trie branch.
+  std::vector<TCodepoint> excluded;
+  excluded.reserve(1 + kCohereKeyEntities.size() + children.size());
+  excluded.push_back('\0');
+  for (const auto& entry : kCohereKeyEntities) {
+    excluded.push_back(entry.first);
+  }
+  for (const auto& entry : children) {
+    excluded.push_back(entry.first);
+  }
+
+  // Sorting makes duplicate exclusions adjacent so that unique + erase can remove them.
+  std::sort(excluded.begin(), excluded.end());
+  excluded.erase(std::unique(excluded.begin(), excluded.end()), excluded.end());
+
+  // Build the positive character class as the gaps between excluded codepoints. Positive
+  // ranges preserve full Unicode support when the grammar is lowered to an FSM.
+  std::vector<GrammarBuilder::CharacterClassElement> ranges;
+  TCodepoint range_start = 0;
+  for (TCodepoint codepoint : excluded) {
+    if (codepoint < range_start) {
+      continue;
+    }
+    if (range_start < codepoint) {
+      ranges.push_back({range_start, codepoint - 1});
+    }
+    range_start = codepoint + 1;
+  }
+  if (range_start <= kMaxUnicodeCodepoint) {
+    ranges.push_back({range_start, kMaxUnicodeCodepoint});
+  }
+  return ranges;
 }
 
 constexpr const char* kStringCacheKey = "{\"type\":\"string\"}";
@@ -66,6 +107,7 @@ const std::string XMLToolCallingConverter::kXMLString = "xml_string";
 const std::string XMLToolCallingConverter::kXMLAny = "xml_any";
 const std::string XMLToolCallingConverter::kXMLObject = "xml_object";
 const std::string XMLToolCallingConverter::kXMLVariableName = "xml_variable_name";
+const std::string CohereXMLToolCallingConverter::kCohereKey = "cohere_key";
 const std::string CohereXMLToolCallingConverter::kCohereAnyScalar = "cohere_any_scalar";
 const std::string CohereXMLToolCallingConverter::kCohereAnyList = "cohere_any_list";
 const std::unordered_map<JSONFormat, XMLToolCallingConverter::XMLWrapper>
@@ -489,11 +531,15 @@ CohereXMLToolCallingConverter::CohereXMLToolCallingConverter(
       ) {}
 
 void CohereXMLToolCallingConverter::AddBasicRules() {
-  // The recursive Any bodies must have stable targets before kXMLAny and kXMLObject are built.
+  // Cohere's dynamic key and recursive Any rules must have stable targets before kXMLObject is
+  // built, because its additional-property formatting reaches them through virtual dispatch.
+  builder_.AddEmptyRule(kCohereKey);
   builder_.AddEmptyRule(kCohereAnyScalar);
   builder_.AddEmptyRule(kCohereAnyList);
 
   XMLToolCallingConverter::AddBasicRules();
+
+  builder_.UpdateRuleBody(kCohereKey, RegexExpression(R"(([^\x00"&<>]|&amp;|&lt;|&gt;|&quot;)+)"));
 
   builder_.UpdateRuleBody(
       kCohereAnyScalar, Choice({RuleRef(kBasicNumber), RuleRef(kBasicBoolean), RuleRef(kBasicNull)})
@@ -632,7 +678,7 @@ int32_t CohereXMLToolCallingConverter::FormatCohereParamWithType(
 ) {
   std::vector<int32_t> elements = {ByteString(xml_wrapper_.key_wrapper_prefix)};
   if (name.has_value()) {
-    elements.push_back(ByteString(" name=\"" + *name + "\""));
+    elements.push_back(ByteString(" name=\"" + SerializeCohereKey(*name) + "\""));
   } else if (key_pattern_expr.has_value()) {
     elements.push_back(ByteString(" name=\""));
     elements.push_back(*key_pattern_expr);
@@ -922,40 +968,37 @@ int32_t CohereXMLToolCallingConverter::FormatOtherProperty(
 
 std::string CohereXMLToolCallingConverter::GetKeyPattern() const {
   if (InCohereValueContext()) {
-    return kXMLVariableName;
+    return kCohereKey;
   }
   return JSONSchemaConverter::GetKeyPattern();
 }
 
-int32_t CohereXMLToolCallingConverter::BuildXMLIdentifierExcludingBody(
-    const XMLIdentifierTrieNode& node, const std::string& rule_name, int depth
+int32_t CohereXMLToolCallingConverter::BuildCohereKeyExcludingBody(
+    const CohereKeyTrieNode& node, int depth
 ) {
   std::vector<int32_t> choices;
   if (depth > 0 && !node.is_terminal) {
     choices.push_back(Empty());
   }
 
-  auto divergent_chars = XMLIdentifierCharClassExcluding(node.children, depth == 0);
-  if (!divergent_chars.empty()) {
-    choices.push_back(Sequence(
-        {builder_.AddCharacterClass(divergent_chars),
-         builder_.AddCharacterClassStar(XMLIdentifierContinuationChars())}
-    ));
-  }
-
-  for (const auto& [c, child] : node.children) {
-    if (!IsXMLIdentifierChar(c, depth == 0)) {
-      continue;
+  int32_t optional_key_suffix = Choice({Empty(), RuleRef(kCohereKey)});
+  int32_t ordinary_key_unit =
+      builder_.AddCharacterClass(CohereOrdinaryKeyRangesExcluding(node.children));
+  choices.push_back(Sequence({ordinary_key_unit, optional_key_suffix}));
+  for (const auto& [codepoint, entity] : kCohereKeyEntities) {
+    if (!node.children.count(codepoint)) {
+      int32_t entity_key_unit = ByteString(entity);
+      choices.push_back(Sequence({entity_key_unit, optional_key_suffix}));
     }
+  }
+
+  for (const auto& [codepoint, child] : node.children) {
     choices.push_back(Sequence(
-        {ByteString(std::string(1, c)), BuildXMLIdentifierExcludingBody(child, rule_name, depth + 1)
-        }
+        {ByteString(SerializeCohereKeyCodepoint(codepoint)),
+         BuildCohereKeyExcludingBody(child, depth + 1)}
     ));
   }
 
-  if (choices.empty()) {
-    return Empty();
-  }
   return Choice(choices);
 }
 
@@ -966,26 +1009,19 @@ int32_t CohereXMLToolCallingConverter::GetKeyPatternExcluding(
     if (properties.empty()) {
       return RuleRef(GetKeyPattern());
     }
-    XMLIdentifierTrieNode root;
+    CohereKeyTrieNode root;
     for (const auto& prop : properties) {
-      XMLIdentifierTrieNode* cur = &root;
-      bool is_valid_identifier = true;
-      for (size_t i = 0; i < prop.name.size(); ++i) {
-        char c = prop.name[i];
-        if (!IsXMLIdentifierChar(c, i == 0)) {
-          is_valid_identifier = false;
-          break;
-        }
-        cur = &cur->children[c];
+      CohereKeyTrieNode* cur = &root;
+      auto codepoints = ParseCohereKeyCodepoints(prop.name);
+      for (TCodepoint codepoint : codepoints) {
+        cur = &cur->children[codepoint];
       }
-      if (is_valid_identifier && !prop.name.empty()) {
+      if (!codepoints.empty()) {
         cur->is_terminal = true;
       }
     }
     int32_t key_rule_id = builder_.AddEmptyRuleWithHint(rule_name + "_cohere_addl_key");
-    builder_.UpdateRuleBody(
-        key_rule_id, BuildXMLIdentifierExcludingBody(root, builder_.GetRule(key_rule_id).name, 0)
-    );
+    builder_.UpdateRuleBody(key_rule_id, BuildCohereKeyExcludingBody(root, 0));
     return RuleRef(key_rule_id);
   }
   return JSONSchemaConverter::GetKeyPatternExcluding(properties, rule_name);

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -1009,9 +1009,9 @@ std::optional<int32_t> CohereXMLToolCallingConverter::GetCache(const std::string
   if (key.empty()) {
     return std::nullopt;
   }
-  // true and {} are equivalent schemas. At the tool-arguments root both are unrestricted
+  // "true" and {} are equivalent schemas. At the tool-arguments root both are unrestricted
   // dictionaries, while nested {} keeps using the aggregate Any body rule.
-  if (AtCohereRoot() && key == "{}") {
+  if (AtCohereRoot() && (key == "{}" || key == "true")) {
     return builder_.GetRuleId(kXMLObject);
   }
   return rule_cache_manager_.GetCache(key, nested_object_level_ > 1 && !InCohereValueContext());

--- a/cpp/json_schema_converter_ext.h
+++ b/cpp/json_schema_converter_ext.h
@@ -176,6 +176,7 @@ class CohereXMLToolCallingConverter : public XMLToolCallingConverter {
   ) override;
   std::string NextSeparator(bool is_end = false) override;
 
+  void AddBasicRules() override;
   void AddCache(const std::string& key, int32_t rule_id) override;
   std::optional<int32_t> GetCache(const std::string& key) const override;
 
@@ -184,6 +185,9 @@ class CohereXMLToolCallingConverter : public XMLToolCallingConverter {
     bool is_terminal = false;
     std::map<char, XMLIdentifierTrieNode> children;
   };
+
+  static const std::string kCohereAnyScalar;
+  static const std::string kCohereAnyList;
 
   int32_t FormatCohereParam(
       const std::optional<std::string>& name,
@@ -197,6 +201,15 @@ class CohereXMLToolCallingConverter : public XMLToolCallingConverter {
       const SchemaSpecPtr& schema,
       int32_t value_rule_id
   );
+  int32_t FormatCohereParamWithType(
+      const std::optional<std::string>& name,
+      const std::optional<int32_t>& key_pattern_expr,
+      int32_t type_expression,
+      int32_t value_rule_id
+  );
+  int32_t FormatAnyCohereParam(
+      const std::optional<std::string>& name, const std::optional<int32_t>& key_pattern_expr
+  );
   int32_t FormatCohereValue(int32_t value_rule_id);
   int32_t GetCohereTypePattern(const SchemaSpecPtr& schema);
   static std::string CohereTypeForJSONLiteral(const std::string& json_value);
@@ -208,6 +221,7 @@ class CohereXMLToolCallingConverter : public XMLToolCallingConverter {
   int32_t BuildXMLIdentifierExcludingBody(
       const XMLIdentifierTrieNode& node, const std::string& rule_name, int depth
   );
+  bool AtCohereRoot() const;
   bool InCohereValueContext() const;
 
   std::vector<const ObjectSpec*> object_stack_;

--- a/cpp/json_schema_converter_ext.h
+++ b/cpp/json_schema_converter_ext.h
@@ -181,11 +181,12 @@ class CohereXMLToolCallingConverter : public XMLToolCallingConverter {
   std::optional<int32_t> GetCache(const std::string& key) const override;
 
  private:
-  struct XMLIdentifierTrieNode {
+  struct CohereKeyTrieNode {
     bool is_terminal = false;
-    std::map<char, XMLIdentifierTrieNode> children;
+    std::map<int32_t, CohereKeyTrieNode> children;
   };
 
+  static const std::string kCohereKey;
   static const std::string kCohereAnyScalar;
   static const std::string kCohereAnyList;
 
@@ -218,9 +219,7 @@ class CohereXMLToolCallingConverter : public XMLToolCallingConverter {
   );
   std::optional<std::vector<SchemaSpecPtr>> GetCohereCompositeOptions(const SchemaSpecPtr& schema
   ) const;
-  int32_t BuildXMLIdentifierExcludingBody(
-      const XMLIdentifierTrieNode& node, const std::string& rule_name, int depth
-  );
+  int32_t BuildCohereKeyExcludingBody(const CohereKeyTrieNode& node, int depth);
   bool AtCohereRoot() const;
   bool InCohereValueContext() const;
 

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -1084,6 +1084,106 @@ def test_cohere_required_accepts_nested_params():
     check_stag_with_instance(structural_tag, named_list_item_output, False)
 
 
+@pytest.mark.parametrize(
+    "function",
+    (
+        pytest.param({"name": "anything"}, id="omitted-parameters"),
+        pytest.param({"name": "anything", "parameters": None}, id="none-parameters"),
+        pytest.param(
+            {
+                "name": "anything",
+                "strict": False,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"only": {"type": "integer"}},
+                    "required": ["only"],
+                    "additionalProperties": False,
+                },
+            },
+            id="strict-false",
+        ),
+    ),
+)
+@pytest.mark.parametrize(
+    "body, accepted",
+    (
+        pytest.param('<cofl:value name="text" type="raw">hello</cofl:value>', True, id="raw"),
+        pytest.param(
+            '<cofl:value name="count" type="json">2</cofl:value>'
+            '<cofl:value name="enabled" type="json">true</cofl:value>'
+            '<cofl:value name="nothing" type="json">null</cofl:value>',
+            True,
+            id="scalars",
+        ),
+        pytest.param(
+            '<cofl:value name="config" type="dict">'
+            '<cofl:value name="mode" type="raw">fast</cofl:value>'
+            '<cofl:value name="items" type="list">'
+            '<cofl:value type="json">1</cofl:value>'
+            '<cofl:value type="dict">'
+            '<cofl:value name="ok" type="json">true</cofl:value>'
+            "</cofl:value>"
+            "</cofl:value>"
+            "</cofl:value>",
+            True,
+            id="recursive-dict",
+        ),
+        pytest.param(
+            '<cofl:value name="items" type="list">'
+            '<cofl:value type="raw">first</cofl:value>'
+            '<cofl:value type="list"></cofl:value>'
+            "</cofl:value>",
+            True,
+            id="recursive-list",
+        ),
+        pytest.param(
+            '<cofl:value name="text" type="json">"hello"</cofl:value>',
+            False,
+            id="quoted-string-under-json",
+        ),
+        pytest.param(
+            '<cofl:value name="config" type="json">{"mode":"fast"}</cofl:value>',
+            False,
+            id="serialized-dict",
+        ),
+        pytest.param(
+            '<cofl:value name="items" type="list">'
+            '<cofl:value name="0" type="raw">first</cofl:value>'
+            "</cofl:value>",
+            False,
+            id="named-list-item",
+        ),
+        pytest.param(
+            '<cofl:value type="dict">'
+            '<cofl:value name="text" type="raw">hello</cofl:value>'
+            "</cofl:value>",
+            False,
+            id="outer-dict-wrapper",
+        ),
+    ),
+)
+def test_cohere_unrestricted_tool_parameters_use_canonical_recursive_values(
+    function, body: str, accepted: bool
+):
+    """Schemas normalized to true retain canonical recursive Cohere Any values."""
+
+    structural_tag = get_model_structural_tag(
+        "cohere",
+        tools=[{"type": "function", "function": function}],
+        tool_choice="required",
+        reasoning=False,
+    )
+
+    output = (
+        "<cofl:tool_calls>"
+        '<cofl:tool_call id="0" name="anything">'
+        f"{body}"
+        "</cofl:tool_call>"
+        "</cofl:tool_calls>"
+    )
+    check_stag_with_instance(structural_tag, output, accepted)
+
+
 def test_cohere_reasoning_prefix_uses_end_thinking_token():
     """Cohere reasoning mode accepts reasoning text before the end-thinking token."""
 
@@ -1413,7 +1513,7 @@ InstanceCase = Tuple[Dict[str, Any], List[str], bool, List[bool]]
 
 def run_instance_case(format_type: str, case: InstanceCase):
     """Run one instance test case (accept/reject per instance string)."""
-    (input_dict, instances, reasoning, expected_accept_per_instance) = case
+    input_dict, instances, reasoning, expected_accept_per_instance = case
     kwargs = _input_dict_to_get_stag_kwargs(format_type, input_dict)
     kwargs["reasoning"] = reasoning
     stag = get_model_structural_tag(**kwargs)

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -1100,7 +1100,20 @@ def test_cohere_required_accepts_nested_params():
                     "additionalProperties": False,
                 },
             },
-            id="strict-false",
+            id="strict-false-additional-properties-false",
+        ),
+        pytest.param(
+            {
+                "name": "anything",
+                "strict": False,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"only": {"type": "integer"}},
+                    "required": ["only"],
+                    "additionalProperties": True,
+                },
+            },
+            id="strict-false-additional-properties-true",
         ),
     ),
 )

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -478,5 +478,54 @@ def test_reasoning_stag(case):
     validate_output(stag_key, tools, tool_choice, reasoning, model_output)
 
 
+@pytest.mark.parametrize(
+    "parameters, arguments, serialized_name",
+    (
+        pytest.param(
+            {"type": "object"}, {"meta": {"my-key": 1}}, 'name="my-key"', id="nested-dynamic"
+        ),
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {"a&b": {"type": "integer"}},
+                "required": ["a&b"],
+                "additionalProperties": False,
+            },
+            {"a&b": 1},
+            'name="a&amp;b"',
+            id="declared-xml-sensitive",
+        ),
+    ),
+)
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="cohere_melody requires Python >= 3.10")
+def test_cohere_melody_property_name_alignment(parameters, arguments, serialized_name):
+    """Cohere property names rendered by Melody align with the generated grammar."""
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "lookup", "description": "", "parameters": parameters},
+        }
+    ]
+    assistant_msg = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_0",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": arguments},
+            }
+        ],
+    }
+
+    model_output = extract_output_melody_cmd5(
+        assistant_msg, tools, template_kwargs={"reasoning": False}
+    )
+    assert serialized_name in model_output
+    validate_output(
+        "cohere", tools, tool_choice="required", reasoning=False, model_output=model_output
+    )
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -1495,23 +1495,28 @@ def test_cohere_additional_properties_do_not_match_declared_keys():
     _check_cohere_grammar(schema, '<cofl:value name="foo" type="raw">wrong</cofl:value>', False)
 
 
-_COHERE_ARBITRARY_JSON_CASES = (
-    # Scalar JSON values.
-    pytest.param("text", '"extra"', id="string"),
-    pytest.param("count", "2", id="number"),
-    pytest.param("enabled", "true", id="boolean"),
-    pytest.param("nothing", "null", id="null"),
-    # Composite JSON values remain serialized inside type="json".
-    pytest.param("items", '[1, "two"]', id="array"),
-    pytest.param("metadata", '{"id": 2}', id="object"),
+_COHERE_CANONICAL_ANY_CASES = (
+    pytest.param("text", "raw", "extra", id="string"),
+    pytest.param("count", "json", "2", id="number"),
+    pytest.param("enabled", "json", "true", id="boolean"),
+    pytest.param("nothing", "json", "null", id="null"),
+    pytest.param(
+        "items",
+        "list",
+        '<cofl:value type="json">1</cofl:value>' '<cofl:value type="raw">two</cofl:value>',
+        id="array",
+    ),
+    pytest.param(
+        "metadata", "dict", '<cofl:value name="id" type="json">2</cofl:value>', id="object"
+    ),
 )
 
 
-@pytest.mark.parametrize("property_name, json_value", _COHERE_ARBITRARY_JSON_CASES)
-def test_cohere_additional_properties_true_accepts_arbitrary_json_values(
-    property_name: str, json_value: str
+@pytest.mark.parametrize("property_name, value_type, body", _COHERE_CANONICAL_ANY_CASES)
+def test_cohere_additional_properties_true_accepts_canonical_any_values(
+    property_name: str, value_type: str, body: str
 ):
-    """Unconstrained Cohere properties accept any JSON value through type=json."""
+    """Unconstrained dynamic properties recursively use canonical Cohere wrappers."""
     schema = {
         "type": "object",
         "properties": {"foo": {"type": "integer"}},
@@ -1520,12 +1525,303 @@ def test_cohere_additional_properties_true_accepts_arbitrary_json_values(
     }
     declared_property = '<cofl:value name="foo" type="json">1</cofl:value>'
     additional_property = (
-        f'<cofl:value name="{property_name}" type="json">{json_value}</cofl:value>'
+        f'<cofl:value name="{property_name}" type="{value_type}">{body}</cofl:value>'
     )
-    wrong_wrapper = f'<cofl:value name="{property_name}" type="raw">{json_value}</cofl:value>'
 
     _check_cohere_grammar(schema, declared_property + additional_property, True)
-    _check_cohere_grammar(schema, declared_property + wrong_wrapper, False)
+
+
+_COHERE_ROOT_ANY_INSTANCE = (
+    '<cofl:value name="text" type="raw">hello</cofl:value>'
+    '<cofl:value name="nested" type="dict">'
+    '<cofl:value name="items" type="list">'
+    '<cofl:value type="json">1</cofl:value>'
+    "</cofl:value>"
+    "</cofl:value>"
+)
+
+
+@pytest.mark.parametrize(
+    "schema", (pytest.param("true", id="true"), pytest.param({}, id="empty-schema"))
+)
+@pytest.mark.parametrize(
+    "instance, accepted",
+    (
+        pytest.param("", True, id="empty-object"),
+        pytest.param(_COHERE_ROOT_ANY_INSTANCE, True, id="populated-object"),
+        pytest.param(
+            f'<cofl:value type="dict">{_COHERE_ROOT_ANY_INSTANCE}</cofl:value>',
+            False,
+            id="outer-dict-wrapper",
+        ),
+    ),
+)
+def test_cohere_root_any_is_unrestricted_object_body(schema, instance: str, accepted: bool):
+    _check_cohere_grammar(schema, instance, accepted)
+
+
+@pytest.mark.parametrize(
+    "instance, accepted",
+    (
+        ('<cofl:value name="value" type="raw">text</cofl:value>', True),
+        ('<cofl:value name="value" type="json">2.5</cofl:value>', True),
+        ('<cofl:value name="value" type="json">false</cofl:value>', True),
+        ('<cofl:value name="value" type="json">null</cofl:value>', True),
+        ('<cofl:value name="value" type="dict"></cofl:value>', True),
+        (
+            '<cofl:value name="value" type="dict">'
+            '<cofl:value name="items" type="list">'
+            '<cofl:value type="raw">first</cofl:value>'
+            '<cofl:value type="dict">'
+            '<cofl:value name="enabled" type="json">true</cofl:value>'
+            "</cofl:value>"
+            "</cofl:value>"
+            "</cofl:value>",
+            True,
+        ),
+        ('<cofl:value name="value" type="list"></cofl:value>', True),
+        (
+            '<cofl:value name="value" type="list">'
+            '<cofl:value type="dict">'
+            '<cofl:value name="inner" type="list">'
+            '<cofl:value type="dict">'
+            '<cofl:value name="leaf" type="raw">done</cofl:value>'
+            "</cofl:value>"
+            "</cofl:value>"
+            "</cofl:value>"
+            "</cofl:value>",
+            True,
+        ),
+        ('<cofl:value name="value" type="json">"text"</cofl:value>', False),
+        ('<cofl:value name="value" type="json">{"id":2}</cofl:value>', False),
+        ('<cofl:value name="value" type="json">[1,2]</cofl:value>', False),
+        (
+            '<cofl:value name="value" type="list">'
+            '<cofl:value name="item" type="raw">text</cofl:value>'
+            "</cofl:value>",
+            False,
+        ),
+        (
+            '<cofl:value name="value" type="dict">'
+            '<cofl:value type="raw">text</cofl:value>'
+            "</cofl:value>",
+            False,
+        ),
+    ),
+)
+def test_cohere_nested_property_true_uses_correlated_any_wrappers(instance: str, accepted: bool):
+    schema = {
+        "type": "object",
+        "properties": {"value": True},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    _check_cohere_grammar(schema, instance, accepted)
+
+
+@pytest.mark.parametrize(
+    "instance, accepted",
+    (
+        pytest.param('<cofl:value name="value" type="raw">text</cofl:value>', True, id="raw"),
+        pytest.param(
+            '<cofl:value name="value" type="list">'
+            '<cofl:value type="dict"></cofl:value>'
+            "</cofl:value>",
+            True,
+            id="recursive-list",
+        ),
+        pytest.param(
+            '<cofl:value name="value" type="json">"text"</cofl:value>',
+            False,
+            id="quoted-string-under-json",
+        ),
+    ),
+)
+def test_cohere_nested_property_empty_schema_uses_correlated_any_wrappers(
+    instance: str, accepted: bool
+):
+    schema = {
+        "type": "object",
+        "properties": {"value": {}},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    _check_cohere_grammar(schema, instance, accepted)
+
+
+def test_cohere_any_supports_deep_recursive_container_references():
+    schema = {
+        "type": "object",
+        "properties": {"value": True},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    unnamed_dict = (
+        '<cofl:value type="dict">'
+        '<cofl:value name="leaf" type="json">null</cofl:value>'
+        "</cofl:value>"
+    )
+    for _ in range(32):
+        unnamed_dict = (
+            '<cofl:value type="dict">'
+            '<cofl:value name="child" type="list">'
+            f"{unnamed_dict}"
+            "</cofl:value>"
+            "</cofl:value>"
+        )
+    instance = f'<cofl:value name="value" type="list">{unnamed_dict}</cofl:value>'
+
+    _check_cohere_grammar(schema, instance, True)
+
+
+@pytest.mark.parametrize(
+    "instance, accepted",
+    (
+        pytest.param(
+            '<cofl:value name="values" type="list">'
+            '<cofl:value type="raw">text</cofl:value>'
+            '<cofl:value type="json">3</cofl:value>'
+            '<cofl:value type="dict"></cofl:value>'
+            '<cofl:value type="list"></cofl:value>'
+            "</cofl:value>",
+            True,
+            id="unnamed-items",
+        ),
+        pytest.param(
+            '<cofl:value name="values" type="list">'
+            '<cofl:value name="0" type="raw">text</cofl:value>'
+            "</cofl:value>",
+            False,
+            id="named-item",
+        ),
+    ),
+)
+def test_cohere_array_items_true_use_unnamed_correlated_any_wrappers(instance: str, accepted: bool):
+    schema = {
+        "type": "object",
+        "properties": {"values": {"type": "array", "items": True}},
+        "required": ["values"],
+        "additionalProperties": False,
+    }
+    _check_cohere_grammar(schema, instance, accepted)
+
+
+@pytest.mark.parametrize(
+    "instance, accepted",
+    (
+        pytest.param(
+            '<cofl:value name="values" type="list">'
+            '<cofl:value type="list">'
+            '<cofl:value type="dict">'
+            '<cofl:value name="leaf" type="null"></cofl:value>'
+            "</cofl:value>"
+            "</cofl:value>"
+            "</cofl:value>",
+            False,
+            id="invalid-null-type",
+        ),
+        pytest.param(
+            '<cofl:value name="values" type="list">'
+            '<cofl:value type="list">'
+            '<cofl:value type="dict">'
+            '<cofl:value name="leaf" type="json">null</cofl:value>'
+            "</cofl:value>"
+            "</cofl:value>"
+            "</cofl:value>",
+            True,
+            id="recursive-values",
+        ),
+    ),
+)
+def test_cohere_array_items_empty_schema_use_unnamed_recursive_values(
+    instance: str, accepted: bool
+):
+    schema = {
+        "type": "object",
+        "properties": {"values": {"type": "array", "items": {}}},
+        "required": ["values"],
+        "additionalProperties": False,
+    }
+    _check_cohere_grammar(schema, instance, accepted)
+
+
+@pytest.mark.parametrize(
+    "instance, accepted",
+    (
+        pytest.param('<cofl:value name="value" type="raw">text</cofl:value>', True, id="raw"),
+        pytest.param(
+            '<cofl:value name="value" type="dict">'
+            '<cofl:value name="items" type="list"></cofl:value>'
+            "</cofl:value>",
+            True,
+            id="recursive-dict",
+        ),
+        pytest.param(
+            '<cofl:value name="value" type="json">{"items":[]}</cofl:value>',
+            False,
+            id="serialized-dict",
+        ),
+    ),
+)
+def test_cohere_ref_resolving_to_any_uses_correlated_wrappers(instance: str, accepted: bool):
+    schema = {
+        "type": "object",
+        "$defs": {"Value": {}},
+        "properties": {"value": {"$ref": "#/$defs/Value"}},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    _check_cohere_grammar(schema, instance, accepted)
+
+
+@pytest.mark.parametrize(
+    "instance, accepted",
+    (
+        pytest.param('<cofl:value name="value" type="raw">text</cofl:value>', True, id="raw"),
+        pytest.param('<cofl:value name="value" type="json">2</cofl:value>', True, id="scalar"),
+        pytest.param('<cofl:value name="value" type="list"></cofl:value>', True, id="list"),
+        pytest.param(
+            '<cofl:value name="value" type="json">[2]</cofl:value>', False, id="serialized-list"
+        ),
+    ),
+)
+def test_cohere_any_inside_composite_uses_correlated_wrappers(instance: str, accepted: bool):
+    schema = {
+        "type": "object",
+        "properties": {"value": {"anyOf": [True, {"type": "integer", "minimum": 10}]}},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    _check_cohere_grammar(schema, instance, accepted)
+
+
+@pytest.mark.parametrize(
+    "instance, accepted",
+    (
+        pytest.param('<cofl:value name="value" type="raw">text</cofl:value>', True, id="raw"),
+        pytest.param('<cofl:value name="value" type="json">2</cofl:value>', True, id="scalar"),
+        pytest.param(
+            '<cofl:value name="value" type="dict">'
+            '<cofl:value name="nested" type="list"></cofl:value>'
+            "</cofl:value>",
+            True,
+            id="recursive-dict",
+        ),
+        pytest.param(
+            '<cofl:value name="value" type="json">{"nested":[]}</cofl:value>',
+            False,
+            id="serialized-dict",
+        ),
+    ),
+)
+def test_cohere_multi_all_of_any_fallback_uses_correlated_wrappers(instance: str, accepted: bool):
+    schema = {
+        "type": "object",
+        "properties": {"value": {"allOf": [{"type": "string"}, {"type": "integer"}]}},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    _check_cohere_grammar(schema, instance, accepted)
 
 
 def test_cohere_additional_properties_support_nested_schema():
@@ -1668,11 +1964,13 @@ def test_cohere_nested_pattern_properties():
     _check_cohere_grammar(schema, accepted.replace("item_name", "other"), False)
 
 
-@pytest.mark.parametrize("property_name, json_value", _COHERE_ARBITRARY_JSON_CASES)
-def test_cohere_property_names_accept_arbitrary_json_values(property_name: str, json_value: str):
-    """Property-name constraints leave Cohere values unconstrained JSON."""
+@pytest.mark.parametrize("property_name, value_type, body", _COHERE_CANONICAL_ANY_CASES)
+def test_cohere_property_names_accept_canonical_any_values(
+    property_name: str, value_type: str, body: str
+):
+    """Property-name constraints leave Cohere values canonically unconstrained."""
     schema = {"type": "object", "propertyNames": {"pattern": "^[a-z_]+$"}}
-    instance = f'<cofl:value name="{property_name}" type="json">{json_value}</cofl:value>'
+    instance = f'<cofl:value name="{property_name}" type="{value_type}">{body}</cofl:value>'
 
     _check_cohere_grammar(schema, instance, True)
 
@@ -1680,8 +1978,10 @@ def test_cohere_property_names_accept_arbitrary_json_values(property_name: str, 
 @pytest.mark.parametrize(
     "instance",
     (
-        pytest.param('<cofl:value name="Bad" type="json">"extra"</cofl:value>', id="invalid-name"),
-        pytest.param('<cofl:value name="text" type="raw">extra</cofl:value>', id="wrong-wrapper"),
+        pytest.param('<cofl:value name="Bad" type="raw">extra</cofl:value>', id="invalid-name"),
+        pytest.param(
+            '<cofl:value name="text" type="json">"extra"</cofl:value>', id="wrong-wrapper"
+        ),
     ),
 )
 def test_cohere_property_names_reject_invalid_name_or_wrapper(instance: str):
@@ -1763,7 +2063,7 @@ def test_cohere_property_names_preserve_value_constraints(
 
 
 def test_cohere_nested_property_names():
-    """Nested Cohere dictionaries retain property-name constraints and JSON values."""
+    """Nested Cohere dictionaries retain property-name constraints and canonical values."""
     schema = {
         "type": "object",
         "properties": {"config": {"type": "object", "propertyNames": {"pattern": "^item_[a-z]+$"}}},
@@ -1771,7 +2071,9 @@ def test_cohere_nested_property_names():
     }
     accepted = (
         '<cofl:value name="config" type="dict">'
-        '<cofl:value name="item_data" type="json">{"id": 1}</cofl:value>'
+        '<cofl:value name="item_data" type="dict">'
+        '<cofl:value name="id" type="json">1</cofl:value>'
+        "</cofl:value>"
         "</cofl:value>"
     )
 
@@ -2436,7 +2738,7 @@ _XML_DYNAMIC_PROPERTY_CASES = (
         "cohere_xml",
         '<cofl:value name="name" type="raw">n</cofl:value>',
         '<cofl:value name="x_key" type="json">3</cofl:value>',
-        '<cofl:value name="x_key" type="json">"v"</cofl:value>',
+        '<cofl:value name="x_key" type="raw">v</cofl:value>',
     ),
 )
 

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -1476,8 +1476,8 @@ def test_cohere_nested_dict_and_list_values():
     _check_cohere_grammar(schema, named_list_item, False)
 
 
-def test_cohere_additional_properties_do_not_match_declared_keys():
-    """Additional Cohere properties cannot reuse names declared in properties."""
+def test_cohere_additional_properties_with_declared_keys():
+    """Additional properties support Cohere keys without reusing declared names."""
     schema = {
         "type": "object",
         "properties": {"foo": {"type": "integer"}},
@@ -1485,14 +1485,82 @@ def test_cohere_additional_properties_do_not_match_declared_keys():
         "additionalProperties": {"type": "string"},
     }
 
-    _check_cohere_grammar(schema, '<cofl:value name="foo" type="json">1</cofl:value>', True)
-    _check_cohere_grammar(
-        schema,
+    accepted = (
         '<cofl:value name="foo" type="json">1</cofl:value>'
-        '<cofl:value name="bar" type="raw">extra</cofl:value>',
-        True,
+        '<cofl:value name="x" type="raw">one unit</cofl:value>'
+        '<cofl:value name="extra-key" type="raw">ordinary suffix</cofl:value>'
+        '<cofl:value name="&amp;x" type="raw">entity suffix</cofl:value>'
     )
+    _check_cohere_grammar(schema, accepted, True)
     _check_cohere_grammar(schema, '<cofl:value name="foo" type="raw">wrong</cofl:value>', False)
+
+
+@pytest.mark.parametrize(
+    "serialized_key, accepted",
+    (
+        pytest.param("my-key", True, id="hyphen"),
+        pytest.param("a.b", True, id="period"),
+        pytest.param("0", True, id="leading-digit"),
+        pytest.param("日本語", True, id="unicode"),
+        pytest.param("a&amp;b", True, id="escaped-ampersand"),
+        pytest.param("a&lt;b", True, id="escaped-less-than"),
+        pytest.param("a&gt;b", True, id="escaped-greater-than"),
+        pytest.param("a&quot;b", True, id="escaped-quote"),
+        pytest.param("", False, id="empty"),
+        pytest.param("a&b", False, id="unescaped-ampersand"),
+        pytest.param("a<b", False, id="unescaped-less-than"),
+        pytest.param("a>b", False, id="unescaped-greater-than"),
+        pytest.param("a&ampb", False, id="incomplete-entity"),
+        pytest.param("a\0b", False, id="embedded-null"),
+    ),
+)
+def test_cohere_nested_any_dynamic_attribute_keys(serialized_key: str, accepted: bool):
+    """Nested Any dictionaries accept only canonical, nonempty XML attribute keys."""
+    schema = {
+        "type": "object",
+        "properties": {"meta": True},
+        "required": ["meta"],
+        "additionalProperties": False,
+    }
+    instance = (
+        '<cofl:value name="meta" type="dict">'
+        f'<cofl:value name="{serialized_key}" type="json">1</cofl:value>'
+        "</cofl:value>"
+    )
+
+    _check_cohere_grammar(schema, instance, accepted)
+
+
+@pytest.mark.parametrize(
+    "declared_key, serialized_key",
+    (
+        pytest.param("my-key", "my-key", id="hyphen"),
+        pytest.param("a.b", "a.b", id="period"),
+        pytest.param("0", "0", id="leading-digit"),
+        pytest.param("日本語", "日本語", id="unicode"),
+        pytest.param("a&b", "a&amp;b", id="escaped-ampersand"),
+        pytest.param("a<b", "a&lt;b", id="escaped-less-than"),
+        pytest.param("a>b", "a&gt;b", id="escaped-greater-than"),
+        pytest.param('a"b', "a&quot;b", id="escaped-quote"),
+    ),
+)
+def test_cohere_additional_properties_exclude_nonidentifier_declared_keys(
+    declared_key: str, serialized_key: str
+):
+    """Declared non-identifier keys are serialized and excluded from additional properties."""
+    schema = {
+        "type": "object",
+        "properties": {declared_key: {"type": "integer"}},
+        "required": [declared_key],
+        "additionalProperties": {"type": "string"},
+    }
+
+    _check_cohere_grammar(
+        schema, f'<cofl:value name="{serialized_key}" type="json">1</cofl:value>', True
+    )
+    _check_cohere_grammar(
+        schema, f'<cofl:value name="{serialized_key}" type="raw">wrong</cofl:value>', False
+    )
 
 
 _COHERE_CANONICAL_ANY_CASES = (


### PR DESCRIPTION
Adds canonical recursive Cohere XML support for unrestricted JSON Schema values, correlating raw, json, dict, and list wrappers with their matching body grammars. Also aligns root true and {} behavior and adds coverage for nested values, references, composites, and unrestricted tool parameters