### PR TITLE
fix: preserve JSON escapes in length-constrained strings

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -2370,8 +2370,63 @@ int32_t JSONSchemaConverter::GenerateString(const StringSpec& spec, const std::s
   }
   // Check for length constraints
   if (spec.min_length != 0 || spec.max_length != -1) {
-    int32_t character =
-        builder_.AddCharacterClass({{'"', '"'}, {'\\', '\\'}, {'\r', '\r'}, {'\n', '\n'}}, true);
+    // Each repetition must match exactly one JSON character so the Repeat budget counts
+    // characters (JSON Schema maxLength counts characters of the decoded string). An
+    // unescaped code point is one repetition; one complete escape sequence is also one.
+    // A bare [^"\\\r\n] class here would drop the escape branch entirely (issue #800),
+    // making \n/\"/\\/\\uXXXX unemittable inside length-bounded strings.
+    // kBasicEscape is not reused: it accepts every \uXXXX uniformly, so a surrogate pair
+    // (one code point spelled as two escapes) would cost two repetitions and lone
+    // surrogates would be admitted. Enumerate instead: a BMP escape is one repetition,
+    // a high+low surrogate pair is one repetition, and a lone surrogate matches nothing.
+    // The unescaped class mirrors AddHelperRules: all of U+0000-U+001F must stay escaped
+    // per RFC 8259 section 7.
+    int32_t unescaped_character =
+        builder_.AddCharacterClass({{0, 0x1f}, {'"', '"'}, {'\\', '\\'}}, true);
+    int32_t short_escape_character = builder_.AddCharacterClass(
+        {{'"', '"'},
+         {'\\', '\\'},
+         {'/', '/'},
+         {'b', 'b'},
+         {'f', 'f'},
+         {'n', 'n'},
+         {'r', 'r'},
+         {'t', 't'}}
+    );
+    int32_t hex_character = builder_.AddCharacterClass({{'0', '9'}, {'A', 'F'}, {'a', 'f'}});
+    int32_t non_surrogate_lead =
+        builder_.AddCharacterClass({{'0', '9'}, {'A', 'C'}, {'E', 'F'}, {'a', 'c'}, {'e', 'f'}});
+    int32_t surrogate_lead = builder_.AddCharacterClass({{'D', 'D'}, {'d', 'd'}});
+    int32_t bmp_escape = Sequence(
+        {ByteString("u"),
+         Choice(
+             {Sequence({non_surrogate_lead, hex_character, hex_character, hex_character}),
+              Sequence(
+                  {surrogate_lead,
+                   builder_.AddCharacterClass({{'0', '7'}}),
+                   hex_character,
+                   hex_character}
+              )}
+         )}
+    );
+    int32_t surrogate_pair_escape = Sequence(
+        {ByteString("u"),
+         surrogate_lead,
+         builder_.AddCharacterClass({{'8', '9'}, {'A', 'B'}, {'a', 'b'}}),
+         hex_character,
+         hex_character,
+         ByteString("\\u"),
+         surrogate_lead,
+         builder_.AddCharacterClass({{'C', 'F'}, {'c', 'f'}}),
+         hex_character,
+         hex_character}
+    );
+    int32_t character = Choice(
+        {unescaped_character,
+         Sequence({ByteString("\\"), short_escape_character}),
+         Sequence({ByteString("\\"), bmp_escape}),
+         Sequence({ByteString("\\"), surrogate_pair_escape})}
+    );
     int32_t body = Repeat(rule_name + "_characters", character, spec.min_length, spec.max_length);
     return Sequence({ByteString("\""), body, ByteString("\"")});
   }

--- a/tests/python/test_json_schema_converter.py
+++ b/tests/python/test_json_schema_converter.py
@@ -2482,6 +2482,71 @@ def test_min_max_length():
     check_schema_with_instance(schema, instance_rejected, is_accepted=False, any_whitespace=True)
 
 
+def test_min_max_length_allows_json_escapes():
+    # Issue #800: the length-bounded path used a bare [^"\\\r\n] class with no escape
+    # alternative, so \" \\ \/ \b \f \n \r \t and \uXXXX were unrepresentable and a model
+    # needing one could never close the string.
+    schema = {"type": "string", "maxLength": 10}
+
+    check_schema_with_instance(schema, r'"ab\ncd"', any_whitespace=True)
+    check_schema_with_instance(schema, r'"a\tb"', any_whitespace=True)
+    check_schema_with_instance(schema, r'"say \"hi\""', any_whitespace=True)
+    check_schema_with_instance(schema, r'"back\\slash"', any_whitespace=True)
+    check_schema_with_instance(schema, r'"a\/b"', any_whitespace=True)
+    check_schema_with_instance(schema, r'"a\bb"', any_whitespace=True)
+    check_schema_with_instance(schema, r'"a\fb"', any_whitespace=True)
+    check_schema_with_instance(schema, r'"a\rb"', any_whitespace=True)
+    check_schema_with_instance(schema, r'"a\u0062c"', any_whitespace=True)
+
+    # minLength alone and combined bounds share the same path.
+    check_schema_with_instance({"type": "string", "minLength": 3}, r'"a\nb"')
+    check_schema_with_instance({"type": "string", "minLength": 1, "maxLength": 3}, r'"a\nb"')
+
+
+def test_min_max_length_counts_escape_as_one_character():
+    # maxLength counts characters of the decoded string: one escape is one character.
+    check_schema_with_instance({"type": "string", "minLength": 3}, r'"a\nb"')
+    check_schema_with_instance({"type": "string", "maxLength": 2}, r'"a\nb"', is_accepted=False)
+    check_schema_with_instance(
+        {"type": "string", "maxLength": 10}, r'"\n\n\n\n\n\n\n\n\n\n"', any_whitespace=True
+    )
+    check_schema_with_instance(
+        {"type": "string", "maxLength": 10},
+        r'"\n\n\n\n\n\n\n\n\n\n\n"',
+        is_accepted=False,
+        any_whitespace=True,
+    )
+
+
+def test_min_max_length_rejects_unescaped_controls():
+    # Unescaped U+0000-U+001F are invalid JSON; the old class admitted them (except \r\n).
+    schema = {"type": "string", "minLength": 1, "maxLength": 3}
+
+    check_schema_with_instance(schema, '"a\tb"', is_accepted=False)
+    check_schema_with_instance(schema, '"a\nb"', is_accepted=False)
+
+
+def test_min_max_length_counts_surrogate_pair_as_one_character():
+    # U+1F600 is one code point however it is spelled: raw UTF-8 or a \uXXXX pair.
+    schema = {"type": "string", "maxLength": 1}
+
+    check_schema_with_instance(schema, r'"\uD83D\uDE00"', any_whitespace=True)
+    check_schema_with_instance(schema, '"\U0001f600"', any_whitespace=True)
+    check_schema_with_instance(
+        schema, r'"\uD83D\uDE00\uD83D\uDE00"', is_accepted=False, any_whitespace=True
+    )
+
+
+def test_min_max_length_rejects_lone_surrogate_escapes():
+    schema = {"type": "string", "maxLength": 4}
+
+    check_schema_with_instance(schema, r'"\uD800"', is_accepted=False, any_whitespace=True)
+    check_schema_with_instance(schema, r'"\uDC00"', is_accepted=False, any_whitespace=True)
+    # Non-surrogate \uXXXX stays legal.
+    check_schema_with_instance(schema, r'"\uD7FF"', any_whitespace=True)
+    check_schema_with_instance(schema, r'"\uE000"', any_whitespace=True)
+
+
 def test_type_array():
     schema = {
         "type": ["integer", "string"],


### PR DESCRIPTION
## Root cause

`JSONSchemaConverter::GenerateString` lowers a string with `minLength`/`maxLength` to a bounded repetition over a bare negated class:

```cpp
builder_.AddCharacterClass({{'"', '"'}, {'\\\\', '\\\\'}, {'\\r', '\\r'}, {'\\n', '\\n'}}, true)
```

That production has no `"\\\\" basic_escape` alternative, so every RFC 8259 escape (`\\"`, `\\\\`, `\\/`, `\\b`, `\\f`, `\\n`, `\\r`, `\\t`, `\\uXXXX`) is unreachable inside a length-bounded string, while plain `{"type": "string"}` accepts them via `basic_string_sub`. The class also admits unescaped U+0000–U+001F (except CR/LF), which RFC 8259 forbids. Reported in #800; the `pattern` path already uses the JSON-string-aware regex and is unaffected, and `propertyNames` bounds flow through this same function so they are fixed too.

## Fix

Each `Repeat` element now matches exactly one JSON character (JSON Schema maxLength counts characters of the decoded string):

- unescaped code point `[^\\0-\\x1f"\\\\]` (mirrors `AddHelperRules`, closing the C0 hole),
- short escape `\\\\["\\\\/bfnrt]` — one repetition,
- BMP `\\uXXXX` (non-surrogate lead, incl. `D0`–`D7`) — one repetition,
- surrogate pair `\\uD83D\\uDE00` (high `D8`–`DB` + low `DC`–`DF`) — one repetition; lone surrogates match nothing.

`kBasicEscape` is deliberately not reused: it accepts every `\\uXXXX` uniformly, which would make a pair cost two repetitions and admit lone surrogates.

## Tests

- New in `tests/python/test_json_schema_converter.py`:
  - `test_min_max_length_allows_json_escapes` — all short escapes + `\\uXXXX` accepted under `maxLength`/`minLength`/both (issue repro: `a\\nb`, `a\\tb`, `a\\\\b`, `a\\"b`),
  - `test_min_max_length_counts_escape_as_one_character` — `"a\\nb"` needs `minLength: 3`, exceeds `maxLength: 2`; 10 vs 11 escapes against `maxLength: 10`,
  - `test_min_max_length_rejects_unescaped_controls` — raw TAB/LF rejected,
  - `test_min_max_length_counts_surrogate_pair_as_one_character` — raw U+1F600 and `\\uD83D\\uDE00` fit `maxLength: 1`, two pairs do not,
  - `test_min_max_length_rejects_lone_surrogate_escapes` — `\\uD800`/`\\uDC00` rejected, `\\uD7FF`/`\\uE000` accepted.
- Results: `test_json_schema_converter.py` — 527 passed; `test_json_schema_direct_converter.py` — 26 passed. `clang-format`, `ruff`, `isort` clean for the touched lines.

Refs #800