### PR TITLE
perf: grow indirect parser history geometrically

### DIFF
--- a/cpp/support/compact_2d_array.h
+++ b/cpp/support/compact_2d_array.h
@@ -368,7 +368,14 @@ inline int32_t Compact2DArray<DataType>::PushBackIndirect(
     const std::vector<const DataType*>& new_data
 ) {
   CheckCanAppendData(new_data.size());
-  data_.reserve(data_.size() + new_data.size());
+  const size_t needed = data_.size() + new_data.size();
+  if (needed > data_.capacity()) {
+    // Exact-size reservations repeatedly relocate the full parser history.
+    // Grow geometrically while respecting the array's int32_t index limit.
+    const size_t doubled =
+        data_.capacity() > kMaxRepresentableSize / 2 ? kMaxRepresentableSize : data_.capacity() * 2;
+    data_.reserve(doubled > needed ? doubled : needed);
+  }
   for (const DataType* element : new_data) {
     data_.push_back(*element);
   }

--- a/tests/cpp/test_compact_2d_array.cc
+++ b/tests/cpp/test_compact_2d_array.cc
@@ -1,0 +1,83 @@
+/*!
+ * Copyright (c) 2026 by Contributors
+ * \file tests/cpp/test_compact_2d_array.cc
+ * \brief Indirect append correctness and amortized-growth regressions.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "support/compact_2d_array.h"
+
+namespace xgrammar {
+namespace {
+
+struct CopyCounted {
+  int value;
+  int64_t* operations;
+
+  CopyCounted(int value, int64_t* operations) : value(value), operations(operations) {}
+  CopyCounted(const CopyCounted& other) : value(other.value), operations(other.operations) {
+    ++*operations;
+  }
+  CopyCounted(CopyCounted&& other) noexcept : value(other.value), operations(other.operations) {
+    ++*operations;
+  }
+  CopyCounted& operator=(const CopyCounted&) = default;
+  CopyCounted& operator=(CopyCounted&&) = default;
+};
+
+TEST(Compact2DArrayTest, IndirectAppendHasAmortizedLinearRelocations) {
+  // Count copies/moves instead of measuring wall-clock latency. Exact reserve
+  // previously relocated the full retained history at every new high-water mark.
+  for (bool rollback : {false, true}) {
+    SCOPED_TRACE(rollback);
+    int64_t operations = 0;
+    const CopyCounted external(42, &operations);
+    const std::vector<const CopyCounted*> incoming{&external};
+    Compact2DArray<CopyCounted> array;
+    constexpr int kRows = 1024;
+    for (int i = 0; i < kRows; ++i) {
+      EXPECT_EQ(array.PushBackIndirect(incoming), i);
+      if (rollback) {
+        array.PushBackIndirect(incoming);
+        array.PushBackIndirect(incoming);
+        array.PopBack(2);
+      }
+      ASSERT_EQ(array.size(), i + 1);
+    }
+    // Loose linear bound includes payload insertion plus geometric relocation;
+    // it does not depend on a particular std::vector growth factor.
+    EXPECT_LT(operations, 10 * kRows);
+    for (int i = 0; i < kRows; ++i) EXPECT_EQ(array[i][0].value, 42);
+  }
+}
+
+TEST(Compact2DArrayTest, IndirectEmptyAndMultipleElementRowsSurviveRollback) {
+  Compact2DArray<int> array;
+  const int first = 7;
+  const int second = 19;
+  EXPECT_EQ(array.PushBackIndirect({}), 0);
+  EXPECT_EQ(array[0].size(), 0);
+  for (int i = 0; i < 100; ++i) {
+    const int index = array.PushBackIndirect({&second, &first, &second});
+    ASSERT_EQ(array[index].size(), 3);
+    EXPECT_EQ(array[index][0], 19);
+    EXPECT_EQ(array[index][1], 7);
+    EXPECT_EQ(array[index][2], 19);
+    array.PushBackIndirect({});
+    array.PushBackIndirect({&first});
+    array.PopBack(2);
+    ASSERT_EQ(array.size(), i + 2);
+  }
+  array.PopBack(100);
+  ASSERT_EQ(array.size(), 1);
+  EXPECT_EQ(array[0].size(), 0);
+  EXPECT_EQ(array.PushBackIndirect({&first}), 1);
+  EXPECT_EQ(array[1][0], 7);
+}
+
+}  // namespace
+}  // namespace xgrammar


### PR DESCRIPTION
## Summary

Related to #873. Prepared following @thincal's invitation to submit the independently verified candidate.

This targets **preview/v0.2.6rc3**, not main: the affected `PushBackIndirect` path is preview-only. Please confirm this is the preferred integration branch; draft status keeps that release-routing decision explicit.

- Grow indirect history storage geometrically instead of reserving exactly the next size on every append; retain the existing int32 index limit.
- Add deterministic operation-count regressions with speculative append/rollback and content checks for empty and multi-element rows.
- Credit: the diagnosis, introducing-commit bisect and geometric-growth proposal are **thincal's work** in #873. This contribution adds implementation hardening and independent regression validation.

## Test Plan

At head `4e4d55b17c22fe8101b000d80d8de71c9c3aa96b`, parent `07cb2dfadb89241f84b36a1a6006f5c9b34b63e3`:

- Rebuilt `xgrammar_test`; full configured C++ CTest target: **108/108 passed** on WSL Linux (latest rerun September 9).
- Changed-file pre-commit hooks and standalone Ruff passed. Full-repository pre-commit was attempted: Windows line-ending normalization and existing YAML comment formatting prevent a clean pass; unrelated workflow comment edits were reverted, with no tracked changes remaining.
- Rebuilt `xgrammar_bindings` from this checkout and ran the focused Python suite with its native library: **28 passed, 40 deselected**, covering speculative tree traversal, rollback, fork and token validation. Command: `pytest tests/python/test_speculative_decoding.py tests/python/test_grammar_matcher_basic.py -k 'traverse or rollback or fork or validate_tokens'`. The harness only redirects library discovery away from an installed wheel; it does not replace native behavior. Three warnings concern pytest plugin assertion rewriting and deprecated `max_rollback_tokens`. This is not the full Python suite or GPU serving validation.
- Earlier matched ASan/UBSan regression: baseline one test passes and the growth test fails; patched cases pass. Deterministic operation counts, not timing thresholds, form the regression assertions.
- Earlier native matcher check used the reporter's grammar, seeded 32k synthetic vocabulary and 20k tokens. Compared exact mask bytes between baseline and patch, including rollback/replay and branching speculative traversal, for trigger and clean controls. Local timings flattened for the trigger; no universal speedup claim.

Not validated: real production vocabulary, end-to-end GPU serving, internal-alias input pointers, or allocations at the int32 memory boundary. No captured model outputs or tests were fabricated. This implementation and verification were prepared with Codex assistance; reporter review is not represented as code-owner approval or contributor DCO certification.
