### PR TITLE
fix: compile FromLark under C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,11 @@ if(XGRAMMAR_BUILD_CXX_TESTS)
 
   include(GoogleTest)
   gtest_discover_tests(xgrammar_test)
+
+  add_executable(xgrammar_header_test tests/cpp20/test_public_headers.cc)
+  set_target_properties(xgrammar_header_test PROPERTIES CXX_STANDARD 20)
+  target_link_libraries(xgrammar_header_test xgrammar gtest_main)
+  gtest_discover_tests(xgrammar_header_test)
 endif()
 
 if(XGRAMMAR_ENABLE_COVERAGE)

--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -81,6 +81,9 @@ struct NamedGrammar;
  * rule2 ::= character_class_star_grammar_expr(id_of_a_character_class_grammar_expr)
  */
 class Grammar {
+  // The default argument must not instantiate vector until NamedGrammar is complete.
+  static const std::vector<NamedGrammar>& EmptyNamedGrammars();
+
  public:
   /*!
    * \brief Get the EBNF string of the grammar.
@@ -142,7 +145,7 @@ class Grammar {
   static Grammar FromLark(
       const std::string& lark_string,
       const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt,
-      const std::vector<NamedGrammar>& named_grammars = {}
+      const std::vector<NamedGrammar>& named_grammars = EmptyNamedGrammars()
   );
 
   /*!
@@ -215,6 +218,11 @@ struct NamedGrammar {
   /*! \brief An existing grammar or a Lark source with its own `start` rule. */
   std::variant<Grammar, std::string> grammar;
 };
+
+inline const std::vector<NamedGrammar>& Grammar::EmptyNamedGrammars() {
+  static const std::vector<NamedGrammar> empty;
+  return empty;
+}
 
 }  // namespace xgrammar
 

--- a/tests/cpp20/test_public_headers.cc
+++ b/tests/cpp20/test_public_headers.cc
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+#include <xgrammar/xgrammar.h>
+
+TEST(PublicHeadersTest, FromLarkDefaultArguments) {
+  const std::string source = R"(start: "x")";
+  const auto expected = xgrammar::Grammar::FromLark(source, std::nullopt, {}).ToString();
+  EXPECT_EQ(xgrammar::Grammar::FromLark(source).ToString(), expected);
+  EXPECT_EQ(xgrammar::Grammar::FromLark(source, std::nullopt).ToString(), expected);
+
+  auto from_lark = &xgrammar::Grammar::FromLark;
+  EXPECT_EQ(from_lark(source, std::nullopt, {}).ToString(), expected);
+}


### PR DESCRIPTION
`FromLark`'s default argument fails with libc++ in C++20/23 because `NamedGrammar` is still incomplete. Define the empty vector after the type, keeping the signature unchanged.

Adds a C++20 regression test. All 72 C++ tests, C++17/20/23 compile checks, pre-commit and ruff pass on Xcode 27.

Related: #674.
