### PR TITLE
feat: support DeepSeek V4.1 structural tag format

### DIFF
--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -4151,6 +4151,7 @@ std::optional<JSONFormat> JSONFormatFromString(const std::string& format) {
       {"minimax_xml", JSONFormat::kMiniMaxXML},
       {"minimax_m3_xml", JSONFormat::kMiniMaxM3XML},
       {"deepseek_xml", JSONFormat::kDeepSeekXML},
+      {"deepseek_v4_1_xml", JSONFormat::kDeepSeekV41XML},
       {"glm_xml", JSONFormat::kGlmXML},
       {"cohere_xml", JSONFormat::kCohereXML},
       {"kimi_k3_xml", JSONFormat::kKimiK3XML},
@@ -4205,6 +4206,7 @@ Grammar JSONSchemaToGrammar(
     case JSONFormat::kQwenXML:
     case JSONFormat::kMiniMaxXML:
     case JSONFormat::kDeepSeekXML:
+    case JSONFormat::kDeepSeekV41XML:
     case JSONFormat::kGlmXML:
     case JSONFormat::kKimiK3XML: {
       XMLToolCallingConverter converter(
@@ -4309,6 +4311,7 @@ std::string JSONSchemaToEBNF(
     case JSONFormat::kQwenXML:
     case JSONFormat::kMiniMaxXML:
     case JSONFormat::kDeepSeekXML:
+    case JSONFormat::kDeepSeekV41XML:
     case JSONFormat::kGlmXML:
     case JSONFormat::kKimiK3XML: {
       XMLToolCallingConverter converter(

--- a/cpp/json_schema_converter.h
+++ b/cpp/json_schema_converter.h
@@ -202,12 +202,13 @@ enum class JSONFormat : int {
   kCohereXML = 5,
   kKimiK3XML = 6,
   kMiniMaxM3XML = 7,
+  kDeepSeekV41XML = 8,
 };
 
 /*!
  * \brief Convert a format name to JSONFormat.
  * \param format One of "json", "qwen_xml", "minimax_xml", "minimax_m3_xml", "deepseek_xml",
- * "glm_xml", "cohere_xml", or "kimi_k3_xml".
+ * "glm_xml", "cohere_xml", "kimi_k3_xml", or "deepseek_v4_1_xml".
  * \return The corresponding JSONFormat, or std::nullopt if the name is not recognized.
  */
 std::optional<JSONFormat> JSONFormatFromString(const std::string& format);

--- a/cpp/json_schema_converter_ext.cc
+++ b/cpp/json_schema_converter_ext.cc
@@ -411,6 +411,8 @@ const std::unordered_map<JSONFormat, XMLToolCallingConverter::XMLWrapper>
           "",
           // TODO(Linzhang): We do not validate the string's value, and we accept both.
           "</｜DSML｜parameter>"}},
+        {JSONFormat::kDeepSeekV41XML,
+         {"<｜DSML｜ parameter name=\"", "", "", "</｜DSML｜ parameter>"}},
         {JSONFormat::kGlmXML, {"<arg_key>", "</arg_key>", "<arg_value>", "</arg_value>"}},
         {JSONFormat::kCohereXML, {"<cofl:value", ">", "", "</cofl:value>"}},
         {JSONFormat::kKimiK3XML,
@@ -452,7 +454,7 @@ std::string XMLToolCallingConverter::XMLValue(const std::string& json_value) con
 }
 
 int32_t XMLToolCallingConverter::XMLKeySuffix(const std::optional<std::string>& pinned_type) {
-  if (json_format_ == JSONFormat::kDeepSeekXML) {
+  if (json_format_ == JSONFormat::kDeepSeekXML || json_format_ == JSONFormat::kDeepSeekV41XML) {
     return Sequence(
         {ByteString("\" string=\""),
          Choice({ByteString("true"), ByteString("false")}),
@@ -792,6 +794,10 @@ void XMLToolCallingConverter::AddCache(const std::string& key, int32_t rule_id) 
 std::optional<int32_t> XMLToolCallingConverter::GetCache(const std::string& key) const {
   if (key.empty()) {
     return std::nullopt;
+  }
+  if (json_format_ == JSONFormat::kDeepSeekV41XML && nested_object_level_ == 0 && key == "{}") {
+    // Unconstrained tool arguments are an XML parameter list, not one parameter's raw value.
+    return rule_cache_manager_.GetCache(kObjectCacheKey, false);
   }
   // At level 0, {"type":"object"} is the root tool-arguments object and uses XML parameter
   // tags. At level 1 it is the value of one such parameter and must use the inner JSON object

--- a/cpp/structural_tag.cc
+++ b/cpp/structural_tag.cc
@@ -563,10 +563,11 @@ Result<JSONSchemaFormat, ISTError> StructuralTagParser::ParseJSONSchemaFormat(
       style = it->second.get<std::string>();
       if (style != "json" && style != "qwen_xml" && style != "minimax_xml" &&
           style != "minimax_m3_xml" && style != "deepseek_xml" && style != "glm_xml" &&
-          style != "cohere_xml" && style != "kimi_k3_xml") {
+          style != "cohere_xml" && style != "kimi_k3_xml" && style != "deepseek_v4_1_xml") {
         return ResultErr<ISTError>(
             "style must be \"json\", \"qwen_xml\", \"minimax_xml\", \"minimax_m3_xml\", "
-            "\"deepseek_xml\", \"glm_xml\", \"cohere_xml\", or \"kimi_k3_xml\""
+            "\"deepseek_xml\", \"glm_xml\", \"cohere_xml\", \"kimi_k3_xml\", or "
+            "\"deepseek_v4_1_xml\""
         );
       }
     }

--- a/cpp/structural_tag.h
+++ b/cpp/structural_tag.h
@@ -83,8 +83,8 @@ struct ConstStringFormat {
 struct JSONSchemaFormat {
   static constexpr const char* type = "json_schema";
   std::string json_schema;
-  // "json","qwen_xml","minimax_xml","minimax_m3_xml","deepseek_xml","glm_xml","cohere_xml",
-  // "kimi_k3_xml"
+  // "json", "qwen_xml", "minimax_xml", "minimax_m3_xml", "deepseek_xml", "glm_xml",
+  // "cohere_xml", "kimi_k3_xml", "deepseek_v4_1_xml"
   std::string style = "json";
   // Whether to allow object properties to appear in any order. See
   // Grammar::FromJSONSchema / JSONSchemaToEBNF for the semantics.

--- a/docs/structural_tag/structural_tag.md
+++ b/docs/structural_tag/structural_tag.md
@@ -152,7 +152,7 @@ Matches content that conforms to a JSON Schema.
 | Field | Type | Default |
 | --- | --- | --- |
 | `json_schema` | `object` | (required) |
-| `style` | `"json"` \| `"qwen_xml"` \| `"minimax_xml"` \| `"minimax_m3_xml"` \| `"deepseek_xml"` \| `"glm_xml"` \| `"cohere_xml"` \| `"kimi_k3_xml"` | `"json"` |
+| `style` | `"json"` \| `"qwen_xml"` \| `"minimax_xml"` \| `"minimax_m3_xml"` \| `"deepseek_xml"` \| `"deepseek_v4_1_xml"` \| `"glm_xml"` \| `"cohere_xml"` \| `"kimi_k3_xml"` | `"json"` |
 | `any_order` | `bool` | `false` |
 
 - **Use it when**: the structured part is naturally expressed as schema-constrained data
@@ -163,7 +163,8 @@ Matches content that conforms to a JSON Schema.
 - `"qwen_xml"`: Qwen-style XML parameters, such as `<parameter=name>value</parameter>`
 - `"minimax_xml"`: MiniMax-style XML parameters, such as `<parameter name="name">value</parameter>`
 - `"minimax_m3_xml"`: MiniMax M3 namespace-prefixed XML. Fixed-name objects and arrays are encoded recursively, for example `]<]minimax[>[<city>Paris]<]minimax[>[</city>`. Schemas requiring runtime property names—for example schemas that permit `additionalProperties` or use `patternProperties` / `propertyNames`—and unconstrained schemas are rejected. String pattern, recognized format, and length constraints are also unsupported because string bodies must exclude the namespace marker.
-- `"deepseek_xml"`: DeepSeek-v3.2 XML parameter format
+- `"deepseek_xml"`: DeepSeek-V3.2 / V4 XML parameter format
+- `"deepseek_v4_1_xml"`: DeepSeek-V4.1 XML parameters, using `<｜DSML｜ parameter name="key" string="true|false">value</｜DSML｜ parameter>` (the space after `｜DSML｜` is significant)
 - `"glm_xml"`: GLM-style XML parameter format, such as `<arg_key>name</arg_key><arg_value>value</arg_value>`
 - `"cohere_xml"`: Cohere-style XML values, such as `<cofl:value name="name" type="raw">value</cofl:value>`
 - `"kimi_k3_xml"`: Kimi-K3 argument format, such as `<|open|>argument key="name" type="string"<|sep|>value<|close|>argument<|sep|>`. The `type` attribute is fixed to the type each declared property is rendered with (`integer` and `number` schemas both render as `number`); keys with no declared schema accept any type name.

--- a/docs/structural_tag/tool_calling_and_reasoning.md
+++ b/docs/structural_tag/tool_calling_and_reasoning.md
@@ -23,7 +23,7 @@ Use it when you need to constrain the model to output in a fixed pattern such as
 
 ### Parameters
 
-- **model** (`str`): The structural-tag style. Valid values are `"llama"`, `"qwen_3"`, `"qwen_3_5"`, `"qwen_3_coder"`, `"kimi"`, `"kimi_k3"`, `"deepseek_r1"`, `"deepseek_v3_1"`, `"harmony"`, `"deepseek_v3_2"`, `"minimax"`, `"minimax_m3"`, `"glm_4_7"`, `"deepseek_v4"`, `"cohere"`, `"exaone"`.
+- **model** (`str`): The structural-tag style. Valid values are `"llama"`, `"qwen_3"`, `"qwen_3_5"`, `"qwen_3_coder"`, `"kimi"`, `"kimi_k3"`, `"deepseek_r1"`, `"deepseek_v3_1"`, `"harmony"`, `"deepseek_v3_2"`, `"minimax"`, `"minimax_m3"`, `"glm_4_7"`, `"deepseek_v4"`, `"deepseek_v4_1"`, `"cohere"`, `"exaone"`.
 - **tools** (`List[ToolParam | dict]`, optional): Function and builtin tools available to the model. The list can contain two kinds of tools:
   - **Function tools** use the OpenAI Chat Completions shape:
     ```json
@@ -214,8 +214,62 @@ The `model` argument of `get_model_structural_tag` accepts the style names below
 | `"minimax_m3"` | MiniMax-M3 |
 | `"glm_4_7"` | GLM-5, GLM-4.7 |
 | `"deepseek_v4"` | DeepSeek-V4 |
+| `"deepseek_v4_1"` | DeepSeek-V4.1-Flash |
 | `"cohere"` | Cohere Command models using XML tool calls |
 | `"exaone"` | EXAONE-4.0-32B, EXAONE-4.0-1.2B |
+
+### DeepSeek-V4.1
+
+Use `"deepseek_v4_1"` for V4.1-Flash. Its tool-call syntax differs from V4:
+the outer block is `<｜DSML｜ calls>`, and both `invoke` and `parameter` have a
+space after `｜DSML｜`. Strings are raw text; other parameter values are JSON.
+The corresponding `JSONSchemaFormat` style is `"deepseek_v4_1_xml"`.
+
+```python
+import xgrammar as xgr
+from transformers import AutoTokenizer
+from xgrammar.builtin_structural_tag import get_model_structural_tag
+
+tokenizer = AutoTokenizer.from_pretrained("deepseek-ai/DeepSeek-V4.1-Flash")
+tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer, vocab_size=129280)
+stag = get_model_structural_tag(
+    "deepseek_v4_1",
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"],
+                "additionalProperties": False,
+            },
+        },
+    }],
+    tool_choice="required",
+    reasoning=True,
+)
+compiled = xgr.GrammarCompiler(tokenizer_info).compile_structural_tag(stag)
+matcher = xgr.GrammarMatcher(compiled)
+```
+
+The release supplies a Python [reference encoder](https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash/blob/main/encoding/encoding.py)
+and [deepseek-recipe](https://github.com/deepseek-ai/deepseek-recipe), rather than a
+Jinja chat template. Build the prompt with one of these encoders and start the
+matcher on the generated continuation. The prompt already ends with `<think>`
+in thinking mode or `</think>` in chat mode; set `reasoning` to match that mode.
+The generated reasoning ends with `</think>`. EOS (`<｜end▁of▁sentence｜>`, token 1)
+is handled by the matcher's stop token. Numeric reasoning effort and image inputs
+affect the prompt, not this output grammar.
+
+The parameter schema uses the same conversion rules as `deepseek_xml`; the
+`string` attribute is currently accepted independently of the value type.
+
+For namespaced tools, pass the qualified wire name (for example, `web::search`)
+in `function.name`, including in named or allowed tool choices. Separate provider
+`namespace` fields must be normalized by the caller before invoking this API.
+When tools are disabled or absent, calls blocks remain forbidden even if
+`exclude_special_tokens=False` allows thinking tokens in free text.
 
 ## Extending with custom models
 

--- a/python/xgrammar/builtin_structural_tag.py
+++ b/python/xgrammar/builtin_structural_tag.py
@@ -2342,24 +2342,83 @@ def get_deepseek_v4_structural_tag(
 
     - DeepSeek-V4
     """
-    INVOKE_BEGIN_PREFIX = '<｜DSML｜invoke name="'
+    return _get_deepseek_v4_structural_tag(
+        tools,
+        tool_choice,
+        reasoning,
+        any_order,
+        exclude_special_tokens,
+        max_whitespace_cnt,
+        v4_1=False,
+    )
+
+
+@register_model_structural_tag("deepseek_v4_1")
+def get_deepseek_v4_1_structural_tag(
+    tools: Optional[List[FunctionToolParam]] = None,
+    builtin_tools: Optional[List[BuiltinToolParam]] = None,
+    tool_choice: Literal["auto", "required", "forced"] = "auto",
+    reasoning: Literal["enabled", "disabled", "auto"] = "enabled",
+    any_order: bool = False,
+    exclude_special_tokens: bool = True,
+    max_whitespace_cnt: Optional[int] = None,
+    **kwargs: Any,
+) -> StructuralTag:
+    """Get DeepSeek-V4.1-Flash reasoning and tool-call structural tag format.
+
+    Corresponding model key: ``"deepseek_v4_1"``.
+
+    Reference: https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash/blob/main/encoding/encoding.py
+
+    V4.1 uses ``<｜DSML｜ calls>`` with space-prefixed ``invoke`` and
+    ``parameter`` tags. String arguments are raw text; other values are JSON.
+    Namespace-qualified tools use ``namespace::name`` as the function name.
+
+    Apply this tag after the generation prompt, which already ends in
+    ``<think>`` (reasoning) or ``</think>`` (chat). EOS is handled by the
+    tokenizer's stop token. Reasoning effort and image inputs are encoded
+    in the prompt and do not change the output grammar.
+    """
+    return _get_deepseek_v4_structural_tag(
+        tools,
+        tool_choice,
+        reasoning,
+        any_order,
+        exclude_special_tokens,
+        max_whitespace_cnt,
+        v4_1=True,
+    )
+
+
+def _get_deepseek_v4_structural_tag(
+    tools: Optional[List[FunctionToolParam]],
+    tool_choice: Literal["auto", "required", "forced"],
+    reasoning: Literal["enabled", "disabled", "auto"],
+    any_order: bool,
+    exclude_special_tokens: bool,
+    max_whitespace_cnt: Optional[int],
+    *,
+    v4_1: bool,
+) -> StructuralTag:
+    invoke = " invoke" if v4_1 else "invoke"
+    calls = " calls" if v4_1 else "tool_calls"
+    INVOKE_BEGIN_PREFIX = f'<｜DSML｜{invoke} name="'
     INVOKE_BEGIN_SUFFIX = '">\n'
     # See get_deepseek_v3_2_structural_tag for the rationale on INVOKE_END +
     # INVOKE_SEPARATOR splitting the single "\n" join that the chat template
     # uses between consecutive <｜DSML｜invoke> blocks.
-    INVOKE_END = "</｜DSML｜invoke>\n"
+    INVOKE_END = f"</｜DSML｜{invoke}>\n"
     INVOKE_SEPARATOR = ""
     TOOL_CALLS_PREFIX = "\n\n"
-    FUNCTION_CALLS_BEGIN = "<｜DSML｜tool_calls>\n"
-    FUNCTION_CALLS_END = "</｜DSML｜tool_calls>"
-    FUNCTION_CALLS_TRIGGER = "<｜DSML｜tool_calls>"
+    FUNCTION_CALLS_BEGIN = f"<｜DSML｜{calls}>\n"
+    FUNCTION_CALLS_END = f"</｜DSML｜{calls}>"
+    FUNCTION_CALLS_TRIGGER = f"<｜DSML｜{calls}>"
     THINK_TAG_BEGIN = "<think>"
     THINK_TAG_END = "</think>"
     THINK_EXCLUDE_TOKENS = ["<think>", "</think>"]
-    XML_STYLE = "deepseek_xml"
+    XML_STYLE = "deepseek_v4_1_xml" if v4_1 else "deepseek_xml"
 
     tools = tools or []
-    builtin_tools = builtin_tools or []
     if tool_choice == "auto":
         tags = []
         for tool in tools:
@@ -2397,9 +2456,12 @@ def get_deepseek_v4_structural_tag(
                 excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS),
             )
         else:
-            suffix_tag = AnyTextFormat(
-                excludes=_text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS)
-            )
+            excludes = _text_excludes(exclude_special_tokens, THINK_EXCLUDE_TOKENS)
+            if v4_1:
+                # With no available tools (including tool_choice="none"), a calls block
+                # must not slip through as unconstrained text.
+                excludes = [*excludes, FUNCTION_CALLS_TRIGGER]
+            suffix_tag = AnyTextFormat(excludes=excludes)
 
     elif tool_choice == "forced":
         if not tools:

--- a/python/xgrammar/structural_tag.py
+++ b/python/xgrammar/structural_tag.py
@@ -40,12 +40,14 @@ class JSONSchemaFormat(BaseModel):
         "glm_xml",
         "cohere_xml",
         "kimi_k3_xml",
+        "deepseek_v4_1_xml",
     ] = "json"
     """How to parse the content. Valid values: \"json\" (standard JSON), \"qwen_xml\" (Qwen XML:
     <parameter=key>value</parameter>), \"minimax_xml\" (MiniMax XML:
     <parameter name=\"key\">value</parameter>), \"minimax_m3_xml\" (MiniMax M3 recursive
     namespace XML: ]<]minimax[>[<key>value]<]minimax[>[</key>),
     \"deepseek_xml\" (DeepSeek XML(DeepSeek-v3.2): <{dsml_token}parameter name=\"key\" string=\"true|false\">value</{dsml_token}parameter>),
+    \"deepseek_v4_1_xml\" (DeepSeek-V4.1: <{dsml_token} parameter name=\"key\" string=\"true|false\">value</{dsml_token} parameter>),
     \"glm_xml\" (GLM XML: <arg_key>key</arg_key><arg_value>value</arg_value>),
     \"cohere_xml\" (Cohere XML: <cofl:value name=\"key\" type=\"raw|json|dict|list\">value</cofl:value>),
     \"kimi_k3_xml\" (Kimi-K3: <|open|>argument key=\"key\" type=\"type\"<|sep|>value<|close|>argument<|sep|>)."""

--- a/python/xgrammar/testing.py
+++ b/python/xgrammar/testing.py
@@ -33,6 +33,7 @@ def _json_schema_to_ebnf(
         "glm_xml",
         "cohere_xml",
         "kimi_k3_xml",
+        "deepseek_v4_1_xml",
     ] = "json",
     any_order: bool = False,
 ) -> str:
@@ -67,9 +68,9 @@ def _json_schema_to_ebnf(
 
     json_format : str, default: "json"
         The generated grammar format. One of "json", "qwen_xml", "minimax_xml",
-        "minimax_m3_xml", "deepseek_xml", "glm_xml", "cohere_xml", or "kimi_k3_xml".
-        MiniMax M3 encodes fixed-name nested objects and arrays recursively; the other XML
-        styles use their existing model-specific encodings.
+        "minimax_m3_xml", "deepseek_xml", "deepseek_v4_1_xml", "glm_xml", "cohere_xml",
+        or "kimi_k3_xml". MiniMax M3 encodes fixed-name nested objects and arrays
+        recursively; the other XML styles use their existing model-specific encodings.
 
     Returns
     -------

--- a/tests/python/test_builtin_structural_tag.py
+++ b/tests/python/test_builtin_structural_tag.py
@@ -13,6 +13,7 @@ from xgrammar.builtin_structural_tag import (
     get_deepseek_r1_structural_tag,
     get_deepseek_v3_1_structural_tag,
     get_deepseek_v3_2_structural_tag,
+    get_deepseek_v4_1_structural_tag,
     get_deepseek_v4_structural_tag,
     get_glm_4_7_structural_tag,
     get_harmony_structural_tag,
@@ -279,6 +280,7 @@ def test_reasoning_boolean_aliases(boolean_value: bool, mode: Literal["enabled",
         "minimax_m3",
         "glm_4_7",
         "deepseek_v4",
+        "deepseek_v4_1",
         "cohere",
         "exaone",
     ],
@@ -303,6 +305,7 @@ def test_reasoning_auto_builds_for_every_model(model: str):
         "minimax_m3",
         "glm_4_7",
         "deepseek_v4",
+        "deepseek_v4_1",
         "cohere",
         "exaone",
     ],
@@ -314,7 +317,16 @@ def test_reasoning_auto_uses_an_optional_complete_prefix(model: str):
 
 
 @pytest.mark.parametrize(
-    "model", ["kimi", "deepseek_r1", "deepseek_v3_1", "deepseek_v3_2", "deepseek_v4", "glm_4_7"]
+    "model",
+    [
+        "kimi",
+        "deepseek_r1",
+        "deepseek_v3_1",
+        "deepseek_v3_2",
+        "deepseek_v4",
+        "deepseek_v4_1",
+        "glm_4_7",
+    ],
 )
 def test_standard_reasoning_auto_accepts_complete_reasoning_or_direct_response(model: str):
     structural_tag = get_model_structural_tag(model, tools=[], reasoning="auto")
@@ -1362,6 +1374,7 @@ def test_qwen_reasoning_suffix_stays_inside_the_optional_prefix(model: str):
         get_harmony_structural_tag,
         get_deepseek_v3_2_structural_tag,
         get_deepseek_v4_structural_tag,
+        get_deepseek_v4_1_structural_tag,
         get_minimax_structural_tag,
         get_glm_4_7_structural_tag,
         get_cohere_structural_tag,
@@ -1451,6 +1464,7 @@ _EXCLUDE_TOKEN_MODELS = [
     "deepseek_v3_1",
     "deepseek_v3_2",
     "deepseek_v4",
+    "deepseek_v4_1",
     "qwen_3",
     "qwen_3_5",
     "minimax",
@@ -1477,13 +1491,16 @@ def test_exclude_special_tokens_default_excludes_think_tokens(model, tools):
 
 @pytest.mark.parametrize("model", _EXCLUDE_TOKEN_MODELS)
 @pytest.mark.parametrize("tools", [make_tools(["search"]), []])
-def test_exclude_special_tokens_false_excludes_nothing(model, tools):
-    """Opting out with ``exclude_special_tokens=False`` excludes nothing from free text."""
+def test_exclude_special_tokens_false_keeps_format_constraints(model, tools):
+    """Opting out allows special tokens while retaining tool availability constraints."""
 
     structural_tag = get_model_structural_tag(
         model, tools=tools, reasoning=True, exclude_special_tokens=False
     )
-    assert all(excludes == [] for excludes in _collect_excludes(structural_tag))
+    allowed_excludes = (
+        [[], ["<｜DSML｜ calls>"]] if model == "deepseek_v4_1" and not tools else [[]]
+    )
+    assert all(excludes in allowed_excludes for excludes in _collect_excludes(structural_tag))
     # The less-restrictive grammar must still build.
     xgr.Grammar.from_structural_tag(structural_tag)
 
@@ -2473,6 +2490,7 @@ _ANY_ORDER_MODELS = [
     "deepseek_v3_1",
     "deepseek_v3_2",
     "deepseek_v4",
+    "deepseek_v4_1",
     "minimax",
     "minimax_m3",
     "glm_4_7",

--- a/tests/python/test_builtin_structural_tag_alignment.py
+++ b/tests/python/test_builtin_structural_tag_alignment.py
@@ -1,11 +1,12 @@
 """Validate builtin structural tags against official model renderers.
 
-Uses tokenizer.apply_chat_template (or encoding scripts for DeepSeek V3.2/V4)
+Uses tokenizer.apply_chat_template (or encoding scripts for DeepSeek V3.2/V4/V4.1)
 and Cohere Melody for CMD5 to render model outputs, then checks that xgrammar
 structural tag grammars accept them. Requires encoding_dsv32.py and
-encoding_dsv4.py in the same directory.
+encoding_dsv4.py in the same directory. V4.1 uses a revision-pinned official encoder.
 """
 
+import importlib.util
 import json
 import os
 import sys
@@ -108,6 +109,8 @@ MODEL_CONFIGS = [
     ("glm_4_7", "zai-org/GLM-4.7-Flash", False, {"enable_thinking": False}),
     ("deepseek_v4", "ENCODER:dsv4", True, {"thinking_mode": "thinking"}),
     ("deepseek_v4", "ENCODER:dsv4", False, {"thinking_mode": "chat"}),
+    ("deepseek_v4_1", "ENCODER:dsv41", True, {"thinking_mode": "thinking"}),
+    ("deepseek_v4_1", "ENCODER:dsv41", False, {"thinking_mode": "chat"}),
     # Command A+'s Hugging Face template still emits CMD4 JSON action blocks. Use
     # Cohere's official Melody renderer, which is the source of truth for CMD5.
     ("cohere", "MELODY:cmd5", True, {"reasoning": True}),
@@ -160,6 +163,7 @@ EOS_SUFFIXES = {
     "glm_4_7": [],
     "deepseek_v3_2": ["<｜end▁of▁sentence｜>"],
     "deepseek_v4": ["<｜end▁of▁sentence｜>"],
+    "deepseek_v4_1": ["<｜end▁of▁sentence｜>"],
     "cohere": ["<|END_OF_TURN_TOKEN|>"],
     "exaone": ["[|endofturn|]"],
 }
@@ -272,9 +276,28 @@ def extract_output_tokenizer(model_id, stag_key, assistant_msg, tools, template_
     return strip_eos(output, stag_key, tokenizer)
 
 
+@lru_cache(maxsize=1)
+def load_deepseek_v41_encoder():
+    """Load the official, revision-pinned renderer (the release has no Jinja template)."""
+    from huggingface_hub import hf_hub_download
+
+    path = hf_hub_download(
+        "deepseek-ai/DeepSeek-V4.1-Flash",
+        "encoding/encoding.py",
+        revision="dba1be0a40aa45a94ad051997016db3960a90277",
+    )
+    spec = importlib.util.spec_from_file_location("encoding_dsv41", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def extract_output_encoder(encoder_name, stag_key, assistant_msg, tools, template_kwargs):
     if encoder_name == "dsv32":
         from encoding_dsv32 import encode_messages, eos_token
+    elif encoder_name == "dsv41":
+        encoder = load_deepseek_v41_encoder()
+        encode_messages, eos_token = encoder.encode_messages, encoder.eos_token
     else:
         from encoding_dsv4 import encode_messages, eos_token
 

--- a/tests/python/test_deepseek_v4_1.py
+++ b/tests/python/test_deepseek_v4_1.py
@@ -1,0 +1,280 @@
+"""DeepSeek-V4.1 output constraints, including the spaces in its DSML tag names."""
+
+import copy
+import json
+
+import pytest
+
+import xgrammar as xgr
+from xgrammar.builtin_structural_tag import get_model_structural_tag
+from xgrammar.structural_tag import JSONSchemaFormat, StructuralTag
+from xgrammar.testing import _is_grammar_accept_string, _json_schema_to_ebnf
+
+SCHEMA = {
+    "type": "object",
+    "properties": {"query": {"type": "string"}, "limit": {"type": "integer", "minimum": 1}},
+    "required": ["query", "limit"],
+    "additionalProperties": False,
+}
+TOOLS = [
+    {"type": "function", "function": {"name": name, "parameters": SCHEMA}}
+    for name in ("search", "other")
+]
+CALL = (
+    '<｜DSML｜ invoke name="search">\n'
+    '<｜DSML｜ parameter name="query" string="true">北京\n<code>"hi"</code></｜DSML｜ parameter>\n'
+    '<｜DSML｜ parameter name="limit" string="false">2</｜DSML｜ parameter>\n'
+    "</｜DSML｜ invoke>\n"
+)
+CALLS = "\n\n<｜DSML｜ calls>\n" + CALL + "</｜DSML｜ calls>"
+
+
+def make_grammar(reasoning=False, choice="required", **kwargs):
+    return xgr.Grammar.from_structural_tag(
+        get_model_structural_tag(
+            "deepseek_v4_1", tools=TOOLS, reasoning=reasoning, tool_choice=choice, **kwargs
+        )
+    )
+
+
+@pytest.mark.parametrize("reasoning", [False, True])
+@pytest.mark.parametrize("policy", ["auto", "required", "forced", "none", "allowed"])
+def test_tool_choice(reasoning, policy):
+    choice = policy
+    if policy == "forced":
+        choice = {"type": "function", "function": {"name": "search"}}
+    elif policy == "allowed":
+        choice = {
+            "type": "allowed_tools",
+            "allowed_tools": {
+                "mode": "required",
+                "tools": [{"type": "function", "function": {"name": "search"}}],
+            },
+        }
+    grammar = make_grammar(reasoning, choice)
+    prefix = "Plan the search.</think>" if reasoning else ""
+    assert _is_grammar_accept_string(grammar, prefix + CALLS) == (policy != "none")
+    assert _is_grammar_accept_string(grammar, prefix + "Hello") == (policy in ["auto", "none"])
+    parallel = CALLS.replace("</｜DSML｜ calls>", CALL + "</｜DSML｜ calls>")
+    assert _is_grammar_accept_string(grammar, prefix + parallel) == (
+        policy in ["auto", "required", "allowed"]
+    )
+    other = CALLS.replace('name="search"', 'name="other"')
+    assert _is_grammar_accept_string(grammar, prefix + other) == (policy in ["auto", "required"])
+
+
+@pytest.mark.parametrize("policy", ["auto", "required"])
+@pytest.mark.parametrize(
+    "output",
+    [
+        CALLS.replace('name="search"', 'name="unknown"'),
+        CALLS.replace('name="query"', 'name="unknown"'),
+        CALLS.replace('string="false">2', 'string="false">0'),
+        CALLS.replace('string="false">2', 'string="false">"two"'),
+        CALLS.replace(
+            '<｜DSML｜ parameter name="limit" string="false">2</｜DSML｜ parameter>\n', ""
+        ),
+        CALLS.replace("</｜DSML｜ invoke>\n", "</｜DSML｜ invoke>\n\n"),
+        CALLS.replace("｜DSML｜ parameter", "｜DSML｜parameter"),
+        CALLS.replace("｜DSML｜ invoke", "｜DSML｜invoke"),
+        "\n\n<｜DSML｜ calls>\n</｜DSML｜ calls>",
+        CALLS[: -len("</｜DSML｜ calls>")],
+    ],
+)
+def test_invalid_calls(policy, output):
+    assert not _is_grammar_accept_string(make_grammar(choice=policy), output)
+
+
+def test_reasoning_and_prompt_boundary():
+    grammar = make_grammar(reasoning=True)
+    assert _is_grammar_accept_string(grammar, "</think>" + CALLS)
+    assert not _is_grammar_accept_string(grammar, CALLS)
+    assert not _is_grammar_accept_string(grammar, "thinking</think>")
+    assert not _is_grammar_accept_string(make_grammar(), "</think>" + CALLS)
+
+
+def test_v4_is_a_different_wire_format():
+    legacy = xgr.Grammar.from_structural_tag(
+        get_model_structural_tag(
+            "deepseek_v4", tools=TOOLS, reasoning=False, tool_choice="required"
+        )
+    )
+    legacy_output = CALLS.replace("｜DSML｜ calls", "｜DSML｜tool_calls").replace(
+        "｜DSML｜ ", "｜DSML｜"
+    )
+    assert _is_grammar_accept_string(legacy, legacy_output)
+    assert not _is_grammar_accept_string(legacy, CALLS)
+    assert not _is_grammar_accept_string(make_grammar(), legacy_output)
+
+
+@pytest.mark.parametrize("exclude_special_tokens", [False, True])
+def test_no_tools(exclude_special_tokens):
+    grammar = xgr.Grammar.from_structural_tag(
+        get_model_structural_tag(
+            "deepseek_v4_1", reasoning=False, exclude_special_tokens=exclude_special_tokens
+        )
+    )
+    assert _is_grammar_accept_string(grammar, "Hello")
+    assert not _is_grammar_accept_string(grammar, CALLS)
+
+
+def test_namespaced_tool():
+    tool = copy.deepcopy(TOOLS[0])
+    tool["function"]["name"] = "web::search"
+    grammar = xgr.Grammar.from_structural_tag(
+        get_model_structural_tag(
+            "deepseek_v4_1",
+            tools=[tool],
+            reasoning=False,
+            tool_choice={"type": "function", "function": {"name": "web::search"}},
+        )
+    )
+    assert _is_grammar_accept_string(grammar, CALLS.replace('name="search"', 'name="web::search"'))
+    assert not _is_grammar_accept_string(grammar, CALLS)
+
+
+@pytest.mark.parametrize("any_order", [False, True])
+def test_parameter_order(any_order):
+    lines = CALLS.splitlines(keepends=True)
+    # query's raw string spans two lines; reverse the two complete parameters.
+    output = "".join(lines[:4] + lines[6:7] + lines[4:6] + lines[7:])
+    assert output != CALLS
+    assert _is_grammar_accept_string(make_grammar(any_order=any_order), output) == any_order
+
+
+@pytest.mark.parametrize(
+    "schema,value,string_attr",
+    [
+        ({"type": "string"}, 'raw "quotes" & <tag>\n你好', "true"),
+        ({"type": "integer"}, "42", "false"),
+        ({"type": "number"}, "-1.25", "false"),
+        ({"type": "boolean"}, "true", "false"),
+        ({"type": "null"}, "null", "false"),
+        ({"type": "array", "items": {"type": "integer"}}, "[1, 2]", "false"),
+        (
+            {"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]},
+            '{"x": "hi"}',
+            "false",
+        ),
+        ({"const": "fixed"}, "fixed", "true"),
+        ({"enum": [1, 2]}, "2", "false"),
+        ({"anyOf": [{"type": "string"}, {"type": "null"}]}, "null", "false"),
+    ],
+)
+def test_parameter_style(schema, value, string_attr):
+    schema = {
+        "type": "object",
+        "properties": {"value": schema},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    output = f'<｜DSML｜ parameter name="value" string="{string_attr}">{value}</｜DSML｜ parameter>'
+    stag = StructuralTag(format=JSONSchemaFormat(json_schema=schema, style="deepseek_v4_1_xml"))
+    # Exercise both the production structural-tag converter and the EBNF conversion path.
+    for grammar in [
+        xgr.Grammar.from_structural_tag(stag),
+        xgr.Grammar.from_ebnf(_json_schema_to_ebnf(schema, json_format="deepseek_v4_1_xml")),
+    ]:
+        assert _is_grammar_accept_string(grammar, output)
+        assert not _is_grammar_accept_string(
+            grammar, output.replace("｜DSML｜ parameter", "｜DSML｜parameter")
+        )
+        assert not _is_grammar_accept_string(grammar, output + output)
+
+
+@pytest.mark.parametrize("parameters", [{}, {"type": "object", "properties": {}}, None])
+def test_empty_arguments(parameters):
+    tool = {"type": "function", "function": {"name": "ping", "parameters": parameters}}
+    grammar = xgr.Grammar.from_structural_tag(
+        get_model_structural_tag(
+            "deepseek_v4_1", tools=[tool], reasoning=False, tool_choice="required"
+        )
+    )
+    output = '\n\n<｜DSML｜ calls>\n<｜DSML｜ invoke name="ping">\n\n</｜DSML｜ invoke>\n</｜DSML｜ calls>'
+    assert _is_grammar_accept_string(grammar, output)
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        {"name": "search"},
+        {"name": "search", "parameters": None},
+        {"name": "search", "parameters": {}},
+        {"name": "search", "parameters": SCHEMA, "strict": False},
+    ],
+)
+def test_unconstrained_tool_parameters(function):
+    grammar = xgr.Grammar.from_structural_tag(
+        get_model_structural_tag(
+            "deepseek_v4_1",
+            tools=[{"type": "function", "function": function}],
+            reasoning=False,
+            tool_choice="required",
+        )
+    )
+    assert _is_grammar_accept_string(grammar, CALLS)
+
+
+def test_whitespace_limit_and_serialization():
+    stag = get_model_structural_tag(
+        "deepseek_v4_1", tools=TOOLS, tool_choice="required", reasoning=False, max_whitespace_cnt=2
+    )
+    grammar = xgr.Grammar.from_structural_tag(json.loads(stag.model_dump_json()))
+    assert _is_grammar_accept_string(grammar, CALLS)
+    assert not _is_grammar_accept_string(
+        grammar, CALLS.replace('string="false">2', 'string="false">   2')
+    )
+
+
+@pytest.mark.hf_token_required
+@pytest.mark.parametrize("reasoning", [False, True])
+@pytest.mark.parametrize("policy", ["auto", "required", "forced"])
+def test_official_tokenizer_masks(reasoning, policy):
+    from test_builtin_structural_tag_alignment import extract_output_encoder
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        "deepseek-ai/DeepSeek-V4.1-Flash", revision="dba1be0a40aa45a94ad051997016db3960a90277"
+    )
+    info = xgr.TokenizerInfo.from_huggingface(tokenizer, vocab_size=129280)
+    assert info.vocab_type == xgr.VocabType.BYTE_LEVEL
+    assert info.stop_token_ids == [1]
+    assert tokenizer.encode("｜DSML｜", add_special_tokens=False) == [128825]
+    tool_choice = (
+        {"type": "function", "function": {"name": "search"}} if policy == "forced" else policy
+    )
+    tools = copy.deepcopy(TOOLS)
+    stag = get_model_structural_tag(
+        "deepseek_v4_1", tools=tools, reasoning=reasoning, tool_choice=tool_choice
+    )
+    compiled = xgr.GrammarCompiler(info).compile_structural_tag(stag)
+    matcher = xgr.GrammarMatcher(compiled)
+    bitmask = xgr.allocate_token_bitmask(1, info.vocab_size)
+    message = {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "Plan." if reasoning else "",
+        "tool_calls": [
+            {
+                "type": "function",
+                "function": {"name": name, "arguments": {"query": "北京\n<code>", "limit": 2}},
+            }
+            for name in (["search"] if policy == "forced" else ["search", "other"])
+        ],
+    }
+    output = extract_output_encoder(
+        "dsv41",
+        "deepseek_v4_1",
+        message,
+        tools,
+        {"thinking_mode": "thinking" if reasoning else "chat"},
+    )
+    token_ids = tokenizer.encode(output, add_special_tokens=False)
+    assert tokenizer.decode(token_ids) == output
+    for index, token_id in enumerate(token_ids + [tokenizer.eos_token_id]):
+        matcher.fill_next_token_bitmask(bitmask)
+        if policy != "auto" and index < len(token_ids):
+            assert not (int(bitmask[0, 0]) >> tokenizer.eos_token_id) & 1
+        assert (int(bitmask[0, token_id // 32]) >> (token_id % 32)) & 1, token_id
+        assert matcher.accept_token(token_id), token_id
+    assert matcher.is_terminated()

--- a/tests/python/test_function_calling_converter.py
+++ b/tests/python/test_function_calling_converter.py
@@ -2773,6 +2773,12 @@ def test_cohere_resolves_chained_recursive_ref():
 
 _XML_DYNAMIC_PROPERTY_CASES = (
     (
+        "deepseek_v4_1_xml",
+        '<｜DSML｜ parameter name="name" string="true">n</｜DSML｜ parameter>',
+        '<｜DSML｜ parameter name="x_key" string="false">3</｜DSML｜ parameter>',
+        '<｜DSML｜ parameter name="x_key" string="true">v</｜DSML｜ parameter>',
+    ),
+    (
         "qwen_xml",
         "<parameter=name>n</parameter>",
         "<parameter=x_key>3</parameter>",

--- a/tests/python/test_structural_tag_converter.py
+++ b/tests/python/test_structural_tag_converter.py
@@ -3288,7 +3288,7 @@ json_format_error_test_data = [
     ),
     (
         '{"type": "structural_tag", "format": {"type": "json_schema", "json_schema": {"type": "string"}, "style": "not_string"}}',
-        'style must be "json", "qwen_xml", "minimax_xml", "minimax_m3_xml", "deepseek_xml", "glm_xml", "cohere_xml", or "kimi_k3_xml"',
+        'style must be "json", "qwen_xml", "minimax_xml", "minimax_m3_xml", "deepseek_xml", "glm_xml", "cohere_xml", "kimi_k3_xml", or "deepseek_v4_1_xml"',
     ),
     # RepeatFormat Errors - illegal min/max
     (

--- a/tests/python/test_tokenizer_info.py
+++ b/tests/python/test_tokenizer_info.py
@@ -44,6 +44,7 @@ tokenizer_path__vocab_type__prepend_space = [
     ("THUDM/glm-4-9b-chat", xgr.VocabType.RAW, False),
     ("THUDM/chatglm3-6b", xgr.VocabType.BYTE_FALLBACK, True),
     ("deepseek-ai/DeepSeek-R1", xgr.VocabType.BYTE_LEVEL, False),
+    ("deepseek-ai/DeepSeek-V4.1-Flash", xgr.VocabType.BYTE_LEVEL, False),
     ("deepseek-ai/DeepSeek-R1-Distill-Qwen-7B", xgr.VocabType.BYTE_LEVEL, False),
     ("deepseek-ai/DeepSeek-R1-Distill-Llama-8B", xgr.VocabType.BYTE_LEVEL, False),
     ("openGPT-X/Teuken-7B-instruct-v0.6", xgr.VocabType.BYTE_FALLBACK, True),

--- a/web/src/structural_tag.ts
+++ b/web/src/structural_tag.ts
@@ -18,6 +18,7 @@ export interface JSONSchemaFormat {
     | "minimax_xml"
     | "minimax_m3_xml"
     | "deepseek_xml"
+    | "deepseek_v4_1_xml"
     | "glm_xml"
     | "cohere_xml";
 }

--- a/web/src/xgrammar_binding.cc
+++ b/web/src/xgrammar_binding.cc
@@ -157,6 +157,7 @@ EMSCRIPTEN_BINDINGS(xgrammar) {
       .value("kQwenXML", xgrammar::JSONFormat::kQwenXML)
       .value("kMiniMaxXML", xgrammar::JSONFormat::kMiniMaxXML)
       .value("kDeepSeekXML", xgrammar::JSONFormat::kDeepSeekXML)
+      .value("kDeepSeekV41XML", xgrammar::JSONFormat::kDeepSeekV41XML)
       .value("kCohereXML", xgrammar::JSONFormat::kCohereXML);
 
   // Register std::optional used in Grammar::FromJSONSchema


### PR DESCRIPTION
DeepSeek-V4.1-Flash uses spaced DSML tags (`<｜DSML｜ calls>`, `<｜DSML｜ invoke>`, and `<｜DSML｜ parameter>`), so the V4 grammar rejects its tool calls. Add the `deepseek_v4_1` builtin and `deepseek_v4_1_xml` schema style, following the [official encoder](https://huggingface.co/deepseek-ai/DeepSeek-V4.1-Flash/blob/dba1be0a40aa45a94ad051997016db3960a90277/encoding/encoding.py).

Reuse the existing DeepSeek XML conversion rules and a shared V4/V4.1 builder. Expose the format through Python, C++, and TypeScript. For the new style, an unconstrained root schema resolves to an XML parameter list so tools without a parameter schema can emit DSML calls. Existing V4 behavior is preserved.

This PR is limited to format support. Like the existing DeepSeek XML converter, it accepts the `string` attribute independently of the value type. Attribute/value correlation is reviewed separately in #886.

Validation of this format-only branch (`e85869056a74c176d24fd1d4c3a64a5a7c05e4d2`):

- Structural-tag/converter/matcher regression: **1998 passed**.
- Revision-pinned official encoder, real tokenizer masks, and V4 compatibility: **59 passed**.
- C++: **72 passed** on the format implementation; this update changes only documentation and test organization.
- Pre-commit passed. The TypeScript declarations are unchanged from the previously passing typecheck.

```bash
cmake --build tmp/2026-09-10-deepseek-v41/build-main -j 12
# Select the checkout and rebuilt native library in PYTHONPATH, or install from source.
python -m pytest -q tests/python/test_builtin_structural_tag.py tests/python/test_function_calling_converter.py \
  tests/python/test_structural_tag_converter.py tests/python/test_grammar_matcher_structural_tag.py \
  -m 'not hf_token_required' -o addopts='' --tb=short
python -m pytest -q tests/python/test_builtin_structural_tag_alignment.py tests/python/test_tokenizer_info.py \
  -k 'official or deepseek_v4 or DeepSeek-V4.1' -m hf_token_required -o addopts='' --tb=short
ctest --test-dir tmp/2026-09-10-deepseek-v41/build-main --output-on-failure -j 8
pre-commit run --from-ref origin/main --to-ref HEAD
```

Mask tests check each encoded token, complete termination, and no premature EOS in required/named mode. These validate the output protocol; full model inference was not run. All selected Hugging Face cases executed locally.

AI assistance: implementation, testing, and PR preparation used Codex.

