### PR TITLE
build: set the Python stub package for standalone CMake

### DIFF
--- a/cpp/tvm_ffi/CMakeLists.txt
+++ b/cpp/tvm_ffi/CMakeLists.txt
@@ -23,7 +23,15 @@ target_link_libraries(python_methods PUBLIC xgrammar)
 
 # TVM-FFI shared library: C++ bindings entry point
 add_library(xgrammar_bindings SHARED tvm_ffi.cc)
-tvm_ffi_configure_target(xgrammar_bindings STUB_DIR "${PROJECT_SOURCE_DIR}/python" STUB_INIT ON)
+tvm_ffi_configure_target(
+  xgrammar_bindings
+  STUB_DIR
+  "${PROJECT_SOURCE_DIR}/python"
+  STUB_INIT
+  ON
+  STUB_PKG
+  xgrammar
+)
 install(TARGETS xgrammar_bindings DESTINATION .)
 tvm_ffi_install(xgrammar_bindings DESTINATION .)
 target_include_directories(xgrammar_bindings PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
## Problem

A standalone CMake build with Python bindings enabled can finish successfully but leave the source package unimportable: `ModuleNotFoundError: No module named 'xgrammar.tvm_ffi_binding'`.

`tvm_ffi_configure_target` defaults its stub package to `SKBUILD_PROJECT_NAME` when available, otherwise to the target name. Outside scikit-build, our target name is `xgrammar_bindings`, so the generated command uses `--init-pypkg xgrammar_bindings --init-prefix xgrammar_bindings.`. The native registrations actually live under `xgrammar.tvm_ffi_binding.*`, and the required binding modules are not generated.

## Fix

Pass `STUB_PKG xgrammar` explicitly. Standalone CMake then uses the same package/prefix as the existing wheel path. This changes only `cpp/tvm_ffi/CMakeLists.txt`; no generated files or changes from #881 are included. The option is present in the supported TVM-FFI v0.1.10 helper as well as the tested 0.1.13.post3 installation.

## Verification

On baseline `10bc0d735a4b9be6bdb6b76f6551584502855cef`, from an independent worktree with no pre-generated stubs, configured Release with GNU 13.3.0 and Python 3.12.3, then built with `cmake --build build-linux-validation -j 4`. Both CMake Python interpreter selectors pointed at the same environment. The build exited successfully but importing the exact source package with its just-built library failed with the missing binding module above.

After this change, rebuilding automatically generated the binding package; no manual stub command was used in this worktree. Three relevant Python files passed against the native build: **1,484 passed**, with one pytest assertion-rewrite warning for already-imported `anyio`:

- `tests/python/test_builtin_structural_tag.py`
- `tests/python/test_structural_tag_converter.py`
- `tests/python/test_json_schema_direct_converter.py`

The source-tree test harness explicitly selected the newly built library because an older installed wheel was also present. Only library-path lookup was redirected; native operations were real and docs mode was disabled.

Also built an actual wheel with `uv build --wheel` / scikit-build-core 1.0.3, installed that wheel into an isolated target directory without replacing existing packages, and verified its import path, native JSON-schema compilation, valid-input acceptance and invalid-input rejection. This wheel smoke used ordinary library discovery, with no loader override. Applicable changed-file pre-commit hooks passed. No cross-platform, full-project, or GPU/model coverage is claimed.

## AI assistance

Codex assisted with diagnosis, implementation and local verification. This draft is for maintainer review and does not claim independent human verification or assigned ownership.
