### PR TITLE
feat: add cached Lark compilation API

### DIFF
--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -1033,6 +1034,10 @@ class GrammarCompilerSub {
 
   CompiledGrammar CompileRegex(const std::string& regex);
 
+  CompiledGrammar CompileLark(
+      const std::string& lark_string, const std::vector<NamedGrammar>& named_grammars
+  );
+
   CompiledGrammar CompileStructuralTag(const std::string& structural_tag_json);
 
   CompiledGrammar CompileGrammar(const Grammar& grammar);
@@ -1182,6 +1187,12 @@ CompiledGrammar GrammarCompilerSub::CompileRegex(const std::string& regex) {
   return MultiThreadCompileGrammar(Grammar::FromRegex(regex));
 }
 
+CompiledGrammar GrammarCompilerSub::CompileLark(
+    const std::string& lark_string, const std::vector<NamedGrammar>& named_grammars
+) {
+  return MultiThreadCompileGrammar(Grammar::FromLark(lark_string, tokenizer_info_, named_grammars));
+}
+
 CompiledGrammar GrammarCompilerSub::CompileGrammar(const Grammar& grammar) {
   return MultiThreadCompileGrammar(grammar);
 }
@@ -1292,12 +1303,32 @@ class GrammarCompilerCacheKeys {
     XGRAMMAR_EQUAL_BY_MEMBERS(RegexKey, &RegexKey::regex);
   };
 
+  struct LarkNamedGrammarKey {
+    std::string name;
+    bool is_lark_source;
+    std::string source_or_ebnf;
+    std::string root_rule_name;
+    std::variant<Grammar, std::string> value;
+
+    bool operator==(const LarkNamedGrammarKey& other) const {
+      return std::tie(name, is_lark_source, source_or_ebnf, root_rule_name) ==
+             std::tie(other.name, other.is_lark_source, other.source_or_ebnf, other.root_rule_name);
+    }
+  };
+
+  struct LarkKey {
+    std::string lark_string;
+    std::vector<LarkNamedGrammarKey> named_grammars;
+
+    XGRAMMAR_EQUAL_BY_MEMBERS(LarkKey, &LarkKey::lark_string, &LarkKey::named_grammars);
+  };
+
   struct BuiltinJSONGrammarKey {
     XGRAMMAR_EQUAL_BY_MEMBERS_EMPTY(BuiltinJSONGrammarKey);
   };
 
-  using UnionKey =
-      std::variant<SchemaKey, StructuralTagKey, GrammarKey, RegexKey, BuiltinJSONGrammarKey>;
+  using UnionKey = std::
+      variant<SchemaKey, StructuralTagKey, GrammarKey, RegexKey, LarkKey, BuiltinJSONGrammarKey>;
 };
 
 }  // namespace xgrammar
@@ -1328,6 +1359,29 @@ XGRAMMAR_HASH_BY_MEMBERS(
     xgrammar::GrammarCompilerCacheKeys::RegexKey,
     &xgrammar::GrammarCompilerCacheKeys::RegexKey::regex
 );
+
+XGRAMMAR_HASH_BY_MEMBERS(
+    xgrammar::GrammarCompilerCacheKeys::LarkNamedGrammarKey,
+    &xgrammar::GrammarCompilerCacheKeys::LarkNamedGrammarKey::name,
+    &xgrammar::GrammarCompilerCacheKeys::LarkNamedGrammarKey::is_lark_source,
+    &xgrammar::GrammarCompilerCacheKeys::LarkNamedGrammarKey::source_or_ebnf,
+    &xgrammar::GrammarCompilerCacheKeys::LarkNamedGrammarKey::root_rule_name
+);
+
+namespace std {
+template <>
+struct hash<xgrammar::GrammarCompilerCacheKeys::LarkKey> {
+  std::size_t operator()(const xgrammar::GrammarCompilerCacheKeys::LarkKey& key) const noexcept {
+    uint64_t seed = std::hash<std::string>{}(key.lark_string);
+    for (const auto& named_grammar : key.named_grammars) {
+      xgrammar::HashCombineBinary(
+          seed, std::hash<xgrammar::GrammarCompilerCacheKeys::LarkNamedGrammarKey>{}(named_grammar)
+      );
+    }
+    return seed;
+  }
+};
+}  // namespace std
 
 XGRAMMAR_HASH_BY_MEMBERS_EMPTY(xgrammar::GrammarCompilerCacheKeys::BuiltinJSONGrammarKey);
 
@@ -1383,6 +1437,10 @@ class GrammarCompiler::Impl {
 
   CompiledGrammar CompileRegex(const std::string& regex);
 
+  CompiledGrammar CompileLark(
+      const std::string& lark_string, const std::vector<NamedGrammar>& named_grammars
+  );
+
   CompiledGrammar CompileGrammar(const Grammar& grammar);
 
   CompiledGrammar CompileGrammar(const std::string& ebnf_str, std::string root_rule_name);
@@ -1398,6 +1456,8 @@ class GrammarCompiler::Impl {
   using StructuralTagKey = GrammarCompilerCacheKeys::StructuralTagKey;
   using GrammarKey = GrammarCompilerCacheKeys::GrammarKey;
   using RegexKey = GrammarCompilerCacheKeys::RegexKey;
+  using LarkNamedGrammarKey = GrammarCompilerCacheKeys::LarkNamedGrammarKey;
+  using LarkKey = GrammarCompilerCacheKeys::LarkKey;
   using BuiltinJSONGrammarKey = GrammarCompilerCacheKeys::BuiltinJSONGrammarKey;
   using UnionKey = GrammarCompilerCacheKeys::UnionKey;
 
@@ -1446,6 +1506,13 @@ CompiledGrammar GrammarCompiler::Impl::Compute(const UnionKey& key) {
         } else if constexpr (std::is_same_v<KeyType, RegexKey>) {
           const auto& [regex] = key;
           return this->no_cache_compiler_.CompileRegex(regex);
+        } else if constexpr (std::is_same_v<KeyType, LarkKey>) {
+          std::vector<NamedGrammar> named_grammars;
+          named_grammars.reserve(key.named_grammars.size());
+          for (const auto& named_grammar : key.named_grammars) {
+            named_grammars.push_back({named_grammar.name, named_grammar.value});
+          }
+          return this->no_cache_compiler_.CompileLark(key.lark_string, named_grammars);
         } else if constexpr (std::is_same_v<KeyType, BuiltinJSONGrammarKey>) {
           return this->no_cache_compiler_.CompileBuiltinJSONGrammar();
         } else {
@@ -1495,6 +1562,43 @@ CompiledGrammar GrammarCompiler::Impl::CompileRegex(const std::string& regex) {
     return no_cache_compiler_.CompileRegex(regex);
   }
   return grammar_level_cache_.Get(RegexKey{regex});
+}
+
+CompiledGrammar GrammarCompiler::Impl::CompileLark(
+    const std::string& lark_string, const std::vector<NamedGrammar>& named_grammars
+) {
+  if (!cache_enabled_) {
+    return no_cache_compiler_.CompileLark(lark_string, named_grammars);
+  }
+
+  std::vector<LarkNamedGrammarKey> named_grammar_keys;
+  named_grammar_keys.reserve(named_grammars.size());
+  for (const auto& named_grammar : named_grammars) {
+    if (std::holds_alternative<std::string>(named_grammar.grammar)) {
+      const auto& source = std::get<std::string>(named_grammar.grammar);
+      named_grammar_keys.push_back(
+          {named_grammar.name, /*is_lark_source=*/true, source, "", named_grammar.grammar}
+      );
+    } else {
+      const auto& grammar = std::get<Grammar>(named_grammar.grammar);
+      named_grammar_keys.push_back(
+          {named_grammar.name,
+           /*is_lark_source=*/false,
+           grammar.ToString(),
+           grammar->GetRootRule().name,
+           named_grammar.grammar}
+      );
+    }
+  }
+  std::sort(
+      named_grammar_keys.begin(),
+      named_grammar_keys.end(),
+      [](const LarkNamedGrammarKey& lhs, const LarkNamedGrammarKey& rhs) {
+        return std::tie(lhs.name, lhs.is_lark_source, lhs.source_or_ebnf, lhs.root_rule_name) <
+               std::tie(rhs.name, rhs.is_lark_source, rhs.source_or_ebnf, rhs.root_rule_name);
+      }
+  );
+  return grammar_level_cache_.Get(LarkKey{lark_string, std::move(named_grammar_keys)});
 }
 
 CompiledGrammar GrammarCompiler::Impl::CompileGrammar(const Grammar& grammar) {
@@ -1568,6 +1672,12 @@ CompiledGrammar GrammarCompiler::CompileStructuralTag(const std::string& structu
 
 CompiledGrammar GrammarCompiler::CompileRegex(const std::string& regex) {
   return pimpl_->CompileRegex(regex);
+}
+
+CompiledGrammar GrammarCompiler::CompileLark(
+    const std::string& lark_string, const std::vector<NamedGrammar>& named_grammars
+) {
+  return pimpl_->CompileLark(lark_string, named_grammars);
 }
 
 CompiledGrammar GrammarCompiler::CompileGrammar(const Grammar& grammar) {

--- a/cpp/tvm_ffi/tvm_ffi.cc
+++ b/cpp/tvm_ffi/tvm_ffi.cc
@@ -174,6 +174,30 @@ class GrammarObj : public ffi::Object {
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("xgrammar.tvm_ffi_binding.Grammar", GrammarObj, ffi::Object);
 };
 
+static std::vector<NamedGrammar> NamedGrammarsFromViews(
+    ffi::AnyView names_view, ffi::AnyView values_view
+) {
+  auto names = names_view.cast<ffi::Array<ffi::Any>>();
+  auto values = values_view.cast<ffi::Array<ffi::Any>>();
+  if (names.size() != values.size()) {
+    throw XGrammarError("Named grammar names and values must have the same length");
+  }
+  std::vector<NamedGrammar> named_grammars;
+  named_grammars.reserve(static_cast<size_t>(names.size()));
+  for (int64_t i = 0; i < static_cast<int64_t>(names.size()); ++i) {
+    std::string name = names[i].cast<ffi::String>();
+    ffi::AnyView value = values[i];
+    if (const auto* grammar_obj = value.as<GrammarObj>()) {
+      named_grammars.push_back({std::move(name), grammar_obj->value});
+    } else if (value.as<ffi::String>()) {
+      named_grammars.push_back({std::move(name), std::string(value.cast<ffi::String>())});
+    } else {
+      throw XGrammarError("Named grammar values must be Grammar or Lark strings");
+    }
+  }
+  return named_grammars;
+}
+
 class CompiledGrammarObj : public ffi::Object {
  public:
   CompiledGrammar value;
@@ -397,24 +421,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
               tokenizer_info =
                   tokenizer_info_view.cast<ffi::ObjectRef>().as<TokenizerInfoObj>()->value;
             }
-            auto named_grammar_names = named_grammar_names_view.cast<ffi::Array<ffi::Any>>();
-            auto named_grammar_values = named_grammar_values_view.cast<ffi::Array<ffi::Any>>();
-            if (named_grammar_names.size() != named_grammar_values.size()) {
-              throw XGrammarError("Named grammar names and values must have the same length");
-            }
-            std::vector<NamedGrammar> named_grammars;
-            named_grammars.reserve(static_cast<size_t>(named_grammar_names.size()));
-            for (int64_t i = 0; i < static_cast<int64_t>(named_grammar_names.size()); ++i) {
-              std::string name = named_grammar_names[i].cast<ffi::String>();
-              ffi::AnyView value = named_grammar_values[i];
-              if (const auto* grammar_obj = value.as<GrammarObj>()) {
-                named_grammars.push_back({std::move(name), grammar_obj->value});
-              } else if (value.as<ffi::String>()) {
-                named_grammars.push_back({std::move(name), std::string(value.cast<ffi::String>())});
-              } else {
-                throw XGrammarError("Named grammar values must be Grammar or Lark strings");
-              }
-            }
+            auto named_grammars =
+                NamedGrammarsFromViews(named_grammar_names_view, named_grammar_values_view);
             return ffi::ObjectRef(ffi::make_object<GrammarObj>(
                 Grammar::FromLark(lark_string, tokenizer_info, named_grammars)
             ));
@@ -550,6 +558,21 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           [](GrammarCompilerObj* o, ffi::String regex) {
             return ffi::ObjectRef(ffi::make_object<CompiledGrammarObj>(o->value.CompileRegex(regex))
             );
+          }
+      )
+      .def(
+          "compile_lark",
+          [](GrammarCompilerObj* o,
+             ffi::String lark_string,
+             ffi::AnyView named_grammar_names_view,
+             ffi::AnyView named_grammar_values_view) {
+            XGRAMMAR_FFI_TRY_BEGIN();
+            auto named_grammars =
+                NamedGrammarsFromViews(named_grammar_names_view, named_grammar_values_view);
+            return ffi::ObjectRef(ffi::make_object<CompiledGrammarObj>(
+                o->value.CompileLark(lark_string, named_grammars)
+            ));
+            XGRAMMAR_FFI_TRY_END();
           }
       )
       .def(

--- a/docs/defining_structures/lark_grammar.md
+++ b/docs/defining_structures/lark_grammar.md
@@ -46,14 +46,18 @@ xgr.Grammar.from_lark(
 - `named_grammars` supplies external grammars referenced with `@name` in the Lark source. See
   [Named Grammars](#named-grammars).
 
-The returned grammar is compiled and matched like any other grammar:
+Use `GrammarCompiler.compile_lark` to parse and compile a Lark source in one call. The compiler's
+tokenizer information is used to resolve special tokens, and repeated calls with the same source
+and named grammars reuse the cached result when caching is enabled:
 
 ```python
 tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer)
 compiler = xgr.GrammarCompiler(tokenizer_info)
-compiled = compiler.compile_grammar(xgr.Grammar.from_lark('start: "a" | "b"'))
+compiled = compiler.compile_lark('start: "a" | "b"')
 matcher = xgr.GrammarMatcher(compiled)
 ```
+
+Use `Grammar.from_lark` instead when an uncompiled `Grammar` object is needed.
 
 Errors in the grammar raise `RuntimeError` with the line, the column, and the offending source
 line:

--- a/docs/start/workflow_of_xgrammar.md
+++ b/docs/start/workflow_of_xgrammar.md
@@ -68,7 +68,7 @@ To accelerate mask generation, XGrammar performs preprocessing on the grammar us
 * Simplify the grammar and build automata
 * Compute an adaptive token mask cache. It will be used at runtime to generate the real mask
 
-[`xgr.GrammarCompiler`](xgrammar.GrammarCompiler) processes the grammar and produces a [`xgr.CompiledGrammar`](xgrammar.CompiledGrammar) object. Each [`xgr.GrammarCompiler`](xgrammar.GrammarCompiler) is bound to a specific [`xgr.TokenizerInfo`](xgrammar.TokenizerInfo) object. When given a grammar, it uses this tokenizer info to compile it. You can pass in a Grammar object directly, or provide a raw EBNF string, JSON Schema, or regex pattern:
+[`xgr.GrammarCompiler`](xgrammar.GrammarCompiler) processes the grammar and produces a [`xgr.CompiledGrammar`](xgrammar.CompiledGrammar) object. Each [`xgr.GrammarCompiler`](xgrammar.GrammarCompiler) is bound to a specific [`xgr.TokenizerInfo`](xgrammar.TokenizerInfo) object. When given a grammar, it uses this tokenizer info to compile it. You can pass in a Grammar object directly, or provide a raw EBNF string, Lark grammar, JSON Schema, or regex pattern:
 
 ```python
 grammar_compiler = xgr.GrammarCompiler(tokenizer_info)
@@ -82,6 +82,8 @@ compiled_grammar = grammar_compiler.compile_builtin_json_grammar()
 compiled_grammar = grammar_compiler.compile_regex(regex_string)
 # or
 compiled_grammar = grammar_compiler.compile_grammar(ebnf_string)
+# or
+compiled_grammar = grammar_compiler.compile_lark(lark_string)
 ```
 
 ### Multi-threaded Compilation
@@ -112,7 +114,12 @@ compiled_grammar1, compiled_grammar2 = asyncio.run(compile_grammars())
 
 [`xgr.GrammarCompiler`](xgrammar.GrammarCompiler) also includes a cache. If the same grammar is compiled again, the cached result is returned directly. Set `cache_enabled` to `True` to enable the cache, and `cache_limit_bytes` to control the maximum memory usage for the cache. The cache uses LRU (Least Recently Used) eviction policy.
 
-The EBNF string, JSON Schema string, regex pattern are used as the cache key for [`compile_grammar`](xgrammar.GrammarCompiler.compile_grammar), [`compile_json_schema`](xgrammar.GrammarCompiler.compile_json_schema), [`compile_regex`](xgrammar.GrammarCompiler.compile_regex), respectively. By caching the input string directly, we further reduce the time spent constructing the grammar.
+The EBNF string, Lark source and named grammars, JSON Schema string, and regex pattern are used as
+cache keys for [`compile_grammar`](xgrammar.GrammarCompiler.compile_grammar),
+[`compile_lark`](xgrammar.GrammarCompiler.compile_lark),
+[`compile_json_schema`](xgrammar.GrammarCompiler.compile_json_schema), and
+[`compile_regex`](xgrammar.GrammarCompiler.compile_regex), respectively. By caching the source
+input directly, XGrammar also avoids reconstructing the grammar on a cache hit.
 
 ```python
 grammar_compiler = xgr.GrammarCompiler(tokenizer_info, cache_enabled=True, cache_limit_bytes=128 * 1024 * 1024)

--- a/include/xgrammar/compiler.h
+++ b/include/xgrammar/compiler.h
@@ -85,6 +85,15 @@ class GrammarCompiler {
   /*! \brief Get the compiled grammar for pure JSON. */
   CompiledGrammar CompileBuiltinJSONGrammar();
 
+  /*!
+   * \brief Get the compiled grammar for a Lark grammar string.
+   * \param lark_string The Lark grammar. The root rule must be named "start".
+   * \param named_grammars Grammar objects or Lark sources that can be referenced with `@name`.
+   */
+  CompiledGrammar CompileLark(
+      const std::string& lark_string, const std::vector<NamedGrammar>& named_grammars = {}
+  );
+
   /*! \brief Get the compiled grammar for a grammar. */
   CompiledGrammar CompileGrammar(const Grammar& grammar);
 

--- a/python/xgrammar/compiler.py
+++ b/python/xgrammar/compiler.py
@@ -8,6 +8,7 @@ from .base import XGRObject, _core
 from .grammar import (
     Grammar,
     StructuralTagItem,
+    _convert_named_grammars_to_lists,
     _convert_schema_to_str,
     _get_structural_tag_str_from_args,
 )
@@ -236,6 +237,35 @@ class GrammarCompiler(XGRObject):
             The compiled grammar.
         """
         return CompiledGrammar._create_from_handle(self._handle.compile_regex(regex))
+
+    def compile_lark(
+        self, lark_string: str, *, named_grammars: Optional[Dict[str, Union[Grammar, str]]] = None
+    ) -> CompiledGrammar:
+        """Compile a grammar from Lark syntax.
+
+        The compiler's tokenizer info is used to resolve named special tokens.
+        When caching is enabled, repeated calls with the same Lark source and
+        named grammars reuse the previous compiled result.
+
+        Parameters
+        ----------
+        lark_string : str
+            The Lark grammar source. It must define a ``start`` rule.
+
+        named_grammars : Optional[Dict[str, Union[Grammar, str]]]
+            Grammars referenced by ``@name`` in the Lark source. String values
+            contain Lark grammar sources with their own ``start`` rules. Dictionary
+            keys are passed without the leading ``@``.
+
+        Returns
+        -------
+        compiled_grammar : CompiledGrammar
+            The compiled Lark grammar.
+        """
+        names, values = _convert_named_grammars_to_lists(named_grammars)
+        return CompiledGrammar._create_from_handle(
+            self._handle.compile_lark(lark_string, names, values)
+        )
 
     @overload
     def compile_structural_tag(

--- a/python/xgrammar/grammar.py
+++ b/python/xgrammar/grammar.py
@@ -13,6 +13,29 @@ if TYPE_CHECKING:
     from .tokenizer_info import TokenizerInfo
 
 
+def _convert_named_grammars_to_lists(
+    named_grammars: Optional[Dict[str, Union["Grammar", str]]]
+) -> Tuple[List[str], List[Any]]:
+    if named_grammars is None:
+        named_grammars = {}
+    if not isinstance(named_grammars, dict):
+        raise TypeError("named_grammars must be a dictionary")
+    names: List[str] = []
+    values: List[Any] = []
+    for name, grammar_or_source in named_grammars.items():
+        if not isinstance(name, str):
+            raise TypeError("named grammar names must be strings")
+        if isinstance(grammar_or_source, Grammar):
+            value = grammar_or_source._handle
+        elif isinstance(grammar_or_source, str):
+            value = grammar_or_source
+        else:
+            raise TypeError("named grammar values must be Grammar instances or Lark strings")
+        names.append(name)
+        values.append(value)
+    return names, values
+
+
 def _convert_instance_to_str(instance: Union[str, Dict[str, Any], StructuralTag]) -> str:
     """Convert a instance to a string representation. It returns the schema in string format because
     it's faster to send to C++.
@@ -328,23 +351,7 @@ class Grammar(XGRObject):
             keys are passed without the leading ``@``.
         """
         tokenizer_handle = None if tokenizer_info is None else tokenizer_info._handle
-        if named_grammars is None:
-            named_grammars = {}
-        if not isinstance(named_grammars, dict):
-            raise TypeError("named_grammars must be a dictionary")
-        names: List[str] = []
-        values: List[Any] = []
-        for name, grammar_or_source in named_grammars.items():
-            if not isinstance(name, str):
-                raise TypeError("named grammar names must be strings")
-            if isinstance(grammar_or_source, Grammar):
-                value = grammar_or_source._handle
-            elif isinstance(grammar_or_source, str):
-                value = grammar_or_source
-            else:
-                raise TypeError("named grammar values must be Grammar instances or Lark strings")
-            names.append(name)
-            values.append(value)
+        names, values = _convert_named_grammars_to_lists(named_grammars)
         return Grammar._create_from_handle(
             _core.Grammar.from_lark(lark_string, tokenizer_handle, names, values)
         )

--- a/tests/cpp/test_lark_converter.cc
+++ b/tests/cpp/test_lark_converter.cc
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
 #include <xgrammar/xgrammar.h>
 
+#include <algorithm>
 #include <string>
+#include <vector>
 
 #include "test_utils.h"
 
@@ -75,6 +77,40 @@ TEST(LarkConverterTest, NamedGrammarSources) {
       XGrammarError,
       "circular named grammar reference: @left -> @right -> @left"
   );
+}
+
+TEST(LarkConverterTest, GrammarCompilerCachesLarkSources) {
+  TokenizerInfo tokenizer_info(std::vector<std::string>{});
+  GrammarCompiler compiler(tokenizer_info, /*max_threads=*/1, /*cache_enabled=*/true);
+
+  auto first = compiler.CompileLark(R"(start: "a")");
+  auto repeated = compiler.CompileLark(R"(start: "a")");
+  EXPECT_EQ(first.ImplPtr(), repeated.ImplPtr());
+
+  std::vector<NamedGrammar> named_grammars = {
+      {"left", std::string(R"(start: "a")")}, {"right", std::string(R"(start: "b")")}
+  };
+  auto with_named_grammars = compiler.CompileLark("start: @left @right", named_grammars);
+  std::reverse(named_grammars.begin(), named_grammars.end());
+  auto with_reordered_named_grammars = compiler.CompileLark("start: @left @right", named_grammars);
+  EXPECT_EQ(with_named_grammars.ImplPtr(), with_reordered_named_grammars.ImplPtr());
+
+  auto with_different_named_grammar = compiler.CompileLark(
+      "start: @left @right",
+      {{"left", std::string(R"(start: "a")")}, {"right", std::string(R"(start: "c")")}}
+  );
+  EXPECT_NE(with_named_grammars.ImplPtr(), with_different_named_grammar.ImplPtr());
+
+  auto with_grammar_object =
+      compiler.CompileLark("start: @item", {{"item", Grammar::FromLark(R"(start: "item")")}});
+  auto with_equivalent_grammar_object =
+      compiler.CompileLark("start: @item", {{"item", Grammar::FromLark(R"(start: "item")")}});
+  EXPECT_EQ(with_grammar_object.ImplPtr(), with_equivalent_grammar_object.ImplPtr());
+
+  GrammarCompiler uncached_compiler(tokenizer_info, /*max_threads=*/1, /*cache_enabled=*/false);
+  auto uncached_first = uncached_compiler.CompileLark(R"(start: "a")");
+  auto uncached_second = uncached_compiler.CompileLark(R"(start: "a")");
+  EXPECT_NE(uncached_first.ImplPtr(), uncached_second.ImplPtr());
 }
 
 TEST(LarkConverterTest, DynamicToolCallLowersToTagDispatch) {

--- a/tests/python/test_lark.py
+++ b/tests/python/test_lark.py
@@ -10,8 +10,7 @@ def _compile_lark(
     grammar: str, tokenizer_info: Optional[xgr.TokenizerInfo] = None
 ) -> xgr.CompiledGrammar:
     tokenizer_info = tokenizer_info or xgr.TokenizerInfo([])
-    grammar_obj = xgr.Grammar.from_lark(grammar, tokenizer_info=tokenizer_info)
-    return xgr.GrammarCompiler(tokenizer_info, cache_enabled=False).compile_grammar(grammar_obj)
+    return xgr.GrammarCompiler(tokenizer_info, cache_enabled=False).compile_lark(grammar)
 
 
 def _matches_string(compiled: xgr.CompiledGrammar, value: str) -> bool:
@@ -74,6 +73,33 @@ def _assert_lark_error(
     assert "Lark error at line " in error
     assert ", column " in error
     return error
+
+
+def test_compile_lark_api_uses_compiler_tokenizer_and_named_grammars() -> None:
+    tokenizer_info = xgr.TokenizerInfo(["a", "<|tool|>", "b"])
+    compiler = xgr.GrammarCompiler(tokenizer_info)
+    compiled = compiler.compile_lark(
+        "start: <|tool|> @item", named_grammars={"item": 'start: "a" | "b"'}
+    )
+    assert _matches_token_sequence(compiled, [1, 0])
+    assert _matches_token_sequence(compiled, [1, 2])
+    assert not _matches_token_sequence(compiled, [0])
+
+    compiled_with_grammar_object = compiler.compile_lark(
+        "start: @item", named_grammars={"item": xgr.Grammar.from_lark('start: "a"')}
+    )
+    assert _matches_token_sequence(compiled_with_grammar_object, [0])
+
+
+def test_compile_lark_named_grammar_argument_validation() -> None:
+    compiler = xgr.GrammarCompiler(xgr.TokenizerInfo([]))
+    item = xgr.Grammar.from_lark('start: "x"')
+    with pytest.raises(TypeError, match="must be a dictionary"):
+        compiler.compile_lark("start: @item", named_grammars=[item])  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="names must be strings"):
+        compiler.compile_lark("start: @item", named_grammars={1: item})  # type: ignore[dict-item]
+    with pytest.raises(TypeError, match="values must be Grammar instances or Lark strings"):
+        compiler.compile_lark("start: @item", named_grammars={"item": 1})  # type: ignore[dict-item]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add direct `GrammarCompiler::CompileLark` and `GrammarCompiler.compile_lark` APIs
- cache compiled Lark results by source and normalized named grammars, including order-independent mappings
- reuse named-grammar binding validation and document the direct compilation path

## Testing

- `pre-commit run --files <changed files>`
- `ctest --test-dir build-tests --output-on-failure -j 224` (71 passed)
- `pytest -q tests/python/test_lark.py` (388 passed)
- `pytest -q -m 'not hf_token_required'` (3513 passed, 1 skipped, 662 deselected)
- `XGRAMMAR_BUILD_DOCS=1 python -m sphinx -b html docs docs/_build/html`
