### PR TITLE
fix: reject malformed function tools falling back to builtins

### DIFF
--- a/python/xgrammar/openai_tool_call_schema.py
+++ b/python/xgrammar/openai_tool_call_schema.py
@@ -13,7 +13,7 @@ different flat tool and tool_choice shapes; see the class docstrings below.
 
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 # ============================================================
 # tools: list[FunctionToolParam]
@@ -103,6 +103,13 @@ class BuiltinToolParam(BaseModel):
     but XGrammar and serving engines need it to constrain the arguments emitted
     by the model.
     """
+
+    @field_validator("type")
+    @classmethod
+    def validate_builtin_type(cls, value: str) -> str:
+        if value == "function":
+            raise ValueError("The 'function' type requires a function tool definition.")
+        return value
 
 
 ToolParam = Union[FunctionToolParam, BuiltinToolParam]

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -354,6 +354,27 @@ def test_public_api_validation_errors(kwargs: Dict[str, Any], error_substring: s
     assert error_substring in str(exc_info.value)
 
 
+@pytest.mark.parametrize(
+    "tool",
+    [
+        {"type": "function"},
+        {"type": "function", "function": None},
+        {"type": "function", "function": {}},
+        {"type": "function", "function": {"name": 42}},
+    ],
+)
+def test_normalize_tool_choice_rejects_malformed_function(tool):
+    with pytest.raises(ValueError):
+        normalize_tool_choice(tools=[tool])
+    with pytest.raises(ValueError):
+        get_model_structural_tag("harmony", tools=[tool])
+
+
+def test_builtin_tool_rejects_function_type():
+    with pytest.raises(ValueError, match="requires a function tool definition"):
+        BuiltinToolParam(type="function")
+
+
 def test_normalize_tool_choice_named_function():
     """normalize_tool_choice returns one forced function for named choices."""
 


### PR DESCRIPTION
## Problem

Malformed Chat Completions function tools can silently become builtin tools during normalization. For example, both `{"type": "function"}` and `{"type": "function", "function": {"name": 42}}` are accepted by the `ToolParam` union as `BuiltinToolParam(type="function")`. The function payload is discarded instead of producing a validation error, and the structural-tag builder can treat `function` as the output tool name with unconstrained arguments.

`FunctionToolParam` correctly rejects these inputs, but the builtin union member accepts any string as its type and ignores the extra `function` field. This lets invalid function definitions fall through to the other member.

## Change

Reserve the `function` type for function-tool definitions by rejecting it in `BuiltinToolParam`. This applies to both dictionary normalization and direct builtin model construction. Other builtin type strings remain open-ended; valid function definitions are unchanged.

Add four malformed-input regressions exercising `normalize_tool_choice` and `get_model_structural_tag`, plus a direct-construction regression. Existing named-function, allowed-tool, builtin-tool and native grammar tests cover the valid paths. The change is limited to two Python files; it does not modify tool-choice policy, native grammar compilation, or support for the separate Responses API tool shape.

## Verification

Baseline: `10bc0d735a4b9be6bdb6b76f6551584502855cef`.

- On unmodified source, a standalone probe of the real schema module accepted both malformed examples above; valid function and builtin controls passed.
- After the change, the probe rejects both examples and the valid controls still pass.
- Built the current checkout's native bindings on Linux with GNU 13.3.0 / Release, Python 3.12.3, and ran the complete `tests/python/test_builtin_structural_tag.py`: **378 passed**, one pytest assertion-rewrite warning for already-imported `anyio`, with `HF_HUB_OFFLINE=1`.
- All applicable changed-file pre-commit hooks, changed-file Ruff, and `git diff --check` passed.
- Extended native-backed regression across `test_builtin_structural_tag.py`, `test_structural_tag_converter.py`, and `test_json_schema_direct_converter.py`: **1,489 passed**, with the same single warning. This includes the 378 tests above, not an additional disjoint count.
- Negative control on the same three files, loading the exact baseline schema module from git into memory before importing XGrammar: **5 failed / 1,484 passed**. All five added malformed-input cases fail because no validation error is raised. The rest of the Python source and compiled native library are unchanged by the fix. No working-tree source was overwritten for this control.

The native test runner explicitly selected the newly built checkout library and verified the Python source path because the existing environment also contained an older installed XGrammar wheel. Only library-path discovery was redirected; native functions were not mocked and docs-mode loading was disabled. Local build setup required selecting the same interpreter for CMake's `Python` and `Python3` and generating FFI stubs with the registered `xgrammar.tvm_ffi_binding.` prefix. These local setup steps are not part of the patch.

Additional adjacent native-path validation at the same head: `test_function_calling_converter.py` and `test_grammar_matcher_structural_tag.py` produced **246 passed / 12 skipped / 1 warning**. All 12 skips are existing HF_TOKEN-gated tests; they are not counted as passing. This checks converter and matcher behavior beyond input normalization, not a live model or server request. The same path-only test harness and offline setting were used.

The initial lightweight docs-mode tests are not counted as native validation. No full-project, GPU, or live-model validation is claimed.

## AI assistance

Codex assisted with investigation, implementation, and local verification. This is a draft for maintainer review; it does not claim independent human validation or an assigned ownership role.
