### PR TITLE
fix: preserve tokenizer info JSON round trips

### DIFF
--- a/cpp/support/encoding.h
+++ b/cpp/support/encoding.h
@@ -299,11 +299,9 @@ inline std::optional<CharHandlingError> Latin1ToBytes(
 */
 inline void ByteToLatin1(const std::string& bytes, std::string* result) {
   result->clear();
-  const char* data = bytes.c_str();
+  result->reserve(bytes.size());
 
-  for (int current_idx = 0; *(data + current_idx) != '\0'; current_idx++) {
-    const unsigned char& current_char = static_cast<unsigned char>(*(data + current_idx));
-
+  for (unsigned char current_char : bytes) {
     // Ascii character, directly add to result.
     if (current_char <= 0x7F) {
       result->push_back(static_cast<char>(current_char));

--- a/cpp/tokenizer_info.cc
+++ b/cpp/tokenizer_info.cc
@@ -299,10 +299,7 @@ TokenizerInfo::Impl::Impl(
   };
   std::sort(sorted_decoded_vocab_.begin(), sorted_decoded_vocab_.end(), f_compare_token);
 
-  token_id_to_sorted_vocab_index_.assign(vocab_size_, -1);
-  for (int32_t i = 0; i < static_cast<int32_t>(sorted_decoded_vocab_.size()); ++i) {
-    token_id_to_sorted_vocab_index_[sorted_decoded_vocab_[i].first] = i;
-  }
+  BuildTokenIdToSortedVocabIndex();
 
   // The value means: the subtree is [i, trie_subtree_nodes_range[i]).
   trie_subtree_nodes_range_.resize(sorted_decoded_vocab_.size(), 0);
@@ -322,6 +319,13 @@ TokenizerInfo::Impl::Impl(
     prefix_stack.pop();
   }
   BuildTokenCharData();
+}
+
+void TokenizerInfo::Impl::BuildTokenIdToSortedVocabIndex() {
+  token_id_to_sorted_vocab_index_.assign(vocab_size_, -1);
+  for (int32_t i = 0; i < static_cast<int32_t>(sorted_decoded_vocab_.size()); ++i) {
+    token_id_to_sorted_vocab_index_[sorted_decoded_vocab_[i].first] = i;
+  }
 }
 
 void TokenizerInfo::Impl::BuildTokenCharData() {
@@ -521,6 +525,7 @@ std::variant<TokenizerInfo, SerializationError> TokenizerInfo::DeserializeJSON(
   if (auto err = AutoDeserializeJSON(&tokenizer_info, json_string, true, "TokenizerInfo")) {
     return err.value();
   }
+  tokenizer_info->BuildTokenIdToSortedVocabIndex();
   tokenizer_info->BuildTokenCharData();
   return tokenizer_info;
 }

--- a/cpp/tokenizer_info_impl.h
+++ b/cpp/tokenizer_info_impl.h
@@ -41,6 +41,7 @@ class TokenizerInfo::Impl {
   }
   const std::vector<int32_t>& GetTokenCharCounts() const;
   int32_t GetMaxTokenChars() const;
+  void BuildTokenIdToSortedVocabIndex();
   void BuildTokenCharData();
 
   std::string DumpMetadata() const;

--- a/tests/cpp/test_serialization.cc
+++ b/tests/cpp/test_serialization.cc
@@ -4,7 +4,9 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 #include "fsm.h"
@@ -12,6 +14,7 @@
 #include "support/dynamic_bitset.h"
 #include "support/json_serializer.h"
 #include "test_utils.h"
+#include "tokenizer_info_impl.h"
 
 namespace xgrammar {
 
@@ -272,6 +275,26 @@ TEST(XGrammarSerializationTest, TestString) {
     ASSERT_FALSE(error.has_value());
     ASSERT_EQ(deserialized, value);
   }
+}
+
+TEST(XGrammarSerializationTest, TestTokenizerInfoRoundtripPreservesDerivedData) {
+  using namespace xgrammar;
+
+  TokenizerInfo original(
+      {std::string("\0", 1), "a", "</s>"}, VocabType::RAW, 4, std::vector<int32_t>{2}
+  );
+  auto recovered_or_error = TokenizerInfo::DeserializeJSON(original.SerializeJSON());
+
+  ASSERT_TRUE(std::holds_alternative<TokenizerInfo>(recovered_or_error));
+  const auto& recovered = std::get<TokenizerInfo>(recovered_or_error);
+  EXPECT_EQ(recovered.GetDecodedVocab(), original.GetDecodedVocab());
+  EXPECT_EQ(
+      recovered.ImplPtr()->GetTokenIdToSortedVocabIndex(),
+      original.ImplPtr()->GetTokenIdToSortedVocabIndex()
+  );
+  EXPECT_EQ(
+      recovered.ImplPtr()->GetTokenIdToSortedVocabIndex(), (std::vector<int32_t>{0, 1, -1, -1})
+  );
 }
 
 TEST(XGrammarSerializationTest, TestFSMEdge) {

--- a/tests/python/test_serialization.py
+++ b/tests/python/test_serialization.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, RootModel
 from transformers import AutoTokenizer  # type: ignore
 
 import xgrammar as xgr
-from xgrammar.testing import _is_grammar_accept_string
+from xgrammar.testing import _get_masked_tokens_from_bitmask, _is_grammar_accept_string
 
 
 def construct_grammar():
@@ -194,6 +194,30 @@ def test_serialize_tokenizer_info_functional():
 
     test_input = "aaa"
     assert matcher_original.accept_string(test_input) == matcher_recovered.accept_string(test_input)
+
+
+def test_serialize_tokenizer_info_token_grammar_functional():
+    """Test binary vocab preservation and token masks after deserialization."""
+    original_tokenizer_info = xgr.TokenizerInfo(
+        [b"\x00", b"a", b"</s>"], vocab_type=xgr.VocabType.RAW, vocab_size=4, stop_token_ids=[2]
+    )
+    recovered_tokenizer_info = xgr.TokenizerInfo.deserialize_json(
+        original_tokenizer_info.serialize_json()
+    )
+
+    assert recovered_tokenizer_info.decoded_vocab == original_tokenizer_info.decoded_vocab
+
+    grammar = xgr.Grammar.from_ebnf("root ::= Token(1)\n")
+    compiled_grammar = xgr.GrammarCompiler(
+        recovered_tokenizer_info, cache_enabled=False
+    ).compile_grammar(grammar)
+    matcher = xgr.GrammarMatcher(compiled_grammar)
+    token_bitmask = xgr.allocate_token_bitmask(1, recovered_tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected_token_ids = _get_masked_tokens_from_bitmask(
+        token_bitmask, recovered_tokenizer_info.vocab_size
+    )
+    assert rejected_token_ids == [0, 2, 3]
 
 
 def test_serialize_compiled_grammar():


### PR DESCRIPTION
## Summary

- Preserve embedded NUL bytes when serializing tokenizer vocabulary entries.
- Rebuild `TokenizerInfo`'s derived token-to-sorted-vocabulary index after JSON deserialization.
- Add regression coverage for token-level grammar bitmasks after a JSON round trip.

## Reproduction

```python
import xgrammar as xgr
from xgrammar.testing import _get_masked_tokens_from_bitmask

tokenizer_info = xgr.TokenizerInfo(
    [b"\x00", b"a", b"</s>"],
    vocab_type=xgr.VocabType.RAW,
    vocab_size=4,
    stop_token_ids=[2],
)
recovered = xgr.TokenizerInfo.deserialize_json(tokenizer_info.serialize_json())

assert recovered.decoded_vocab == tokenizer_info.decoded_vocab

grammar = xgr.Grammar.from_ebnf("root ::= Token(1)\n")
compiled = xgr.GrammarCompiler(recovered, cache_enabled=False).compile_grammar(grammar)
matcher = xgr.GrammarMatcher(compiled)
bitmask = xgr.allocate_token_bitmask(1, recovered.vocab_size)
matcher.fill_next_token_bitmask(bitmask)

rejected = _get_masked_tokens_from_bitmask(bitmask, recovered.vocab_size)
assert rejected == [0, 2, 3]
```

Before this change, the NUL token became `b""`, and token-mask generation could crash because the deserialized reverse token index was empty. After the fix, the vocabulary round trip is lossless and only token `1` is enabled.

## Tests

- `build/xgrammar_test` (72 passed)
- `pytest -m "not hf_token_required"` (3459 passed, 56 skipped)
