### PR TITLE
fix: compile FromLark under C++20

### DIFF
--- a/include/xgrammar/grammar.h
+++ b/include/xgrammar/grammar.h
@@ -81,6 +81,8 @@ struct NamedGrammar;
  * rule2 ::= character_class_star_grammar_expr(id_of_a_character_class_grammar_expr)
  */
 class Grammar {
+  static const std::vector<NamedGrammar>& EmptyNamedGrammars();
+
  public:
   /*!
    * \brief Get the EBNF string of the grammar.
@@ -142,7 +144,7 @@ class Grammar {
   static Grammar FromLark(
       const std::string& lark_string,
       const std::optional<TokenizerInfo>& tokenizer_info = std::nullopt,
-      const std::vector<NamedGrammar>& named_grammars = {}
+      const std::vector<NamedGrammar>& named_grammars = EmptyNamedGrammars()
   );
 
   /*!
@@ -215,6 +217,11 @@ struct NamedGrammar {
   /*! \brief An existing grammar or a Lark source with its own `start` rule. */
   std::variant<Grammar, std::string> grammar;
 };
+
+inline const std::vector<NamedGrammar>& Grammar::EmptyNamedGrammars() {
+  static const std::vector<NamedGrammar> empty;
+  return empty;
+}
 
 }  // namespace xgrammar
 

--- a/tests/cpp/test_lark_converter.cc
+++ b/tests/cpp/test_lark_converter.cc
@@ -9,6 +9,16 @@
 
 using namespace xgrammar;
 
+TEST(LarkConverterTest, DefaultArguments) {
+  const std::string source = R"(start: "x")";
+  const auto expected = Grammar::FromLark(source, std::nullopt, {}).ToString();
+  EXPECT_EQ(Grammar::FromLark(source).ToString(), expected);
+  EXPECT_EQ(Grammar::FromLark(source, std::nullopt).ToString(), expected);
+
+  auto from_lark = &Grammar::FromLark;
+  EXPECT_EQ(from_lark(source, std::nullopt, {}).ToString(), expected);
+}
+
 TEST(LarkConverterTest, CoreSyntaxAndImports) {
   auto grammar = Grammar::FromLark(R"(
     %import common.INT


### PR DESCRIPTION
`FromLark`'s default argument fails with libc++ in C++20/23 because `NamedGrammar` is still incomplete. Define the empty vector after the type, keeping the signature unchanged.

Adds coverage to the existing Lark tests. All 72 C++ tests, C++17/20/23 compile checks, pre-commit and ruff pass on Xcode 27.

Related: #674.
